### PR TITLE
feat(core): Thunderbird profile-aware discovery + mbox/.msf pairing (SP4a)

### DIFF
--- a/src/Mail2Pst.Cli/DiscoverCommand.cs
+++ b/src/Mail2Pst.Cli/DiscoverCommand.cs
@@ -30,7 +30,7 @@ internal static class DiscoverCommand
 
         try
         {
-            DiscoveryResult r = MailTreeDiscovery.Discover(input);
+            DiscoveryResult r = MailProfileDiscovery.Discover(input);
             var output = new
             {
                 type = "discovery",
@@ -39,7 +39,7 @@ internal static class DiscoverCommand
                 sources = r.Sources.Select(s => new
                 {
                     path = s.Path, type = s.Type, targetFolderPath = s.TargetFolderPath,
-                    displayName = s.DisplayName, sourceBytes = s.SourceBytes,
+                    displayName = s.DisplayName, sourceBytes = s.SourceBytes, msfPath = s.MsfPath,
                 }),
                 warnings = r.Warnings.Select(w => new
                 {
@@ -47,6 +47,12 @@ internal static class DiscoverCommand
                     segment = w.Segment, segmentIndex = w.SegmentIndex, relatedPaths = w.RelatedPaths, message = w.Message,
                 }),
                 skipped = r.Skipped.Select(s => new { code = s.Code, path = s.Path, reason = s.Reason }),
+                pairing = new
+                {
+                    pairedMsfCount = r.Pairing.PairedMsfCount,
+                    unpairedMboxCount = r.Pairing.UnpairedMboxCount,
+                    orphanMsfCount = r.Pairing.OrphanMsfCount,
+                },
             };
             Console.WriteLine(CliEventSerializer.Serialize(output, indented: true));
             return 0;

--- a/src/Mail2Pst.Core/Config/SourceConfig.cs
+++ b/src/Mail2Pst.Core/Config/SourceConfig.cs
@@ -12,4 +12,5 @@ public class SourceConfig
     public string Type { get; set; } = string.Empty;
     public string? TargetFolder { get; set; }
     public List<string>? TargetFolderPath { get; set; }
+    public string? MsfPath { get; set; }
 }

