### PR TITLE
feat(core): .msf join + Thunderbird tags to Outlook categories + junk/flag fidelity (SP3)

### DIFF
--- a/src/Mail2Pst.Core/Config/ConfigValidator.cs
+++ b/src/Mail2Pst.Core/Config/ConfigValidator.cs
@@ -17,6 +17,9 @@ public static class ConfigValidator
 {
     public static void Validate(ConversionConfig config)
     {
+        if (config.JunkHandling == JunkHandlingMode.Folder)
+            throw new ConfigValidationException("JunkHandling 'Folder' is not supported until SP4 (junk-folder routing is a pipeline concern). Use 'Off' or 'Category'.");
+
         if (config.Outputs is null || config.Outputs.Count == 0)
             throw new ConfigValidationException("Config has no outputs; at least one output group is required.");
 

--- a/src/Mail2Pst.Core/Config/ConversionConfig.cs
+++ b/src/Mail2Pst.Core/Config/ConversionConfig.cs
@@ -9,4 +9,5 @@ namespace Mail2Pst.Core.Config;
 public class ConversionConfig
 {
     public List<OutputGroupConfig> Outputs { get; set; } = new();
+    public JunkHandlingMode JunkHandling { get; set; } = JunkHandlingMode.Off;
 }

--- a/src/Mail2Pst.Core/Config/JunkHandlingMode.cs
+++ b/src/Mail2Pst.Core/Config/JunkHandlingMode.cs
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+namespace Mail2Pst.Core.Config;
+
+/// <summary>How .msf junk (junkscore >= 50) is emitted into the PST. Folder is modeled but
+/// not accepted until SP4 (folder routing is a pipeline concern).</summary>
+public enum JunkHandlingMode { Off, Category, Folder }

--- a/src/Mail2Pst.Core/Models/MailMessage.cs
+++ b/src/Mail2Pst.Core/Models/MailMessage.cs
@@ -30,5 +30,7 @@ public class MailMessage
     public bool IsReplied { get; set; } = false;
     public bool IsForwarded { get; set; } = false;
     public bool IsFlagged { get; set; } = false;
+    public bool IsJunk { get; set; } = false;
+    public List<string> Categories { get; set; } = new();
     public MailImportance Importance { get; set; } = MailImportance.Normal;
 }

--- a/src/Mail2Pst.Core/Msf/MessageIdNormalizer.cs
+++ b/src/Mail2Pst.Core/Msf/MessageIdNormalizer.cs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+namespace Mail2Pst.Core.Msf;
+
+/// <summary>
+/// Canonicalizes a Message-ID for joining: trims, treats blank as absent, and
+/// ensures angle brackets. Shared by the MIME mapper and the .msf joiner so both
+/// sides compare with identical normalization. Comparison is ordinal.
+/// </summary>
+public static class MessageIdNormalizer
+{
+    public static string? NormalizeForJoin(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        value = value.Trim();
+        if (value.StartsWith("<") && value.EndsWith(">")) return value;
+        return $"<{value}>";
+    }
+}

--- a/src/Mail2Pst.Core/Msf/MsfEnricher.cs
+++ b/src/Mail2Pst.Core/Msf/MsfEnricher.cs
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Models;
+
+namespace Mail2Pst.Core.Msf;
+
+public sealed class MsfEnrichmentOptions
+{
+    public IMsfTagResolver TagResolver { get; set; } = new DefaultMsfTagResolver();
+    public JunkHandlingMode JunkHandling { get; set; } = JunkHandlingMode.Off;
+}
+
+public sealed class MsfEnrichmentResult
+{
+    public int Matched { get; set; }
+    public int SkippedMissingId { get; set; }
+    public int SkippedDuplicateId { get; set; }
+    public int NoMsfMatch { get; set; }
+    public int ExpungedMatched { get; set; }
+}
+
+/// <summary>
+/// Joins .msf rows to MailMessages by uniquely-resolvable normalized Message-ID and applies
+/// the .msf's authoritative flags, junk, and tags. Pure; no I/O or file pairing (SP4 wires that).
+/// </summary>
+public static class MsfEnricher
+{
+    public static MsfEnrichmentResult Enrich(
+        IReadOnlyList<MailMessage> messages, MsfReadResult msf, MsfEnrichmentOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(messages);
+        ArgumentNullException.ThrowIfNull(msf);
+        ArgumentNullException.ThrowIfNull(options);
+        var result = new MsfEnrichmentResult();
+
+        // Index the .msf side by normalized id; mark non-unique keys.
+        var byId = new Dictionary<string, MsfMessage>(StringComparer.Ordinal);
+        var dupMsf = new HashSet<string>(StringComparer.Ordinal);
+        foreach (MsfMessage m in msf.Messages)
+        {
+            string? key = MessageIdNormalizer.NormalizeForJoin(m.MessageId);
+            if (key is null) continue;
+            if (!byId.TryAdd(key, m)) dupMsf.Add(key);
+        }
+        // Mark mbox-side duplicate keys too.
+        var mailKeyCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (MailMessage mail in messages)
+        {
+            string? key = MessageIdNormalizer.NormalizeForJoin(mail.MessageId);
+            if (key is not null) mailKeyCounts[key] = mailKeyCounts.GetValueOrDefault(key) + 1;
+        }
+
+        foreach (MailMessage mail in messages)
+        {
+            string? key = MessageIdNormalizer.NormalizeForJoin(mail.MessageId);
+            if (key is null) { result.SkippedMissingId++; continue; }
+            if (mailKeyCounts[key] > 1 || dupMsf.Contains(key)) { result.SkippedDuplicateId++; continue; }
+            if (!byId.TryGetValue(key, out MsfMessage? row)) { result.NoMsfMatch++; continue; }
+
+            // .msf wins for scalar flags.
+            mail.IsRead = row.IsRead;
+            mail.IsReplied = row.IsReplied;
+            mail.IsForwarded = row.IsForwarded;
+            mail.IsFlagged = row.IsFlagged;
+            mail.IsJunk = row.IsJunk;
+
+            var resolved = new List<string>(options.TagResolver.Resolve(row.Keywords));
+            if (options.JunkHandling == JunkHandlingMode.Category && row.IsJunk) resolved.Add("Junk");
+            MergeCategories(mail.Categories, resolved);
+
+            if (row.IsExpunged) result.ExpungedMatched++;
+            result.Matched++;
+        }
+        return result;
+    }
+
+    // Append new categories to existing, dedupe ordinal, preserve first occurrence; never remove.
+    private static void MergeCategories(List<string> existing, IReadOnlyList<string> additions)
+    {
+        var seen = new HashSet<string>(existing, StringComparer.Ordinal);
+        foreach (string c in additions) if (seen.Add(c)) existing.Add(c);
+    }
+}

--- a/src/Mail2Pst.Core/Msf/MsfEnricher.cs
+++ b/src/Mail2Pst.Core/Msf/MsfEnricher.cs
@@ -45,7 +45,8 @@ public static class MsfEnricher
         {
             string? key = MessageIdNormalizer.NormalizeForJoin(m.MessageId);
             if (key is null) continue;
-            if (!byId.TryAdd(key, m)) dupMsf.Add(key);
+            // On a duplicate, drop the first-seen entry too so byId and dupMsf stay consistent.
+            if (!byId.TryAdd(key, m)) { byId.Remove(key); dupMsf.Add(key); }
         }
         // Mark mbox-side duplicate keys too.
         var mailKeyCounts = new Dictionary<string, int>(StringComparer.Ordinal);

--- a/src/Mail2Pst.Core/Msf/MsfTagResolver.cs
+++ b/src/Mail2Pst.Core/Msf/MsfTagResolver.cs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Mail2Pst.Core.Msf;
+
+public interface IMsfTagResolver
+{
+    IReadOnlyList<string> Resolve(IReadOnlyList<string> keywords);
+}
+
+/// <summary>
+/// SP3 default: drop internal junk tokens, map the five built-in $labelN to Thunderbird's
+/// default tag names, pass custom tokens through, dedupe (ordinal, first wins). SP4 replaces
+/// this with prefs.js-backed resolution. (English defaults are a best guess; TB lets users
+/// rename/localize them — prefs.js is authoritative.)
+/// </summary>
+public sealed class DefaultMsfTagResolver : IMsfTagResolver
+{
+    private static readonly HashSet<string> Filtered = new(StringComparer.Ordinal) { "NonJunk" };
+    private static readonly Dictionary<string, string> Labels = new(StringComparer.Ordinal)
+    {
+        ["$label1"] = "Important", ["$label2"] = "Work", ["$label3"] = "Personal",
+        ["$label4"] = "To Do",     ["$label5"] = "Later",
+    };
+
+    public IReadOnlyList<string> Resolve(IReadOnlyList<string> keywords)
+    {
+        var result = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (string kw in keywords)
+        {
+            if (Filtered.Contains(kw)) continue;
+            string name = Labels.TryGetValue(kw, out string? mapped) ? mapped : kw;
+            if (seen.Add(name)) result.Add(name);
+        }
+        return result;
+    }
+}

--- a/src/Mail2Pst.Core/Parsing/Mime/MimeMessageMapper.cs
+++ b/src/Mail2Pst.Core/Parsing/Mime/MimeMessageMapper.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Msf;
 using MimeKit;
 
 namespace Mail2Pst.Core.Parsing.Mime;
@@ -59,10 +60,10 @@ public class MimeMessageMapper
             HtmlBody = mime.HtmlBody,
             Attachments = ExtractAttachments(mime, warnings),
             Source = sourceRef,
-            MessageId = EnsureAngleBrackets(mime.MessageId),
-            InReplyTo = EnsureAngleBrackets(mime.InReplyTo),
+            MessageId = MessageIdNormalizer.NormalizeForJoin(mime.MessageId),
+            InReplyTo = MessageIdNormalizer.NormalizeForJoin(mime.InReplyTo),
             References = mime.References.Count > 0
-                ? string.Join(" ", mime.References.Select(id => EnsureAngleBrackets(id)).OfType<string>())
+                ? string.Join(" ", mime.References.Select(id => MessageIdNormalizer.NormalizeForJoin(id)).OfType<string>())
                 : null,
             IsRead = ParseIsRead(mime, mozillaStatus),
             IsReplied = mozillaStatus is { } f1 && (f1 & MozillaStatusReplied) != 0,
@@ -121,14 +122,6 @@ public class MimeMessageMapper
             return status.Contains('R', StringComparison.OrdinalIgnoreCase);
 
         return true;
-    }
-
-    private static string? EnsureAngleBrackets(string? value)
-    {
-        if (string.IsNullOrWhiteSpace(value)) return null;
-        value = value.Trim();
-        if (value.StartsWith("<") && value.EndsWith(">")) return value;
-        return $"<{value}>";
     }
 
     /// <summary>

