### PR TITLE
feat(core): .msf flag/column interpreter (SP2)

### DIFF
--- a/src/Mail2Pst.Core/Msf/MsfDiagnostic.cs
+++ b/src/Mail2Pst.Core/Msf/MsfDiagnostic.cs
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+
+namespace Mail2Pst.Core.Msf;
+
+/// <summary>A single non-fatal interpretation problem for one cell of one row.</summary>
+public sealed class MsfDiagnostic
+{
+    public string RowId { get; }
+    public string Column { get; }
+    public string RawValue { get; }
+    public string Reason { get; }
+
+    public MsfDiagnostic(string rowId, string column, string rawValue, string reason)
+    {
+        RowId = rowId ?? throw new ArgumentNullException(nameof(rowId));
+        Column = column ?? throw new ArgumentNullException(nameof(column));
+        RawValue = rawValue ?? throw new ArgumentNullException(nameof(rawValue));
+        Reason = reason ?? throw new ArgumentNullException(nameof(reason));
+    }
+}

--- a/src/Mail2Pst.Core/Msf/MsfMessage.cs
+++ b/src/Mail2Pst.Core/Msf/MsfMessage.cs
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Mail2Pst.Core.Msf;
+
+/// <summary>Immutable typed view of one Thunderbird msgs-table row. A faithful mirror — no reconciliation.</summary>
+public sealed class MsfMessage
+{
+    public string RowId { get; }
+    public MsfMessageFlags RawFlags { get; }
+    public int? JunkScore { get; }
+    public IReadOnlyList<string> Keywords { get; }
+    public int Label { get; }
+    public long? MsgOffset { get; }
+    public string? MessageId { get; }
+
+    public MsfMessage(
+        string rowId,
+        MsfMessageFlags rawFlags,
+        int? junkScore,
+        IReadOnlyList<string> keywords,
+        int label,
+        long? msgOffset,
+        string? messageId)
+    {
+        RowId = rowId ?? throw new ArgumentNullException(nameof(rowId));
+        if (keywords is null) throw new ArgumentNullException(nameof(keywords));
+        RawFlags = rawFlags;
+        JunkScore = junkScore;
+        Keywords = new ReadOnlyCollection<string>(keywords.ToList()); // defensive copy
+        Label = label;
+        MsgOffset = msgOffset;
+        MessageId = messageId;
+    }
+
+    public bool IsRead      => (RawFlags & MsfMessageFlags.Read) != 0;
+    public bool IsReplied   => (RawFlags & MsfMessageFlags.Replied) != 0;
+    public bool IsForwarded => (RawFlags & MsfMessageFlags.Forwarded) != 0;
+    public bool IsFlagged   => (RawFlags & MsfMessageFlags.Marked) != 0;
+    public bool IsExpunged  => (RawFlags & MsfMessageFlags.Expunged) != 0;
+    public bool IsJunk      => JunkScore >= 50;
+}

--- a/src/Mail2Pst.Core/Msf/MsfMessageFlags.cs
+++ b/src/Mail2Pst.Core/Msf/MsfMessageFlags.cs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+
+namespace Mail2Pst.Core.Msf;
+
+/// <summary>
+/// Thunderbird message flags bitfield, mirroring Mozilla's <c>nsMsgMessageFlags.h</c>.
+/// <see cref="LabelsMask"/> is named for completeness only; SP2 does not interpret it
+/// into a label (see the SP2 design's non-reconciliation rule).
+/// </summary>
+[Flags]
+public enum MsfMessageFlags : uint
+{
+    None       = 0u,
+    Read       = 0x00000001u,
+    Replied    = 0x00000002u,
+    Marked     = 0x00000004u,
+    Expunged   = 0x00000008u,
+    HasRe      = 0x00000010u,
+    Offline    = 0x00000080u,
+    Forwarded  = 0x00001000u,
+    New        = 0x00010000u,
+    LabelsMask = 0x0E000000u,
+    Attachment = 0x10000000u,
+}

--- a/src/Mail2Pst.Core/Msf/MsfMessageReader.cs
+++ b/src/Mail2Pst.Core/Msf/MsfMessageReader.cs
@@ -49,11 +49,27 @@ public static class MsfMessageReader
         MsfMessageFlags flags = ParseFlags(row, diagnostics);
         int? junkScore = ParseJunkScore(row, diagnostics);
         IReadOnlyList<string> keywords = ParseKeywords(row);
-        int label = 0;
+        int label = ParseLabel(row, diagnostics);
         long? msgOffset = null;
         string? messageId = null;
 
         return new MsfMessage(row.Id, flags, junkScore, keywords, label, msgOffset, messageId);
