### PR TITLE
feat(core): generic Mork (.msf) reader

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -44,3 +44,10 @@ MimeKit
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
 -------------------------------------------------------------------------------
+Mork reader (src/Mail2Pst.Core/Mork/)
+  Parsing approach adapted from knk106/MorkReader (public domain, Unlicense).
+  Source: https://github.com/knk106/MorkReader
+  Retrieved/inspected at commit f347dbeb87ee (2025-07-16).
+  This is project-native GPL-3.0-or-later code; the public-domain origin imposes
+  no obligation, but the provenance is recorded for hygiene.
+-------------------------------------------------------------------------------

--- a/src/Mail2Pst.Core/Mork/MorkDocument.cs
+++ b/src/Mail2Pst.Core/Mork/MorkDocument.cs
@@ -3,7 +3,6 @@
 
 #nullable enable
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/Mail2Pst.Core/Mork/MorkDocument.cs
+++ b/src/Mail2Pst.Core/Mork/MorkDocument.cs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Mail2Pst.Core.Mork;
+
+public sealed class MorkDocument
+{
+    public IReadOnlyList<MorkTable> Tables { get; }
+
+    public MorkDocument(IEnumerable<MorkTable> tables)
+    {
+        Tables = new List<MorkTable>(tables).AsReadOnly();
+    }
+
+    public IReadOnlyList<MorkTable> GetTables(string scope, string kind) =>
+        Tables.Where(t => t.Scope == scope && t.Kind == kind).ToList().AsReadOnly();
+
+    public bool TryGetSingleTable(string scope, string kind, out MorkTable table)
+    {
+        var m = GetTables(scope, kind);
+        table = m.Count == 1 ? m[0] : default!;
+        return m.Count == 1;
+    }
+}

--- a/src/Mail2Pst.Core/Mork/MorkFormatException.cs
+++ b/src/Mail2Pst.Core/Mork/MorkFormatException.cs
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+
+namespace Mail2Pst.Core.Mork;
+
+/// <summary>Thrown on structural/syntactic Mork corruption. Unknown CONTENT is not an error.</summary>
+public sealed class MorkFormatException : Exception
+{
+    public MorkFormatException(string message) : base(message) { }
+    public MorkFormatException(string message, Exception inner) : base(message, inner) { }
+}

--- a/src/Mail2Pst.Core/Mork/MorkReader.cs
+++ b/src/Mail2Pst.Core/Mork/MorkReader.cs
@@ -49,11 +49,22 @@ public static class MorkReader
 
 /// <summary>
 /// Stateful assembler: drives a token list produced by <see cref="MorkTokenizer"/>
-/// and builds a <see cref="MorkDocument"/> (atom dictionary + tables + rows).
+/// and builds a <see cref="MorkDocument"/> (atom dictionaries + tables + rows).
 /// Applies append-log merge semantics: transaction groups are processed in file
 /// order; row restatements overwrite/add named cells (unnamed cells retained);
 /// row cuts remove the row; delete-then-re-add recreates it. Last-write-wins per
 /// (table, row, column). No cell-cut form exists in Thunderbird .msf (Task 0).
