### PR TITLE
chore: gitignore local .rules/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,6 @@ _manualtest/
 docs/
 reviews/
 .claude-memory/
+.rules/
 CLAUDE.md
 todo.md


### PR DESCRIPTION
Adds `.rules/` to `.gitignore`. It's a local, private, OneDrive-synced folder holding durable
workflow/rules docs (`dev-workflow.md`, `repo-health-roadmap.md`) and the `.claude-memory/` snapshot —
the same class as the already-ignored `docs/` / `reviews/`. Ensures the folder is ignored on every
clone (incl. the home PC), not just locally.

No file contents are added to the repo — this only declares the folder ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)