+    }
+
+    private static int ParseLabel(MorkRow row, List<MsfDiagnostic> diagnostics)
+    {
+        if (!row.TryGetCell("label", out string raw) || raw.Length == 0)
+        {
+            return 0;
+        }
+
+        if (int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out int value))
+        {
+            return value; // verbatim — no clamping (faithful mirror)
+        }
+
+        diagnostics.Add(new MsfDiagnostic(row.Id, "label", raw, "not a number"));
+        return 0;
     }
 
     private static IReadOnlyList<string> ParseKeywords(MorkRow row)

--- a/src/Mail2Pst.Core/Msf/MsfMessageReader.cs
+++ b/src/Mail2Pst.Core/Msf/MsfMessageReader.cs
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using Mail2Pst.Core.Mork;
+
+namespace Mail2Pst.Core.Msf;
+
+/// <summary>
+/// Interprets a generic <see cref="MorkDocument"/> into typed Thunderbird per-message metadata.
+/// Pure and in-memory: no I/O, no mbox join, no PST coupling.
+/// </summary>
+public static class MsfMessageReader
+{
+    internal const string MsgsScope = "ns:msg:db:row:scope:msgs:all";
+    internal const string MsgsKind  = "ns:msg:db:table:kind:msgs";
+
+    /// <summary>
+    /// Interprets the single msgs table in <paramref name="doc"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="doc"/> is null.</exception>
+    /// <exception cref="MorkFormatException">The document does not contain exactly one msgs table.</exception>
+    public static MsfReadResult Read(MorkDocument doc)
+    {
+        ArgumentNullException.ThrowIfNull(doc);
+
+        IReadOnlyList<MorkTable> tables = doc.GetTables(MsgsScope, MsgsKind);
+        if (tables.Count != 1)
+        {
+            throw new MorkFormatException(
+                $"Expected exactly one Thunderbird msgs table, found {tables.Count}.");
+        }
+
+        var messages = new List<MsfMessage>();
+        var diagnostics = new List<MsfDiagnostic>();
+        foreach (MorkRow row in tables[0].Rows.Values)
+        {
+            messages.Add(ReadRow(row, diagnostics));
+        }
+
+        return new MsfReadResult(messages, diagnostics);
+    }
+
+    // Diagnostic order is contractual: flags, junkscore, label, msgOffset.
+    private static MsfMessage ReadRow(MorkRow row, List<MsfDiagnostic> diagnostics)
+    {
+        MsfMessageFlags flags = MsfMessageFlags.None;
+        int? junkScore = null;
+        IReadOnlyList<string> keywords = Array.Empty<string>();
+        int label = 0;
+        long? msgOffset = null;
+        string? messageId = null;
+
+        return new MsfMessage(row.Id, flags, junkScore, keywords, label, msgOffset, messageId);
+    }
+}

--- a/src/Mail2Pst.Core/Msf/MsfMessageReader.cs
+++ b/src/Mail2Pst.Core/Msf/MsfMessageReader.cs
@@ -48,12 +48,29 @@ public static class MsfMessageReader
     {
         MsfMessageFlags flags = ParseFlags(row, diagnostics);
         int? junkScore = ParseJunkScore(row, diagnostics);
-        IReadOnlyList<string> keywords = Array.Empty<string>();
+        IReadOnlyList<string> keywords = ParseKeywords(row);
         int label = 0;
         long? msgOffset = null;
         string? messageId = null;
 
         return new MsfMessage(row.Id, flags, junkScore, keywords, label, msgOffset, messageId);
+    }
+
+    private static IReadOnlyList<string> ParseKeywords(MorkRow row)
+    {
+        if (!row.TryGetCell("keywords", out string raw) || raw.Length == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        var result = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (string token in raw.Split(' ')) // ASCII space only, by intent
+        {
+            if (token.Length == 0) continue;        // drop empties from consecutive/leading/trailing spaces
+            if (seen.Add(token)) result.Add(token); // ordinal dedupe, first wins, order preserved
+        }
+        return result;
     }
 
     private static int? ParseJunkScore(MorkRow row, List<MsfDiagnostic> diagnostics)

--- a/src/Mail2Pst.Core/Msf/MsfMessageReader.cs
+++ b/src/Mail2Pst.Core/Msf/MsfMessageReader.cs
@@ -3,6 +3,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Mail2Pst.Core.Mork;
 
 namespace Mail2Pst.Core.Msf;
@@ -45,7 +46,7 @@ public static class MsfMessageReader
     // Diagnostic order is contractual: flags, junkscore, label, msgOffset.
     private static MsfMessage ReadRow(MorkRow row, List<MsfDiagnostic> diagnostics)
     {
-        MsfMessageFlags flags = MsfMessageFlags.None;
+        MsfMessageFlags flags = ParseFlags(row, diagnostics);
         int? junkScore = null;
         IReadOnlyList<string> keywords = Array.Empty<string>();
         int label = 0;
@@ -53,5 +54,21 @@ public static class MsfMessageReader
         string? messageId = null;
 
         return new MsfMessage(row.Id, flags, junkScore, keywords, label, msgOffset, messageId);
+    }
+
+    private static MsfMessageFlags ParseFlags(MorkRow row, List<MsfDiagnostic> diagnostics)
+    {
+        if (!row.TryGetCell("flags", out string raw) || raw.Length == 0)
+        {
+            return MsfMessageFlags.None;
+        }
+
+        if (uint.TryParse(raw, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out uint value))
+        {
+            return (MsfMessageFlags)value;
+        }
+
+        diagnostics.Add(new MsfDiagnostic(row.Id, "flags", raw, "not valid hex"));
+        return MsfMessageFlags.None;
     }
 }