--- a/src/Mail2Pst.Core/Writing/PstWriter.cs
+++ b/src/Mail2Pst.Core/Writing/PstWriter.cs
@@ -476,6 +476,12 @@ public class PstWriter
             note.PC.SetDateTimeProperty(PropertyID.PidTagLastVerbExecutionTime, LastVerbTime(message));
         }
 
+        if (message.Categories.Count > 0)
+        {
+            ushort keywordsId = PSTFileFormat.PropertyNameToIDMap.GetOrCreateStringNamedProperty(file, 2, "Keywords");
+            note.PC.SetMultiStringProperty((PSTFileFormat.PropertyID)keywordsId, message.Categories);
+        }
+
         note.SaveChanges();
         folder.AddMessage(note);
         folder.SaveChanges();

--- a/tests/Mail2Pst.Core.Tests/Config/JunkHandlingConfigTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Config/JunkHandlingConfigTests.cs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Collections.Generic;
+using Mail2Pst.Core.Config;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Config;
+
+public class JunkHandlingConfigTests
+{
+    private static ConversionConfig Base(JunkHandlingMode junk) => new()
+    {
+        JunkHandling = junk,
+        Outputs = new List<OutputGroupConfig>
+        {
+            new() { Name = "P", MaxSizeMB = 100, FolderMapping = FolderMappingMode.Mirror,
+                    Sources = new List<SourceConfig> { new() { Type = "mbox", Path = "x.mbox" } } },
+        },
+    };
+
+    [Fact]
+    public void Default_IsOff()
+        => Assert.Equal(JunkHandlingMode.Off, new ConversionConfig().JunkHandling);
+
+    [Theory]
+    [InlineData(JunkHandlingMode.Off)]
+    [InlineData(JunkHandlingMode.Category)]
+    public void OffAndCategory_AreAccepted(JunkHandlingMode junk)
+        => ConfigValidator.Validate(Base(junk)); // does not throw
+
+    [Fact]
+    public void Folder_IsRejected_UntilSp4()
+    {
+        var ex = Assert.Throws<ConfigValidationException>(() => ConfigValidator.Validate(Base(JunkHandlingMode.Folder)));
+        Assert.Contains("Folder", ex.Message);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Msf/MessageIdNormalizerTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/MessageIdNormalizerTests.cs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using Mail2Pst.Core.Msf;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Msf;
+
+public class MessageIdNormalizerTests
+{
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    [InlineData("   ", null)]
+    [InlineData("<abc@host>", "<abc@host>")]
+    [InlineData("abc@host", "<abc@host>")]
+    [InlineData("  abc@host  ", "<abc@host>")]
+    public void NormalizeForJoin_Cases(string? input, string? expected)
+        => Assert.Equal(expected, MessageIdNormalizer.NormalizeForJoin(input));
+}

--- a/tests/Mail2Pst.Core.Tests/Msf/MsfEnricherTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/MsfEnricherTests.cs
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Collections.Generic;
+using System.Linq;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Mork;
+using Mail2Pst.Core.Msf;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Msf;
+
+public class MsfEnricherTests
+{
+    private const string MsgsScope = MsfMessageReader.MsgsScope;
+    private const string MsgsKind  = MsfMessageReader.MsgsKind;
+
+    private static MorkRow Row(string id, params (string col, string val)[] cells) =>
+        new MorkRow(id, cells.ToDictionary(c => c.col, c => c.val, System.StringComparer.Ordinal));
+
+    private static MsfReadResult Msf(params MorkRow[] rows)
+    {
+        var dict = rows.ToDictionary(r => r.Id, r => r, System.StringComparer.Ordinal);
+        var table = new MorkTable("1", MsgsScope, MsgsKind, dict);
+        return MsfMessageReader.Read(new MorkDocument(new[] { table }));
+    }
+
+    private static MsfEnrichmentOptions Opts(JunkHandlingMode junk = JunkHandlingMode.Off) =>
+        new() { TagResolver = new DefaultMsfTagResolver(), JunkHandling = junk };
+
+    [Fact]
+    public void UniqueMatch_OverridesFlags_SetsJunk_AddsCategories()
+    {
+        var mail = new MailMessage { MessageId = "<a@h>", IsRead = false, IsFlagged = false };
+        // flags 5 = read+marked; junkscore 80; keywords "$label1 work".
+        // Cells are built directly here (no Mork tokenizer), so the literal "$label1" is fine — no $24 escape.
+        MsfReadResult msf = Msf(Row("1", ("message-id", "a@h"), ("flags", "5"),
+            ("junkscore", "80"), ("keywords", "$label1 work")));
+
+        var result = MsfEnricher.Enrich(new[] { mail }, msf, Opts());
+
+        Assert.Equal(1, result.Matched);
+        Assert.True(mail.IsRead);
+        Assert.True(mail.IsFlagged);
+        Assert.True(mail.IsJunk);
+        Assert.Equal(new[] { "Important", "work" }, mail.Categories); // $label1 -> Important, NonJunk filtered, dedup
+    }
+
+    [Fact]
+    public void DuplicateId_OnMsfSide_SkipsAll_NoEnrichment()
+    {
+        var mail = new MailMessage { MessageId = "<dup@h>", IsRead = false };
+        MsfReadResult msf = Msf(
+            Row("1", ("message-id", "dup@h"), ("flags", "1")),
+            Row("2", ("message-id", "dup@h"), ("flags", "1")));
+        var result = MsfEnricher.Enrich(new[] { mail }, msf, Opts());
+        Assert.Equal(0, result.Matched);
+        Assert.Equal(1, result.SkippedDuplicateId);
+        Assert.False(mail.IsRead); // untouched
+    }
+
+    [Fact]
+    public void MissingId_IsSkipped_AndCounted()
+    {
+        var mail = new MailMessage { MessageId = null, IsRead = false };
+        MsfReadResult msf = Msf(Row("1", ("message-id", "x@h"), ("flags", "1")));
+        var result = MsfEnricher.Enrich(new[] { mail }, msf, Opts());
+        Assert.Equal(0, result.Matched);
+        Assert.Equal(1, result.SkippedMissingId);
+        Assert.False(mail.IsRead);
+    }
+
+    [Fact]
+    public void NoMsfMatch_LeavesMessageUnchanged()
+    {
+        var mail = new MailMessage { MessageId = "<nomatch@h>", IsRead = false };
+        MsfReadResult msf = Msf(Row("1", ("message-id", "other@h"), ("flags", "1")));
+        var result = MsfEnricher.Enrich(new[] { mail }, msf, Opts());
+        Assert.Equal(1, result.NoMsfMatch);
+        Assert.False(mail.IsRead);
+    }
+
+    [Fact]
+    public void JunkCategoryMode_AddsJunkCategory_WhenJunk()
+    {
+        var mail = new MailMessage { MessageId = "<j@h>" };
+        MsfReadResult msf = Msf(Row("1", ("message-id", "j@h"), ("junkscore", "90"), ("keywords", "work")));
+        MsfEnricher.Enrich(new[] { mail }, msf, Opts(JunkHandlingMode.Category));
+        Assert.Contains("Junk", mail.Categories);
+        Assert.Contains("work", mail.Categories);
+    }
+
+    [Fact]
+    public void JunkOffMode_DoesNotAddJunkCategory()
+    {
+        var mail = new MailMessage { MessageId = "<j2@h>" };
+        MsfReadResult msf = Msf(Row("1", ("message-id", "j2@h"), ("junkscore", "90")));
+        MsfEnricher.Enrich(new[] { mail }, msf, Opts(JunkHandlingMode.Off));
+        Assert.True(mail.IsJunk);
+        Assert.DoesNotContain("Junk", mail.Categories);
+    }
+
+    [Fact]
+    public void ExpungedMatchedRow_IsKept_AndCounted()
+    {
+        var mail = new MailMessage { MessageId = "<e@h>", IsRead = false };
+        MsfReadResult msf = Msf(Row("1", ("message-id", "e@h"), ("flags", "9"))); // 0x9 = read+expunged
+        var result = MsfEnricher.Enrich(new[] { mail }, msf, Opts());
+        Assert.Equal(1, result.Matched);
+        Assert.Equal(1, result.ExpungedMatched);
+        Assert.True(mail.IsRead); // still enriched, not dropped
+    }
+
+    [Fact]
+    public void CategoriesMergeWithExisting_DedupePreservingFirst()
+    {
+        var mail = new MailMessage { MessageId = "<m@h>", Categories = { "work", "keep" } };
+        MsfReadResult msf = Msf(Row("1", ("message-id", "m@h"), ("keywords", "work newtag")));
+        MsfEnricher.Enrich(new[] { mail }, msf, Opts());
+        Assert.Equal(new[] { "work", "keep", "newtag" }, mail.Categories);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Msf/MsfEnricherTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/MsfEnricherTests.cs
@@ -60,6 +60,19 @@ public class MsfEnricherTests
     }
 
     [Fact]
+    public void DuplicateId_OnMboxSide_SkipsAll()
+    {
+        var mail1 = new MailMessage { MessageId = "<dup@h>", IsRead = false };
+        var mail2 = new MailMessage { MessageId = "<dup@h>", IsRead = false };
+        MsfReadResult msf = Msf(Row("1", ("message-id", "dup@h"), ("flags", "1")));
+        var result = MsfEnricher.Enrich(new[] { mail1, mail2 }, msf, Opts());
+        Assert.Equal(0, result.Matched);
+        Assert.Equal(2, result.SkippedDuplicateId);
+        Assert.False(mail1.IsRead); // both untouched
+        Assert.False(mail2.IsRead);
+    }
+
+    [Fact]
     public void MissingId_IsSkipped_AndCounted()
     {
         var mail = new MailMessage { MessageId = null, IsRead = false };

--- a/tests/Mail2Pst.Core.Tests/Vendor/StringNamedPropertyTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Vendor/StringNamedPropertyTests.cs
@@ -22,4 +22,66 @@ public class StringNamedPropertyTests
         Assert.Throws<System.IO.InvalidDataException>(
             () => PropertyContext.DeserializeMultiString(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }));
     }
+
+    [Fact]
+    public void Keywords_StringNamedProp_Registers_RoundTrips_AndIsIdempotent()
+    {
+        string dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "mail2pst-sp3-" + System.Guid.NewGuid());
+        System.IO.Directory.CreateDirectory(dir);
+        string path = System.IO.Path.Combine(dir, "t.pst");
+        string template = System.IO.Path.Combine(System.AppContext.BaseDirectory, "assets", "template.pst");
+        System.IO.File.Copy(template, path);
+        ushort writtenId;
+        var categories = new System.Collections.Generic.List<string> { "Thunderbird", "Important", "Ældre" };
+        try
+        {
+            var file = new PSTFile(path, System.IO.FileAccess.ReadWrite);
+            file.BeginSavingChanges();
+            PSTFolder folder = file.TopOfPersonalFolders.CreateChildFolder("Inbox", FolderItemTypeName.Note);
+            writtenId = PropertyNameToIDMap.GetOrCreateStringNamedProperty(file, 2, "Keywords");
+            // idempotent: second call returns the same id, does not double-register
+            Assert.Equal(writtenId, PropertyNameToIDMap.GetOrCreateStringNamedProperty(file, 2, "Keywords"));
+            Note note = Note.CreateNewNote(file, folder.NodeID);
+            note.Subject = "probe";
+            note.PC.SetMultiStringProperty((PropertyID)writtenId, categories);
+            note.SaveChanges();
+            folder.AddMessage(note); folder.SaveChanges();
+            file.EndSavingChanges(); file.CloseFile();
+
+            var reopened = new PSTFile(path, System.IO.FileAccess.Read);
+            try
+            {
+                ushort? resolved = PropertyNameToIDMap.ResolveStringNamedProperty(reopened, 2, "Keywords");
+                Assert.True(resolved.HasValue);
+                Assert.Equal(writtenId, resolved!.Value);
+                var inbox = (MailFolder)reopened.TopOfPersonalFolders.FindChildFolder("Inbox")!;
+                Note readBack = inbox.GetNote(0);
+                PropertyContextRecord rec = readBack.PC.GetRecordByPropertyID((PropertyID)resolved.Value);
+                Assert.NotNull(rec);
+                Assert.Equal(PropertyTypeName.PtypMultiString, rec.wPropType);
+                Assert.Equal(categories, PropertyContext.DeserializeMultiString(readBack.PC.GetExternalRecordData(rec)));
+
+                // Lock the corrected hash-bucket index (the spike's key finding): the CRC-keyed string
+                // NameID for "Keywords" must sit at (crc ^ ((2<<1)|1)) % bucketCount — NOT the vendored
+                // off-by-one (N+wGuid)<<1. A broken bucket write would still pass the stream-scan resolve above.
+                PSTNode mapNode = reopened.GetNode((uint)InternalNodeName.NID_NAME_TO_ID_MAP);
+                byte[] nameBytes = System.Text.Encoding.Unicode.GetBytes("Keywords");
+                uint crc = PSTCRCCalculation.ComputeCRC(nameBytes, nameBytes.Length);
+                int bucketCount = mapNode.PC.GetInt32Property(PropertyID.PidTagNameidBucketCount)!.Value;
+                ushort bucketIndex = (ushort)((crc ^ (uint)((2 << 1) | 1)) % (uint)bucketCount);
+                var bucketProp = (PropertyID)((uint)PropertyID.PidTagNameidBucketBase + bucketIndex);
+                byte[] bucket = mapNode.PC.GetBytesProperty(bucketProp) ?? System.Array.Empty<byte>();
+                bool found = false;
+                for (int i = 0; i + NameID.Length <= bucket.Length; i += NameID.Length)
+                {
+                    var nid = new NameID(bucket, i);
+                    if (nid.IsStringIdentifier && nid.dwPropertyID == crc && nid.wGuid == 2 &&
+                        nid.wPropIdx == (ushort)(writtenId - 0x8000)) { found = true; break; }
+                }
+                Assert.True(found, "CRC-keyed \"Keywords\" string NameID must be in the bucket at the corrected index");
+            }
+            finally { reopened.CloseFile(); }
+        }
+        finally { try { System.IO.Directory.Delete(dir, true); } catch { } }
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Vendor/StringNamedPropertyTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Vendor/StringNamedPropertyTests.cs
@@ -15,4 +15,11 @@ public class StringNamedPropertyTests
         byte[] blob = PropertyContext.SerializeMultiString(values);
         Assert.Equal(values, PropertyContext.DeserializeMultiString(blob));
     }
+
+    [Fact]
+    public void MultiString_Deserializer_RejectsOversizedCount()
+    {
+        Assert.Throws<System.IO.InvalidDataException>(
+            () => PropertyContext.DeserializeMultiString(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }));
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Vendor/StringNamedPropertyTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Vendor/StringNamedPropertyTests.cs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Collections.Generic;
+using PSTFileFormat;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Vendor;
+
+public class StringNamedPropertyTests
+{
+    [Fact]
+    public void MultiString_Serializer_RoundTrips_IncludingNonAscii()
+    {
+        var values = new List<string> { "Work", "Important", "Ældre" };
+        byte[] blob = PropertyContext.SerializeMultiString(values);
+        Assert.Equal(values, PropertyContext.DeserializeMultiString(blob));
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/CategoryRoundTripTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/CategoryRoundTripTests.cs
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Mork;
+using Mail2Pst.Core.Msf;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests;
+
+public class CategoryRoundTripTests
+{
+    private static string NewOutDir()
+    {
+        string d = Path.Combine(Path.GetTempPath(), "mail2pst-cat-" + Guid.NewGuid());
+        Directory.CreateDirectory(d);
+        return d;
+    }
+
+    [Fact]
+    public void Categories_RoundTrip_IncludingNonAscii_AndFlagsPreserved()
+    {
+        var msgs = new List<MailMessage>
+        {
+            new() { MessageId = "<c1@h>", Subject = "one", IsRead = true, IsFlagged = true,
+                    Categories = { "Work", "Important", "Ældre" } },
+            new() { MessageId = "<c2@h>", Subject = "two", Categories = { "Junk" } },
+            new() { MessageId = "<c3@h>", Subject = "three" }, // no categories
+        };
+        string outDir = NewOutDir();
+        try
+        {
+            var outputs = RoundTripHarness.ConvertMessages(msgs, outDir);
+            IReadOnlyList<ReadBackMessage> read = PstReader.Read(outputs).SelectMany(f => f.Messages).ToList();
+            ReadBackMessage By(string id) => read.Single(m => m.MessageId == id);
+
+            Assert.Equal(new[] { "Work", "Important", "Ældre" }, By("<c1@h>").Categories);
+            Assert.True(By("<c1@h>").IsRead);
+            Assert.True(By("<c1@h>").IsFlagged);
+            Assert.Equal(new[] { "Junk" }, By("<c2@h>").Categories);
+            Assert.Empty(By("<c3@h>").Categories);
+        }
+        finally { Directory.Delete(outDir, true); }
+    }
+
+    [Fact]
+    public void JunkCategory_AddedByEnricher_RoundTrips()
+    {
+        // Proves the SP3 path end-to-end: the ENRICHER adds "Junk" (JunkHandling.Category), not a manual preload.
+        var mail = new MailMessage { MessageId = "<jr@h>", Subject = "junky" };
+        var row = new MorkRow("1", new Dictionary<string, string>(StringComparer.Ordinal)
+            { ["message-id"] = "jr@h", ["junkscore"] = "90", ["keywords"] = "work" });
+        var table = new MorkTable("1", MsfMessageReader.MsgsScope, MsfMessageReader.MsgsKind,
+            new Dictionary<string, MorkRow> { ["1"] = row });
+        MsfReadResult msf = MsfMessageReader.Read(new MorkDocument(new[] { table }));
+
+        MsfEnricher.Enrich(new[] { mail }, msf,
+            new MsfEnrichmentOptions { JunkHandling = JunkHandlingMode.Category });
+
+        string outDir = NewOutDir();
+        try
+        {
+            var outputs = RoundTripHarness.ConvertMessages(new[] { mail }, outDir);
+            ReadBackMessage read = PstReader.Read(outputs).SelectMany(f => f.Messages).Single();
+            Assert.Contains("Junk", read.Categories);
+            Assert.Contains("work", read.Categories);
+        }
+        finally { Directory.Delete(outDir, true); }
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/PstReader.cs
+++ b/tests/Mail2Pst.Integration.Tests/PstReader.cs
@@ -25,7 +25,8 @@ public sealed record ReadBackMessage(
     bool IsRead,
     bool IsReplied,
     bool IsForwarded,
-    bool IsFlagged);
+    bool IsFlagged,
+    IReadOnlyList<string> Categories);
 
 public sealed record ReadFolder(IReadOnlyList<string> Path, IReadOnlyList<ReadBackMessage> Messages)
 {
@@ -52,8 +53,9 @@ public static class PstReader
             var pst = new PSTFile(path, FileAccess.Read);
             try
             {
+                ushort? keywordsId = PSTFileFormat.PropertyNameToIDMap.ResolveStringNamedProperty(pst, 2, "Keywords");
                 foreach (PSTFolder folder in pst.TopOfPersonalFolders.GetChildFolders())
-                    ReadFolderRecursive(folder, new List<string>(), byKey, order);
+                    ReadFolderRecursive(folder, new List<string>(), byKey, order, keywordsId);
             }
             finally { pst.CloseFile(); }
         }
@@ -63,7 +65,8 @@ public static class PstReader
 
     private static void ReadFolderRecursive(
         PSTFolder folder, List<string> parentPath,
-        Dictionary<string, (List<string> Path, List<ReadBackMessage> Msgs)> byKey, List<string> order)
+        Dictionary<string, (List<string> Path, List<ReadBackMessage> Msgs)> byKey, List<string> order,
+        ushort? keywordsId)
     {
         var path = new List<string>(parentPath) { folder.DisplayName };
         string key = FolderPathKey.Join(path);
@@ -77,7 +80,7 @@ public static class PstReader
                 order.Add(key);
             }
             for (int i = 0; i < mf.MessageCount; i++)
-                entry.Msgs.Add(ReadNote(mf.GetNote(i)));
+                entry.Msgs.Add(ReadNote(mf.GetNote(i), keywordsId));
         }
         else if (folder.MessageCount > 0)
         {
@@ -87,10 +90,10 @@ public static class PstReader
         }
 
         foreach (PSTFolder child in folder.GetChildFolders())
-            ReadFolderRecursive(child, path, byKey, order);
+            ReadFolderRecursive(child, path, byKey, order, keywordsId);
     }
 
-    private static ReadBackMessage ReadNote(Note note)
+    private static ReadBackMessage ReadNote(Note note, ushort? keywordsId)
     {
         // Recipients: read EmailAddress via GetRecipient(); read kind via RecipientsTable directly
         // because GetRecipient() does NOT populate RecipientType (always returns default To).
@@ -137,6 +140,15 @@ public static class PstReader
         bool isReplied = lastVerb is 102 or 103;   // reply / reply-all
         bool isForwarded = lastVerb is 104;          // forward
 
+        // Read "Keywords" named property (MV-Unicode) as categories.
+        IReadOnlyList<string> categories = Array.Empty<string>();
+        if (keywordsId is ushort kid)
+        {
+            var rec = note.PC.GetRecordByPropertyID((PSTFileFormat.PropertyID)kid);
+            if (rec != null)
+                categories = PSTFileFormat.PropertyContext.DeserializeMultiString(note.PC.GetExternalRecordData(rec));
+        }
+
         return new ReadBackMessage(
             Subject: note.Subject,
             FromAddress: fromAddress,
@@ -148,7 +160,8 @@ public static class PstReader
             IsRead: isRead,
             IsReplied: isReplied,
             IsForwarded: isForwarded,
-            IsFlagged: isFlagged);
+            IsFlagged: isFlagged,
+            Categories: categories);
     }
 
     private static RecipientKind MapKind(int? raw)