--- a/src/Mail2Pst.Core/Discovery/DiscoveryResult.cs
+++ b/src/Mail2Pst.Core/Discovery/DiscoveryResult.cs
@@ -7,7 +7,8 @@ using System.Collections.Generic;
 namespace Mail2Pst.Core.Discovery;
 
 public sealed record DiscoveredSource(
-    string Path, string Type, IReadOnlyList<string> TargetFolderPath, string DisplayName, long SourceBytes);
+    string Path, string Type, IReadOnlyList<string> TargetFolderPath, string DisplayName, long SourceBytes,
+    string? MsfPath);
 
 public sealed record DiscoveryWarning(
     string Code, string Path, IReadOnlyList<string>? TargetFolderPath,
@@ -15,8 +16,11 @@ public sealed record DiscoveryWarning(
 
 public sealed record DiscoverySkipped(string Code, string Path, string Reason);
 
+public sealed record DiscoveryPairingSummary(int PairedMsfCount, int UnpairedMboxCount, int OrphanMsfCount);
+
 public sealed record DiscoveryResult(
     string Root, string Layout,
     IReadOnlyList<DiscoveredSource> Sources,
     IReadOnlyList<DiscoveryWarning> Warnings,
-    IReadOnlyList<DiscoverySkipped> Skipped);
+    IReadOnlyList<DiscoverySkipped> Skipped,
+    DiscoveryPairingSummary Pairing);

--- a/src/Mail2Pst.Core/Discovery/MailProfileDiscovery.cs
+++ b/src/Mail2Pst.Core/Discovery/MailProfileDiscovery.cs
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Mail2Pst.Core.Discovery;
+
+/// <summary>
+/// Profile-aware orchestrator over <see cref="MailTreeDiscovery"/>. Auto-classifies the input
+/// (Thunderbird store-root / profile / single account tree), walks each account directory with the
+/// account name as the top folder segment, and merges the results with a cross-account duplicate pass.
+/// Parse-free; pairs mbox with sibling .msf via path existence only (no .msf parsing).
+/// </summary>
+public static class MailProfileDiscovery
+{
+    private static readonly string[] StoreNames = { "Mail", "ImapMail" };
+
+    public static DiscoveryResult Discover(string path)
+    {
+        string ownName = new DirectoryInfo(path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)).Name;
+
+        // 1) Store-root: the input directory itself is named Mail/ImapMail.
+        if (StoreNames.Contains(ownName, StringComparer.OrdinalIgnoreCase))
+            return DiscoverStores(path, new[] { path }, "thunderbird-store-root");
+
+        // 2) Profile: contains Mail and/or ImapMail child directories.
+        var stores = StoreNames
+            .Select(s => Path.Combine(path, s))
+            .Where(Directory.Exists)
+            .ToList();
+        if (stores.Count > 0)
+            return DiscoverStores(path, stores, "thunderbird-profile");
+
+        // 3) Single tree: today's behaviour, no prefix.
+        return MailTreeDiscovery.Discover(path);
+    }
+
+    private static DiscoveryResult DiscoverStores(string root, IReadOnlyList<string> stores, string layout)
+    {
+        // Track each source's ORIGIN (the account directory it came from) so the cross-account dedupe
+        // can require >1 distinct origin — two same-named account dirs collide on path AND first segment,
+        // so a first-segment check would miss them.
+        var indexed = new List<(DiscoveredSource Source, string OriginKey)>();
+        var warnings = new List<DiscoveryWarning>();
+        var skipped = new List<DiscoverySkipped>();
+        int paired = 0, unpaired = 0, orphan = 0;
+
+        foreach (string store in stores)
+        {
+            string[] entries;
+            try { entries = Directory.GetFileSystemEntries(store); }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                skipped.Add(new DiscoverySkipped("unreadable", store, ex.Message));
+                warnings.Add(new DiscoveryWarning("unreadable", store, null, null, null, null,
+                    $"Could not read store: {ex.Message}"));
+                continue;
+            }
+
+            foreach (string entry in entries.OrderBy(e => e, StringComparer.OrdinalIgnoreCase))
+            {
+                FileAttributes attr;
+                try { attr = File.GetAttributes(entry); }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    skipped.Add(new DiscoverySkipped("unreadable", entry, ex.Message)); continue;
+                }
+
+                // Never follow symlinks/reparse points (mirrors MailTreeDiscovery's policy).
+                if ((attr & FileAttributes.ReparsePoint) != 0)
+                {
+                    skipped.Add(new DiscoverySkipped("symlink-skipped", entry, "Symlink/reparse-point not followed."));
+                    warnings.Add(new DiscoveryWarning("symlink-skipped", entry, null, null, null, null,
+                        "Symlink/reparse-point skipped."));
+                    continue;
+                }
+
+                if ((attr & FileAttributes.Directory) == 0)
+                {
+                    // Loose file directly under Mail/ or ImapMail/ — accounts are directories only.
+                    skipped.Add(new DiscoverySkipped("unexpected-file-in-store-root", entry, "Not an account directory."));
+                    warnings.Add(new DiscoveryWarning("unexpected-file-in-store-root", entry, null, null, null, null,
+                        "Unexpected file directly under a mail store; skipped."));
+                    continue;
+                }
+
+                string account = Path.GetFileName(entry);
+                DiscoveryResult acct;
+                try { acct = MailTreeDiscovery.Discover(entry, new[] { account }); }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    skipped.Add(new DiscoverySkipped("unreadable", entry, ex.Message));
+                    warnings.Add(new DiscoveryWarning("unreadable", entry, null, null, null, null,
+                        $"Could not read account: {ex.Message}"));
+                    continue;
+                }
+
+                foreach (DiscoveredSource s in acct.Sources) indexed.Add((s, entry)); // OriginKey = account dir path
+                warnings.AddRange(acct.Warnings);
+                skipped.AddRange(acct.Skipped);
+                paired += acct.Pairing.PairedMsfCount;
+                unpaired += acct.Pairing.UnpairedMboxCount;
+                orphan += acct.Pairing.OrphanMsfCount;
+            }
+        }
+
+        AddCrossAccountDuplicateWarnings(indexed, warnings);
+
+        var sources = indexed.Select(x => x.Source).ToList();
+        return new DiscoveryResult(root, layout, sources, warnings, skipped,
+            new DiscoveryPairingSummary(paired, unpaired, orphan));
+    }
+
+    // Emit a duplicate-target-folder-path warning ONLY for groups whose sources come from >1 distinct
+    // ORIGIN (account dir). Same-account duplicates were already warned by MailTreeDiscovery's per-tree
+    // pass, so they are not re-emitted here.
+    private static void AddCrossAccountDuplicateWarnings(
+        List<(DiscoveredSource Source, string OriginKey)> indexed, List<DiscoveryWarning> warnings)
+    {
+        var groups = indexed
+            .GroupBy(x => string.Join('\0', x.Source.TargetFolderPath), StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Count() > 1
+                     && g.Select(x => x.OriginKey).Distinct(StringComparer.OrdinalIgnoreCase).Count() > 1);
+
+        foreach (var g in groups)
+        {
+            DiscoveredSource first = g.First().Source;
+            warnings.Add(new DiscoveryWarning("duplicate-target-folder-path", first.Path,
+                first.TargetFolderPath, null, null, g.Select(x => x.Source.Path).ToList(),
+                $"Multiple sources map to target folder {string.Join(" / ", first.TargetFolderPath)}."));
+        }
+    }
+}