--- a/src/Mail2Pst.Core/Msf/MsfMessageReader.cs
+++ b/src/Mail2Pst.Core/Msf/MsfMessageReader.cs
@@ -50,10 +50,26 @@ public static class MsfMessageReader
         int? junkScore = ParseJunkScore(row, diagnostics);
         IReadOnlyList<string> keywords = ParseKeywords(row);
         int label = ParseLabel(row, diagnostics);
-        long? msgOffset = null;
+        long? msgOffset = ParseMsgOffset(row, diagnostics);
         string? messageId = null;
 
         return new MsfMessage(row.Id, flags, junkScore, keywords, label, msgOffset, messageId);
+    }
+
+    private static long? ParseMsgOffset(MorkRow row, List<MsfDiagnostic> diagnostics)
+    {
+        if (!row.TryGetCell("msgOffset", out string raw) || raw.Length == 0)
+        {
+            return null;
+        }
+
+        if (long.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out long value) && value >= 0)
+        {
+            return value;
+        }
+
+        diagnostics.Add(new MsfDiagnostic(row.Id, "msgOffset", raw, "not a non-negative integer"));
+        return null;
     }
 
     private static int ParseLabel(MorkRow row, List<MsfDiagnostic> diagnostics)

--- a/src/Mail2Pst.Core/Msf/MsfMessageReader.cs
+++ b/src/Mail2Pst.Core/Msf/MsfMessageReader.cs
@@ -47,13 +47,29 @@ public static class MsfMessageReader
     private static MsfMessage ReadRow(MorkRow row, List<MsfDiagnostic> diagnostics)
     {
         MsfMessageFlags flags = ParseFlags(row, diagnostics);
-        int? junkScore = null;
+        int? junkScore = ParseJunkScore(row, diagnostics);
         IReadOnlyList<string> keywords = Array.Empty<string>();
         int label = 0;
         long? msgOffset = null;
         string? messageId = null;
 
         return new MsfMessage(row.Id, flags, junkScore, keywords, label, msgOffset, messageId);
+    }
+
+    private static int? ParseJunkScore(MorkRow row, List<MsfDiagnostic> diagnostics)
+    {
+        if (!row.TryGetCell("junkscore", out string raw) || raw.Length == 0)
+        {
+            return null;
+        }
+
+        if (int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out int value))
+        {
+            return value;
+        }
+
+        diagnostics.Add(new MsfDiagnostic(row.Id, "junkscore", raw, "not a number"));
+        return null;
     }
 
     private static MsfMessageFlags ParseFlags(MorkRow row, List<MsfDiagnostic> diagnostics)

--- a/src/Mail2Pst.Core/Msf/MsfMessageReader.cs
+++ b/src/Mail2Pst.Core/Msf/MsfMessageReader.cs
@@ -51,9 +51,18 @@ public static class MsfMessageReader
         IReadOnlyList<string> keywords = ParseKeywords(row);
         int label = ParseLabel(row, diagnostics);
         long? msgOffset = ParseMsgOffset(row, diagnostics);
-        string? messageId = null;
+        string? messageId = ParseMessageId(row);
 
         return new MsfMessage(row.Id, flags, junkScore, keywords, label, msgOffset, messageId);
+    }
+
+    private static string? ParseMessageId(MorkRow row)
+    {
+        if (!row.TryGetCell("message-id", out string raw) || raw.Length == 0)
+        {
+            return null;
+        }
+        return raw; // verbatim — SP3 normalizes both sides before matching
     }
 
     private static long? ParseMsgOffset(MorkRow row, List<MsfDiagnostic> diagnostics)

--- a/src/Mail2Pst.Core/Msf/MsfReadResult.cs
+++ b/src/Mail2Pst.Core/Msf/MsfReadResult.cs
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Mail2Pst.Core.Msf;
+
+/// <summary>Result of interpreting a msgs table: typed messages plus any non-fatal diagnostics.</summary>
+public sealed class MsfReadResult
+{
+    public IReadOnlyList<MsfMessage> Messages { get; }
+    public IReadOnlyList<MsfDiagnostic> Diagnostics { get; }
+
+    public MsfReadResult(IReadOnlyList<MsfMessage> messages, IReadOnlyList<MsfDiagnostic> diagnostics)
+    {
+        if (messages is null) throw new ArgumentNullException(nameof(messages));
+        if (diagnostics is null) throw new ArgumentNullException(nameof(diagnostics));
+        Messages = new ReadOnlyCollection<MsfMessage>(messages.ToList());
+        Diagnostics = new ReadOnlyCollection<MsfDiagnostic>(diagnostics.ToList());
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Msf/MsfMessageReaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/MsfMessageReaderTests.cs
@@ -282,4 +282,65 @@ public class MsfMessageReaderTests
             MsfMessageReader.Read(MsgsDoc(Row("1", ("message-id", " abc@host ")))).Messages);
         Assert.Equal(" abc@host ", m.MessageId);
     }