--- a/tests/Mail2Pst.Integration.Tests/RoundTripComparerTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/RoundTripComparerTests.cs
@@ -14,7 +14,7 @@ public class RoundTripComparerTests
         new() { MessageId = id, Subject = subject, TextBody = "body", From = new MailAddress { Email = "a@b.com" } };
 
     private static ReadBackMessage Read(string id, string subject) =>
-        new(subject, "a@b.com", Array.Empty<ReadRecipient>(), null, Array.Empty<string>(), true, id, false, false, false, false);
+        new(subject, "a@b.com", Array.Empty<ReadRecipient>(), null, Array.Empty<string>(), true, id, false, false, false, false, Array.Empty<string>());
 
     [Fact]
     public void AssertRoundTrip_MetadataMismatch_Throws()

--- a/tests/Mail2Pst.Integration.Tests/RoundTripHarness.cs
+++ b/tests/Mail2Pst.Integration.Tests/RoundTripHarness.cs
@@ -11,6 +11,7 @@ using Mail2Pst.Core.Mapping;
 using Mail2Pst.Core.Models;
 using Mail2Pst.Core.Parsing;
 using Mail2Pst.Core.Reporting;
+using Mail2Pst.Core.Writing;
 
 namespace Mail2Pst.Integration.Tests;
 
