### PR TITLE
fix(core): widen Mork charset support + robust column-dict detection

### DIFF
--- a/src/Mail2Pst.Core/Mail2Pst.Core.csproj
+++ b/src/Mail2Pst.Core/Mail2Pst.Core.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="10.0.9" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
     <PackageReference Include="MimeKit" Version="4.17.0" />
   </ItemGroup>
 </Project>

--- a/src/Mail2Pst.Core/Mork/MorkReader.cs
+++ b/src/Mail2Pst.Core/Mork/MorkReader.cs
@@ -233,21 +233,20 @@ internal sealed class MorkAssembler
     /// <summary>
     /// Peeks ahead without consuming tokens to determine whether this dict is a
     /// column dict. A dict is a column dict if an <c>(a=c)</c> marker appears
-    /// anywhere before the dict's first hex-id atom definition — whether as a nested
-    /// <c>&lt;(a=c)&gt;</c> sub-dict OR as an inline <c>(a=c)</c> cell.
-    /// The common Thunderbird real-corpus layout has the marker first (<c>&lt; &lt;(a=c)&gt; …&gt;</c>),
-    /// but <c>(a=c)</c> marks the column-atom space and may appear before (not only as)
-    /// the first cell — e.g. after a charset hint like <c>(f=iso-8859-1)</c>.
+    /// anywhere within it — whether as a nested <c>&lt;(a=c)&gt;</c> sub-dict OR as an
+    /// inline <c>(a=c)</c> cell — regardless of what atoms or charset hints precede it.
+    /// The common Thunderbird real-corpus layout has the marker first
+    /// (<c>&lt; &lt;(a=c)&gt; …&gt;</c>), but the marker may legitimately follow a charset
+    /// hint like <c>(f=iso-8859-1)</c> or even a hex-id atom definition, so the entire
+    /// dict span is scanned rather than stopping at the first atom.
     /// Returns true if the pattern is found; does NOT advance the cursor.
     /// </summary>
     private bool PeekIsColumnMarker()
     {
-        // Scan forward within this dict's token span (depth-tracked to stay inside)
-        // looking for either:
+        // Scan the whole dict token span (depth-tracked to stay inside) looking for either:
         //   (a) a nested DictOpen immediately followed by "(a=c)" then DictClose, OR
         //   (b) an inline paren-cell with key "a" and value "c".
-        // Stop and return false if we reach a hex-id atom definition first (which
-        // would mean the dict cannot be a column dict at that point).
+        // Reaching the dict's closing > without finding either → not a column dict.
         int p = _pos;
         int depth = 1; // we are already inside the outer DictOpen
 
@@ -282,30 +281,15 @@ internal sealed class MorkAssembler
 
             if (tok.Kind == MorkTokenKind.ParenOpen)
             {
-                // Peek at the cell inside the outer dict (depth == 1).
+                // Inline (a=c) marker at this dict's level → column dict.
                 if (depth == 1 && IsAcCell(p + 1, out _))
-                    return true; // inline (a=c) marker before a hex-id definition
+                    return true;
 
-                // If this is a hex-id atom definition, we stop scanning.
-                // A hex-id cell looks like: ParenOpen Text(hexId) Equals Text(value) ParenClose.
-                // The key must be all-hex and not "a" or "f".
-                if (depth == 1)
-                {
-                    int q = p + 1;
-                    if (q < _tokens.Count && _tokens[q].Kind == MorkTokenKind.Text)
-                    {
-                        string keyStr = Encoding.ASCII.GetString(_tokens[q].Bytes);
-                        if (IsHexId(keyStr)
-                            && !string.Equals(keyStr, "a", StringComparison.OrdinalIgnoreCase)
-                            && !string.Equals(keyStr, "f", StringComparison.OrdinalIgnoreCase))
-                        {
-                            // First hex-id atom reached without seeing (a=c) — not a column dict.
-                            return false;
-                        }
-                    }
-                }
-
-                // Skip past this paren cell without consuming.
+                // Any other cell (including a hex-id atom definition): skip it and keep
+                // scanning. We deliberately do NOT stop at the first hex-id — a column dict
+                // may define scope/kind/column atoms BEFORE its (a=c) marker, so the whole
+                // dict span must be scanned. Value dicts never contain (a=c), so they fall
+                // through to the end and return false (no false positives).
                 p = SkipParenPeek(p);
                 continue;
             }

--- a/src/Mail2Pst.Core/Mork/MorkValueDecoder.cs
+++ b/src/Mail2Pst.Core/Mork/MorkValueDecoder.cs
@@ -10,6 +10,15 @@ namespace Mail2Pst.Core.Mork;
 /// <summary>Decodes a Mork value's assembled byte run to a string using the active charset.</summary>
 internal static class MorkValueDecoder
 {
+    static MorkValueDecoder()
+    {
+        // Real Thunderbird profiles worldwide carry legacy code pages (windows-1252,
+        // shift_jis, big5, euc-jp, koi8-r, …) that .NET Core+ does NOT support out of the
+        // box. Registering the CodePages provider makes Encoding.GetEncoding resolve them
+        // so a non-ASCII/UTF-8 profile is readable instead of rejected at parse time.
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+    }
+
     private static readonly Encoding StrictUtf8 =
         new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
@@ -20,13 +29,31 @@ internal static class MorkValueDecoder
     public static Encoding ResolveCharset(string? hint)
     {
         if (string.IsNullOrWhiteSpace(hint)) return StrictUtf8;
-        return hint!.Trim().ToLowerInvariant() switch
+        string name = hint!.Trim().ToLowerInvariant();
+        switch (name)
         {
-            "utf-8" or "utf8" => StrictUtf8,
-            "iso-8859-1" or "latin1" => Encoding.Latin1,  // Latin1 maps every byte 0..255, so it never fails
-            "us-ascii" or "ascii" => StrictAscii,
-            _ => throw new MorkFormatException($"Unsupported Mork charset: '{hint}'"),
-        };
+            case "utf-8":
+            case "utf8":
+                return StrictUtf8;
+            case "iso-8859-1":
+            case "latin1":
+                return Encoding.Latin1;  // Latin1 maps every byte 0..255, so it never fails
+            case "us-ascii":
+            case "ascii":
+                return StrictAscii;
+        }
+
+        // Anything else: defer to the runtime (now incl. the CodePages provider), but keep
+        // the fail-loud posture — invalid byte sequences throw rather than becoming '?'.
+        // A genuinely unknown charset NAME surfaces as a MorkFormatException.
+        try
+        {
+            return Encoding.GetEncoding(name, EncoderFallback.ExceptionFallback, DecoderFallback.ExceptionFallback);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new MorkFormatException($"Unsupported Mork charset: '{hint}'", ex);
+        }
     }
 
     public static string Decode(IReadOnlyList<byte> bytes, Encoding charset)

--- a/tests/Mail2Pst.Core.Tests/Mork/MorkParseTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mork/MorkParseTests.cs
@@ -115,6 +115,25 @@ public class MorkParseTests
         Assert.Equal("5", t.Rows["1"].Cells["flags"]);
     }
 