+
+    [Fact]
+    public void Read_Diagnostics_MultipleBadCellsInOneRow_FixedColumnOrder()
+    {
+        // All four diagnostic-producing columns bad in one row.
+        MsfReadResult r = MsfMessageReader.Read(MsgsDoc(Row("R1",
+            ("flags", "zz"), ("junkscore", "x"), ("label", "y"), ("msgOffset", "-1"))));
+        Assert.Equal(
+            new[] { "flags", "junkscore", "label", "msgOffset" },
+            r.Diagnostics.Select(d => d.Column).ToArray());
+        Assert.All(r.Diagnostics, d => Assert.Equal("R1", d.RowId));
+    }
+
+    [Fact]
+    public void Read_NoReconciliation_ConflictingSignals_AllPreservedIndependently()
+    {
+        // flags has LabelsMask bits set AND legacy label=3 AND $label1 keyword AND NonJunk AND junkscore=100.
+        // SP2 must keep them all, independently — no cross-derivation, no suppression.
+        MsfMessage m = Assert.Single(MsfMessageReader.Read(MsgsDoc(Row("1",
+            ("flags", "2000000"),                 // a bit inside LabelsMask (0x0E000000)
+            ("label", "3"),
+            ("keywords", "$label1 NonJunk custom"),
+            ("junkscore", "100")))).Messages);
+
+        Assert.Equal((MsfMessageFlags)0x2000000u, m.RawFlags & MsfMessageFlags.LabelsMask);
+        Assert.Equal(3, m.Label);
+        Assert.Equal(new[] { "$label1", "NonJunk", "custom" }, m.Keywords);
+        Assert.Equal(100, m.JunkScore);
+        Assert.True(m.IsJunk);
+    }
+
+    [Fact]
+    public void Read_ParseStringSmoke_InterpretsMsgsTableCells()
+    {
+        // End-to-end through the real SP1 parser (production consumes MorkReader output).
+        // NOTE: in Mork, '$' starts a $XX hex escape, so a LITERAL '$' in a value is encoded $24
+        // ('$' == 0x24). Thus on-disk keywords "$label1 work" are written "$24label1 work"; SP2 sees
+        // the decoded "$label1 work". (A raw "$label1" in Mork source would throw MorkFormatException
+        // "Malformed $XX hex escape" — that is why the direct-construction tests above bypass parsing.)
+        const string columnDict =
+            "< <(a=c)> " +
+            "(80=ns:msg:db:row:scope:msgs:all)" +
+            "(96=ns:msg:db:table:kind:msgs)" +
+            "(88=flags)(81=message-id)(82=keywords)(83=junkscore)(84=label)(85=msgOffset) >\n";
+        const string table =
+            "{1:^80 {(k^96:c)} [D9D1(^88=5)(^81=abc@host)(^82=$24label1 work)(^83=50)(^84=3)(^85=123)] }";
+
+        MorkDocument doc = MorkReader.ParseString(columnDict + table);
+        MsfReadResult result = MsfMessageReader.Read(doc);
+        MsfMessage m = Assert.Single(result.Messages);
+
+        Assert.Equal("D9D1", m.RowId);
+        Assert.True(m.IsRead);
+        Assert.True(m.IsFlagged);
+        Assert.Equal("abc@host", m.MessageId);
+        Assert.Equal(new[] { "$label1", "work" }, m.Keywords);
+        Assert.True(m.IsJunk);
+        Assert.Equal(3, m.Label);
+        Assert.Equal(123L, m.MsgOffset);
+        Assert.Empty(result.Diagnostics);
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Msf/MsfMessageReaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/MsfMessageReaderTests.cs
@@ -197,4 +197,27 @@ public class MsfMessageReaderTests
             MsfMessageReader.Read(MsgsDoc(Row("1", ("keywords", "a\tb c")))).Messages);
         Assert.Equal(new[] { "a\tb", "c" }, m.Keywords);
     }