@@ -24,6 +25,23 @@ public static class RoundTripHarness
     {
         var report = new ConversionRunner(TemplatePath).Run(config, outDir);
         return (report.OutputFiles, report);
+    }
+
+    /// <summary>
+    /// Drives <see cref="PstWriter"/> directly from a list of <see cref="MailMessage"/>s,
+    /// placing all messages into a single "Inbox" folder. Used for tests that build messages
+    /// in-memory rather than parsing an mbox file.
+    /// </summary>
+    public static IReadOnlyList<string> ConvertMessages(IReadOnlyList<MailMessage> messages, string outDir)
+    {
+        var plan = new PstOutputPlan { Name = "P", MaxSizeBytes = 100L * 1024 * 1024, IncludeEmptyFolders = true };
+        IEnumerable<PlannedMessage> planned = messages.Select(m => new PlannedMessage
+        {
+            Message = m,
+            TargetFolderPath = new[] { "Inbox" },
+        });
+        var report = new ConversionReport();
+        return new PstWriter(TemplatePath).WritePlan(plan, planned, outDir, report);
     }
 
     /// <summary>

--- a/vendor/PSTFileFormat-MODIFICATIONS.md
+++ b/vendor/PSTFileFormat-MODIFICATIONS.md
@@ -20,5 +20,8 @@ authoritative description of the local PSTFileFormat modifications.
   (`7129962`).
 - Gmail-Takeout fidelity tweaks: NDR (non-delivery-report) suppression, unread-count
   handling, and locale handling (`e558191`).