+    [Fact]
+    public void Parse_ColumnDict_MarkerPrecededByHexIdAtom_StillRecognisedAsColumnDict()
+    {
+        // Regression for the Kimi review: a column dict where a hex-id atom definition
+        // (80=…scope…) appears BEFORE the <(a=c)> marker. The old "stop at first hex-id"
+        // heuristic in PeekIsColumnMarker returned false here, routing 80/96/88 into the
+        // VALUE map, so resolving the table scope ^80 in the COLUMN map threw.
+        // Format: < (80=…scope…) <(a=c)> (96=…kind…)(88=flags) > + table using ^80/^96/^88.
+        const string src =
+            "< (80=ns:msg:db:row:scope:msgs:all) <(a=c)> (96=ns:msg:db:table:kind:msgs)(88=flags) >\n"
+            + "{1:^80 {(k^96:c)} [1(^88=5)]}";
+        MorkDocument doc = MorkReader.ParseString(src);
+        Assert.True(
+            doc.TryGetSingleTable("ns:msg:db:row:scope:msgs:all", "ns:msg:db:table:kind:msgs", out MorkTable t),
+            $"Column dict not recognised — actual tables: [{string.Join(", ", doc.Tables.Select(x => $"scope={x.Scope} kind={x.Kind}"))}]");
+        Assert.Equal("ns:msg:db:row:scope:msgs:all", t.Scope);
+        Assert.Equal("5", t.Rows["1"].Cells["flags"]);
+    }
+
     // Builds: "< <(a=c)> (f=iso-8859-1)(80=ns:...:msgs:all)(96=ns:...:kind:msgs)(81=subject) >{1:^80 {(k^96:c)} [1(^81=<0xE6>)]}"
     // with the subject value being the single raw byte 0xE6 (NOT $-escaped) to exercise the byte path.
     private static byte[] BuildLatin1Fixture()