+
+    [Theory]
+    [InlineData("0", 0)]
+    [InlineData("3", 3)]
+    [InlineData("7", 7)]
+    [InlineData("9", 9)] // out-of-range but valid int — kept verbatim, not clamped
+    public void Read_Label_ParsedVerbatim(string raw, int expected)
+    {
+        MsfMessage m = Assert.Single(MsfMessageReader.Read(MsgsDoc(Row("1", ("label", raw)))).Messages);
+        Assert.Equal(expected, m.Label);
+    }
+
+    [Theory]
+    [InlineData("red")]           // non-numeric
+    [InlineData("99999999999")]   // overflow int
+    public void Read_Label_Invalid_ZeroPlusDiagnostic(string raw)
+    {
+        MsfReadResult r = MsfMessageReader.Read(MsgsDoc(Row("R1", ("label", raw))));
+        Assert.Equal(0, Assert.Single(r.Messages).Label);
+        MsfDiagnostic d = Assert.Single(r.Diagnostics);
+        Assert.Equal("label", d.Column);
+        Assert.Equal(raw, d.RawValue);
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Msf/MsfMessageReaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/MsfMessageReaderTests.cs
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mail2Pst.Core.Mork;
+using Mail2Pst.Core.Msf;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Msf;
+
+public class MsfMessageReaderTests
+{
+    // Reuse the production constants (internal, visible via InternalsVisibleTo) — no duplicated literals.
+    private const string MsgsScope = MsfMessageReader.MsgsScope;
+    private const string MsgsKind  = MsfMessageReader.MsgsKind;
+
+    // Build a MorkRow directly from (column, value) pairs — bypasses Mork syntax/escaping entirely.
+    private static MorkRow Row(string id, params (string col, string val)[] cells) =>
+        new MorkRow(id, cells.ToDictionary(c => c.col, c => c.val, StringComparer.Ordinal));
+
+    // A MorkDocument whose single table is the msgs table containing the given rows.
+    private static MorkDocument MsgsDoc(params MorkRow[] rows)
+    {
+        var dict = rows.ToDictionary(r => r.Id, r => r, StringComparer.Ordinal);
+        var table = new MorkTable("1", MsgsScope, MsgsKind, dict);
+        return new MorkDocument(new[] { table });
+    }
+
+    [Fact]
+    public void Read_NullDocument_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => MsfMessageReader.Read(null!));
+    }
+
+    [Fact]
+    public void Read_NoMsgsTable_ThrowsMorkFormatException()
+    {
+        var doc = new MorkDocument(Array.Empty<MorkTable>());
+        var ex = Assert.Throws<MorkFormatException>(() => MsfMessageReader.Read(doc));
+        Assert.Contains("found 0", ex.Message);
+    }
+
+    [Fact]
+    public void Read_TwoDistinctMsgsTables_ThrowsMorkFormatException()
+    {
+        // Two DISTINCT table ids with the same scope/kind — genuine ambiguity (not a restate/merge).
+        var t1 = new MorkTable("1", MsgsScope, MsgsKind,
+            new Dictionary<string, MorkRow> { ["A"] = Row("A") });
+        var t2 = new MorkTable("2", MsgsScope, MsgsKind,
+            new Dictionary<string, MorkRow> { ["B"] = Row("B") });
+        var doc = new MorkDocument(new[] { t1, t2 });
+        var ex = Assert.Throws<MorkFormatException>(() => MsfMessageReader.Read(doc));
+        Assert.Contains("found 2", ex.Message);
+    }
+
+    [Fact]
+    public void Read_Row_DefaultsWhenColumnsAbsent()
+    {
+        MsfReadResult result = MsfMessageReader.Read(MsgsDoc(Row("D9D1")));
+        MsfMessage m = Assert.Single(result.Messages);
+        Assert.Equal("D9D1", m.RowId);
+        Assert.Equal(MsfMessageFlags.None, m.RawFlags);
+        Assert.False(m.IsRead);
+        Assert.Null(m.JunkScore);
+        Assert.False(m.IsJunk);
+        Assert.Empty(m.Keywords);
+        Assert.Equal(0, m.Label);
+        Assert.Null(m.MsgOffset);
+        Assert.Null(m.MessageId);
+        Assert.Empty(result.Diagnostics);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Msf/MsfMessageReaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/MsfMessageReaderTests.cs
@@ -130,4 +130,38 @@ public class MsfMessageReaderTests
         Assert.Equal("flags", d.Column);
         Assert.Equal(raw, d.RawValue);
     }