+- Added string-named (MNID_STRING) property support to `PropertyNameToIDMap`/`PropertyName`
+  (register/read/round-trip; corrected string-id hash-bucket index `(wGuid<<1)|N`) + MV-Unicode
+  multi-string setter on `PropertyContext` (ContinuMail, 2026).
 
 See the project git history (`git log -- vendor/PSTFileFormat`) for the full diffs.

--- a/vendor/PSTFileFormat/ListsTablesAndProperties/PropertyContext/PropertyContext.cs
+++ b/vendor/PSTFileFormat/ListsTablesAndProperties/PropertyContext/PropertyContext.cs
@@ -467,6 +467,56 @@ namespace PSTFileFormat
 
             SetExternalProperty(propertyID, PropertyTypeName.PtypObject, propertyBytes);
         }
+
+        public void SetMultiStringProperty(PropertyID id, System.Collections.Generic.IReadOnlyList<string> values)
+            => SetExternalProperty(id, PropertyTypeName.PtypMultiString, SerializeMultiString(values));
+
+        public static byte[] SerializeMultiString(System.Collections.Generic.IReadOnlyList<string> values)
+        {
+            int count = values.Count;
+            byte[][] items = new byte[count][];
+            for (int i = 0; i < count; i++) items[i] = System.Text.Encoding.Unicode.GetBytes(values[i]);
+            int headerLen = 4 + 4 * count;
+            int total = headerLen; foreach (var b in items) total += b.Length;
+            byte[] buf = new byte[total];
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(0), (uint)count);
+            int offset = headerLen;
+            for (int i = 0; i < count; i++)
+            {
+                System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(4 + 4 * i), (uint)offset);
+                offset += items[i].Length;
+            }
+            offset = headerLen;
+            foreach (byte[] item in items) { System.Array.Copy(item, 0, buf, offset, item.Length); offset += item.Length; }
+            return buf;
+        }
+
+        public static System.Collections.Generic.List<string> DeserializeMultiString(byte[] buffer)
+        {
+            if (buffer.Length < 4)
+                throw new System.IO.InvalidDataException("MV-Unicode buffer too short to contain count.");
+            int count = (int)System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(buffer.AsSpan(0));
+            int headerLen = 4 + 4 * count;
+            if (buffer.Length < headerLen)
+                throw new System.IO.InvalidDataException("MV-Unicode buffer too short to contain all offset entries.");
+            int[] offsets = new int[count];
+            for (int i = 0; i < count; i++)
+            {
+                offsets[i] = (int)System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(buffer.AsSpan(4 + 4 * i));
+                if (offsets[i] < headerLen || offsets[i] > buffer.Length)
+                    throw new System.IO.InvalidDataException("MV-Unicode offset is out of range.");
+                if (i > 0 && offsets[i] < offsets[i - 1])
+                    throw new System.IO.InvalidDataException("MV-Unicode offsets are not non-decreasing.");
+            }
+            var result = new System.Collections.Generic.List<string>(count);
+            for (int i = 0; i < count; i++)
+            {
+                int start = offsets[i];
+                int end = (i + 1 < count) ? offsets[i + 1] : buffer.Length;
+                result.Add(System.Text.Encoding.Unicode.GetString(buffer, start, end - start));
+            }
+            return result;
+        }
         #endregion
 
         public List<PropertyContextRecord> GetAllProperties()