+///
+/// Mork has TWO separate atom spaces that reuse the same numeric ids:
+/// - Column atoms: dicts that open with a nested &lt;(a=c)&gt; meta-dict — ids map
+///   to column names / scope strings / kind strings.
+/// - Value atoms: all other dicts — ids map to cell values.
+/// These spaces are kept separate so a value dict cannot clobber column atoms
+/// that share the same hex id.
+///
+/// Resolution by position:
+/// - Table scope ^X, meta-row kind ^X, and a cell's column ref ^X → column map.
+/// - A cell's value ref ^X (the second ^X in (^col^val)) → value map.
 /// </summary>
 internal sealed class MorkAssembler
 {
@@ -61,10 +72,14 @@ internal sealed class MorkAssembler
     private readonly IReadOnlyList<MorkToken> _tokens;
     private int _pos;
 
-    // ---- atom dictionary: hex-id string -> decoded string -------------------
-    // Accumulated globally across all dicts in file order; decoded at definition
-    // time using the charset active for the enclosing dict.
-    private readonly Dictionary<string, string> _atoms =
+    // ---- atom dictionaries: hex-id string -> decoded string -----------------
+    // Column atoms: populated from dicts whose first sub-dict is <(a=c)>.
+    // Value atoms:  populated from all other dicts.
+    // Both accumulated globally across all dicts in file order; decoded at
+    // definition time using the charset active for the enclosing dict.
+    private readonly Dictionary<string, string> _columnAtoms =
+        new Dictionary<string, string>(StringComparer.Ordinal);
+    private readonly Dictionary<string, string> _valueAtoms =
         new Dictionary<string, string>(StringComparer.Ordinal);
 
     // ---- mutable working state: table id -> (scope, kind, rows) ------------
@@ -104,7 +119,7 @@ internal sealed class MorkAssembler
             switch (tok.Kind)
             {
                 case MorkTokenKind.DictOpen:
-                    ReadDict(nestDepth: 0);
+                    ReadDict(nestDepth: 0, parentIsColumn: false);
                     break;
 
                 case MorkTokenKind.BraceOpen:
@@ -149,7 +164,13 @@ internal sealed class MorkAssembler
     // Handles nested meta-dicts (< <(a=c)> ... >) by tracking depth.
     // -------------------------------------------------------------------------
 
-    private void ReadDict(int nestDepth)
+    /// <summary>
+    /// Reads one dict block.
+    /// <paramref name="nestDepth"/> tracks recursion for charset save/restore.
+    /// <paramref name="parentIsColumn"/> is true when the enclosing dict has already
+    /// been identified as a column dict (so nested calls inherit the space).
+    /// </summary>
+    private void ReadDict(int nestDepth, bool parentIsColumn)
     {
         Expect(MorkTokenKind.DictOpen); // consume '<'
 
@@ -158,25 +179,29 @@ internal sealed class MorkAssembler
         // Top-level dicts (nestDepth == 0) do NOT reset: the active charset persists
         // across all top-level dicts in the file (file-level charset).
         var savedCharset = _charset;
-        // (savedCharset is only used on exit when nestDepth > 0; no reset here)
 
-        // First pass to pick up (f=charset) — Mork dicts can declare charset before atoms,
-        // but real files put it first too. We do a single forward pass: charset applies to
-        // atoms that follow it in the same dict.
+        // Determine if this is a column dict by peeking at the first sub-token:
+        // a column dict begins with a nested <(a=c)> meta-dict (nestDepth == 0),
+        // OR inherits isColumn from the enclosing dict (nestDepth > 0).
+        bool isColumnDict = parentIsColumn || (nestDepth == 0 && PeekIsColumnMarker());
+
         while (_pos < _tokens.Count && Current().Kind != MorkTokenKind.DictClose)
         {
             var tok = Current();
 
             if (tok.Kind == MorkTokenKind.DictOpen)
             {
-                // Nested meta-dict (e.g. < <(a=c)> >) — skip recursively.
-                ReadDict(nestDepth: nestDepth + 1);
+                // Nested meta-dict (e.g. < <(a=c)> >) — recurse, passing the
+                // isColumnDict flag so atoms inside the nested block go to the
+                // right space (though nested dicts are usually just meta markers
+                // with no actual atom definitions).
+                ReadDict(nestDepth: nestDepth + 1, parentIsColumn: isColumnDict);
                 continue;
             }
 
             if (tok.Kind == MorkTokenKind.ParenOpen)
             {
-                ReadDictCell();
+                ReadDictCell(isColumnDict);
                 continue;
             }
 
@@ -194,10 +219,54 @@ internal sealed class MorkAssembler
     }
 
     /// <summary>
+    /// Peeks ahead without consuming tokens to detect the column-dict marker:
+    /// the first non-DictClose content after the already-consumed DictOpen is
+    /// another DictOpen whose first cell is <c>(a=c)</c>.
+    /// Returns true if the pattern matches; does NOT advance the cursor.
+    /// </summary>
+    private bool PeekIsColumnMarker()
+    {
+        // We are sitting at the first token inside the outer dict.
+        // Pattern: DictOpen ParenOpen Text("a") Equals Text("c") ParenClose DictClose …
+        int p = _pos;
+        if (p >= _tokens.Count || _tokens[p].Kind != MorkTokenKind.DictOpen)
+            return false;
+        p++; // skip inner DictOpen
+
+        // Expect '('
+        if (p >= _tokens.Count || _tokens[p].Kind != MorkTokenKind.ParenOpen)
+            return false;
+        p++;
+
+        // Expect Text "a"
+        if (p >= _tokens.Count || _tokens[p].Kind != MorkTokenKind.Text)
+            return false;
+        string key = Encoding.ASCII.GetString(_tokens[p].Bytes);
+        if (!string.Equals(key, "a", StringComparison.OrdinalIgnoreCase))
+            return false;
+        p++;
+
+        // Expect '='
+        if (p >= _tokens.Count || _tokens[p].Kind != MorkTokenKind.Equals)
+            return false;
+        p++;
+
+        // Expect Text "c"
+        if (p >= _tokens.Count || _tokens[p].Kind != MorkTokenKind.Text)
+            return false;
+        string val = Encoding.ASCII.GetString(_tokens[p].Bytes);
+        if (!string.Equals(val, "c", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        return true;
+    }
+
+    /// <summary>
     /// Reads one cell inside a dict: either <c>(hexid=value)</c> (atom definition),
     /// <c>(f=charset)</c> (charset hint), or a dict-meta cell like <c>(a=c)</c> (ignored).
+    /// Atoms are stored in the column map or value map based on <paramref name="isColumnDict"/>.
     /// </summary>
-    private void ReadDictCell()
+    private void ReadDictCell(bool isColumnDict)
     {
         Expect(MorkTokenKind.ParenOpen);
 
@@ -233,22 +302,30 @@ internal sealed class MorkAssembler
 
         Expect(MorkTokenKind.ParenClose);
 
-        // Charset hint?
+        // Charset hint? (f=charset) — update active charset; do NOT store as an atom.
         if (string.Equals(keyStr, "f", StringComparison.OrdinalIgnoreCase))
         {
             _charset = MorkValueDecoder.ResolveCharset(decodedValue);
             return;
         }
 
+        // Dict-meta cells like (a=c) — configure the dict space but do NOT store as atoms.
+        if (string.Equals(keyStr, "a", StringComparison.OrdinalIgnoreCase))
+            return;
+
         // Hex-id atom definition? (only if key is all-hex characters)
         if (IsHexId(keyStr))
         {
             string atomId = keyStr.ToUpperInvariant();
-            _atoms[atomId] = decodedValue;
+            // Store in the appropriate atom space.
+            if (isColumnDict)
+                _columnAtoms[atomId] = decodedValue;
+            else
+                _valueAtoms[atomId] = decodedValue;
             return;
         }
 
-        // Otherwise it's a dict-meta cell (e.g. (a=c)) — ignore.
+        // Otherwise it's an unrecognised dict-meta cell — ignore.
     }
 
     // -------------------------------------------------------------------------
@@ -266,9 +343,9 @@ internal sealed class MorkAssembler
         // Colon separator
         Expect(MorkTokenKind.Colon);
 
-        // Scope atom reference ^XX
+        // Scope atom reference ^XX — resolved in the COLUMN map.
         string scopeAtomId = ExpectAtomRefId();
-        string scope = ResolveAtom(scopeAtomId);
+        string scope = ResolveColumnAtom(scopeAtomId);
 
         // Get-or-create the working table for this id.
         if (!_workingTables.TryGetValue(tableId, out var wt))
@@ -300,7 +377,8 @@ internal sealed class MorkAssembler
             }
             else
             {
-                // Skip unexpected tokens inside table body.
+                // Skip unexpected tokens inside table body (e.g. bare row-id tokens
+                // in thread tables that use a non-standard body format).
                 Advance();
             }
         }
@@ -327,13 +405,13 @@ internal sealed class MorkAssembler
                     string colName = Encoding.ASCII.GetString(Current().Bytes);
                     Advance();
 
-                    // (k^XX:c) — kind cell
+                    // (k^XX:c) — kind cell; resolve ^XX in the COLUMN map.
                     if (string.Equals(colName, "k", StringComparison.OrdinalIgnoreCase)
                         && _pos < _tokens.Count && Current().Kind == MorkTokenKind.AtomRef)
                     {
                         string kindAtomId = Encoding.ASCII.GetString(Current().Bytes).ToUpperInvariant();
                         Advance(); // consume AtomRef
-                        kind = ResolveAtom(kindAtomId);
+                        kind = ResolveColumnAtom(kindAtomId);
                         // Skip remaining tokens until ')'
                         SkipToParenClose();
                     }
@@ -424,7 +502,7 @@ internal sealed class MorkAssembler
 
     /// <summary>
     /// Reads one cell: <c>(^col=litval)</c>, <c>(^col^valAtom)</c>, or <c>(^col=)</c>.
-    /// Column is always an AtomRef; value is either a literal Text or another AtomRef.
+    /// Column ref ^X is resolved in the COLUMN map; value ref ^X is resolved in the VALUE map.
     /// </summary>
     private void ReadCell(Dictionary<string, string> cells)
     {
@@ -433,7 +511,7 @@ internal sealed class MorkAssembler
         if (_pos >= _tokens.Count)
             throw new MorkFormatException("Unterminated cell");
 
-        // Column: must be an AtomRef ^XX
+        // Column: must be an AtomRef ^XX — resolve in COLUMN map.
         if (Current().Kind != MorkTokenKind.AtomRef)
         {
             SkipToParenClose();
@@ -442,7 +520,7 @@ internal sealed class MorkAssembler
 
         string colAtomId = Encoding.ASCII.GetString(Current().Bytes).ToUpperInvariant();
         Advance();
-        string colName = ResolveAtom(colAtomId);
+        string colName = ResolveColumnAtom(colAtomId);
 
         if (_pos >= _tokens.Count)
             throw new MorkFormatException($"Unterminated cell for column '{colName}'");
@@ -465,10 +543,10 @@ internal sealed class MorkAssembler
         }
         else if (Current().Kind == MorkTokenKind.AtomRef)
         {
-            // Atom-ref value: (^col^valAtom)
+            // Atom-ref value: (^col^valAtom) — resolve value in VALUE map.
             string valAtomId = Encoding.ASCII.GetString(Current().Bytes).ToUpperInvariant();
             Advance();
-            cellValue = ResolveAtom(valAtomId);
+            cellValue = ResolveValueAtom(valAtomId);
         }
         else
         {
@@ -525,14 +603,28 @@ internal sealed class MorkAssembler
     }
 
     /// <summary>
-    /// Resolves a hex atom id to its decoded string value.
-    /// Throws <see cref="MorkFormatException"/> if the id was never defined in any dict.
+    /// Resolves a hex atom id to its decoded string in the COLUMN atom map.
+    /// Used for: table scope, meta-row kind, cell column refs.
+    /// Throws <see cref="MorkFormatException"/> if the id was never defined.
     /// </summary>
-    private string ResolveAtom(string hexId)
+    private string ResolveColumnAtom(string hexId)
     {
         string normalised = hexId.ToUpperInvariant();
-        if (!_atoms.TryGetValue(normalised, out string? value))
-            throw new MorkFormatException($"Undefined atom reference: ^{hexId}");
+        if (!_columnAtoms.TryGetValue(normalised, out string? value))
+            throw new MorkFormatException($"Undefined column atom reference: ^{hexId}");
+        return value;
+    }
+
+    /// <summary>
+    /// Resolves a hex atom id to its decoded string in the VALUE atom map.
+    /// Used for: cell value refs (^col^val form).
+    /// Throws <see cref="MorkFormatException"/> if the id was never defined.
+    /// </summary>
+    private string ResolveValueAtom(string hexId)
+    {
+        string normalised = hexId.ToUpperInvariant();
+        if (!_valueAtoms.TryGetValue(normalised, out string? value))
+            throw new MorkFormatException($"Undefined value atom reference: ^{hexId}");
         return value;
     }
 

--- a/src/Mail2Pst.Core/Mork/MorkReader.cs
+++ b/src/Mail2Pst.Core/Mork/MorkReader.cs
@@ -11,7 +11,7 @@ namespace Mail2Pst.Core.Mork;
 
 /// <summary>
 /// Entry point for parsing Mork (.msf) files into a <see cref="MorkDocument"/>.
-/// Handles single-group documents (no cross-group append-log merge — that is Task 5).
+/// Applies full append-log merge semantics across transaction groups.
 /// </summary>
 public static class MorkReader
 {
@@ -50,7 +50,10 @@ public static class MorkReader
 /// <summary>
 /// Stateful assembler: drives a token list produced by <see cref="MorkTokenizer"/>
 /// and builds a <see cref="MorkDocument"/> (atom dictionary + tables + rows).
-/// Cross-group append-log merge is out of scope (Task 5).
+/// Applies append-log merge semantics: transaction groups are processed in file
+/// order; row restatements overwrite/add named cells (unnamed cells retained);
+/// row cuts remove the row; delete-then-re-add recreates it. Last-write-wins per
+/// (table, row, column). No cell-cut form exists in Thunderbird .msf (Task 0).
 /// </summary>
 internal sealed class MorkAssembler
 {
@@ -64,14 +67,29 @@ internal sealed class MorkAssembler
     private readonly Dictionary<string, string> _atoms =
         new Dictionary<string, string>(StringComparer.Ordinal);
 
-    // ---- output -------------------------------------------------------------
-    private readonly List<MorkTable> _tables = new();
+    // ---- mutable working state: table id -> (scope, kind, rows) ------------
+    // Accumulated in file order to implement append-log merge. The final
+    // immutable MorkDocument is built from this at the end of Assemble().
+    // Table ordering is preserved via _tableOrder.
+    private readonly Dictionary<string, WorkingTable> _workingTables =
+        new Dictionary<string, WorkingTable>(StringComparer.Ordinal);
+    private readonly List<string> _tableOrder = new();
 
     // ---- active charset: file-level, persists across top-level dicts -------
     // Initialised once to UTF-8. Updated by (f=<charset>) cells. Top-level dicts
     // inherit the last-set charset (no reset); nested dicts save/restore it so
     // an inner < <(a=c)> … > scope cannot permanently change the outer charset.
     private Encoding _charset = Encoding.UTF8;
+
+    /// <summary>Mutable working state for a single table during assembly.</summary>
+    private sealed class WorkingTable
+    {
+        public string? Scope;
+        public string? Kind;
+        // rowId -> (cells dict, or null if the row has been cut and not re-added)
+        public readonly Dictionary<string, Dictionary<string, string>?> Rows =
+            new Dictionary<string, Dictionary<string, string>?>(StringComparer.Ordinal);
+    }
 
     public MorkAssembler(IReadOnlyList<MorkToken> tokens)
     {
@@ -96,7 +114,8 @@ internal sealed class MorkAssembler
                 case MorkTokenKind.GroupStart:
                 case MorkTokenKind.GroupCommit:
                 case MorkTokenKind.GroupAbort:
-                    // Transaction group markers: consume and continue (Task 5 handles merge).
+                    // Transaction group markers carry no merge meaning beyond ordering;
+                    // their content (dicts + table fragments) flows through the normal path.
                     Advance();
                     break;
 
@@ -107,7 +126,22 @@ internal sealed class MorkAssembler
             }
         }
 
-        return new MorkDocument(_tables);
+        // Build the final immutable MorkDocument from accumulated working state.
+        var tables = new List<MorkTable>(_workingTables.Count);
+        foreach (string tableId in _tableOrder)
+        {
+            var wt = _workingTables[tableId];
+            var rows = new Dictionary<string, MorkRow>(StringComparer.Ordinal);
+            foreach (var kv in wt.Rows)
+            {
+                // Rows that were cut (null cells dict) are excluded from the output.
+                if (kv.Value is not null)
+                    rows[kv.Key] = new MorkRow(kv.Key, kv.Value);
+            }
+            tables.Add(new MorkTable(tableId, wt.Scope, wt.Kind, rows));
+        }
+
+        return new MorkDocument(tables);
     }
 
     // -------------------------------------------------------------------------
@@ -219,6 +253,7 @@ internal sealed class MorkAssembler
 
     // -------------------------------------------------------------------------
     // Table parsing: { id:^scope {meta} rows... }
+    // Merges into the working table for this id (append-log semantics).
     // -------------------------------------------------------------------------
 
     private void ReadTable()
@@ -235,22 +270,33 @@ internal sealed class MorkAssembler
         string scopeAtomId = ExpectAtomRefId();
         string scope = ResolveAtom(scopeAtomId);
 
-        // Meta-row: { (k^XX:c) (s=N) ... }
-        string? kind = null;
-        if (_pos < _tokens.Count && Current().Kind == MorkTokenKind.BraceOpen)
+        // Get-or-create the working table for this id.
+        if (!_workingTables.TryGetValue(tableId, out var wt))
         {
-            kind = ReadMetaRow();
+            wt = new WorkingTable { Scope = scope };
+            _workingTables[tableId] = wt;
+            _tableOrder.Add(tableId);
+        }
+        else
+        {
+            // Re-statement: update scope (last-write-wins) but keep existing rows.
+            wt.Scope = scope;
         }
 
-        // Data rows
-        var rows = new Dictionary<string, MorkRow>(StringComparer.Ordinal);
+        // Meta-row: { (k^XX:c) (s=N) ... }
+        if (_pos < _tokens.Count && Current().Kind == MorkTokenKind.BraceOpen)
+        {
+            string? kind = ReadMetaRow();
+            if (kind is not null)
+                wt.Kind = kind;
+        }
+
+        // Data rows — apply merge semantics to working table.
         while (_pos < _tokens.Count && Current().Kind != MorkTokenKind.BraceClose)
         {
-            var tok = Current();
-            if (tok.Kind == MorkTokenKind.BracketOpen)
+            if (Current().Kind == MorkTokenKind.BracketOpen)
             {
-                var row = ReadRow();
-                rows[row.Id] = row;
+                ReadRowIntoTable(wt);
             }
             else
             {
@@ -260,8 +306,6 @@ internal sealed class MorkAssembler
         }
 
         Expect(MorkTokenKind.BraceClose);
-
-        _tables.Add(new MorkTable(tableId, scope, kind, rows));
     }
 
     /// <summary>Reads the meta-row <c>{ (k^XX:c) ... }</c> and returns the kind string.</summary>
@@ -316,23 +360,58 @@ internal sealed class MorkAssembler
     }
 
     // -------------------------------------------------------------------------
-    // Row parsing: [ id (cells...) ]
+    // Row parsing: [ id (cells...) ] or cut [ -id ]
+    // Applies append-log merge directly into the working table.
     // -------------------------------------------------------------------------
 
-    private MorkRow ReadRow()
+    /// <summary>
+    /// Reads one row bracket from the token stream and applies its effect to
+    /// <paramref name="wt"/>:
+    /// <list type="bullet">
+    ///   <item>Normal row <c>[id (cells…)]</c> — creates the row if absent, or merges
+    ///     cells into the existing row (add/overwrite named cells; unnamed cells
+    ///     retained; empty value overwrites to empty string).</item>
+    ///   <item>Cut row <c>[-id]</c> — removes the row from the working state (sets
+    ///     its entry to null). A later re-add recreates it.</item>
+    /// </list>
+    /// </summary>
+    private void ReadRowIntoTable(WorkingTable wt)
     {
         Expect(MorkTokenKind.BracketOpen);
+
+        // Detect cut: [-id]
+        bool isCut = _pos < _tokens.Count && Current().Kind == MorkTokenKind.Cut;
+        if (isCut)
+            Advance(); // consume Cut token
 
         // Row id
         string rowId = ExpectText();
 
-        var cells = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (isCut)
+        {
+            // Skip any remaining tokens inside the bracket (there should be none, but be safe).
+            while (_pos < _tokens.Count && Current().Kind != MorkTokenKind.BracketClose)
+                Advance();
+            Expect(MorkTokenKind.BracketClose);
+
+            // Mark row as cut (null = deleted).
+            wt.Rows[rowId] = null;
+            return;
+        }
+
+        // Normal row: read cells and merge into working state.
+        // If the row was previously cut (null), re-create it with a fresh dict.
+        if (!wt.Rows.TryGetValue(rowId, out var existingCells) || existingCells is null)
+        {
+            existingCells = new Dictionary<string, string>(StringComparer.Ordinal);
+            wt.Rows[rowId] = existingCells;
+        }
 
         while (_pos < _tokens.Count && Current().Kind != MorkTokenKind.BracketClose)
         {
             if (Current().Kind == MorkTokenKind.ParenOpen)
             {
-                ReadCell(cells);
+                ReadCell(existingCells);
             }
             else
             {
@@ -341,8 +420,6 @@ internal sealed class MorkAssembler
         }
 
         Expect(MorkTokenKind.BracketClose);
-
-        return new MorkRow(rowId, cells);
     }
 
     /// <summary>

--- a/src/Mail2Pst.Core/Mork/MorkReader.cs
+++ b/src/Mail2Pst.Core/Mork/MorkReader.cs
@@ -1,0 +1,490 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Mail2Pst.Core.Mork;
+
+/// <summary>
+/// Entry point for parsing Mork (.msf) files into a <see cref="MorkDocument"/>.
+/// Handles single-group documents (no cross-group append-log merge — that is Task 5).
+/// </summary>
+public static class MorkReader
+{
+    // -------------------------------------------------------------------------
+    // Public / internal entry points
+    // -------------------------------------------------------------------------
+
+    public static MorkDocument Parse(string path)
+    {
+        using var fs = File.OpenRead(path);
+        return Parse(fs);
+    }
+
+    public static MorkDocument Parse(Stream stream)
+    {
+        using var ms = new MemoryStream();
+        stream.CopyTo(ms);
+        return ParseBytes(ms.ToArray());
+    }
+
+    internal static MorkDocument ParseString(string text) =>
+        ParseBytes(Encoding.UTF8.GetBytes(text));
+
+    // -------------------------------------------------------------------------
+    // Core assembler
+    // -------------------------------------------------------------------------
+
+    private static MorkDocument ParseBytes(byte[] bytes)
+    {
+        var tokens = new List<MorkToken>(new MorkTokenizer(bytes).Tokenize());
+        var assembler = new MorkAssembler(tokens);
+        return assembler.Assemble();
+    }
+}
+
+/// <summary>
+/// Stateful assembler: drives a token list produced by <see cref="MorkTokenizer"/>
+/// and builds a <see cref="MorkDocument"/> (atom dictionary + tables + rows).
+/// Cross-group append-log merge is out of scope (Task 5).
+/// </summary>
+internal sealed class MorkAssembler
+{
+    // ---- token cursor -------------------------------------------------------
+    private readonly IReadOnlyList<MorkToken> _tokens;
+    private int _pos;
+
+    // ---- atom dictionary: hex-id string -> decoded string -------------------
+    // Accumulated globally across all dicts in file order; decoded at definition
+    // time using the charset active for the enclosing dict.
+    private readonly Dictionary<string, string> _atoms =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+    // ---- output -------------------------------------------------------------
+    private readonly List<MorkTable> _tables = new();
+
+    // ---- active charset for the current dict (reset per dict) ---------------
+    private Encoding _charset = Encoding.UTF8;
+
+    public MorkAssembler(IReadOnlyList<MorkToken> tokens)
+    {
+        _tokens = tokens;
+    }
+
+    public MorkDocument Assemble()
+    {
+        while (_pos < _tokens.Count)
+        {
+            var tok = Current();
+            switch (tok.Kind)
+            {
+                case MorkTokenKind.DictOpen:
+                    ReadDict(nestDepth: 0);
+                    break;
+
+                case MorkTokenKind.BraceOpen:
+                    ReadTable();
+                    break;
+
+                case MorkTokenKind.GroupStart:
+                case MorkTokenKind.GroupCommit:
+                case MorkTokenKind.GroupAbort:
+                    // Transaction group markers: consume and continue (Task 5 handles merge).
+                    Advance();
+                    break;
+
+                default:
+                    // Skip unrecognised top-level tokens.
+                    Advance();
+                    break;
+            }
+        }
+
+        return new MorkDocument(_tables);
+    }
+
+    // -------------------------------------------------------------------------
+    // Dict parsing
+    // Handles nested meta-dicts (< <(a=c)> ... >) by tracking depth.
+    // -------------------------------------------------------------------------
+
+    private void ReadDict(int nestDepth)
+    {
+        Expect(MorkTokenKind.DictOpen); // consume '<'
+
+        // Reset charset to default for this dict scope.
+        // Outer charset is restored when we recurse (caller's _charset is on the stack).
+        var savedCharset = _charset;
+        _charset = Encoding.UTF8;
+
+        // First pass to pick up (f=charset) — Mork dicts can declare charset before atoms,
+        // but real files put it first too. We do a single forward pass: charset applies to
+        // atoms that follow it in the same dict.
+        while (_pos < _tokens.Count && Current().Kind != MorkTokenKind.DictClose)
+        {
+            var tok = Current();
+
+            if (tok.Kind == MorkTokenKind.DictOpen)
+            {
+                // Nested meta-dict (e.g. < <(a=c)> >) — skip recursively.
+                ReadDict(nestDepth: nestDepth + 1);
+                continue;
+            }
+
+            if (tok.Kind == MorkTokenKind.ParenOpen)
+            {
+                ReadDictCell();
+                continue;
+            }
+
+            // Skip any other token inside a dict (should not normally appear).
+            Advance();
+        }
+
+        Expect(MorkTokenKind.DictClose); // consume '>'
+
+        // Restore charset after we leave this dict scope.
+        // (Nested dict restores on its own; for a top-level dict we just leave the
+        //  charset as-is so subsequent dicts in the file inherit nothing special —
+        //  each top-level dict resets to UTF-8 at entry above.)
+        if (nestDepth > 0)
+            _charset = savedCharset;
+        // For nestDepth==0 (top-level dict): charset set by (f=…) stays active until
+        // the next top-level dict resets it.  That matches the grammar: charset is
+        // per-dict, atoms decoded at definition time.
+    }
+
+    /// <summary>
+    /// Reads one cell inside a dict: either <c>(hexid=value)</c> (atom definition),
+    /// <c>(f=charset)</c> (charset hint), or a dict-meta cell like <c>(a=c)</c> (ignored).
+    /// </summary>
+    private void ReadDictCell()
+    {
+        Expect(MorkTokenKind.ParenOpen);
+
+        if (_pos >= _tokens.Count)
+            throw new MorkFormatException("Unterminated dict cell");
+
+        var keyTok = Current();
+        if (keyTok.Kind != MorkTokenKind.Text)
+        {
+            // Unexpected shape — skip to closing paren.
+            SkipToParenClose();
+            return;
+        }
+
+        string keyStr = Encoding.ASCII.GetString(keyTok.Bytes);
+        Advance(); // consume key Text
+
+        if (_pos >= _tokens.Count || Current().Kind != MorkTokenKind.Equals)
+        {
+            // No '=' — not a key=value cell; skip remainder.
+            SkipToParenClose();
+            return;
+        }
+        Advance(); // consume '='
+
+        // Value is an optional Text token (empty when the tokenizer emits no Text after '=').
+        string valueBytes = "";
+        if (_pos < _tokens.Count && Current().Kind == MorkTokenKind.Text)
+        {
+            valueBytes = MorkValueDecoder.Decode(Current().Bytes, _charset);
+            Advance();
+        }
+
+        Expect(MorkTokenKind.ParenClose);
+
+        // Charset hint?
+        if (string.Equals(keyStr, "f", StringComparison.OrdinalIgnoreCase))
+        {
+            _charset = MorkValueDecoder.ResolveCharset(valueBytes);
+            return;
+        }
+
+        // Hex-id atom definition? (only if key is all-hex characters)
+        if (IsHexId(keyStr))
+        {
+            string atomId = keyStr.ToUpperInvariant();
+            _atoms[atomId] = valueBytes;
+            return;
+        }
+
+        // Otherwise it's a dict-meta cell (e.g. (a=c)) — ignore.
+    }
+
+    // -------------------------------------------------------------------------
+    // Table parsing: { id:^scope {meta} rows... }
+    // -------------------------------------------------------------------------
+
+    private void ReadTable()
+    {
+        Expect(MorkTokenKind.BraceOpen);
+
+        // Table id
+        string tableId = ExpectText();
+
+        // Colon separator
+        Expect(MorkTokenKind.Colon);
+
+        // Scope atom reference ^XX
+        string scopeAtomId = ExpectAtomRefId();
+        string scope = ResolveAtom(scopeAtomId);
+
+        // Meta-row: { (k^XX:c) (s=N) ... }
+        string? kind = null;
+        if (_pos < _tokens.Count && Current().Kind == MorkTokenKind.BraceOpen)
+        {
+            kind = ReadMetaRow();
+        }
+
+        // Data rows
+        var rows = new Dictionary<string, MorkRow>(StringComparer.Ordinal);
+        while (_pos < _tokens.Count && Current().Kind != MorkTokenKind.BraceClose)
+        {
+            var tok = Current();
+            if (tok.Kind == MorkTokenKind.BracketOpen)
+            {
+                var row = ReadRow();
+                rows[row.Id] = row;
+            }
+            else
+            {
+                // Skip unexpected tokens inside table body.
+                Advance();
+            }
+        }
+
+        Expect(MorkTokenKind.BraceClose);
+
+        _tables.Add(new MorkTable(tableId, scope, kind, rows));
+    }
+
+    /// <summary>Reads the meta-row <c>{ (k^XX:c) ... }</c> and returns the kind string.</summary>
+    private string? ReadMetaRow()
+    {
+        Expect(MorkTokenKind.BraceOpen);
+
+        string? kind = null;
+
+        while (_pos < _tokens.Count && Current().Kind != MorkTokenKind.BraceClose)
+        {
+            if (Current().Kind == MorkTokenKind.ParenOpen)
+            {
+                Advance(); // consume '('
+
+                // Expect a Text column name (literal, not AtomRef)
+                if (_pos < _tokens.Count && Current().Kind == MorkTokenKind.Text)
+                {
+                    string colName = Encoding.ASCII.GetString(Current().Bytes);
+                    Advance();
+
+                    // (k^XX:c) — kind cell
+                    if (string.Equals(colName, "k", StringComparison.OrdinalIgnoreCase)
+                        && _pos < _tokens.Count && Current().Kind == MorkTokenKind.AtomRef)
+                    {
+                        string kindAtomId = Encoding.ASCII.GetString(Current().Bytes).ToUpperInvariant();
+                        Advance(); // consume AtomRef
+                        kind = ResolveAtom(kindAtomId);
+                        // Skip remaining tokens until ')'
+                        SkipToParenClose();
+                    }
+                    else
+                    {
+                        // Other meta cell (e.g. (s=N)) — skip to close paren.
+                        SkipToParenClose();
+                    }
+                }
+                else
+                {
+                    // Unexpected shape — skip to close paren.
+                    SkipToParenClose();
+                }
+            }
+            else
+            {
+                Advance();
+            }
+        }
+
+        Expect(MorkTokenKind.BraceClose);
+        return kind;
+    }
+
+    // -------------------------------------------------------------------------
+    // Row parsing: [ id (cells...) ]
+    // -------------------------------------------------------------------------
+
+    private MorkRow ReadRow()
+    {
+        Expect(MorkTokenKind.BracketOpen);
+
+        // Row id
+        string rowId = ExpectText();
+
+        var cells = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        while (_pos < _tokens.Count && Current().Kind != MorkTokenKind.BracketClose)
+        {
+            if (Current().Kind == MorkTokenKind.ParenOpen)
+            {
+                ReadCell(cells);
+            }
+            else
+            {
+                Advance();
+            }
+        }
+
+        Expect(MorkTokenKind.BracketClose);
+
+        return new MorkRow(rowId, cells);
+    }
+
+    /// <summary>
+    /// Reads one cell: <c>(^col=litval)</c>, <c>(^col^valAtom)</c>, or <c>(^col=)</c>.
+    /// Column is always an AtomRef; value is either a literal Text or another AtomRef.
+    /// </summary>
+    private void ReadCell(Dictionary<string, string> cells)
+    {
+        Expect(MorkTokenKind.ParenOpen);
+
+        if (_pos >= _tokens.Count)
+            throw new MorkFormatException("Unterminated cell");
+
+        // Column: must be an AtomRef ^XX
+        if (Current().Kind != MorkTokenKind.AtomRef)
+        {
+            SkipToParenClose();
+            return;
+        }
+
+        string colAtomId = Encoding.ASCII.GetString(Current().Bytes).ToUpperInvariant();
+        Advance();
+        string colName = ResolveAtom(colAtomId);
+
+        if (_pos >= _tokens.Count)
+            throw new MorkFormatException($"Unterminated cell for column '{colName}'");
+
+        string cellValue;
+
+        if (Current().Kind == MorkTokenKind.Equals)
+        {
+            Advance(); // consume '='
+            // Literal value or empty
+            if (_pos < _tokens.Count && Current().Kind == MorkTokenKind.Text)
+            {
+                cellValue = MorkValueDecoder.Decode(Current().Bytes, _charset);
+                Advance();
+            }
+            else
+            {
+                cellValue = ""; // (^col=) with no Text token
+            }
+        }
+        else if (Current().Kind == MorkTokenKind.AtomRef)
+        {
+            // Atom-ref value: (^col^valAtom)
+            string valAtomId = Encoding.ASCII.GetString(Current().Bytes).ToUpperInvariant();
+            Advance();
+            cellValue = ResolveAtom(valAtomId);
+        }
+        else
+        {
+            // Unexpected shape — skip.
+            SkipToParenClose();
+            return;
+        }
+
+        Expect(MorkTokenKind.ParenClose);
+
+        cells[colName] = cellValue;
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private MorkToken Current() => _tokens[_pos];
+
+    private void Advance() => _pos++;
+
+    private void Expect(MorkTokenKind kind)
+    {
+        if (_pos >= _tokens.Count)
+            throw new MorkFormatException($"Expected {kind} but reached end of token stream");
+        if (Current().Kind != kind)
+            throw new MorkFormatException(
+                $"Expected {kind} but got {Current().Kind} at token index {_pos}");
+        Advance();
+    }
+
+    private string ExpectText()
+    {
+        if (_pos >= _tokens.Count)
+            throw new MorkFormatException("Expected Text token but reached end of token stream");
+        if (Current().Kind != MorkTokenKind.Text)
+            throw new MorkFormatException(
+                $"Expected Text but got {Current().Kind} at token index {_pos}");
+        string val = Encoding.ASCII.GetString(Current().Bytes);
+        Advance();
+        return val;
+    }
+
+    private string ExpectAtomRefId()
+    {
+        if (_pos >= _tokens.Count)
+            throw new MorkFormatException("Expected AtomRef token but reached end of token stream");
+        if (Current().Kind != MorkTokenKind.AtomRef)
+            throw new MorkFormatException(
+                $"Expected AtomRef but got {Current().Kind} at token index {_pos}");
+        string id = Encoding.ASCII.GetString(Current().Bytes).ToUpperInvariant();
+        Advance();
+        return id;
+    }
+
+    /// <summary>
+    /// Resolves a hex atom id to its decoded string value.
+    /// Throws <see cref="MorkFormatException"/> if the id was never defined in any dict.
+    /// </summary>
+    private string ResolveAtom(string hexId)
+    {
+        string normalised = hexId.ToUpperInvariant();
+        if (!_atoms.TryGetValue(normalised, out string? value))
+            throw new MorkFormatException($"Undefined atom reference: ^{hexId}");
+        return value;
+    }
+
+    /// <summary>
+    /// Skips tokens until the next unmatched <c>)</c>, then consumes it.
+    /// Used for malformed or ignored cells.
+    /// </summary>
+    private void SkipToParenClose()
+    {
+        int depth = 1; // we already consumed the opening '('
+        while (_pos < _tokens.Count && depth > 0)
+        {
+            switch (Current().Kind)
+            {
+                case MorkTokenKind.ParenOpen:  depth++; Advance(); break;
+                case MorkTokenKind.ParenClose: depth--; Advance(); break;
+                default: Advance(); break;
+            }
+        }
+    }
+
+    /// <summary>Returns true if <paramref name="s"/> is a valid hex integer string (0–9, A–F).</summary>
+    private static bool IsHexId(string s)
+    {
+        if (s.Length == 0) return false;
+        foreach (char c in s)
+        {
+            if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')))
+                return false;
+        }
+        return true;
+    }
+}

--- a/src/Mail2Pst.Core/Mork/MorkReader.cs
+++ b/src/Mail2Pst.Core/Mork/MorkReader.cs
@@ -11,7 +11,9 @@ namespace Mail2Pst.Core.Mork;
 
 /// <summary>
 /// Entry point for parsing Mork (.msf) files into a <see cref="MorkDocument"/>.
-/// Applies full append-log merge semantics across transaction groups.
+/// Applies append-log merge semantics across transaction groups (commit and abort groups
+/// are both treated as committed; abort-rollback is not implemented but not observed in
+/// real Thunderbird .msf files).
 /// </summary>
 public static class MorkReader
 {
@@ -56,7 +58,8 @@ public static class MorkReader
 /// (table, row, column). No cell-cut form exists in Thunderbird .msf (Task 0).
 ///
 /// Mork has TWO separate atom spaces that reuse the same numeric ids:
-/// - Column atoms: dicts that open with a nested &lt;(a=c)&gt; meta-dict — ids map
+/// - Column atoms: dicts that contain a &lt;(a=c)&gt; marker (as a nested sub-dict or an
+///   inline cell) anywhere before the first hex-id atom definition — ids map
 ///   to column names / scope strings / kind strings.
 /// - Value atoms: all other dicts — ids map to cell values.
 /// These spaces are kept separate so a value dict cannot clobber column atoms
@@ -88,6 +91,9 @@ internal sealed class MorkAssembler
     // Table ordering is preserved via _tableOrder.
     private readonly Dictionary<string, WorkingTable> _workingTables =
         new Dictionary<string, WorkingTable>(StringComparer.Ordinal);
+    // Parallel list that records table-id insertion order. Dictionary<> does not
+    // guarantee enumeration order, so a separate list is needed to emit tables in
+    // file order (matching the append-log semantics promised by MorkDocument).
     private readonly List<string> _tableOrder = new();
 
     // ---- active charset: file-level, persists across top-level dicts -------
@@ -129,8 +135,11 @@ internal sealed class MorkAssembler
                 case MorkTokenKind.GroupStart:
                 case MorkTokenKind.GroupCommit:
                 case MorkTokenKind.GroupAbort:
-                    // Transaction group markers carry no merge meaning beyond ordering;
-                    // their content (dicts + table fragments) flows through the normal path.
+                    // Transaction group markers: their enclosed content (dicts + table
+                    // fragments) is processed in file order through the normal path.
+                    // NOTE: GroupAbort aborted-group writes are currently treated as committed
+                    // — abort-rollback is not implemented; abort markers are not observed in
+                    // real Thunderbird .msf files.
                     Advance();
                     break;
 
@@ -180,9 +189,12 @@ internal sealed class MorkAssembler
         // across all top-level dicts in the file (file-level charset).
         var savedCharset = _charset;
 
-        // Determine if this is a column dict by peeking at the first sub-token:
-        // a column dict begins with a nested <(a=c)> meta-dict (nestDepth == 0),
-        // OR inherits isColumn from the enclosing dict (nestDepth > 0).
+        // Determine if this is a column dict by scanning ahead within the dict:
+        // a column dict has an (a=c) marker (as a nested <(a=c)> sub-dict OR as an
+        // inline (a=c) cell) anywhere before its first hex-id atom definition.
+        // The common real-corpus layout is marker-first, but the spec allows a charset
+        // cell like (f=iso-8859-1) to precede the marker — we handle both.
+        // nestDepth > 0 means we are already inside a column dict and inherit the space.
         bool isColumnDict = parentIsColumn || (nestDepth == 0 && PeekIsColumnMarker());
 
         while (_pos < _tokens.Count && Current().Kind != MorkTokenKind.DictClose)
@@ -219,46 +231,133 @@ internal sealed class MorkAssembler
     }
 
     /// <summary>
-    /// Peeks ahead without consuming tokens to detect the column-dict marker:
-    /// the first non-DictClose content after the already-consumed DictOpen is
-    /// another DictOpen whose first cell is <c>(a=c)</c>.
-    /// Returns true if the pattern matches; does NOT advance the cursor.
+    /// Peeks ahead without consuming tokens to determine whether this dict is a
+    /// column dict. A dict is a column dict if an <c>(a=c)</c> marker appears
+    /// anywhere before the dict's first hex-id atom definition — whether as a nested
+    /// <c>&lt;(a=c)&gt;</c> sub-dict OR as an inline <c>(a=c)</c> cell.
+    /// The common Thunderbird real-corpus layout has the marker first (<c>&lt; &lt;(a=c)&gt; …&gt;</c>),
+    /// but <c>(a=c)</c> marks the column-atom space and may appear before (not only as)
+    /// the first cell — e.g. after a charset hint like <c>(f=iso-8859-1)</c>.
+    /// Returns true if the pattern is found; does NOT advance the cursor.
     /// </summary>
     private bool PeekIsColumnMarker()
     {
-        // We are sitting at the first token inside the outer dict.
-        // Pattern: DictOpen ParenOpen Text("a") Equals Text("c") ParenClose DictClose …
+        // Scan forward within this dict's token span (depth-tracked to stay inside)
+        // looking for either:
+        //   (a) a nested DictOpen immediately followed by "(a=c)" then DictClose, OR
+        //   (b) an inline paren-cell with key "a" and value "c".
+        // Stop and return false if we reach a hex-id atom definition first (which
+        // would mean the dict cannot be a column dict at that point).
         int p = _pos;
-        if (p >= _tokens.Count || _tokens[p].Kind != MorkTokenKind.DictOpen)
-            return false;
-        p++; // skip inner DictOpen
+        int depth = 1; // we are already inside the outer DictOpen
 
-        // Expect '('
-        if (p >= _tokens.Count || _tokens[p].Kind != MorkTokenKind.ParenOpen)
-            return false;
-        p++;
+        while (p < _tokens.Count && depth > 0)
+        {
+            var tok = _tokens[p];
 
-        // Expect Text "a"
-        if (p >= _tokens.Count || _tokens[p].Kind != MorkTokenKind.Text)
-            return false;
+            if (tok.Kind == MorkTokenKind.DictOpen)
+            {
+                // Nested dict: check if its first (and only) cell is the (a=c) marker.
+                // Token stream after DictOpen: ParenOpen Text("a") Equals Text("c") ParenClose DictClose …
+                // IsAcCell expects to start at the Text token (after the leading ParenOpen).
+                int q = p + 1; // q -> ParenOpen (if (a=c) cell)
+                if (q < _tokens.Count
+                    && _tokens[q].Kind == MorkTokenKind.ParenOpen
+                    && IsAcCell(q + 1, out _))
+                {
+                    // Confirmed nested <(a=c)> — this is a column dict.
+                    return true;
+                }
+                depth++;
+                p++;
+                continue;
+            }
+
+            if (tok.Kind == MorkTokenKind.DictClose)
+            {
+                depth--;
+                p++;
+                continue;
+            }
+
+            if (tok.Kind == MorkTokenKind.ParenOpen)
+            {
+                // Peek at the cell inside the outer dict (depth == 1).
+                if (depth == 1 && IsAcCell(p + 1, out _))
+                    return true; // inline (a=c) marker before a hex-id definition
+
+                // If this is a hex-id atom definition, we stop scanning.
+                // A hex-id cell looks like: ParenOpen Text(hexId) Equals Text(value) ParenClose.
+                // The key must be all-hex and not "a" or "f".
+                if (depth == 1)
+                {
+                    int q = p + 1;
+                    if (q < _tokens.Count && _tokens[q].Kind == MorkTokenKind.Text)
+                    {
+                        string keyStr = Encoding.ASCII.GetString(_tokens[q].Bytes);
+                        if (IsHexId(keyStr)
+                            && !string.Equals(keyStr, "a", StringComparison.OrdinalIgnoreCase)
+                            && !string.Equals(keyStr, "f", StringComparison.OrdinalIgnoreCase))
+                        {
+                            // First hex-id atom reached without seeing (a=c) — not a column dict.
+                            return false;
+                        }
+                    }
+                }
+
+                // Skip past this paren cell without consuming.
+                p = SkipParenPeek(p);
+                continue;
+            }
+
+            p++;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Peeks at tokens starting at <paramref name="p"/> to check whether they form
+    /// an <c>(a=c)</c> meta-cell: <c>Text("a") Equals Text("c") ParenClose</c>.
+    /// Sets <paramref name="pAfter"/> to the index after the ParenClose.
+    /// Does NOT require a leading ParenOpen (caller checks context).
+    /// </summary>
+    private bool IsAcCell(int p, out int pAfter)
+    {
+        pAfter = p;
+        if (p >= _tokens.Count || _tokens[p].Kind != MorkTokenKind.Text) return false;
         string key = Encoding.ASCII.GetString(_tokens[p].Bytes);
-        if (!string.Equals(key, "a", StringComparison.OrdinalIgnoreCase))
-            return false;
+        if (!string.Equals(key, "a", StringComparison.OrdinalIgnoreCase)) return false;
         p++;
-
-        // Expect '='
-        if (p >= _tokens.Count || _tokens[p].Kind != MorkTokenKind.Equals)
-            return false;
+        if (p >= _tokens.Count || _tokens[p].Kind != MorkTokenKind.Equals) return false;
         p++;
-
-        // Expect Text "c"
-        if (p >= _tokens.Count || _tokens[p].Kind != MorkTokenKind.Text)
-            return false;
+        if (p >= _tokens.Count || _tokens[p].Kind != MorkTokenKind.Text) return false;
         string val = Encoding.ASCII.GetString(_tokens[p].Bytes);
-        if (!string.Equals(val, "c", StringComparison.OrdinalIgnoreCase))
-            return false;
-
+        if (!string.Equals(val, "c", StringComparison.OrdinalIgnoreCase)) return false;
+        p++;
+        if (p >= _tokens.Count || _tokens[p].Kind != MorkTokenKind.ParenClose) return false;
+        pAfter = p + 1;
         return true;
+    }
+
+    /// <summary>
+    /// Skips a paren-delimited group starting at <paramref name="p"/> (which must point
+    /// at the <c>ParenOpen</c>) and returns the index of the token after the matching
+    /// <c>ParenClose</c>. Used for lookahead scanning in <see cref="PeekIsColumnMarker"/>.
+    /// </summary>
+    private int SkipParenPeek(int p)
+    {
+        int depth = 0;
+        while (p < _tokens.Count)
+        {
+            switch (_tokens[p].Kind)
+            {
+                case MorkTokenKind.ParenOpen:  depth++; p++; break;
+                case MorkTokenKind.ParenClose: depth--; p++; if (depth == 0) return p; break;
+                default: p++; break;
+            }
+        }
+        return p; // unterminated — return end
     }
 
     /// <summary>
@@ -467,7 +566,8 @@ internal sealed class MorkAssembler
 
         if (isCut)
         {
-            // Skip any remaining tokens inside the bracket (there should be none, but be safe).
+            // Defensive: real .msf cut rows contain only [-id] with no further cells,
+            // but skip any remaining tokens to stay robust against malformed input.
             while (_pos < _tokens.Count && Current().Kind != MorkTokenKind.BracketClose)
                 Advance();
             Expect(MorkTokenKind.BracketClose);

--- a/src/Mail2Pst.Core/Mork/MorkReader.cs
+++ b/src/Mail2Pst.Core/Mork/MorkReader.cs
@@ -84,8 +84,8 @@ internal sealed class MorkAssembler
     /// <summary>Mutable working state for a single table during assembly.</summary>
     private sealed class WorkingTable
     {
-        public string? Scope;
-        public string? Kind;
+        public string? Scope { get; set; }
+        public string? Kind { get; set; }
         // rowId -> (cells dict, or null if the row has been cut and not re-added)
         public readonly Dictionary<string, Dictionary<string, string>?> Rows =
             new Dictionary<string, Dictionary<string, string>?>(StringComparer.Ordinal);

--- a/src/Mail2Pst.Core/Mork/MorkReader.cs
+++ b/src/Mail2Pst.Core/Mork/MorkReader.cs
@@ -62,12 +62,15 @@ internal sealed class MorkAssembler
     // Accumulated globally across all dicts in file order; decoded at definition
     // time using the charset active for the enclosing dict.
     private readonly Dictionary<string, string> _atoms =
-        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        new Dictionary<string, string>(StringComparer.Ordinal);
 
     // ---- output -------------------------------------------------------------
     private readonly List<MorkTable> _tables = new();
 
-    // ---- active charset for the current dict (reset per dict) ---------------
+    // ---- active charset: file-level, persists across top-level dicts -------
+    // Initialised once to UTF-8. Updated by (f=<charset>) cells. Top-level dicts
+    // inherit the last-set charset (no reset); nested dicts save/restore it so
+    // an inner < <(a=c)> … > scope cannot permanently change the outer charset.
     private Encoding _charset = Encoding.UTF8;
 
     public MorkAssembler(IReadOnlyList<MorkToken> tokens)
@@ -116,10 +119,12 @@ internal sealed class MorkAssembler
     {
         Expect(MorkTokenKind.DictOpen); // consume '<'
 
-        // Reset charset to default for this dict scope.
-        // Outer charset is restored when we recurse (caller's _charset is on the stack).
+        // Nested dicts (nestDepth > 0) save and restore the charset so an inner
+        // < <(a=c)> … > scope cannot permanently change the outer charset.
+        // Top-level dicts (nestDepth == 0) do NOT reset: the active charset persists
+        // across all top-level dicts in the file (file-level charset).
         var savedCharset = _charset;
-        _charset = Encoding.UTF8;
+        // (savedCharset is only used on exit when nestDepth > 0; no reset here)
 
         // First pass to pick up (f=charset) — Mork dicts can declare charset before atoms,
         // but real files put it first too. We do a single forward pass: charset applies to
@@ -147,15 +152,11 @@ internal sealed class MorkAssembler
 
         Expect(MorkTokenKind.DictClose); // consume '>'
 
-        // Restore charset after we leave this dict scope.
-        // (Nested dict restores on its own; for a top-level dict we just leave the
-        //  charset as-is so subsequent dicts in the file inherit nothing special —
-        //  each top-level dict resets to UTF-8 at entry above.)
+        // Restore charset on exit from a nested dict only. Top-level dict charset
+        // changes (from (f=…) cells) persist for subsequent top-level dicts so that
+        // value atoms defined after the first dict still use the correct encoding.
         if (nestDepth > 0)
             _charset = savedCharset;
-        // For nestDepth==0 (top-level dict): charset set by (f=…) stays active until
-        // the next top-level dict resets it.  That matches the grammar: charset is
-        // per-dict, atoms decoded at definition time.
     }
 
     /// <summary>
@@ -189,10 +190,10 @@ internal sealed class MorkAssembler
         Advance(); // consume '='
 
         // Value is an optional Text token (empty when the tokenizer emits no Text after '=').
-        string valueBytes = "";
+        string decodedValue = "";
         if (_pos < _tokens.Count && Current().Kind == MorkTokenKind.Text)
         {
-            valueBytes = MorkValueDecoder.Decode(Current().Bytes, _charset);
+            decodedValue = MorkValueDecoder.Decode(Current().Bytes, _charset);
             Advance();
         }
 
@@ -201,7 +202,7 @@ internal sealed class MorkAssembler
         // Charset hint?
         if (string.Equals(keyStr, "f", StringComparison.OrdinalIgnoreCase))
         {
-            _charset = MorkValueDecoder.ResolveCharset(valueBytes);
+            _charset = MorkValueDecoder.ResolveCharset(decodedValue);
             return;
         }
 
@@ -209,7 +210,7 @@ internal sealed class MorkAssembler
         if (IsHexId(keyStr))
         {
             string atomId = keyStr.ToUpperInvariant();
-            _atoms[atomId] = valueBytes;
+            _atoms[atomId] = decodedValue;
             return;
         }
 

--- a/src/Mail2Pst.Core/Mork/MorkRow.cs
+++ b/src/Mail2Pst.Core/Mork/MorkRow.cs
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Mail2Pst.Core.Mork;
+
+public sealed class MorkRow
+{
+    public string Id { get; }
+    public IReadOnlyDictionary<string, string> Cells { get; }
+
+    public MorkRow(string id, IReadOnlyDictionary<string, string> cells)
+    {
+        Id = id;
+        Cells = new ReadOnlyDictionary<string, string>(
+            new Dictionary<string, string>(cells, StringComparer.Ordinal));
+    }
+
+    public bool TryGetCell(string column, out string value) => Cells.TryGetValue(column, out value!);
+}

--- a/src/Mail2Pst.Core/Mork/MorkTable.cs
+++ b/src/Mail2Pst.Core/Mork/MorkTable.cs
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Mail2Pst.Core.Mork;
+
+public sealed class MorkTable
+{
+    public string Id { get; }
+    public string? Scope { get; }
+    public string? Kind { get; }
+    public IReadOnlyDictionary<string, MorkRow> Rows { get; }
+
+    public MorkTable(string id, string? scope, string? kind, IReadOnlyDictionary<string, MorkRow> rows)
+    {
+        Id = id;
+        Scope = scope;
+        Kind = kind;
+        Rows = new ReadOnlyDictionary<string, MorkRow>(
+            new Dictionary<string, MorkRow>(rows, StringComparer.Ordinal));
+    }
+}

--- a/src/Mail2Pst.Core/Mork/MorkToken.cs
+++ b/src/Mail2Pst.Core/Mork/MorkToken.cs
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+
+namespace Mail2Pst.Core.Mork;
+
+/// <summary>Purely lexical token kinds emitted by <see cref="MorkTokenizer"/>.</summary>
+public enum MorkTokenKind
+{
+    /// <summary>Opening &lt; of a dict section.</summary>
+    DictOpen,
+    /// <summary>Closing &gt; of a dict section.</summary>
+    DictClose,
+    /// <summary>Opening { of a table or meta group.</summary>
+    BraceOpen,
+    /// <summary>Closing } of a table or meta group.</summary>
+    BraceClose,
+    /// <summary>Opening [ of a row.</summary>
+    BracketOpen,
+    /// <summary>Closing ] of a row.</summary>
+    BracketClose,
+    /// <summary>Opening ( of a cell or dict atom.</summary>
+    ParenOpen,
+    /// <summary>Closing ) of a cell or dict atom.</summary>
+    ParenClose,
+    /// <summary>^hexid reference; Bytes = the hex id bytes (ASCII).</summary>
+    AtomRef,
+    /// <summary>= separator between column and value.</summary>
+    Equals,
+    /// <summary>: scope/namespace separator.</summary>
+    Colon,
+    /// <summary>Row-cut marker; emitted when - immediately follows [.</summary>
+    Cut,
+    /// <summary>Transaction group start @$${hexid{@; Bytes = the hex id bytes.</summary>
+    GroupStart,
+    /// <summary>Transaction group commit @$$}hexid}@; Bytes = the hex id bytes.</summary>
+    GroupCommit,
+    /// <summary>Transaction group abort @$$!hexid!@; Bytes = the hex id bytes.</summary>
+    GroupAbort,
+    /// <summary>
+    /// A run of text (atom id, atom value, row id, table id, etc.) with all $XX and \x
+    /// escapes already resolved into raw bytes. Bytes = the decoded byte sequence.
+    /// </summary>
+    Text,
+}
+
+/// <summary>A single lexical token from the Mork byte stream.</summary>
+public readonly struct MorkToken
+{
+    public MorkTokenKind Kind { get; }
+    public byte[] Bytes { get; }
+
+    public MorkToken(MorkTokenKind kind, byte[] bytes)
+    {
+        Kind = kind;
+        Bytes = bytes;
+    }
+
+    public MorkToken(MorkTokenKind kind) : this(kind, System.Array.Empty<byte>()) { }
+
+    public override string ToString() =>
+        $"{Kind}" + (Bytes.Length > 0 ? $"({System.Text.Encoding.ASCII.GetString(Bytes)})" : "");
+}

--- a/src/Mail2Pst.Core/Mork/MorkTokenizer.cs
+++ b/src/Mail2Pst.Core/Mork/MorkTokenizer.cs
@@ -130,6 +130,17 @@ public sealed class MorkTokenizer
                 case (byte)'=':
                     _pos++;
                     yield return new MorkToken(MorkTokenKind.Equals);
+                    // After '=' inside a paren we are in value context: read the entire
+                    // value as one text run that stops only at the unescaped ')'.
+                    // This preserves spaces, colons, '=' signs, etc. as literal content.
+                    if (_delimStack.Count > 0 && _delimStack.Peek() == (byte)'(')
+                    {
+                        byte[] value = ReadValueRun();
+                        if (value.Length > 0)
+                            yield return new MorkToken(MorkTokenKind.Text, value);
+                        // If value is empty (e.g. "(^col=)") emit no Text token;
+                        // the outer loop will handle the ')' and emit ParenClose.
+                    }
                     break;
 
                 case (byte)':':
@@ -228,21 +239,13 @@ public sealed class MorkTokenizer
 
     // -------------------------------------------------------------------------
     // Read a plain text run with $XX and \x escape resolution.
-    // Stops at structural characters, delimiters, or end-of-input.
-    //
-    // Context: inside a paren (value context) we must still stop at structural
-    // operators (=, ^, :, @) so they get emitted as their own tokens, but we
-    // must NOT stop at unescaped ')' — that is handled by the escape logic
-    // (backslash-escapes ')' literally) and by the stop condition.
-    // Outside paren context we stop at all delimiters and operators.
+    // Stops at structural characters (including ')'), delimiters, whitespace,
+    // or end-of-input.  Used for atom ids, row ids, table ids, and literal
+    // text that appears BEFORE '=' inside a '(' (column names, atom text, etc.).
+    // For the value that follows '=' inside a '(' use ReadValueRun() instead.
     // -------------------------------------------------------------------------
     private byte[] ReadTextRun()
     {
-        // In value context (inside paren) we are reading a value literal.
-        // We stop at: ) ^ = : @ and whitespace (but not at escaped versions).
-        // Outside paren we also stop at < > { } [ ] ( ).
-        bool insideParen = _delimStack.Count > 0 && _delimStack.Peek() == (byte)'(';
-
         var buf = new List<byte>(16);
 
         while (_pos < _input.Length)
@@ -303,6 +306,68 @@ public sealed class MorkTokenizer
                 break;
 
             // Raw byte (incl. high bytes) — pass through directly
+            buf.Add(b);
+            _pos++;
+        }
+
+        return buf.ToArray();
+    }
+
+    // -------------------------------------------------------------------------
+    // Read a Mork value run: the text that follows '=' inside a '('.
+    // Resolves $XX hex escapes and \<x> backslash escapes exactly like
+    // ReadTextRun, but the ONLY non-escape stop condition is an unescaped ')'.
+    // Every other byte — spaces, ':', '=', '<', '[', etc. — is literal content.
+    // Returns an empty array when the next byte is ')' (empty value).
+    // -------------------------------------------------------------------------
+    private byte[] ReadValueRun()
+    {
+        var buf = new List<byte>(32);
+
+        while (_pos < _input.Length)
+        {
+            byte b = _input[_pos];
+
+            if (b == '$')
+            {
+                if (_pos + 2 >= _input.Length)
+                    throw new MorkFormatException($"Incomplete $XX hex escape at position {_pos}");
+                byte hi = _input[_pos + 1];
+                byte lo = _input[_pos + 2];
+                if (!IsHexDigit(hi) || !IsHexDigit(lo))
+                    throw new MorkFormatException($"Malformed $XX hex escape at position {_pos}");
+                buf.Add((byte)(HexVal(hi) << 4 | HexVal(lo)));
+                _pos += 3;
+                continue;
+            }
+
+            if (b == '\\')
+            {
+                _pos++; // consume backslash
+                if (_pos >= _input.Length)
+                    break; // backslash at very end — treat as continuation contributing nothing
+
+                byte next = _input[_pos];
+                // Backslash at end-of-line = line continuation, contributes nothing
+                if (next == '\r' || next == '\n')
+                {
+                    if (next == '\r' && _pos + 1 < _input.Length && _input[_pos + 1] == '\n')
+                        _pos += 2;
+                    else
+                        _pos++;
+                    continue;
+                }
+                // Any other char after backslash: emit the literal char
+                buf.Add(next);
+                _pos++;
+                continue;
+            }
+
+            // Unescaped ')' terminates the value — leave it for the outer loop
+            if (b == ')')
+                break;
+
+            // All other bytes (including spaces, ':', '=', '<', etc.) are literal value content
             buf.Add(b);
             _pos++;
         }

--- a/src/Mail2Pst.Core/Mork/MorkTokenizer.cs
+++ b/src/Mail2Pst.Core/Mork/MorkTokenizer.cs
@@ -254,42 +254,8 @@ public sealed class MorkTokenizer
 
             // --- Escape sequences must be handled BEFORE stop-char checks so that
             //     e.g. \) is a literal ')' rather than a close-paren stop. ---
-
-            if (b == '$')
-            {
-                // $XX hex escape — valid inside any text context
-                if (_pos + 2 >= _input.Length)
-                    throw new MorkFormatException($"Incomplete $XX hex escape at position {_pos}");
-                byte hi = _input[_pos + 1];
-                byte lo = _input[_pos + 2];
-                if (!IsHexDigit(hi) || !IsHexDigit(lo))
-                    throw new MorkFormatException($"Malformed $XX hex escape at position {_pos}");
-                buf.Add((byte)(HexVal(hi) << 4 | HexVal(lo)));
-                _pos += 3;
+            if (TryReadEscape(buf))
                 continue;
-            }
-
-            if (b == '\\')
-            {
-                _pos++; // consume backslash
-                if (_pos >= _input.Length)
-                    break; // backslash at very end — treat as continuation contributing nothing
-
-                byte next = _input[_pos];
-                // Backslash at end-of-line (CR, LF, or CRLF) = line continuation, contributes nothing
-                if (next == '\r' || next == '\n')
-                {
-                    if (next == '\r' && _pos + 1 < _input.Length && _input[_pos + 1] == '\n')
-                        _pos += 2;
-                    else
-                        _pos++;
-                    continue;
-                }
-                // Any other char after backslash: emit the literal char
-                buf.Add(next);
-                _pos++;
-                continue;
-            }
 
             // --- Non-escape stop conditions ---
 
@@ -328,40 +294,8 @@ public sealed class MorkTokenizer
         {
             byte b = _input[_pos];
 
-            if (b == '$')
-            {
-                if (_pos + 2 >= _input.Length)
-                    throw new MorkFormatException($"Incomplete $XX hex escape at position {_pos}");
-                byte hi = _input[_pos + 1];
-                byte lo = _input[_pos + 2];
-                if (!IsHexDigit(hi) || !IsHexDigit(lo))
-                    throw new MorkFormatException($"Malformed $XX hex escape at position {_pos}");
-                buf.Add((byte)(HexVal(hi) << 4 | HexVal(lo)));
-                _pos += 3;
+            if (TryReadEscape(buf))
                 continue;
-            }
-
-            if (b == '\\')
-            {
-                _pos++; // consume backslash
-                if (_pos >= _input.Length)
-                    break; // backslash at very end — treat as continuation contributing nothing
-
-                byte next = _input[_pos];
-                // Backslash at end-of-line = line continuation, contributes nothing
-                if (next == '\r' || next == '\n')
-                {
-                    if (next == '\r' && _pos + 1 < _input.Length && _input[_pos + 1] == '\n')
-                        _pos += 2;
-                    else
-                        _pos++;
-                    continue;
-                }
-                // Any other char after backslash: emit the literal char
-                buf.Add(next);
-                _pos++;
-                continue;
-            }
 
             // Unescaped ')' terminates the value — leave it for the outer loop
             if (b == ')')
@@ -373,6 +307,63 @@ public sealed class MorkTokenizer
         }
 
         return buf.ToArray();
+    }
+
+    // -------------------------------------------------------------------------
+    // Shared escape helper used by ReadTextRun and ReadValueRun.
+    // If the byte at _pos is '$', consumes a $XX hex escape (two hex digits),
+    // appends the decoded byte to buf, advances _pos by 3, and returns true.
+    // If the byte at _pos is '\', consumes the backslash escape or line-
+    // continuation exactly as the Mork spec requires, advances _pos past
+    // whatever was consumed, and returns true (even for a bare '\' at EOI
+    // or a line-continuation that contributes no byte).
+    // Returns false if _pos does not point at '$' or '\', leaving _pos and buf
+    // unchanged so the caller can apply its own stop conditions.
+    // -------------------------------------------------------------------------
+    private bool TryReadEscape(List<byte> buf)
+    {
+        if (_pos >= _input.Length)
+            return false;
+
+        byte b = _input[_pos];
+
+        if (b == '$')
+        {
+            // $XX hex escape — valid inside any text context
+            if (_pos + 2 >= _input.Length)
+                throw new MorkFormatException($"Incomplete $XX hex escape at position {_pos}");
+            byte hi = _input[_pos + 1];
+            byte lo = _input[_pos + 2];
+            if (!IsHexDigit(hi) || !IsHexDigit(lo))
+                throw new MorkFormatException($"Malformed $XX hex escape at position {_pos}");
+            buf.Add((byte)(HexVal(hi) << 4 | HexVal(lo)));
+            _pos += 3;
+            return true;
+        }
+
+        if (b == '\\')
+        {
+            _pos++; // consume backslash
+            if (_pos >= _input.Length)
+                return true; // backslash at very end — treat as continuation contributing nothing
+
+            byte next = _input[_pos];
+            // Backslash at end-of-line (CR, LF, or CRLF) = line continuation, contributes nothing
+            if (next == '\r' || next == '\n')
+            {
+                if (next == '\r' && _pos + 1 < _input.Length && _input[_pos + 1] == '\n')
+                    _pos += 2;
+                else
+                    _pos++;
+                return true;
+            }
+            // Any other char after backslash: emit the literal char
+            buf.Add(next);
+            _pos++;
+            return true;
+        }
+
+        return false;
     }
 
     // -------------------------------------------------------------------------

--- a/src/Mail2Pst.Core/Mork/MorkTokenizer.cs
+++ b/src/Mail2Pst.Core/Mork/MorkTokenizer.cs
@@ -301,7 +301,9 @@ public sealed class MorkTokenizer
             if (b == ')')
                 break;
 
-            // All other bytes (including spaces, ':', '=', '<', etc.) are literal value content
+            // All other bytes (including spaces, ':', '=', '<', '@', etc.) are literal value
+            // content. '@' is treated as a literal here because group markers (@$${…{@) only
+            // appear at the top-level token stream, never inside a paren value run.
             buf.Add(b);
             _pos++;
         }

--- a/src/Mail2Pst.Core/Mork/MorkTokenizer.cs
+++ b/src/Mail2Pst.Core/Mork/MorkTokenizer.cs
@@ -1,0 +1,365 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Mail2Pst.Core.Mork;
+
+/// <summary>
+/// Purely lexical byte scanner for the Mozilla Mork (.msf) format.
+/// Emits structural tokens and escape-resolved value bytes; does NOT resolve
+/// atom references, charset, or semantics — those are assembler concerns.
+/// </summary>
+public sealed class MorkTokenizer
+{
+    private readonly byte[] _input;
+    private int _pos;
+
+    // Delimiter balance stack for unterminated-construct detection.
+    // We track open delimiters that require a matching close.
+    private readonly Stack<byte> _delimStack = new();
+
+    public MorkTokenizer(byte[] input)
+    {
+        _input = input ?? throw new ArgumentNullException(nameof(input));
+    }
+
+    /// <summary>Tokenizes the full input and yields all tokens.</summary>
+    /// <exception cref="MorkFormatException">
+    /// Thrown on unbalanced/unterminated constructs or malformed escapes.
+    /// Note: tokens are yielded lazily; callers must enumerate to trigger validation.
+    /// </exception>
+    public IEnumerable<MorkToken> Tokenize()
+    {
+        _pos = 0;
+        _delimStack.Clear();
+
+        while (_pos < _input.Length)
+        {
+            // Skip whitespace
+            if (IsWhitespace(_input[_pos]))
+            {
+                _pos++;
+                continue;
+            }
+
+            // Skip // line comments
+            if (_pos + 1 < _input.Length && _input[_pos] == '/' && _input[_pos + 1] == '/')
+            {
+                SkipLineComment();
+                continue;
+            }
+
+            byte b = _input[_pos];
+
+            // @ — could be a transaction group marker (@$${…{@ or @$$}…}@)
+            if (b == '@')
+            {
+                MorkToken? groupTok = TryReadGroupMarker();
+                if (groupTok.HasValue)
+                {
+                    yield return groupTok.Value;
+                    continue;
+                }
+                // Bare @ is not a recognised form — skip it (or throw if strict needed).
+                // The Mork spec uses @ only in group markers; treat lone @ as format error.
+                throw new MorkFormatException($"Unexpected '@' at position {_pos}");
+            }
+
+            switch (b)
+            {
+                case (byte)'<':
+                    _delimStack.Push(b);
+                    _pos++;
+                    yield return new MorkToken(MorkTokenKind.DictOpen);
+                    break;
+
+                case (byte)'>':
+                    ExpectClose((byte)'<', '>');
+                    _pos++;
+                    yield return new MorkToken(MorkTokenKind.DictClose);
+                    break;
+
+                case (byte)'{':
+                    _delimStack.Push(b);
+                    _pos++;
+                    yield return new MorkToken(MorkTokenKind.BraceOpen);
+                    break;
+
+                case (byte)'}':
+                    ExpectClose((byte)'{', '}');
+                    _pos++;
+                    yield return new MorkToken(MorkTokenKind.BraceClose);
+                    break;
+
+                case (byte)'[':
+                {
+                    _delimStack.Push(b);
+                    _pos++;
+                    yield return new MorkToken(MorkTokenKind.BracketOpen);
+
+                    // Row-cut: a '-' immediately after '[' (possibly with the '-' directly next, no whitespace)
+                    if (_pos < _input.Length && _input[_pos] == '-')
+                    {
+                        _pos++;
+                        yield return new MorkToken(MorkTokenKind.Cut);
+                    }
+                    break;
+                }
+
+                case (byte)']':
+                    ExpectClose((byte)'[', ']');
+                    _pos++;
+                    yield return new MorkToken(MorkTokenKind.BracketClose);
+                    break;
+
+                case (byte)'(':
+                    _delimStack.Push(b);
+                    _pos++;
+                    yield return new MorkToken(MorkTokenKind.ParenOpen);
+                    break;
+
+                case (byte)')':
+                    ExpectClose((byte)'(', ')');
+                    _pos++;
+                    yield return new MorkToken(MorkTokenKind.ParenClose);
+                    break;
+
+                case (byte)'=':
+                    _pos++;
+                    yield return new MorkToken(MorkTokenKind.Equals);
+                    break;
+
+                case (byte)':':
+                    _pos++;
+                    yield return new MorkToken(MorkTokenKind.Colon);
+                    break;
+
+                case (byte)'^':
+                {
+                    // Atom reference: ^hexid  — read hex digits (and letters) until a non-hex char
+                    _pos++; // skip '^'
+                    byte[] id = ReadAtomId();
+                    yield return new MorkToken(MorkTokenKind.AtomRef, id);
+                    break;
+                }
+
+                default:
+                {
+                    // Plain text token: a run of non-delimiter, non-whitespace bytes
+                    // (atom ids, row ids, table ids, literal values outside parens)
+                    byte[] text = ReadTextRun();
+                    if (text.Length > 0)
+                        yield return new MorkToken(MorkTokenKind.Text, text);
+                    break;
+                }
+            }
+        }
+
+        // After exhausting input, any open delimiters left = unterminated construct
+        if (_delimStack.Count > 0)
+        {
+            char open = (char)_delimStack.Peek();
+            throw new MorkFormatException($"Unterminated '{open}' construct at end of input");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Group marker: @$${<hexid>{@  (GroupStart)  or  @$$}<hexid>}@  (GroupCommit)
+    // Grammar (from Task-0 spike):
+    //   GroupStart  = @$${  <hexid>  {@
+    //   GroupCommit = @$$}  <hexid>  }@
+    //   GroupAbort  = @$$!  <hexid>  !@   (kept in enum but not seen in the wild)
+    // -------------------------------------------------------------------------
+    private MorkToken? TryReadGroupMarker()
+    {
+        // Need at least @$$x (4 bytes) + <hexid> + x@
+        int start = _pos;
+        if (_pos + 3 >= _input.Length) return null;
+        if (_input[_pos] != '@' || _input[_pos + 1] != '$' || _input[_pos + 2] != '$') return null;
+
+        byte typeChar = _input[_pos + 3]; // '{', '}', or '!'
+        MorkTokenKind kind;
+        byte closingChar;
+        switch (typeChar)
+        {
+            case (byte)'{': kind = MorkTokenKind.GroupStart;  closingChar = (byte)'{'; break;
+            case (byte)'}': kind = MorkTokenKind.GroupCommit; closingChar = (byte)'}'; break;
+            case (byte)'!': kind = MorkTokenKind.GroupAbort;  closingChar = (byte)'!'; break;
+            default: return null; // not a group marker
+        }
+
+        _pos += 4; // consume @$${  or @$$}  or @$$!
+
+        // Read the hex id up to the matching closingChar
+        int idStart = _pos;
+        while (_pos < _input.Length && _input[_pos] != closingChar)
+            _pos++;
+
+        if (_pos >= _input.Length)
+            throw new MorkFormatException($"Unterminated transaction group marker starting at {start}");
+
+        byte[] hexId = _input[idStart.._pos];
+        _pos++; // consume the closing char (the second { or } or !)
+
+        // Expect trailing '@'
+        if (_pos >= _input.Length || _input[_pos] != '@')
+            throw new MorkFormatException($"Missing trailing '@' in transaction group marker at {start}");
+        _pos++; // consume @
+
+        return new MorkToken(kind, hexId);
+    }
+
+    // -------------------------------------------------------------------------
+    // Read a ^atom-id: hex digits + upper/lowercase letters until a stop char.
+    // In Mork atom ids are hex (e.g. 88, A0) but allow alpha for safety.
+    // -------------------------------------------------------------------------
+    private byte[] ReadAtomId()
+    {
+        int start = _pos;
+        while (_pos < _input.Length && IsAtomIdChar(_input[_pos]))
+            _pos++;
+        if (_pos == start)
+            throw new MorkFormatException($"Empty atom reference ('^' not followed by an id) at position {_pos}");
+        return _input[start.._pos];
+    }
+
+    // -------------------------------------------------------------------------
+    // Read a plain text run with $XX and \x escape resolution.
+    // Stops at structural characters, delimiters, or end-of-input.
+    //
+    // Context: inside a paren (value context) we must still stop at structural
+    // operators (=, ^, :, @) so they get emitted as their own tokens, but we
+    // must NOT stop at unescaped ')' — that is handled by the escape logic
+    // (backslash-escapes ')' literally) and by the stop condition.
+    // Outside paren context we stop at all delimiters and operators.
+    // -------------------------------------------------------------------------
+    private byte[] ReadTextRun()
+    {
+        // In value context (inside paren) we are reading a value literal.
+        // We stop at: ) ^ = : @ and whitespace (but not at escaped versions).
+        // Outside paren we also stop at < > { } [ ] ( ).
+        bool insideParen = _delimStack.Count > 0 && _delimStack.Peek() == (byte)'(';
+
+        var buf = new List<byte>(16);
+
+        while (_pos < _input.Length)
+        {
+            byte b = _input[_pos];
+
+            // --- Escape sequences must be handled BEFORE stop-char checks so that
+            //     e.g. \) is a literal ')' rather than a close-paren stop. ---
+
+            if (b == '$')
+            {
+                // $XX hex escape — valid inside any text context
+                if (_pos + 2 >= _input.Length)
+                    throw new MorkFormatException($"Incomplete $XX hex escape at position {_pos}");
+                byte hi = _input[_pos + 1];
+                byte lo = _input[_pos + 2];
+                if (!IsHexDigit(hi) || !IsHexDigit(lo))
+                    throw new MorkFormatException($"Malformed $XX hex escape at position {_pos}");
+                buf.Add((byte)(HexVal(hi) << 4 | HexVal(lo)));
+                _pos += 3;
+                continue;
+            }
+
+            if (b == '\\')
+            {
+                _pos++; // consume backslash
+                if (_pos >= _input.Length)
+                    break; // backslash at very end — treat as continuation contributing nothing
+
+                byte next = _input[_pos];
+                // Backslash at end-of-line (CR, LF, or CRLF) = line continuation, contributes nothing
+                if (next == '\r' || next == '\n')
+                {
+                    if (next == '\r' && _pos + 1 < _input.Length && _input[_pos + 1] == '\n')
+                        _pos += 2;
+                    else
+                        _pos++;
+                    continue;
+                }
+                // Any other char after backslash: emit the literal char
+                buf.Add(next);
+                _pos++;
+                continue;
+            }
+
+            // --- Non-escape stop conditions ---
+
+            // Stop at ')' (unescaped close paren)
+            if (b == ')')
+                break;
+
+            // Stop at any other structural character
+            if (IsStopChar(b))
+                break;
+
+            // Line comment — stop the text run and let outer loop handle it
+            if (b == '/' && _pos + 1 < _input.Length && _input[_pos + 1] == '/')
+                break;
+
+            // Raw byte (incl. high bytes) — pass through directly
+            buf.Add(b);
+            _pos++;
+        }
+
+        return buf.ToArray();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void SkipLineComment()
+    {
+        // Skip everything up to (but not including) the next LF/CR
+        while (_pos < _input.Length && _input[_pos] != '\n' && _input[_pos] != '\r')
+            _pos++;
+    }
+
+    private void ExpectClose(byte expectedOpen, char closeChar)
+    {
+        if (_delimStack.Count == 0 || _delimStack.Peek() != expectedOpen)
+            throw new MorkFormatException(
+                $"Unmatched '{closeChar}' at position {_pos}: no corresponding '{(char)expectedOpen}'");
+        _delimStack.Pop();
+    }
+
+    private static bool IsWhitespace(byte b) =>
+        b == ' ' || b == '\t' || b == '\r' || b == '\n';
+
+    private static bool IsAtomIdChar(byte b) =>
+        (b >= '0' && b <= '9') ||
+        (b >= 'a' && b <= 'f') ||
+        (b >= 'A' && b <= 'F') ||
+        // Allow broader hex-ish range: Mork uses upper hex (0-9, A-F) but be lenient
+        (b >= 'g' && b <= 'z') ||
+        (b >= 'G' && b <= 'Z');
+
+    /// <summary>Characters that terminate a plain text run outside of paren context.</summary>
+    private static bool IsStopChar(byte b) =>
+        b == '<' || b == '>' ||
+        b == '{' || b == '}' ||
+        b == '[' || b == ']' ||
+        b == '(' || b == ')' ||
+        b == '=' || b == ':' ||
+        b == '^' || b == '@' ||
+        IsWhitespace(b);
+
+    private static bool IsHexDigit(byte b) =>
+        (b >= '0' && b <= '9') ||
+        (b >= 'a' && b <= 'f') ||
+        (b >= 'A' && b <= 'F');
+
+    private static int HexVal(byte b)
+    {
+        if (b >= '0' && b <= '9') return b - '0';
+        if (b >= 'a' && b <= 'f') return b - 'a' + 10;
+        if (b >= 'A' && b <= 'F') return b - 'A' + 10;
+        return 0;
+    }
+}

--- a/src/Mail2Pst.Core/Mork/MorkValueDecoder.cs
+++ b/src/Mail2Pst.Core/Mork/MorkValueDecoder.cs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Mail2Pst.Core.Mork;
+
+/// <summary>Decodes a Mork value's assembled byte run to a string using the active charset.</summary>
+internal static class MorkValueDecoder
+{
+    private static readonly Encoding StrictUtf8 =
+        new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+    // Strict ASCII: invalid high bytes throw instead of silently becoming '?' (fail-loud posture).
+    private static readonly Encoding StrictAscii =
+        Encoding.GetEncoding("us-ascii", EncoderFallback.ExceptionFallback, DecoderFallback.ExceptionFallback);
+
+    public static Encoding ResolveCharset(string? hint)
+    {
+        if (string.IsNullOrWhiteSpace(hint)) return StrictUtf8;
+        return hint!.Trim().ToLowerInvariant() switch
+        {
+            "utf-8" or "utf8" => StrictUtf8,
+            "iso-8859-1" or "latin1" => Encoding.Latin1,  // Latin1 maps every byte 0..255, so it never fails
+            "us-ascii" or "ascii" => StrictAscii,
+            _ => throw new MorkFormatException($"Unsupported Mork charset: '{hint}'"),
+        };
+    }
+
+    public static string Decode(IReadOnlyList<byte> bytes, Encoding charset)
+    {
+        byte[] arr = bytes as byte[] ?? bytes.ToArray();
+        try { return charset.GetString(arr); }
+        catch (DecoderFallbackException ex) { throw new MorkFormatException("Invalid byte sequence for charset", ex); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Mork/MorkMergeTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mork/MorkMergeTests.cs
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using Mail2Pst.Core.Mork;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Mork;
+
+public class MorkMergeTests
+{
+    private const string Dict = "< (80=ns:msg:db:row:scope:msgs:all)(96=ns:msg:db:table:kind:msgs)(88=flags)(81=subject) >\n";
+    private static MorkRow Row(string src, string id) =>
+        MorkReader.ParseString(Dict + src).TryGetSingleTable("ns:msg:db:row:scope:msgs:all", "ns:msg:db:table:kind:msgs", out var t)
+            ? t.Rows[id] : throw new System.Exception("table/row missing");
+
+    [Fact]
+    public void Merge_LaterUpdateOverwritesCell_LastWriteWins()
+    {
+        // row 1 flags=1, then a later group updates flags=5 -> final 5; subject from first write retained
+        var r = Row("{1:^80 {(k^96:c)} [1(^88=1)(^81=hi)] } @$${1{@ {1:^80 [1(^88=5)] } @$$}1}@", "1");
+        Assert.Equal("5", r.Cells["flags"]);
+        Assert.Equal("hi", r.Cells["subject"]); // untouched cell retained
+    }
+
+    [Fact]
+    public void Merge_RowCut_RemovesRow()
+    {
+        var doc = MorkReader.ParseString(Dict + "{1:^80 {(k^96:c)} [1(^88=1)] } @$${1{@ {1:^80 [-1] } @$$}1}@");
+        Assert.True(doc.TryGetSingleTable("ns:msg:db:row:scope:msgs:all", "ns:msg:db:table:kind:msgs", out var t));
+        Assert.False(t.Rows.ContainsKey("1"));
+    }
+
+    [Fact]
+    public void Merge_DeleteThenReAdd_RowPresentWithReAddedCells()
+    {
+        var doc = MorkReader.ParseString(Dict + "{1:^80 {(k^96:c)} [1(^88=1)] } @$${1{@ {1:^80 [-1] } @$$}1}@ @$${2{@ {1:^80 [1(^88=9)] } @$$}2}@");
+        Assert.True(doc.TryGetSingleTable("ns:msg:db:row:scope:msgs:all", "ns:msg:db:table:kind:msgs", out var t));
+        Assert.True(t.Rows.ContainsKey("1"));
+        Assert.Equal("9", t.Rows["1"].Cells["flags"]);
+    }
+
+    [Fact]
+    public void Merge_RowUpdateToEmptyValue_CellPresentButEmpty()
+    {
+        // Task 0 RESOLVED: Thunderbird .msf has NO cell-cut. `(^81=)` is an EMPTY-STRING value applied
+        // by a normal row update — the cell stays PRESENT with value "". Deletion is row-level only
+        // (`[-id]`). (121,093 such empty cells in the real corpus, all in normal non-cut rows.)
+        var r = Row("{1:^80 {(k^96:c)} [1(^88=1)(^81=hi)] } @$${1{@ {1:^80 [1(^81=)] } @$$}1}@", "1");
+        Assert.Equal("1", r.Cells["flags"]);   // untouched cell retained
+        Assert.Equal("", r.Cells["subject"]);  // overwritten to empty string (NOT removed)
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Mork/MorkMergeTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mork/MorkMergeTests.cs
@@ -7,7 +7,8 @@ namespace Mail2Pst.Core.Tests.Mork;
 
 public class MorkMergeTests
 {
-    private const string Dict = "< (80=ns:msg:db:row:scope:msgs:all)(96=ns:msg:db:table:kind:msgs)(88=flags)(81=subject) >\n";
+    // Column dict: leading <(a=c)> marks this as the column atom space.
+    private const string Dict = "< <(a=c)> (80=ns:msg:db:row:scope:msgs:all)(96=ns:msg:db:table:kind:msgs)(88=flags)(81=subject) >\n";
     private static MorkRow Row(string src, string id) =>
         MorkReader.ParseString(Dict + src).TryGetSingleTable("ns:msg:db:row:scope:msgs:all", "ns:msg:db:table:kind:msgs", out var t)
             ? t.Rows[id] : throw new System.Exception("table/row missing");

--- a/tests/Mail2Pst.Core.Tests/Mork/MorkModelTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mork/MorkModelTests.cs
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Collections.Generic;
+using Mail2Pst.Core.Mork;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Mork;
+
+public class MorkModelTests
+{
+    private static MorkTable Table(string id, string scope, string kind) =>
+        new(id, scope, kind, new Dictionary<string, MorkRow>
+        {
+            ["1"] = new MorkRow("1", new Dictionary<string, string> { ["flags"] = "5" }),
+        });
+
+    [Fact]
+    public void TryGetCell_PresentAndAbsent()
+    {
+        var row = new MorkRow("1", new Dictionary<string, string> { ["flags"] = "5" });
+        Assert.True(row.TryGetCell("flags", out string v));
+        Assert.Equal("5", v);
+        Assert.False(row.TryGetCell("subject", out _));
+    }
+
+    [Fact]
+    public void GetTables_ReturnsAllMatches_TryGetSingle_FalseOnMultiple()
+    {
+        var doc = new MorkDocument(new[]
+        {
+            Table("1", "scopeX", "kindX"),
+            Table("2", "scopeX", "kindX"), // same scope+kind, different Id — must both survive
+        });
+        Assert.Equal(2, doc.GetTables("scopeX", "kindX").Count);
+        Assert.False(doc.TryGetSingleTable("scopeX", "kindX", out _)); // ambiguous -> false
+    }
+
+    [Fact]
+    public void TryGetSingleTable_TrueOnExactlyOne_FalseOnZero()
+    {
+        var doc = new MorkDocument(new[] { Table("1", "scopeX", "kindX") });
+        Assert.True(doc.TryGetSingleTable("scopeX", "kindX", out MorkTable t));
+        Assert.Equal("1", t.Id);
+        Assert.False(doc.TryGetSingleTable("nope", "nope", out _));
+    }
+
+    [Fact]
+    public void MorkRow_IsImmutableSnapshot()
+    {
+        var source = new Dictionary<string, string> { ["flags"] = "1" };
+        var row = new MorkRow("1", source);
+        source["flags"] = "9";                       // mutate the source after construction
+        Assert.Equal("1", row.Cells["flags"]);       // snapshot unaffected
+        Assert.IsNotType<Dictionary<string, string>>(row.Cells); // not a downcastable mutable dict
+    }
+
+    [Fact]
+    public void MorkTable_RowsAreImmutableSnapshot()
+    {
+        var rows = new Dictionary<string, MorkRow> { ["1"] = new MorkRow("1", new Dictionary<string, string>()) };
+        var table = new MorkTable("t", "s", "k", rows);
+        rows.Clear();                                 // mutate the source after construction
+        Assert.True(table.Rows.ContainsKey("1"));     // snapshot unaffected
+        Assert.IsNotType<Dictionary<string, MorkRow>>(table.Rows);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Mork/MorkParseTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mork/MorkParseTests.cs
@@ -96,6 +96,25 @@ public class MorkParseTests
         Assert.Equal("5", t.Rows["1"].Cells["flags"]);
     }
 
+    [Fact]
+    public void Parse_ColumnDict_MarkerPrecededByCharsetCell_StillRecognisedAsColumnDict()
+    {
+        // Regression for I-1: a column dict where the charset cell (f=iso-8859-1)
+        // appears BEFORE the <(a=c)> marker. The dict must still be classified as a
+        // column dict so that scope/kind/column atom defs are placed in the column map.
+        // Format: < (f=iso-8859-1) <(a=c)> (80=…scope…)(96=…kind…)(88=flags) >
+        // followed by a table and a row that uses column refs ^80, ^96, ^88.
+        const string src =
+            "< (f=iso-8859-1) <(a=c)> (80=ns:msg:db:row:scope:msgs:all)(96=ns:msg:db:table:kind:msgs)(88=flags) >\n"
+            + "{1:^80 {(k^96:c)} [1(^88=5)]}";
+        MorkDocument doc = MorkReader.ParseString(src);
+        Assert.True(
+            doc.TryGetSingleTable("ns:msg:db:row:scope:msgs:all", "ns:msg:db:table:kind:msgs", out MorkTable t),
+            $"Column dict not recognised — actual tables: [{string.Join(", ", doc.Tables.Select(x => $"scope={x.Scope} kind={x.Kind}"))}]");
+        Assert.Equal("ns:msg:db:row:scope:msgs:all", t.Scope);
+        Assert.Equal("5", t.Rows["1"].Cells["flags"]);
+    }
+
     // Builds: "< <(a=c)> (f=iso-8859-1)(80=ns:...:msgs:all)(96=ns:...:kind:msgs)(81=subject) >{1:^80 {(k^96:c)} [1(^81=<0xE6>)]}"
     // with the subject value being the single raw byte 0xE6 (NOT $-escaped) to exercise the byte path.
     private static byte[] BuildLatin1Fixture()

--- a/tests/Mail2Pst.Core.Tests/Mork/MorkParseTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mork/MorkParseTests.cs
@@ -52,6 +52,17 @@ public class MorkParseTests
     }
 
     [Fact]
+    public void Parse_EmptyCell_StoresEmptyString()
+    {
+        // (^88=5) → flags="5"; (^81=) → subject="" (cell present, value empty literal)
+        MorkDocument doc = MorkReader.ParseString(Dict + "{1:^80 {(k^96:c)} [1(^88=5)(^81=)] }");
+        Assert.True(doc.TryGetSingleTable("ns:msg:db:row:scope:msgs:all", "ns:msg:db:table:kind:msgs", out MorkTable t));
+        MorkRow r = t.Rows["1"];
+        Assert.Equal("5", r.Cells["flags"]);
+        Assert.Equal("", r.Cells["subject"]);
+    }
+
+    [Fact]
     public void Parse_MalformedStructure_Throws()
     {
         Assert.Throws<MorkFormatException>(() => MorkReader.ParseString("< (80=x) " /* unterminated dict */));

--- a/tests/Mail2Pst.Core.Tests/Mork/MorkParseTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mork/MorkParseTests.cs
@@ -9,23 +9,29 @@ namespace Mail2Pst.Core.Tests.Mork;
 
 public class MorkParseTests
 {
-    private const string Dict = "< (80=ns:msg:db:row:scope:msgs:all)(96=ns:msg:db:table:kind:msgs)(88=flags)(81=subject)(A0=hello) >\n";
+    // Column dict: leading <(a=c)> marks this as the column atom space.
+    // Defines scope (80), kind (96), and column names (88=flags, 81=subject, A0=hello).
+    private const string ColumnDict = "< <(a=c)> (80=ns:msg:db:row:scope:msgs:all)(96=ns:msg:db:table:kind:msgs)(88=flags)(81=subject) >\n";
 
     [Fact]
     public void Parse_TableRow_LiteralAndRefCells()
     {
         // table scope ^80, kind ^96; row 1 with flags=5 (literal) and subject=^A0 (atom ref -> "hello")
-        MorkDocument doc = MorkReader.ParseString(Dict + "{1:^80 {(k^96:c)} [1(^88=5)(^81^A0)] }");
+        // ^A0 is a value atom ref — needs a separate VALUE dict (no <(a=c)>).
+        string src = ColumnDict
+            + "< (A0=hello) >\n"
+            + "{1:^80 {(k^96:c)} [1(^88=5)(^81^A0)] }";
+        MorkDocument doc = MorkReader.ParseString(src);
         Assert.True(doc.TryGetSingleTable("ns:msg:db:row:scope:msgs:all", "ns:msg:db:table:kind:msgs", out MorkTable t));
         MorkRow r = t.Rows["1"];
         Assert.Equal("5", r.Cells["flags"]);
-        Assert.Equal("hello", r.Cells["subject"]); // atom ref resolved
+        Assert.Equal("hello", r.Cells["subject"]); // value atom ref resolved from value map
     }
 
     [Fact]
     public void Parse_DictOnly_NoTables()
     {
-        MorkDocument doc = MorkReader.ParseString(Dict);
+        MorkDocument doc = MorkReader.ParseString(ColumnDict);
         Assert.Empty(doc.Tables);
     }
 
@@ -33,7 +39,7 @@ public class MorkParseTests
     public void Parse_UnknownColumnAndScope_Preserved()
     {
         // unknown column atom F0=customThing, unknown table kind -> must NOT throw; preserved as strings
-        string src = "< (80=ns:msg:db:row:scope:msgs:all)(F0=customThing)(F1=ns:msg:db:table:kind:weird) >\n"
+        string src = "< <(a=c)> (80=ns:msg:db:row:scope:msgs:all)(F0=customThing)(F1=ns:msg:db:table:kind:weird) >\n"
                    + "{1:^80 {(k^F1:c)} [1(^F0=xyz)] }";
         MorkDocument doc = MorkReader.ParseString(src);
         MorkTable t = doc.Tables.Single();
@@ -55,7 +61,7 @@ public class MorkParseTests
     public void Parse_EmptyCell_StoresEmptyString()
     {
         // (^88=5) → flags="5"; (^81=) → subject="" (cell present, value empty literal)
-        MorkDocument doc = MorkReader.ParseString(Dict + "{1:^80 {(k^96:c)} [1(^88=5)(^81=)] }");
+        MorkDocument doc = MorkReader.ParseString(ColumnDict + "{1:^80 {(k^96:c)} [1(^88=5)(^81=)] }");
         Assert.True(doc.TryGetSingleTable("ns:msg:db:row:scope:msgs:all", "ns:msg:db:table:kind:msgs", out MorkTable t));
         MorkRow r = t.Rows["1"];
         Assert.Equal("5", r.Cells["flags"]);
@@ -66,6 +72,28 @@ public class MorkParseTests
     public void Parse_MalformedStructure_Throws()
     {
         Assert.Throws<MorkFormatException>(() => MorkReader.ParseString("< (80=x) " /* unterminated dict */));
+    }
+
+    [Fact]
+    public void Parse_ColumnVsValueAtomSpaces_SeparateIds()
+    {
+        // Regression: column dict defines 80=ns:msg:db:row:scope:msgs:all and 96=ns:msg:db:table:kind:msgs
+        // and 88=flags. Then a value dict reuses id 80 with a different value.
+        // The table scope ^80 must resolve from the COLUMN map (not the value dict),
+        // so Scope must be "ns:msg:db:row:scope:msgs:all" — NOT "somevalue".
+        // Similarly, Kind ^96 must resolve to "ns:msg:db:table:kind:msgs".
+        const string columnDict = "< <(a=c)> (80=ns:msg:db:row:scope:msgs:all)(96=ns:msg:db:table:kind:msgs)(88=flags) >\n";
+        const string valueDict  = "< (80=somevalue) >\n"; // reuses id 80 — must NOT clobber column map
+        const string table      = "{1:^80 {(k^96:c)} [1(^88=5)]}";
+        MorkDocument doc = MorkReader.ParseString(columnDict + valueDict + table);
+        Assert.True(doc.TryGetSingleTable(
+            "ns:msg:db:row:scope:msgs:all",
+            "ns:msg:db:table:kind:msgs",
+            out MorkTable t),
+            $"Expected msgs table; actual tables: [{string.Join(", ", doc.Tables.Select(x => $"scope={x.Scope} kind={x.Kind}"))}]");
+        Assert.Equal("ns:msg:db:row:scope:msgs:all", t.Scope);
+        Assert.Equal("ns:msg:db:table:kind:msgs",   t.Kind);
+        Assert.Equal("5", t.Rows["1"].Cells["flags"]);
     }
 
     // Builds: "< <(a=c)> (f=iso-8859-1)(80=ns:...:msgs:all)(96=ns:...:kind:msgs)(81=subject) >{1:^80 {(k^96:c)} [1(^81=<0xE6>)]}"

--- a/tests/Mail2Pst.Core.Tests/Mork/MorkParseTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mork/MorkParseTests.cs
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Mork;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Mork;
+
+public class MorkParseTests
+{
+    private const string Dict = "< (80=ns:msg:db:row:scope:msgs:all)(96=ns:msg:db:table:kind:msgs)(88=flags)(81=subject)(A0=hello) >\n";
+
+    [Fact]
+    public void Parse_TableRow_LiteralAndRefCells()
+    {
+        // table scope ^80, kind ^96; row 1 with flags=5 (literal) and subject=^A0 (atom ref -> "hello")
+        MorkDocument doc = MorkReader.ParseString(Dict + "{1:^80 {(k^96:c)} [1(^88=5)(^81^A0)] }");
+        Assert.True(doc.TryGetSingleTable("ns:msg:db:row:scope:msgs:all", "ns:msg:db:table:kind:msgs", out MorkTable t));
+        MorkRow r = t.Rows["1"];
+        Assert.Equal("5", r.Cells["flags"]);
+        Assert.Equal("hello", r.Cells["subject"]); // atom ref resolved
+    }
+
+    [Fact]
+    public void Parse_DictOnly_NoTables()
+    {
+        MorkDocument doc = MorkReader.ParseString(Dict);
+        Assert.Empty(doc.Tables);
+    }
+
+    [Fact]
+    public void Parse_UnknownColumnAndScope_Preserved()
+    {
+        // unknown column atom F0=customThing, unknown table kind -> must NOT throw; preserved as strings
+        string src = "< (80=ns:msg:db:row:scope:msgs:all)(F0=customThing)(F1=ns:msg:db:table:kind:weird) >\n"
+                   + "{1:^80 {(k^F1:c)} [1(^F0=xyz)] }";
+        MorkDocument doc = MorkReader.ParseString(src);
+        MorkTable t = doc.Tables.Single();
+        Assert.Equal("ns:msg:db:table:kind:weird", t.Kind);
+        Assert.Equal("xyz", t.Rows["1"].Cells["customThing"]);
+    }
+
+    [Fact]
+    public void Parse_Charset_Latin1HighByteViaByteStream()
+    {
+        // charset hint iso-8859-1; subject value is the raw byte 0xE6 ('æ'). MUST use the byte path.
+        byte[] src = BuildLatin1Fixture(); // dict declares (f=iso-8859-1); row subject cell value = single 0xE6 byte
+        using var ms = new MemoryStream(src);
+        MorkDocument doc = MorkReader.Parse(ms);
+        Assert.Equal("æ", doc.Tables.Single().Rows["1"].Cells["subject"]);
+    }
+
+    [Fact]
+    public void Parse_MalformedStructure_Throws()
+    {
+        Assert.Throws<MorkFormatException>(() => MorkReader.ParseString("< (80=x) " /* unterminated dict */));
+    }
+
+    // Builds: "< <(a=c)> (f=iso-8859-1)(80=ns:...:msgs:all)(96=ns:...:kind:msgs)(81=subject) >{1:^80 {(k^96:c)} [1(^81=<0xE6>)]}"
+    // with the subject value being the single raw byte 0xE6 (NOT $-escaped) to exercise the byte path.
+    private static byte[] BuildLatin1Fixture()
+    {
+        string head = "< <(a=c)> (f=iso-8859-1)(80=ns:msg:db:row:scope:msgs:all)(96=ns:msg:db:table:kind:msgs)(81=subject) >\n{1:^80 {(k^96:c)} [1(^81=";
+        string tail = ")] }";
+        var bytes = new System.Collections.Generic.List<byte>();
+        bytes.AddRange(System.Text.Encoding.ASCII.GetBytes(head));
+        bytes.Add(0xE6);
+        bytes.AddRange(System.Text.Encoding.ASCII.GetBytes(tail));
+        return bytes.ToArray();
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Mork/MorkTokenizerTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mork/MorkTokenizerTests.cs
@@ -82,4 +82,41 @@ public class MorkTokenizerTests
     {
         Assert.Throws<MorkFormatException>(() => Toks("[1(^88=1)"));
     }
+
+    [Fact]
+    public void Tokenize_ValueWithSpace_PreservesSpace()
+    {
+        // (80=hello world) — the space between "hello" and "world" is literal value content.
+        // Must produce exactly one Text token containing the full string "hello world",
+        // not two separate Text tokens with the space discarded.
+        MorkToken[] t = Toks("(80=hello world)");
+        MorkToken[] valueTokens = t.Where(x => x.Kind == MorkTokenKind.Text && Encoding.ASCII.GetString(x.Bytes) == "hello world").ToArray();
+        Assert.Single(valueTokens);
+    }
+
+    [Fact]
+    public void Tokenize_ValueWithColon_ColonIsLiteralNotToken()
+    {
+        // (80=Re: hi) — the ':' inside the value is literal, NOT a Colon structural token.
+        MorkToken[] t = Toks("(80=Re: hi)");
+        // No standalone Colon token should exist
+        Assert.DoesNotContain(t, x => x.Kind == MorkTokenKind.Colon);
+        // The entire value should be in one Text token containing ':'
+        MorkToken txt = Assert.Single(t, x => x.Kind == MorkTokenKind.Text && Encoding.ASCII.GetString(x.Bytes).Contains(":"));
+        Assert.Equal("Re: hi", Encoding.ASCII.GetString(txt.Bytes));
+    }
+
+    [Fact]
+    public void Tokenize_EmptyValue_NoTextTokenBetweenEqualsAndParenClose()
+    {
+        // (^81=) — empty value after '=': must emit ParenOpen, AtomRef, Equals, ParenClose
+        // with NO Text token between Equals and ParenClose.
+        MorkToken[] t = Toks("(^81=)");
+        Assert.Equal(MorkTokenKind.ParenOpen,  t[0].Kind);
+        Assert.Equal(MorkTokenKind.AtomRef,    t[1].Kind);
+        Assert.Equal("81", Encoding.ASCII.GetString(t[1].Bytes));
+        Assert.Equal(MorkTokenKind.Equals,     t[2].Kind);
+        Assert.Equal(MorkTokenKind.ParenClose, t[3].Kind);
+        Assert.Equal(4, t.Length);
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Mork/MorkTokenizerTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mork/MorkTokenizerTests.cs
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Linq;
+using System.Text;
+using Mail2Pst.Core.Mork;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Mork;
+
+public class MorkTokenizerTests
+{
+    private static MorkToken[] Toks(string s) => new MorkTokenizer(Encoding.ASCII.GetBytes(s)).Tokenize().ToArray();
+
+    [Fact]
+    public void Tokenize_HeaderCommentAndWhitespace_Ignored()
+    {
+        // A // line comment and surrounding whitespace/newlines produce no tokens.
+        MorkToken[] t = Toks("// <!-- <mdb:mork:z v=\"1.4\"/> -->\n   \r\n");
+        Assert.Empty(t);
+    }
+
+    [Fact]
+    public void Tokenize_DictWithAtom_EmitsDelimitersAndText()
+    {
+        // < (80=flags) >  -> DictOpen, ParenOpen, Text 80, Equals, Text flags, ParenClose, DictClose
+        MorkToken[] t = Toks("< (80=flags) >");
+        Assert.Equal(MorkTokenKind.DictOpen, t.First().Kind);
+        Assert.Equal(MorkTokenKind.DictClose, t.Last().Kind);
+        Assert.Contains(t, x => x.Kind == MorkTokenKind.Text && Encoding.ASCII.GetString(x.Bytes) == "flags");
+        Assert.Contains(t, x => x.Kind == MorkTokenKind.Equals);
+    }
+
+    [Fact]
+    public void Tokenize_RowWithLiteralAndRefCells_EmitsGenericTokens()
+    {
+        // [1(^88=5)(^81^A0)] -> BracketOpen, Text 1, ParenOpen, AtomRef 88, Equals, Text 5, ParenClose,
+        //                       ParenOpen, AtomRef 81, AtomRef A0, ParenClose, BracketClose
+        MorkToken[] t = Toks("[1(^88=5)(^81^A0)]");
+        Assert.Equal(MorkTokenKind.BracketOpen, t[0].Kind);
+        Assert.Equal(MorkTokenKind.BracketClose, t[^1].Kind);
+        Assert.Contains(t, x => x.Kind == MorkTokenKind.AtomRef && Encoding.ASCII.GetString(x.Bytes) == "88");
+        Assert.Contains(t, x => x.Kind == MorkTokenKind.AtomRef && Encoding.ASCII.GetString(x.Bytes) == "A0");
+        Assert.Contains(t, x => x.Kind == MorkTokenKind.Text && Encoding.ASCII.GetString(x.Bytes) == "5");
+    }
+
+    [Fact]
+    public void Tokenize_RowCut_EmitsCutToken()
+    {
+        MorkToken[] t = Toks("[-1(^88=1)]");
+        Assert.Contains(t, x => x.Kind == MorkTokenKind.Cut);
+    }
+
+    [Fact]
+    public void Tokenize_TransactionGroupMarkers_Emitted()
+    {
+        // @$${1{@ ... @$$}1}@  -> GroupStart ... GroupCommit  (exact bytes per Task 0)
+        MorkToken[] t = Toks("@$${1{@ [1(^88=1)] @$$}1}@");
+        Assert.Contains(t, x => x.Kind == MorkTokenKind.GroupStart);
+        Assert.Contains(t, x => x.Kind == MorkTokenKind.GroupCommit);
+    }
+
+    [Fact]
+    public void Tokenize_DollarHexEscape_DecodesToByte()
+    {
+        // $E6 in a value contributes byte 0xE6
+        MorkToken[] t = Toks("(80=$E6)");
+        MorkToken txt = t.Last(x => x.Kind == MorkTokenKind.Text);
+        Assert.Equal(new byte[] { 0xE6 }, txt.Bytes);
+    }
+
+    [Fact]
+    public void Tokenize_BackslashEscape_LiteralChar()
+    {
+        // \) is a literal ')' inside a value
+        MorkToken[] t = Toks(@"(80=a\)b)");
+        MorkToken txt = t.Last(x => x.Kind == MorkTokenKind.Text);
+        Assert.Equal(Encoding.ASCII.GetBytes("a)b"), txt.Bytes);
+    }
+
+    [Fact]
+    public void Tokenize_UnterminatedRow_Throws()
+    {
+        Assert.Throws<MorkFormatException>(() => Toks("[1(^88=1)"));
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Mork/MorkValueDecoderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mork/MorkValueDecoderTests.cs
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Text;
+using Mail2Pst.Core.Mork;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Mork;
+
+public class MorkValueDecoderTests
+{
+    [Fact]
+    public void Decode_Latin1_HighByte_DecodesToChar()
+    {
+        // 0xE6 under ISO-8859-1 is 'æ'
+        string s = MorkValueDecoder.Decode(new byte[] { 0xE6 }, MorkValueDecoder.ResolveCharset("iso-8859-1"));
+        Assert.Equal("æ", s);
+    }
+
+    [Fact]
+    public void Decode_Utf8_MultiByteRun_DecodesAsWhole()
+    {
+        // 0xC3 0xA6 is 'æ' in UTF-8 — must decode the whole run, not byte-by-byte
+        string s = MorkValueDecoder.Decode(new byte[] { 0xC3, 0xA6 }, MorkValueDecoder.ResolveCharset(null));
+        Assert.Equal("æ", s);
+    }
+
+    [Fact]
+    public void Decode_AsciiRun_RoundTrips()
+    {
+        string s = MorkValueDecoder.Decode(Encoding.ASCII.GetBytes("flags"), MorkValueDecoder.ResolveCharset(null));
+        Assert.Equal("flags", s);
+    }
+
+    [Fact]
+    public void ResolveCharset_NullOrEmpty_DefaultsUtf8()
+    {
+        Assert.Equal(Encoding.UTF8.WebName, MorkValueDecoder.ResolveCharset(null).WebName);
+        Assert.Equal(Encoding.UTF8.WebName, MorkValueDecoder.ResolveCharset("").WebName);
+    }
+
+    [Fact]
+    public void ResolveCharset_Unknown_Throws()
+    {
+        Assert.Throws<MorkFormatException>(() => MorkValueDecoder.ResolveCharset("ebcdic-cp-us"));
+    }
+
+    [Fact]
+    public void Decode_InvalidUtf8_ThrowsMorkFormatException()
+    {
+        // 0xC3 0x28 is an invalid UTF-8 sequence — must fail loud, not emit a replacement char.
+        Assert.Throws<MorkFormatException>(() =>
+            MorkValueDecoder.Decode(new byte[] { 0xC3, 0x28 }, MorkValueDecoder.ResolveCharset("utf-8")));
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/MorkCorpusTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/MorkCorpusTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
 // SPDX-License-Identifier: GPL-3.0-or-later
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using Mail2Pst.Core.Mork;
@@ -24,7 +25,8 @@ public class MorkCorpusTests
         Assert.True(msgs.Rows.Count > 100, $"expected many rows, got {msgs.Rows.Count}");
         int unread = msgs.Rows.Values.Count(r =>
             r.TryGetCell("flags", out string f)
-            && (Convert.ToInt32(f, 16) & 0x1) == 0);
+            && int.TryParse(f, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out int fv)
+            && (fv & 0x1) == 0);
         Assert.True(unread > 0, "expected at least some unread rows (flags bit 0x1 clear)");
     }
 }

--- a/tests/Mail2Pst.Integration.Tests/MorkCorpusTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/MorkCorpusTests.cs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Mork;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests;
+
+public class MorkCorpusTests
+{
+    [SkippableFact]
+    public void RealMsf_Parses_AndHasReadUnreadMix()
+    {
+        string? path = Environment.GetEnvironmentVariable("MAIL2PST_MORK_CORPUS_MSF");
+        Skip.If(string.IsNullOrEmpty(path), "MAIL2PST_MORK_CORPUS_MSF not set");
+        Skip.IfNot(File.Exists(path), $"MAIL2PST_MORK_CORPUS_MSF points to a missing file: {path}");
+
+        MorkDocument doc = MorkReader.Parse(path!);
+        Assert.True(doc.TryGetSingleTable("ns:msg:db:row:scope:msgs:all", "ns:msg:db:table:kind:msgs", out MorkTable msgs));
+
+        // Aggregate-only. NEVER assert/print subject/sender text (PII).
+        Assert.True(msgs.Rows.Count > 100, $"expected many rows, got {msgs.Rows.Count}");
+        int unread = msgs.Rows.Values.Count(r =>
+            r.TryGetCell("flags", out string f)
+            && (Convert.ToInt32(f, 16) & 0x1) == 0);
+        Assert.True(unread > 0, "expected at least some unread rows (flags bit 0x1 clear)");
+    }
+}


### PR DESCRIPTION
## Why

Foundation for recovering real Thunderbird message-flag fidelity (read/unread, starred, replied, junk, tags). Thunderbird keeps that state in its per-folder `.msf` (Mork) index, NOT in the mbox — so for IMAP/EWS accounts an mbox-based conversion cannot recover it. Reading the `.msf` is the only mbox-side path. This PR is the first, isolated sub-project: a parser for the Mork format. No flag interpretation, no PST mapping, no profile discovery, no pipeline wiring yet.

## What

A read-only, strings-only **generic Mork reader** under `src/Mail2Pst.Core/Mork/` (public within Core; no CLI/GUI surface):

- `MorkValueDecoder` + `MorkFormatException` — strict charset / `$XX` byte-run decoding (invalid bytes fail loud).
- `MorkTokenizer` — purely lexical byte scanner (escape-resolving; delimiter-balance validation).
- Immutable `MorkDocument` / `MorkTable` / `MorkRow` (`ReadOnlyDictionary` snapshots).
- `MorkReader` assembler — drives the tokenizer and builds the document: resolves Mork's **two separate atom spaces** (column dict `<(a=c)>` vs value dicts, which reuse the same ids) by position, and applies **append-log merge** across transaction groups (row restate overwrites named cells, row-cut `[-id]` removes, delete-then-re-add recreates, last-write-wins).

Strict/fail-loud posture: structural corruption throws `MorkFormatException`; unknown tables/columns/cells are preserved as strings (not errors).

## Validation

- Synthetic, PII-free fixtures cover every construct (tokenizer escapes, atom resolution, the two atom spaces, merge cases, malformed -> throw).
- An env-gated (`MAIL2PST_MORK_CORPUS_MSF`, `[SkippableFact]`, aggregate-only, never asserts PII) test parses a real ~16k-message Gmail `INBOX.msf` and confirms the msgs table resolves by scope/kind with a real read/unread/starred mix. That real-corpus run is what surfaced the two-atom-space requirement that synthetic tests alone missed.

## Effect / scope

Internal parsing library only — **no change to any existing conversion behavior, no CLI/GUI surface, no release**. It is the foundation for later sub-projects (flag interpretation -> PST mapping -> live-profile discovery -> pipeline wiring). The vendored PST boundary is untouched; the Mork reader is project-native GPL-3.0 code that borrows parsing approach from the public-domain `knk106/MorkReader` (recorded in `NOTICE`).

No `CHANGELOG` entry: this sub-project has no user-facing effect; the changelog entry will come with the feature that exposes flag fidelity to users.