+
+    [Theory]
+    [InlineData("0",   0,   false)]
+    [InlineData("49",  49,  false)]
+    [InlineData("50",  50,  true)]
+    [InlineData("100", 100, true)]
+    public void Read_JunkScore_ThresholdAt50(string raw, int expected, bool isJunk)
+    {
+        MsfMessage m = Assert.Single(MsfMessageReader.Read(MsgsDoc(Row("1", ("junkscore", raw)))).Messages);
+        Assert.Equal(expected, m.JunkScore);
+        Assert.Equal(isJunk, m.IsJunk);
+    }
+
+    [Fact]
+    public void Read_JunkScore_EmptyOrAbsent_NullNotJunk_NoDiagnostic()
+    {
+        var r = MsfMessageReader.Read(MsgsDoc(Row("1", ("junkscore", ""))));
+        MsfMessage m = Assert.Single(r.Messages);
+        Assert.Null(m.JunkScore);
+        Assert.False(m.IsJunk);
+        Assert.Empty(r.Diagnostics);
+    }
+
+    [Theory]
+    [InlineData("high")]          // non-numeric
+    [InlineData("99999999999")]   // overflow int
+    public void Read_JunkScore_Invalid_NullPlusDiagnostic(string raw)
+    {
+        MsfReadResult r = MsfMessageReader.Read(MsgsDoc(Row("R1", ("junkscore", raw))));
+        Assert.Null(Assert.Single(r.Messages).JunkScore);
+        MsfDiagnostic d = Assert.Single(r.Diagnostics);
+        Assert.Equal("junkscore", d.Column);
+        Assert.Equal(raw, d.RawValue);
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Msf/MsfMessageReaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/MsfMessageReaderTests.cs
@@ -248,4 +248,38 @@ public class MsfMessageReaderTests
         Assert.Null(Assert.Single(r.Messages).MsgOffset);
         Assert.Empty(r.Diagnostics);
     }
+
+    [Fact]
+    public void Read_MessageId_Verbatim_NoAngleBracketNormalization()
+    {
+        // Bare id (no angle brackets) is preserved exactly — SP3 owns normalization for joining.
+        MsfMessage m = Assert.Single(
+            MsfMessageReader.Read(MsgsDoc(Row("1", ("message-id", "abc@host")))).Messages);
+        Assert.Equal("abc@host", m.MessageId);
+    }
+
+    [Fact]
+    public void Read_MessageId_AngleBracketsPreservedAsStored()
+    {
+        MsfMessage m = Assert.Single(
+            MsfMessageReader.Read(MsgsDoc(Row("1", ("message-id", "<abc@host>")))).Messages);
+        Assert.Equal("<abc@host>", m.MessageId);
+    }
+
+    [Fact]
+    public void Read_MessageId_EmptyString_DefaultsToNull_NoDiagnostic()
+    {
+        var r = MsfMessageReader.Read(MsgsDoc(Row("1", ("message-id", ""))));
+        Assert.Null(Assert.Single(r.Messages).MessageId);
+        Assert.Empty(r.Diagnostics);
+    }
+
+    [Fact]
+    public void Read_MessageId_WhitespacePreservedVerbatim()
+    {
+        // "verbatim" really means verbatim — no trimming. Locks against a future "helpful" .Trim().
+        MsfMessage m = Assert.Single(
+            MsfMessageReader.Read(MsgsDoc(Row("1", ("message-id", " abc@host ")))).Messages);
+        Assert.Equal(" abc@host ", m.MessageId);
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Msf/MsfMessageReaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/MsfMessageReaderTests.cs
@@ -220,4 +220,32 @@ public class MsfMessageReaderTests
         Assert.Equal("label", d.Column);
         Assert.Equal(raw, d.RawValue);
     }
+
+    [Fact]
+    public void Read_MsgOffset_Parsed()
+    {
+        MsfMessage m = Assert.Single(MsfMessageReader.Read(MsgsDoc(Row("1", ("msgOffset", "12345")))).Messages);
+        Assert.Equal(12345L, m.MsgOffset);
+    }
+
+    [Theory]
+    [InlineData("-1")]                    // negative
+    [InlineData("99999999999999999999")]  // overflow long
+    [InlineData("xyz")]                    // non-numeric
+    public void Read_MsgOffset_Invalid_NullPlusDiagnostic(string raw)
+    {
+        MsfReadResult r = MsfMessageReader.Read(MsgsDoc(Row("R1", ("msgOffset", raw))));
+        Assert.Null(Assert.Single(r.Messages).MsgOffset);
+        MsfDiagnostic d = Assert.Single(r.Diagnostics);
+        Assert.Equal("msgOffset", d.Column);
+        Assert.Equal(raw, d.RawValue);
+    }
+
+    [Fact]
+    public void Read_MsgOffset_EmptyOrAbsent_Null_NoDiagnostic()
+    {
+        var r = MsfMessageReader.Read(MsgsDoc(Row("1", ("msgOffset", ""))));
+        Assert.Null(Assert.Single(r.Messages).MsgOffset);
+        Assert.Empty(r.Diagnostics);
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Msf/MsfMessageReaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/MsfMessageReaderTests.cs
@@ -164,4 +164,37 @@ public class MsfMessageReaderTests
         Assert.Equal("junkscore", d.Column);
         Assert.Equal(raw, d.RawValue);
     }