--- a/vendor/PSTFileFormat/ListsTablesAndProperties/PropertyContext/PropertyContext.cs
+++ b/vendor/PSTFileFormat/ListsTablesAndProperties/PropertyContext/PropertyContext.cs
@@ -495,10 +495,11 @@ namespace PSTFileFormat
         {
             if (buffer.Length < 4)
                 throw new System.IO.InvalidDataException("MV-Unicode buffer too short to contain count.");
-            int count = (int)System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(buffer.AsSpan(0));
-            int headerLen = 4 + 4 * count;
-            if (buffer.Length < headerLen)
+            uint rawCount = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(buffer.AsSpan(0));
+            if (rawCount > (uint)(buffer.Length - 4) / 4)   // also guards headerLen overflow
                 throw new System.IO.InvalidDataException("MV-Unicode buffer too short to contain all offset entries.");
+            int count = (int)rawCount;
+            int headerLen = 4 + 4 * count;
             int[] offsets = new int[count];
             for (int i = 0; i < count; i++)
             {
@@ -517,6 +518,7 @@ namespace PSTFileFormat
             }
             return result;
         }
+
         #endregion
 
         public List<PropertyContextRecord> GetAllProperties()

--- a/vendor/PSTFileFormat/Messaging/NamedProperties/PropertyName.cs
+++ b/vendor/PSTFileFormat/Messaging/NamedProperties/PropertyName.cs
@@ -1,11 +1,13 @@
 /* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
- * 
+ *
  * You can redistribute this program and/or modify it under the terms of
  * the GNU Lesser Public License as published by the Free Software Foundation,
  * either version 3 of the License, or (at your option) any later version.
- * 
+ *
  * Maintainer: Tal Aloni <tal@kmrom.com>
  */
