### PR TITLE
ci(leak-check): scope push trigger to main/master

### DIFF
--- a/.github/workflows/leak-check.yml
+++ b/.github/workflows/leak-check.yml
@@ -1,7 +1,14 @@
 # SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
 # SPDX-License-Identifier: GPL-3.0-or-later
 name: leak-check
-on: [push, pull_request]
+# Scan pushes to the integration branches and every PR diff. We deliberately do NOT scan pushes
+# to feature/Dependabot branches: those are covered by the pull_request diff scan, and a rebased
+# branch orphans github.event.before so `git diff before..head` errors out (bad object) and the
+# job fails spuriously. PRs gate everything that reaches main anyway.
+on:
+  push:
+    branches: [main, master]
+  pull_request:
 jobs:
   leak-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem
Dependabot rebases its update branches, which orphans `github.event.before`. The push-triggered `leak-check` job then runs `git diff <before>..<head>` against an unreachable object and exits 1 — a **spurious failure**, not a real PII/secret finding. It surfaces as a second, failing `leak-check` check on Dependabot PRs (#1, #2), making them look UNSTABLE.

## Fix
Scope the `push` trigger to the integration branches `main`/`master`. The `pull_request` diff scan (`base..head`) already covers every feature and Dependabot branch with a reachable range, and branch protection means PRs gate everything that reaches `main`.

## Effect
- Kills the orphaned-`before` crash on rebased branches.
- Leaves exactly one reliable `leak-check` per PR (prereq for making `leak-check` a required status check in branch protection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)