--- a/src/Mail2Pst.Core/Discovery/MailTreeDiscovery.cs
+++ b/src/Mail2Pst.Core/Discovery/MailTreeDiscovery.cs
@@ -31,16 +31,17 @@ public static class MailTreeDiscovery
         public readonly List<DiscoverySkipped> Skipped = new();
         public bool SawSbd;
         public int MetadataCount;
+        public int PairedMsf, UnpairedMbox, OrphanMsf;
     }
 
-    public static DiscoveryResult Discover(string rootDir)
+    public static DiscoveryResult Discover(string rootDir, IReadOnlyList<string>? pathPrefix = null)
     {
         var ctx = new Ctx();
 
         // Root enumeration failure propagates (caller treats as fatal). Sub-directory failures
         // are caught inside Walk and recorded.
         string[] rootEntries = Directory.GetFileSystemEntries(rootDir);
-        ProcessEntries(rootDir, rootEntries, Array.Empty<string>(), ctx);
+        ProcessEntries(rootDir, rootEntries, pathPrefix ?? Array.Empty<string>(), ctx);
 
         if (ctx.MetadataCount > 0)
             ctx.Skipped.Add(new DiscoverySkipped("metadata-files-skipped", rootDir,
@@ -50,7 +51,8 @@ public static class MailTreeDiscovery
         AddInvalidNameWarnings(ctx);
 
         string layout = ComputeLayout(ctx);
-        return new DiscoveryResult(rootDir, layout, ctx.Sources, ctx.Warnings, ctx.Skipped);
+        return new DiscoveryResult(rootDir, layout, ctx.Sources, ctx.Warnings, ctx.Skipped,
+            new DiscoveryPairingSummary(ctx.PairedMsf, ctx.UnpairedMbox, ctx.OrphanMsf));
     }
 
     private static void Walk(string dir, IReadOnlyList<string> prefix, Ctx ctx)
@@ -71,8 +73,48 @@ public static class MailTreeDiscovery
     {
         Array.Sort(entries, (a, b) => string.Compare(a, b, StringComparison.OrdinalIgnoreCase));
 
+        // Pre-pass: classify this directory's .msf entries. ONLY a normal, readable, non-reparse,
+        // non-directory .msf FILE is eligible to pair (so SP4b never gets a dangerous/invalid MsfPath). A
+        // .msf that is a symlink/directory/unreadable is fully handled here — and the main loop below skips
+        // ALL .msf-named entries — so each is processed exactly once.
+        var msfByBase = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase); // base -> full .msf path
+        foreach (string e in entries)
+        {
+            string n = Path.GetFileName(e);
+            if (!n.EndsWith(".msf", StringComparison.OrdinalIgnoreCase) || n.StartsWith(".", StringComparison.Ordinal))
+                continue;
+            FileAttributes a;
+            try { a = File.GetAttributes(e); }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                ctx.Skipped.Add(new DiscoverySkipped("unreadable", e, ex.Message));
+                ctx.Warnings.Add(new DiscoveryWarning("unreadable", e, null, null, null, null, $"Could not read entry: {ex.Message}"));
+                continue;
+            }
+            if ((a & FileAttributes.ReparsePoint) != 0)
+            {
+                ctx.Skipped.Add(new DiscoverySkipped("symlink-skipped", e, "Symlink/reparse-point not followed."));
+                ctx.Warnings.Add(new DiscoveryWarning("symlink-skipped", e, null, null, null, null, "Symlink/reparse-point skipped."));
+                continue;
+            }
+            if ((a & FileAttributes.Directory) != 0)
+            {
+                ctx.Skipped.Add(new DiscoverySkipped("unexpected-subdirectory", e, "Directory named .msf is not a summary file."));
+                ctx.Warnings.Add(new DiscoveryWarning("unexpected-subdirectory", e, null, null, null, null, "Directory named .msf skipped."));
+                continue;
+            }
+            msfByBase[n[..^4]] = e; // a normal .msf file — eligible to pair
+        }
+        var pairedBases = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         foreach (string entry in entries)
         {
+            string name = Path.GetFileName(entry);
+
+            // .msf entries were fully classified by the pre-pass — skip every .msf-named entry here.
+            if (name.EndsWith(".msf", StringComparison.OrdinalIgnoreCase) && !name.StartsWith(".", StringComparison.Ordinal))
+                continue;
+
             FileAttributes attr;
             try { attr = File.GetAttributes(entry); }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
@@ -92,8 +134,6 @@ public static class MailTreeDiscovery
                 continue;
             }
 
-            string name = Path.GetFileName(entry);
-
             if ((attr & FileAttributes.Directory) != 0)
             {
                 if (name.EndsWith(".sbd", StringComparison.OrdinalIgnoreCase))
@@ -112,7 +152,7 @@ public static class MailTreeDiscovery
                 continue;
             }
 
-            // File.
+            // File (non-.msf).
             string ext = Path.GetExtension(name);
             if (name.StartsWith(".", StringComparison.Ordinal) || MetadataExtensions.Contains(ext))
             {
@@ -145,7 +185,21 @@ public static class MailTreeDiscovery
 
             string display = name.EndsWith(".mbox", StringComparison.OrdinalIgnoreCase) ? name[..^5] : name;
             var targetPath = new List<string>(prefix) { display };
-            ctx.Sources.Add(new DiscoveredSource(entry, "mbox", targetPath, display, size));
+
+            // Pair this ACCEPTED mbox with its sibling <name>.msf, if present.
+            string? msfPath = null;
+            if (msfByBase.TryGetValue(name, out string? mp)) { msfPath = mp; pairedBases.Add(name); ctx.PairedMsf++; }
+            else ctx.UnpairedMbox++;
+
+            ctx.Sources.Add(new DiscoveredSource(entry, "mbox", targetPath, display, size, msfPath));
+        }
+
+        // Orphan .msf: a .msf whose base was not an accepted mbox in this directory.
+        foreach (var kv in msfByBase)
+        {
+            if (pairedBases.Contains(kv.Key)) continue;
+            ctx.OrphanMsf++;
+            ctx.Skipped.Add(new DiscoverySkipped("orphan-msf", kv.Value, "No paired mbox for this .msf summary file."));
         }
     }
 