+// ContinuMail modification 2026: added string-named (MNID_STRING) property support.
+// See vendor/PSTFileFormat-MODIFICATIONS.md for details.
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -17,25 +19,44 @@ namespace PSTFileFormat
         public PropertyLongID PropertyLongID;
         public Guid PropertySetGuid;
 
+        // String-name (MNID_STRING) fields — null/false for numeric (MNID_ID) names.
+        public string? PropertyStringName;
+        public bool IsStringIdentifier;
+
+        /// <summary>Numeric (MNID_ID) named property.</summary>
         public PropertyName(PropertyLongID propertyLongID, Guid propertySetGuid)
         {
             PropertyLongID = propertyLongID;
             PropertySetGuid = propertySetGuid;
+            IsStringIdentifier = false;
+        }
+
+        /// <summary>String-named (MNID_STRING) named property.</summary>
+        public PropertyName(string propertyStringName, Guid propertySetGuid)
+        {
+            PropertyStringName = propertyStringName;
+            PropertySetGuid = propertySetGuid;
+            IsStringIdentifier = true;
         }
 
         public override bool Equals(object obj)
         {
-            if (obj is PropertyName)
+            if (obj is PropertyName other)
             {
-                return (PropertyLongID == ((PropertyName)obj).PropertyLongID &&
-                        PropertySetGuid == ((PropertyName)obj).PropertySetGuid);
+                if (IsStringIdentifier != other.IsStringIdentifier) return false;
+                if (PropertySetGuid != other.PropertySetGuid) return false;
+                if (IsStringIdentifier)
+                    return string.Equals(PropertyStringName, other.PropertyStringName, StringComparison.Ordinal);
+                return PropertyLongID == other.PropertyLongID;
             }
             return false;
         }
 
         public override int GetHashCode()
         {
-            return PropertyLongID.GetHashCode();
+            if (IsStringIdentifier)
+                return HashCode.Combine(IsStringIdentifier, PropertySetGuid, PropertyStringName ?? string.Empty);
+            return HashCode.Combine(IsStringIdentifier, PropertySetGuid, PropertyLongID);
         }
     }
 }

--- a/vendor/PSTFileFormat/Messaging/NamedProperties/PropertyNameToIDMap.cs
+++ b/vendor/PSTFileFormat/Messaging/NamedProperties/PropertyNameToIDMap.cs
@@ -1,12 +1,16 @@
 /* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
- * 
+ *
  * You can redistribute this program and/or modify it under the terms of
  * the GNU Lesser Public License as published by the Free Software Foundation,
  * either version 3 of the License, or (at your option) any later version.
- * 
+ *
  * Maintainer: Tal Aloni <tal@kmrom.com>
  */
+// ContinuMail modification 2026: added string-named (MNID_STRING) property support
+// (GetOrCreateStringNamedProperty / ResolveStringNamedProperty / FillMap extension).
+// See vendor/PSTFileFormat-MODIFICATIONS.md for details.
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Text;
 using Utilities;
@@ -89,16 +93,31 @@ namespace PSTFileFormat
                 throw new InvalidPropertyException("Invalid NameidStreamEntry");
             }
 
+            byte[] stringStream = node.PC.GetBytesProperty(PropertyID.PidTagNameidStreamString) ?? Array.Empty<byte>();
+
             for (int index = 0; index < buffer.Length; index += 8)
             {
                 NameID nameID = new NameID(buffer, index);
-                if (!nameID.IsStringIdentifier) 
+                if (!nameID.IsStringIdentifier)
                 {
                     ushort propertyShortID = nameID.PropertyShortID;
                     PropertyLongID propertyLongID = (PropertyLongID)nameID.dwPropertyID;
                     Guid propertySetGuid = GetPropertySetGuid(nameID.wGuid);
 
                     m_map.Add(new PropertyName(propertyLongID, propertySetGuid), propertyShortID);
+                }
+                else
+                {
+                    // String-named (MNID_STRING): dwPropertyID is offset into the string stream.
+                    int off = (int)nameID.dwPropertyID;
+                    if (off + 4 > stringStream.Length) continue;
+                    int byteLen = (int)BinaryPrimitives.ReadUInt32LittleEndian(stringStream.AsSpan(off));
+                    if (off + 4 + byteLen > stringStream.Length) continue;
+                    string name = Encoding.Unicode.GetString(stringStream, off + 4, byteLen);
+                    Guid propertySetGuid = GetPropertySetGuid(nameID.wGuid);
+                    var key = new PropertyName(name, propertySetGuid);
+                    if (!m_map.ContainsKey(key))
+                        m_map.Add(key, nameID.PropertyShortID);
                 }
             }
         }
@@ -248,5 +267,121 @@ namespace PSTFileFormat
 
             return oldBuffer.Length / 16;
         }