+
+    [Fact]
+    public void Read_Keywords_SplitDedupeCaseSensitivePreserveOrder()
+    {
+        MsfMessage m = Assert.Single(
+            MsfMessageReader.Read(MsgsDoc(Row("1", ("keywords", "$label1 work $label1 Work")))).Messages);
+        Assert.Equal(new[] { "$label1", "work", "Work" }, m.Keywords);
+    }
+
+    [Fact]
+    public void Read_Keywords_CollapsesEmptyTokensFromExtraSpaces()
+    {
+        MsfMessage m = Assert.Single(
+            MsfMessageReader.Read(MsgsDoc(Row("1", ("keywords", "  a   b ")))).Messages);
+        Assert.Equal(new[] { "a", "b" }, m.Keywords);
+    }
+
+    [Fact]
+    public void Read_Keywords_EmptyOrAbsent_Empty_NoDiagnostic()
+    {
+        var r = MsfMessageReader.Read(MsgsDoc(Row("1", ("keywords", ""))));
+        Assert.Empty(Assert.Single(r.Messages).Keywords);
+        Assert.Empty(r.Diagnostics);
+    }
+
+    [Fact]
+    public void Read_Keywords_TabIsPartOfToken_NotDelimiter()
+    {
+        // ASCII-space-only split BY INTENT: a tab stays inside the token.
+        MsfMessage m = Assert.Single(
+            MsfMessageReader.Read(MsgsDoc(Row("1", ("keywords", "a\tb c")))).Messages);
+        Assert.Equal(new[] { "a\tb", "c" }, m.Keywords);
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Msf/MsfMessageReaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/MsfMessageReaderTests.cs
@@ -129,6 +129,7 @@ public class MsfMessageReaderTests
         Assert.Equal("R1", d.RowId);
         Assert.Equal("flags", d.Column);
         Assert.Equal(raw, d.RawValue);
+        Assert.Equal("not valid hex", d.Reason);
     }
 
     [Theory]
@@ -221,11 +222,13 @@ public class MsfMessageReaderTests
         Assert.Equal(raw, d.RawValue);
     }
 
-    [Fact]
-    public void Read_MsgOffset_Parsed()
+    [Theory]
+    [InlineData("0",     0L)]
+    [InlineData("12345", 12345L)]
+    public void Read_MsgOffset_Parsed(string raw, long expected)
     {
-        MsfMessage m = Assert.Single(MsfMessageReader.Read(MsgsDoc(Row("1", ("msgOffset", "12345")))).Messages);
-        Assert.Equal(12345L, m.MsgOffset);
+        MsfMessage m = Assert.Single(MsfMessageReader.Read(MsgsDoc(Row("1", ("msgOffset", raw)))).Messages);
+        Assert.Equal(expected, m.MsgOffset);
     }
 
     [Theory]

--- a/tests/Mail2Pst.Core.Tests/Msf/MsfMessageReaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/MsfMessageReaderTests.cs
@@ -70,4 +70,64 @@ public class MsfMessageReaderTests
         Assert.Null(m.MessageId);
         Assert.Empty(result.Diagnostics);
     }
+
+    [Theory]
+    [InlineData("1",  true,  false, false, false, false)] // read
+    [InlineData("0",  false, false, false, false, false)] // unread
+    [InlineData("3",  true,  true,  false, false, false)] // read+replied
+    [InlineData("5",  true,  false, false, true,  false)] // read+marked
+    [InlineData("81", true,  false, false, false, false)] // read+offline
+    [InlineData("80", false, false, false, false, false)] // unread+offline
+    [InlineData("8",  false, false, false, false, true)]  // expunged
+    [InlineData("1000", false, false, true, false, false)] // forwarded
+    [InlineData("85", true,  false, false, true,  false)] // read+marked+offline
+    [InlineData("91", true,  false, false, false, false)] // read+hasRe+offline
+    [InlineData("93", true,  true,  false, false, false)] // read+replied+hasRe+offline
+    [InlineData("87", true,  true,  false, true,  false)] // read+replied+marked+offline
+    public void Read_Flags_Interpreted(string hex, bool read, bool replied, bool forwarded, bool marked, bool expunged)
+    {
+        MsfMessage m = Assert.Single(MsfMessageReader.Read(MsgsDoc(Row("1", ("flags", hex)))).Messages);
+        Assert.Equal(read,      m.IsRead);
+        Assert.Equal(replied,   m.IsReplied);
+        Assert.Equal(forwarded, m.IsForwarded);
+        Assert.Equal(marked,    m.IsFlagged);
+        Assert.Equal(expunged,  m.IsExpunged);
+    }
+
+    [Fact]
+    public void Read_Flags_UpperAndLowerHex_ParseSame()
+    {
+        var lower = Assert.Single(MsfMessageReader.Read(MsgsDoc(Row("1", ("flags", "ff")))).Messages);
+        var upper = Assert.Single(MsfMessageReader.Read(MsgsDoc(Row("1", ("flags", "FF")))).Messages);
+        Assert.Equal(upper.RawFlags, lower.RawFlags);
+        Assert.Equal((MsfMessageFlags)0xFFu, lower.RawFlags);
+    }
+
+    [Fact]
+    public void Read_Flags_UnknownBits_PreservedInRawFlags()
+    {
+        MsfMessage m = Assert.Single(MsfMessageReader.Read(MsgsDoc(Row("1", ("flags", "ffffffff")))).Messages);
+        Assert.Equal((MsfMessageFlags)0xFFFFFFFFu, m.RawFlags);
+    }
+
+    [Fact]
+    public void Read_Flags_EmptyOrAbsent_DefaultsToNone_NoDiagnostic()
+    {
+        var empty = MsfMessageReader.Read(MsgsDoc(Row("1", ("flags", ""))));
+        Assert.Equal(MsfMessageFlags.None, Assert.Single(empty.Messages).RawFlags);
+        Assert.Empty(empty.Diagnostics);
+    }
+
+    [Theory]
+    [InlineData("100000000")] // overflow > 0xFFFFFFFF
+    [InlineData("zz")]        // non-hex
+    public void Read_Flags_Invalid_DefaultsToNone_PlusDiagnostic(string raw)
+    {
+        MsfReadResult result = MsfMessageReader.Read(MsgsDoc(Row("R1", ("flags", raw))));
+        Assert.Equal(MsfMessageFlags.None, Assert.Single(result.Messages).RawFlags);
+        MsfDiagnostic d = Assert.Single(result.Diagnostics);
+        Assert.Equal("R1", d.RowId);
+        Assert.Equal("flags", d.Column);
+        Assert.Equal(raw, d.RawValue);
+    }
 }