--- a/tests/Mail2Pst.Core.Tests/Cli/DiscoverCommandE2ETests.cs
+++ b/tests/Mail2Pst.Core.Tests/Cli/DiscoverCommandE2ETests.cs
@@ -92,4 +92,26 @@ public class DiscoverCommandE2ETests
         Assert.True(root.GetProperty("fatal").GetBoolean());
         Assert.Equal(1, root.GetProperty("schemaVersion").GetInt32());
     }
+
+    [Fact]
+    public void Discover_EmitsMsfPath_AndPairingSummary()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "m2p-msf-" + Guid.NewGuid());
+        Directory.CreateDirectory(dir);
+        File.WriteAllBytes(Path.Combine(dir, "Inbox"), Array.Empty<byte>());
+        File.WriteAllBytes(Path.Combine(dir, "Inbox.msf"), Array.Empty<byte>());
+        try
+        {
+            (int exit, string stdout, string stderr) = RunCli($"discover --input \"{dir}\"");
+            Assert.True(exit == 0, $"expected exit 0, got {exit}. stderr: {stderr}");
+
+            using JsonDocument doc = JsonDocument.Parse(stdout);
+            JsonElement root = doc.RootElement;
+            Assert.Equal(1, root.GetProperty("schemaVersion").GetInt32()); // existing serializer contract
+            JsonElement src = root.GetProperty("sources").EnumerateArray().Single();
+            Assert.EndsWith("Inbox.msf", src.GetProperty("msfPath").GetString());
+            Assert.Equal(1, root.GetProperty("pairing").GetProperty("pairedMsfCount").GetInt32());
+        }
+        finally { Directory.Delete(dir, true); }
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Config/MsfPathPlumbingTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Config/MsfPathPlumbingTests.cs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Collections.Generic;
+using System.Linq;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Mapping;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Config;
+
+public class MsfPathPlumbingTests
+{
+    private static ConversionConfig Config(string? msfPath) => new()
+    {
+        Outputs = new List<OutputGroupConfig>
+        {
+            new() { Name = "P", MaxSizeMB = 100, FolderMapping = FolderMappingMode.Mirror,
+                Sources = new List<SourceConfig>
+                {
+                    new() { Type = "mbox", Path = "Inbox", MsfPath = msfPath,
+                            TargetFolderPath = new List<string> { "Inbox" } },
+                } },
+        },
+    };
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Inbox.msf")]
+    public void ConfigValidator_AcceptsAnyMsfPath_NoThrow(string? msfPath)
+        => ConfigValidator.Validate(Config(msfPath)); // lenient: must not throw
+
+    [Fact]
+    public void MsfPath_FlowsThrough_MappingEngine_ToSourceMapping()
+    {
+        List<PstOutputPlan> plans = MappingEngine.BuildPlan(Config("Inbox.msf"));
+        SourceMapping m = plans.Single().SourceMappings.Single();
+        Assert.Equal("Inbox.msf", m.Source.MsfPath);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Discovery/MailProfileDiscoveryTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Discovery/MailProfileDiscoveryTests.cs
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Discovery;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Discovery;
+
+public class MailProfileDiscoveryTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "m2p-prof-" + Guid.NewGuid());
+    public MailProfileDiscoveryTests() => Directory.CreateDirectory(_root);
+    public void Dispose() { try { Directory.Delete(_root, true); } catch { } }
+    private void Touch(string rel)
+    {
+        string p = Path.Combine(_root, rel);
+        Directory.CreateDirectory(Path.GetDirectoryName(p)!);
+        File.WriteAllBytes(p, Array.Empty<byte>());
+    }
+    private string[] Path2(DiscoveredSource s) => s.TargetFolderPath.ToArray();
+
+    [Fact]
+    public void ProfileRoot_WalksAccounts_PrefixesAccountName_AndPairs()
+    {
+        Touch("Mail/Local Folders/Inbox");  Touch("Mail/Local Folders/Inbox.msf");
+        Touch("Mail/Local Folders/Inbox.sbd/Work"); Touch("Mail/Local Folders/Inbox.sbd/Work.msf");
+        Touch("ImapMail/imap.x/INBOX");     Touch("ImapMail/imap.x/INBOX.msf");
+
+        DiscoveryResult r = MailProfileDiscovery.Discover(_root);
+
+        Assert.Equal("thunderbird-profile", r.Layout);
+        Assert.Contains(r.Sources, s => Path2(s).SequenceEqual(new[] { "Local Folders", "Inbox" }) && s.MsfPath != null);
+        // Inbox.sbd/Work is a CHILD of Inbox (the .sbd rule), so the path nests under Inbox.
+        Assert.Contains(r.Sources, s => Path2(s).SequenceEqual(new[] { "Local Folders", "Inbox", "Work" }) && s.MsfPath != null);
+        Assert.Contains(r.Sources, s => Path2(s).SequenceEqual(new[] { "imap.x", "INBOX" }) && s.MsfPath != null);
+        Assert.Equal(3, r.Pairing.PairedMsfCount);
+    }
+
+    [Fact]
+    public void StoreRootInput_NamedMail_EnumeratesAccounts()
+    {
+        Touch("Mail/Local Folders/Inbox");
+        DiscoveryResult r = MailProfileDiscovery.Discover(Path.Combine(_root, "Mail"));
+        Assert.Equal("thunderbird-store-root", r.Layout);
+        Assert.Contains(r.Sources, s => Path2(s).SequenceEqual(new[] { "Local Folders", "Inbox" }));
+    }
+
+    [Fact]
+    public void SingleAccountDir_NoPrefix_TodaysBehaviour()
+    {
+        Touch("Inbox"); Touch("Inbox.msf");
+        DiscoveryResult r = MailProfileDiscovery.Discover(_root);
+        Assert.Equal(new[] { "Inbox" }, Path2(r.Sources.Single())); // no account prefix
+    }
+
+    [Fact]
+    public void LooseFileUnderStore_IsSkippedWithWarning()
+    {
+        Touch("Mail/Local Folders/Inbox");
+        Touch("Mail/loose.txt"); // a file directly under Mail/
+        DiscoveryResult r = MailProfileDiscovery.Discover(_root);
+        Assert.Contains(r.Skipped, k => k.Path.EndsWith("loose.txt", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CrossAccountDuplicate_EmitsOneWarning()
+    {
+        // Same account dir name "Dup" under both Mail/ and ImapMail/ -> same prefixed path ["Dup","Inbox"].
+        Touch("Mail/Dup/Inbox");
+        Touch("ImapMail/Dup/Inbox");
+        DiscoveryResult r = MailProfileDiscovery.Discover(_root);
+        Assert.Single(r.Warnings.Where(w => w.Code == "duplicate-target-folder-path"));
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Discovery/MailProfileDiscoveryTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Discovery/MailProfileDiscoveryTests.cs
@@ -71,6 +71,6 @@ public class MailProfileDiscoveryTests : IDisposable
         Touch("Mail/Dup/Inbox");
         Touch("ImapMail/Dup/Inbox");
         DiscoveryResult r = MailProfileDiscovery.Discover(_root);
-        Assert.Single(r.Warnings.Where(w => w.Code == "duplicate-target-folder-path"));
+        Assert.Single(r.Warnings, w => w.Code == "duplicate-target-folder-path");
     }
 }

--- a/tests/Mail2Pst.Core.Tests/Discovery/MailTreeDiscoveryMsfPairingTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Discovery/MailTreeDiscoveryMsfPairingTests.cs
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Discovery;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Discovery;
+
+public class MailTreeDiscoveryMsfPairingTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "m2p-msf-" + Guid.NewGuid());
+    public MailTreeDiscoveryMsfPairingTests() => Directory.CreateDirectory(_dir);
+    public void Dispose() { try { Directory.Delete(_dir, true); } catch { } }
+    private void Touch(string rel) // creates an empty file (valid empty-folder mbox / never-parsed .msf)
+    {
+        string p = Path.Combine(_dir, rel);
+        Directory.CreateDirectory(Path.GetDirectoryName(p)!);
+        File.WriteAllBytes(p, Array.Empty<byte>());
+    }
+
+    [Fact]
+    public void PairedMbox_GetsMsfPath_AndMsfNotCountedAsMetadata()
+    {
+        Touch("Inbox"); Touch("Inbox.msf");
+        DiscoveryResult r = MailTreeDiscovery.Discover(_dir);
+        DiscoveredSource s = r.Sources.Single();
+        Assert.Equal(Path.Combine(_dir, "Inbox.msf"), s.MsfPath);
+        Assert.Equal(1, r.Pairing.PairedMsfCount);
+        Assert.Equal(0, r.Pairing.UnpairedMboxCount);
+        Assert.Equal(0, r.Pairing.OrphanMsfCount);
+        // paired .msf must NOT show up as a skipped metadata entry
+        Assert.DoesNotContain(r.Skipped, k => k.Path.EndsWith("Inbox.msf", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void UnpairedMbox_HasNullMsfPath()
+    {
+        Touch("Sent"); // no Sent.msf
+        DiscoveryResult r = MailTreeDiscovery.Discover(_dir);
+        Assert.Null(r.Sources.Single().MsfPath);
+        Assert.Equal(1, r.Pairing.UnpairedMboxCount);
+        Assert.Equal(0, r.Pairing.PairedMsfCount);
+    }
+
+    [Fact]
+    public void OrphanMsf_IsCounted_AndSkipped()
+    {
+        Touch("Ghost.msf"); // no sibling base file at all
+        DiscoveryResult r = MailTreeDiscovery.Discover(_dir);
+        Assert.Empty(r.Sources);
+        Assert.Equal(1, r.Pairing.OrphanMsfCount);
+        Assert.Contains(r.Skipped, s => s.Code == "orphan-msf" && s.Path.EndsWith("Ghost.msf", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void MsfBesideNonMboxBase_DoesNotPair_IsOrphan()
+    {
+        // "Foo" is NOT an accepted mbox (non-empty, no envelope postmark) -> Foo.msf must be an orphan,
+        // not a pairing. (The core "accepted-mbox-only" rule lives here in MailTreeDiscovery.)
+        File.WriteAllText(Path.Combine(_dir, "Foo"), "this is not an mbox postmark\n");
+        Touch("Foo.msf");
+        DiscoveryResult r = MailTreeDiscovery.Discover(_dir);
+        Assert.Empty(r.Sources);                    // Foo is not-mbox
+        Assert.Equal(0, r.Pairing.PairedMsfCount);
+        Assert.Equal(1, r.Pairing.OrphanMsfCount);  // Foo.msf has no ACCEPTED mbox sibling
+    }
+
+    [Fact]
+    public void Prefix_PrependsToTargetFolderPath()
+    {
+        Touch("Inbox"); Touch("Inbox.msf");
+        DiscoveryResult r = MailTreeDiscovery.Discover(_dir, new[] { "Local Folders" });
+        Assert.Equal(new[] { "Local Folders", "Inbox" }, r.Sources.Single().TargetFolderPath);
+    }
+}


### PR DESCRIPTION
## Problem
`discover` walked a single flat mail-folder tree and ignored Thunderbird `.msf` summary files. To later run full-fidelity conversion straight from a Thunderbird profile, discovery must classify the input, walk per-account, and pair each mbox with its sibling `.msf` — without yet changing conversion.

## Change
- `SourceConfig.MsfPath` (`string?`), lenient in `ConfigValidator`, flows through `MappingEngine` to `SourceMapping.Source` for a later consumer.
- `MailTreeDiscovery` pairs each **accepted** mbox with a sibling `<name>.msf` by existence only (two-pass, accepted-mbox-only; only a normal non-reparse file is eligible), reports a `DiscoveryPairingSummary` (paired/unpaired/orphan), and takes an optional folder prefix.
- New `MailProfileDiscovery` orchestrator: auto-classifies the input (store-root `Mail`/`ImapMail` → profile → single tree), walks each account directory with the account name as the top folder segment, merges results, and runs a cross-account-only duplicate pass keyed on origin account dir.
- `discover` CLI calls `MailProfileDiscovery` and emits additive `msfPath` (per source) + a `pairing` summary; existing output and `schemaVersion` unchanged.

## Effect
No conversion-behaviour change and no `.msf` parsing — pairing is path-existence only, so no new file-lock risk. Output additions are backward-compatible. Threads the `.msf` path to the conversion boundary for the next sub-project to consume.

## Tests
497 core + 29 integration passing (3 corpus skipped), build clean — adds 16 SP4a tests covering pairing, orphan/unpaired cases, accepted-mbox-only, profile/store-root/single-tree classification, account prefixing, cross-account dedupe, and the CLI `msfPath`/`pairing` output.