+
+        // -----------------------------------------------------------------------
+        // ContinuMail addition 2026: string-named (MNID_STRING) property support.
+        // Scope: built-in GUID hints only (guidHint 0-2 = Guid.Empty/PS_MAPI/
+        // PS_PUBLIC_STRINGS). Arbitrary set-GUIDs would also require a GUID-stream
+        // entry — documented extension point, not implemented here.
+        // -----------------------------------------------------------------------
+
+        private static byte[] Concat(byte[] a, byte[] b)
+        {
+            byte[] r = new byte[a.Length + b.Length];
+            Array.Copy(a, 0, r, 0, a.Length);
+            Array.Copy(b, 0, r, a.Length, b.Length);
+            return r;
+        }
+
+        /// <summary>
+        /// Re-parses the entry + string streams to find the short id assigned to a
+        /// string-named property in the given built-in GUID hint bucket.
+        /// Returns null if not found.
+        /// </summary>
+        public static ushort? ResolveStringNamedProperty(PSTFile file, ushort guidHint, string name)
+        {
+            PSTNode node = file.GetNode((uint)InternalNodeName.NID_NAME_TO_ID_MAP);
+            byte[] entryStream  = node.PC.GetBytesProperty(PropertyID.PidTagNameidStreamEntry)  ?? Array.Empty<byte>();
+            byte[] stringStream = node.PC.GetBytesProperty(PropertyID.PidTagNameidStreamString) ?? Array.Empty<byte>();
+
+            for (int i = 0; i + NameID.Length <= entryStream.Length; i += NameID.Length)
+            {
+                var nid = new NameID(entryStream, i);
+                if (!nid.IsStringIdentifier || nid.wGuid != guidHint) continue;
+
+                int off = (int)nid.dwPropertyID; // offset into the string stream
+                if (off + 4 > stringStream.Length) continue;
+                int byteLen = (int)BinaryPrimitives.ReadUInt32LittleEndian(stringStream.AsSpan(off));
+                if (off + 4 + byteLen > stringStream.Length) continue;
+                string stored = Encoding.Unicode.GetString(stringStream, off + 4, byteLen);
+                if (string.Equals(stored, name, StringComparison.Ordinal))
+                    return nid.PropertyShortID;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Idempotent: if a string-named property with <paramref name="name"/> in
+        /// <paramref name="guidHint"/> already exists in the Name-to-ID map, returns
+        /// its short id. Otherwise registers it (entry stream + name-string stream +
+        /// hash bucket at the corrected index), saves the map node, and returns the
+        /// new short id (0x8000 + wPropIdx).
+        /// </summary>
+        /// <remarks>
+        /// Hash-bucket index: <c>(crc ^ ((guidHint&lt;&lt;1)|1)) % bucketCount</c>
+        /// where crc = CRC32(UTF-16LE name bytes). This differs from the vendored
+        /// <c>AddPropertyToHashBucket</c> which computes <c>(N+wGuid)&lt;&lt;1</c>
+        /// — an off-by-one for string ids (N=1 instead of N=0). Never call
+        /// <c>AddPropertyToHashBucket</c> for string ids; it throws anyway.
+        /// </remarks>
+        public static ushort GetOrCreateStringNamedProperty(PSTFile file, ushort guidHint, string name)
+        {
+            // Idempotency: check first without modifying.
+            ushort? existing = ResolveStringNamedProperty(file, guidHint, name);
+            if (existing.HasValue) return existing.Value;
+
+            PSTNode node = file.GetNode((uint)InternalNodeName.NID_NAME_TO_ID_MAP);
+
+            byte[] entryStream  = node.PC.GetBytesProperty(PropertyID.PidTagNameidStreamEntry)  ?? Array.Empty<byte>();
+            byte[] stringStream = node.PC.GetBytesProperty(PropertyID.PidTagNameidStreamString) ?? Array.Empty<byte>();
+
+            if (entryStream.Length % NameID.Length != 0)
+                throw new InvalidDataException("Corrupt PidTagNameidStreamEntry length");
+
+            ushort wPropIdx = (ushort)(entryStream.Length / NameID.Length);
+            uint stringStreamOffset = (uint)stringStream.Length; // 4-aligned by construction
+
+            byte[] nameBytes = Encoding.Unicode.GetBytes(name); // UTF-16LE, no null terminator
+
+            // --- Name-string stream: [DWORD byteLength][UTF-16LE name][pad to 4-byte boundary] ---
+            int padded = (nameBytes.Length + 3) & ~3;
+            byte[] strEntry = new byte[4 + padded];
+            BinaryPrimitives.WriteUInt32LittleEndian(strEntry.AsSpan(0), (uint)nameBytes.Length);
+            Array.Copy(nameBytes, 0, strEntry, 4, nameBytes.Length);
+            node.PC.SetBytesProperty(PropertyID.PidTagNameidStreamString, Concat(stringStream, strEntry));
+
+            // --- Entry stream: NameID with dwPropertyID = string-stream offset, N=1 (string) ---
+            var entryNameId = new NameID((PropertyLongID)stringStreamOffset, guidHint, wPropIdx)
+            {
+                IdentifierType = true,
+            };
+            byte[] entryBytes = new byte[NameID.Length];
+            entryNameId.WriteBytes(entryBytes, 0);
+            node.PC.SetBytesProperty(PropertyID.PidTagNameidStreamEntry, Concat(entryStream, entryBytes));
+
+            // --- Hash bucket: NameID with dwPropertyID = CRC32(name bytes) ---
+            // Corrected index: (crc ^ ((guidHint<<1)|1)) % bucketCount.
+            // The vendored helper uses (N+wGuid)<<1 which gives the wrong value for N=1
+            // (string ids); since it also throws NotImplementedException for string ids,
+            // we compute the bucket directly here.
+            uint crc = PSTCRCCalculation.ComputeCRC(nameBytes, nameBytes.Length);
+            int bucketCount = node.PC.GetInt32Property(PropertyID.PidTagNameidBucketCount)!.Value;
+            uint arg1 = (uint)((guidHint << 1) | 1);
+            ushort bucketIndex = (ushort)((crc ^ arg1) % (uint)bucketCount);
+            var bucketProp = (PropertyID)((uint)PropertyID.PidTagNameidBucketBase + bucketIndex);
+
+            var bucketNameId = new NameID((PropertyLongID)crc, guidHint, wPropIdx)
+            {
+                IdentifierType = true,
+            };
+            byte[] bucketEntryBytes = new byte[NameID.Length];
+            bucketNameId.WriteBytes(bucketEntryBytes, 0);
+            byte[] bucketStream = node.PC.GetBytesProperty(bucketProp) ?? Array.Empty<byte>();
+            node.PC.SetBytesProperty(bucketProp, Concat(bucketStream, bucketEntryBytes));
+
+            node.SaveChanges();
+            return (ushort)(0x8000 + wPropIdx);
+        }
     }
 }
+


### PR DESCRIPTION
Builds on SP2 (#10) to turn Thunderbird `.msf` metadata into conversion output.

**Half A — vendor (`PSTFileFormat`):** adds string-named (MNID_STRING) property support to `PropertyNameToIDMap`/`PropertyName` (register / read / round-trip, with the corrected string-id hash-bucket index) plus a multi-valued-Unicode setter on `PropertyContext` — enabling the canonical Outlook categories property (`PidNameKeywords` = "Keywords" in `PS_PUBLIC_STRINGS`, `PtypMultiString`). LGPLv3 boundary preserved; changes recorded in `vendor/PSTFileFormat-MODIFICATIONS.md`.

**Half B — core:** `MsfEnricher.Enrich` joins `.msf` rows to parsed `MailMessage`s by **uniquely-resolvable** normalized Message-ID (no deterministic-pick — duplicate/missing ids are skipped and counted), applies the `.msf`-authoritative flags + junk, and resolves tags → categories (`DefaultMsfTagResolver`: filters `NonJunk`, maps the five built-in `$labelN` to default names, passes custom tags through, dedupes). `MailMessage` gains `Categories` + `IsJunk`; `PstWriter` writes `Categories` as the Keywords property; a `JunkHandling` config (Off/Category — Folder modeled but rejected until the pipeline wiring lands). Shared `MessageIdNormalizer` extracted from the MIME mapper (behaviour-preserving).

Categories (including non-ASCII) and junk-as-category are proven round-tripping through the real writer/reader. Faithful mirror — no reconciliation between flag bits, legacy label, and `$labelN`. Pure and testable; live Thunderbird-profile discovery + mbox↔`.msf` pairing remain for the next milestone.

Category colours are out of scope: the vendored writer can't yet emit the FAI master-category-list message (verified during the design spike) — a future enhancement; imported categories work (display/search/filter/group) colourlessly.