--- a/tests/Mail2Pst.Integration.Tests/MsfCorpusTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/MsfCorpusTests.cs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Mork;
+using Mail2Pst.Core.Msf;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests;
+
+public class MsfCorpusTests
+{
+    [SkippableFact]
+    public void RealMsf_Interpreted_AggregateOnly()
+    {
+        string? path = Environment.GetEnvironmentVariable("MAIL2PST_MORK_CORPUS_MSF");
+        Skip.If(string.IsNullOrEmpty(path), "MAIL2PST_MORK_CORPUS_MSF not set");
+        Skip.IfNot(File.Exists(path), $"MAIL2PST_MORK_CORPUS_MSF points to a missing file: {path}");
+
+        MorkDocument doc = MorkReader.Parse(path!);
+        MsfReadResult result = MsfMessageReader.Read(doc);
+
+        // Core invariant: 1:1 with the msgs table rows — every row interpreted, none dropped/duplicated.
+        Assert.True(doc.TryGetSingleTable(
+            MsfMessageReader.MsgsScope, MsfMessageReader.MsgsKind, out MorkTable msgs));
+        Assert.Equal(msgs.Rows.Count, result.Messages.Count);
+        Assert.True(result.Messages.Count > 100, $"expected many messages, got {result.Messages.Count}");
+
+        // Sanity: at least one message has a recognised flag state (proves flags actually interpreted).
+        // Aggregate only — never assert/print PII (subject/sender).
+        Assert.Contains(result.Messages, m => m.IsRead);
+
+        // The read/unread MIX is a property of THIS known corpus (the same MAIL2PST_MORK_CORPUS_MSF
+        // fixture MorkCorpusTests already asserts has unread rows), not of `.msf` in general — an all-read
+        // folder is legitimate. Kept as a fixture expectation, not a universal invariant.
+        Assert.Contains(result.Messages, m => !m.IsRead);
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/MsfCorpusTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/MsfCorpusTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 using System;
 using System.IO;
-using System.Linq;
 using Mail2Pst.Core.Mork;
 using Mail2Pst.Core.Msf;
 using Xunit;


### PR DESCRIPTION
Adds `Mail2Pst.Core.Msf` — a pure, in-memory interpreter layered over the generic Mork reader (#8). It turns a `MorkDocument` into typed per-message Thunderbird metadata:

- read / replied / forwarded / flagged / expunged (from the `flags` bitfield)
- junk (`junkscore >= 50`), keywords, legacy `label`, `msgOffset`, `message-id`
- plus non-fatal `MsfDiagnostic`s for un-interpretable cells

**Faithful mirror:** strings-in, typed-out. No reconciliation between flag bits, the legacy label, and `$labelN` keywords — that decision is deferred to the join/mapping layer (SP3). Defensive per-cell (a bad cell → safe default + a diagnostic; structural problems throw). Pure and unit-testable: no I/O, no mbox join, no PST coupling.

**Tests:** synthetic-fixture unit tests for every column and edge case (flag combinations, junk threshold, keyword split/dedupe, verbatim message-id, diagnostic ordering, no-reconciliation), plus an env-gated aggregate real-corpus test. Full suite green.

Internal engine work toward Direction-2 (recover authoritative per-message flag/tag fidelity from Thunderbird `.msf`); the join + PST mapping land in SP3.