--- a/tests/Mail2Pst.Core.Tests/Mork/MorkValueDecoderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mork/MorkValueDecoderTests.cs
@@ -41,7 +41,37 @@ public class MorkValueDecoderTests
     [Fact]
     public void ResolveCharset_Unknown_Throws()
     {
-        Assert.Throws<MorkFormatException>(() => MorkValueDecoder.ResolveCharset("ebcdic-cp-us"));
+        // A genuinely non-existent charset name still fails loud. (Note: real code-page
+        // names like "ebcdic-cp-us" now resolve via the CodePages provider — see below.)
+        Assert.Throws<MorkFormatException>(() => MorkValueDecoder.ResolveCharset("definitely-not-a-real-charset"));
+    }
+
+    [Fact]
+    public void ResolveCharset_Windows1252_Resolves()
+    {
+        // windows-1252 is extremely common in real-world Thunderbird profiles but is NOT
+        // in the hand-written fast-path allowlist — it must resolve via the CodePages provider.
+        Assert.Equal("windows-1252", MorkValueDecoder.ResolveCharset("windows-1252").WebName);
+    }
+
+    [Fact]
+    public void Decode_Windows1252_HighByte_DecodesToChar()
+    {
+        // 0x80 under windows-1252 is the euro sign '€' (U+20AC) — not a control char as in Latin1.
+        string s = MorkValueDecoder.Decode(new byte[] { 0x80 }, MorkValueDecoder.ResolveCharset("windows-1252"));
+        Assert.Equal("€", s);
+    }
+
+    [Fact]
+    public void ResolveCharset_FallbackCharset_UsesExceptionFallback()
+    {
+        // Charsets resolved via the CodePages fallback path must keep the fail-loud posture:
+        // an invalid byte sequence throws rather than silently becoming a replacement char.
+        // Asserting the wired-up decoder fallback is premise-solid (it does not depend on
+        // which specific bytes a given code page leaves unmapped).
+        Encoding enc = MorkValueDecoder.ResolveCharset("shift_jis");
+        Assert.Equal("shift_jis", enc.WebName);
+        Assert.IsType<DecoderExceptionFallback>(enc.DecoderFallback);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem
External (Kimi 2.6) review of `src/Mail2Pst.Core/Mork` surfaced two verified correctness/robustness gaps in the Mork (`.msf`) reader:

1. **Charset coverage too narrow.** `ResolveCharset` accepted only `utf-8` / `iso-8859-1` / `us-ascii` and threw on everything else. A real-world Thunderbird profile with `(f=windows-1252)`, `(f=shift_jis)`, etc. would fail at parse time — the document couldn't be read at all.
2. **`PeekIsColumnMarker` misclassifies.** The "stop at the first hex-id atom" heuristic returned `false` as soon as it saw a hex-id cell before the `(a=c)` marker, so a column dict like `< (80=…scope…) <(a=c)> (88=flags) >` was routed into the value atom space and later column-ref resolution threw.

## Fix
1. Register the `CodePages` provider (new `System.Text.Encoding.CodePages` dependency) and defer any non-fast-path charset to `Encoding.GetEncoding` with **exception** encoder/decoder fallbacks. Real code pages now resolve; the **fail-loud** posture is preserved (unknown charset name → `MorkFormatException`; invalid byte sequence → throws, never `?`).
2. Drop the hex-id early-out in `PeekIsColumnMarker` so the whole dict span is scanned for the `(a=c)` marker. Value dicts never contain `(a=c)`, so the wider scan adds no false positives.

## Effect
Non-UTF-8/Latin1 Thunderbird profiles parse instead of throwing, and column dicts are detected regardless of atom/charset cells preceding the marker. Internal Core library — no user-facing surface, no CLI contract change.

## Tests
TDD (RED verified before each fix). 4 new tests (hex-id-before-marker column dict; windows-1252 resolve + decode; fallback-charset fail-loud wiring) + 1 updated (the old "unknown charset" test used `ebcdic-cp-us`, now a resolvable code page → switched to a genuinely-bogus name). Full suite green: **408 core + 27 integration (2 env-gated skips), 0 failures.** Release build + single-file self-contained sidecar publish both clean; staged sidecar exe boots (CodePages loads under single-file).

## Deferred (low-priority hardening, cannot trigger on real Thunderbird `.msf`)
Nested-brace skip in `ReadTable`; whitespace-before-cut in the tokenizer.