### PR TITLE
feat: streaming Thunderbird .msf enrichment + convert --profile (SP4b)

### DIFF
--- a/src/Mail2Pst.Cli/ConvertCommand.cs
+++ b/src/Mail2Pst.Cli/ConvertCommand.cs
@@ -21,6 +21,9 @@ internal static class ConvertCommand
         {
             CliArgs.WriteJsonLine(new { type = "error", stage = "convert", message = resolved.Error, fatal = true });
             Console.Error.WriteLine(resolved.Error);
+            Console.Error.WriteLine("Usage:");
+            Console.Error.WriteLine("  continumail-convert convert --config <config.json> --output <dir>");
+            Console.Error.WriteLine("  continumail-convert convert --profile <dir> [--config <options.json>] --output <dir>");
             return 1;
         }
 

--- a/src/Mail2Pst.Cli/ConvertCommand.cs
+++ b/src/Mail2Pst.Cli/ConvertCommand.cs
@@ -16,21 +16,16 @@ internal static class ConvertCommand
 {
     internal static int Run(string[] args)
     {
-        string? configPath = CliArgs.Flag(args, "--config");
-        string? outputDir  = CliArgs.Flag(args, "--output");
-
-        if (configPath is null || outputDir is null)
+        ConvertResolution resolved = ConvertInput.Resolve(args);
+        if (resolved.Error is not null)
         {
-            Console.Error.WriteLine("Usage: continumail-convert convert --config <config.json> --output <dir>");
+            CliArgs.WriteJsonLine(new { type = "error", stage = "convert", message = resolved.Error, fatal = true });
+            Console.Error.WriteLine(resolved.Error);
             return 1;
         }
 
-        if (!File.Exists(configPath))
-        {
-            CliArgs.WriteJsonLine(new { type = "error", stage = "convert", message = $"Config not found: {configPath}", fatal = true });
-            Console.Error.WriteLine($"Config not found: {configPath}");
-            return 1;
-        }
+        string outputDir = resolved.OutputDir!;
+        ConversionConfig config = resolved.Config!;
 
         try
         {
@@ -43,19 +38,7 @@ internal static class ConvertCommand
             return 1;
         }
 
-        CliArgs.WriteJsonLine(new { type = "started", input = configPath, outputDirectory = outputDir });
-
-        ConversionConfig config;
-        try
-        {
-            config = ConfigLoader.Load(configPath);
-        }
-        catch (Exception ex)
-        {
-            CliArgs.WriteJsonLine(new { type = "error", stage = "convert", message = $"Failed to load config: {ex.Message}", fatal = true });
-            Console.Error.WriteLine($"Failed to load config: {ex.Message}");
-            return 1;
-        }
+        CliArgs.WriteJsonLine(new { type = "started", input = resolved.InputLabel, outputDirectory = outputDir });
 
         // The blank PST seed lives embedded in the engine assembly; extract it to a
         // temp file (cleaned up in the finally below). The single-file sidecar is run
@@ -157,6 +140,7 @@ internal static class ConvertCommand
                 outputDirectory = outputDir,
                 report = reportJsonPath,
                 elapsedMs = stopwatch.ElapsedMilliseconds,
+                enrichment = report.EnrichmentSummary,
             });
 
             return 0;

--- a/src/Mail2Pst.Cli/ConvertInput.cs
+++ b/src/Mail2Pst.Cli/ConvertInput.cs
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Discovery;
+
+namespace Mail2Pst.Cli;
+
+/// <summary>Resolved convert inputs, or a user-facing Error string. Pure (no signals/conversion).</summary>
+internal sealed record ConvertResolution(ConversionConfig? Config, string? OutputDir, string? InputLabel, string? Error);
+
+/// <summary>
+/// Resolves `convert` arguments into a ConversionConfig (or an error), supporting --config (existing),
+/// --profile (discover a Thunderbird profile), and --profile + --config (config = options template).
+/// Side-effecting only on the filesystem (reads config / walks profile); no conversion or OS signals,
+/// so it is unit-testable (Mail2Pst.Integration.Tests sees it via InternalsVisibleTo).
+/// </summary>
+internal static class ConvertInput
+{
+    private static readonly System.Collections.Generic.HashSet<string> KnownFlags =
+        new(StringComparer.Ordinal) { "--config", "--profile", "--output" };
+
+    internal static ConvertResolution Resolve(string[] args)
+    {
+        // Reject unknown options and stray positional arguments (spec §5.1) before interpreting flags.
+        string? argError = ValidateKnownArgs(args);
+        if (argError is not null)
+            return new(null, null, null, argError);
+
+        string? configPath = CliArgs.Flag(args, "--config");
+        string? profileDir = CliArgs.Flag(args, "--profile");
+        string? outputDir = CliArgs.Flag(args, "--output");
+
+        if (outputDir is null)
+            return new(null, null, null, "Missing --output <dir>.");
+        if (configPath is null && profileDir is null)
+            return new(null, null, null, "Provide --config <config.json> or --profile <dir>.");
+
+        if (profileDir is not null)
+        {
+            if (!Directory.Exists(profileDir))
+                return new(null, null, null, $"Profile directory not found: {profileDir}");
+
+            ConversionConfig? template = null;
+            if (configPath is not null)
+            {
+                if (!File.Exists(configPath))
+                    return new(null, null, null, $"Config not found: {configPath}");
+                try { template = ConfigLoader.Load(configPath); }
+                catch (Exception ex) { return new(null, null, null, $"Failed to load config: {ex.Message}"); }
+            }
+
+            try
+            {
+                DiscoveryResult discovery = MailProfileDiscovery.Discover(profileDir);
+                ConversionConfig config = ConfigFromDiscovery.Build(discovery, template);
+                return new(config, outputDir, profileDir, null);
+            }
+            catch (Exception ex)
+            {
+                return new(null, null, null, ex.Message);
+            }
+        }
+
+        // --config only (existing behaviour).
+        if (!File.Exists(configPath!))
+            return new(null, null, null, $"Config not found: {configPath}");
+        try
+        {
+            ConversionConfig config = ConfigLoader.Load(configPath!);
+            return new(config, outputDir, configPath, null);
+        }
+        catch (Exception ex)
+        {
+            return new(null, null, null, $"Failed to load config: {ex.Message}");
+        }
+    }
+
+    // Every arg must be a known `--flag` immediately followed by its value. Rejects unknown options,
+    // stray positionals, and a flag whose value is missing (next token is another flag or end-of-args).
+    private static string? ValidateKnownArgs(string[] args)
+    {
+        for (int i = 0; i < args.Length; i++)
+        {
+            string arg = args[i];
+            if (!arg.StartsWith("--", StringComparison.Ordinal))
+                return $"Unexpected argument: {arg}";
+            if (!KnownFlags.Contains(arg))
+                return $"Unknown option: {arg}";
+            if (i + 1 >= args.Length || args[i + 1].StartsWith("--", StringComparison.Ordinal))
+                return $"Missing value for {arg}.";
+            i++; // consume the value
+        }
+        return null;
+    }
+}

--- a/src/Mail2Pst.Cli/InternalsVisibleTo.cs
+++ b/src/Mail2Pst.Cli/InternalsVisibleTo.cs
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Mail2Pst.Integration.Tests")]

--- a/src/Mail2Pst.Cli/Program.cs
+++ b/src/Mail2Pst.Cli/Program.cs
@@ -10,6 +10,7 @@ if (args.Length == 0)
 {
     Console.Error.WriteLine("Usage:");
     Console.Error.WriteLine("  continumail-convert convert  --config <config.json> --output <dir>");
+    Console.Error.WriteLine("  continumail-convert convert  --profile <dir> [--config <options.json>] --output <dir>");
     Console.Error.WriteLine("  continumail-convert scan     --input <path> [--input <path> ...] [--type mbox]");
     Console.Error.WriteLine("  continumail-convert discover --input <dir>");
     return 1;

--- a/src/Mail2Pst.Core/ConversionRunner.cs
+++ b/src/Mail2Pst.Core/ConversionRunner.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using Mail2Pst.Core.Config;
 using Mail2Pst.Core.Mapping;
 using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Msf;
 using Mail2Pst.Core.Parsing;
 using Mail2Pst.Core.Progress;
 using Mail2Pst.Core.Reporting;
@@ -37,6 +38,12 @@ public class ConversionRunner
 
         var report = new ConversionReport();
         List<PstOutputPlan> plans = MappingEngine.BuildPlan(config);
+
+        var enrichmentOptions = new MsfEnrichmentOptions
+        {
+            TagResolver = new DefaultMsfTagResolver(),
+            JunkHandling = config.JunkHandling,
+        };
 
         // Validate source types eagerly so an unsupported type fails loudly
         // before any output file is created, rather than mid-write.
@@ -72,7 +79,7 @@ public class ConversionRunner
         {
             foreach (PstOutputPlan plan in plans)
             {
-                IEnumerable<PlannedMessage> plannedMessages = EnumeratePlannedMessages(plan, report, onProgress);
+                IEnumerable<PlannedMessage> plannedMessages = EnumeratePlannedMessages(plan, report, enrichmentOptions, onProgress);
                 List<string> outputFiles = _writer.WritePlan(plan, plannedMessages, outputDirectory, report, total, onProgress, cancellationToken);
                 report.AddOutputFiles(outputFiles);
             }
@@ -96,57 +103,71 @@ public class ConversionRunner
     }
 
     private static IEnumerable<PlannedMessage> EnumeratePlannedMessages(
-        PstOutputPlan plan, ConversionReport report, Action<ConversionProgressEvent>? onProgress = null)
+        PstOutputPlan plan, ConversionReport report, MsfEnrichmentOptions enrichmentOptions,
+        Action<ConversionProgressEvent>? onProgress = null)
     {
         foreach (SourceMapping mapping in plan.SourceMappings)
         {
-            IMailSourceParser parser = ParserRegistry.Get(mapping.Source.Type);
-            // `using` declaration: the underlying MboxParser.Parse owns a FileStream that is
-            // only released when this enumerator is disposed. Without it, abandoning the
-            // enumeration early (IOException skip below, cancellation, or split-cap stop in the
-            // consumer) would leak the source file handle until GC.
-            using IEnumerator<ParseResult> results = parser.Parse(mapping.Source.Path).GetEnumerator();
+            // Build optional .msf enrichment for this source (records attempted/degraded + any warning,
+            // emitting a live WarningEvent through onProgress on degradation).
+            SourceEnrichmentContext? enrichment =
+                SourceEnrichmentContext.TryCreate(mapping.Source, enrichmentOptions, report, onProgress);
 
-            while (true)
+            // finally (not the natural foreach end) folds the per-message counts, so they survive early
+            // disposal of this iterator (cancellation / split-cap stop / producer fault in the writer).
+            try
             {
-                ParseResult result;
-                try
+                IMailSourceParser parser = ParserRegistry.Get(mapping.Source.Type);
+                using IEnumerator<ParseResult> results = parser.Parse(mapping.Source.Path).GetEnumerator();
+
+                while (true)
                 {
-                    if (!results.MoveNext())
+                    ParseResult result;
+                    try
                     {
+                        if (!results.MoveNext())
+                        {
+                            break;
+                        }
+
+                        result = results.Current;
+                    }
+                    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                    {
+                        report.RecordSkipped(
+                            new SourceReference { SourcePath = mapping.Source.Path, Identifier = "(source)" },
+                            ex.Message);
                         break;
                     }
 
-                    result = results.Current;
-                }
-                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-                {
-                    // A missing/unreadable source (matching the best-effort catch in the
-                    // message-count loop above) is skipped-and-recorded, not allowed to
-                    // crash the whole conversion.
-                    report.RecordSkipped(
-                        new SourceReference { SourcePath = mapping.Source.Path, Identifier = "(source)" },
-                        ex.Message);
-                    break;
-                }
+                    if (!result.Success)
+                    {
+                        report.RecordSkipped(result.Source, result.Error!);
+                        continue;
+                    }
 
-                if (!result.Success)
-                {
-                    report.RecordSkipped(result.Source, result.Error!);
-                    continue;
-                }
+                    foreach (string warning in result.Warnings)
+                    {
+                        report.RecordWarning(result.Source, warning);
+                        onProgress?.Invoke(new WarningEvent(result.Source.SourcePath, result.Source.Identifier, warning));
+                    }
 
-                foreach (string warning in result.Warnings)
-                {
-                    report.RecordWarning(result.Source, warning);
-                    onProgress?.Invoke(new WarningEvent(result.Source.SourcePath, result.Source.Identifier, warning));
-                }
+                    MailMessage message = result.Message!;
+                    enrichment?.Apply(message);
 
-                yield return new PlannedMessage
+                    yield return new PlannedMessage
+                    {
+                        Message = message,
+                        TargetFolderPath = mapping.TargetFolderPath,
+                    };
+                }
+            }
+            finally
+            {
+                if (enrichment is not null)
                 {
-                    Message = result.Message!,
-                    TargetFolderPath = mapping.TargetFolderPath,
-                };
+                    report.RecordEnrichmentCounts(enrichment.Result);
+                }
             }
         }
     }

--- a/src/Mail2Pst.Core/Discovery/ConfigFromDiscovery.cs
+++ b/src/Mail2Pst.Core/Discovery/ConfigFromDiscovery.cs
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Config;
+
+namespace Mail2Pst.Core.Discovery;
+
+/// <summary>
+/// Builds a ConversionConfig from discovery for profile-mode conversion. With no template, uses
+/// defaults. With a template, copies OPTIONS only (top-level + at most one output group's settings);
+/// the template's sources are discarded — discovery supplies the sources. Reused by the SP4c GUI.
+/// </summary>
+public static class ConfigFromDiscovery
+{
+    public static ConversionConfig Build(DiscoveryResult discovery, ConversionConfig? template)
+    {
+        ArgumentNullException.ThrowIfNull(discovery);
+
+        var config = new ConversionConfig();
+        var group = new OutputGroupConfig();
+
+        if (template is not null)
+        {
+            if (template.Outputs.Count > 1)
+                throw new ConfigValidationException(
+                    "Profile mode accepts a config template with at most one output group; " +
+                    $"found {template.Outputs.Count}.");
+
+            config.JunkHandling = template.JunkHandling;
+
+            if (template.Outputs.Count == 1)
+            {
+                OutputGroupConfig t = template.Outputs[0];
+                group.Name = t.Name;
+                group.MaxSizeMB = t.MaxSizeMB;
+                group.IncludeEmptyFolders = t.IncludeEmptyFolders;
+                group.FolderMapping = t.FolderMapping;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(group.Name))
+            group.Name = DeriveName(discovery.Root);
+
+        group.Sources = discovery.Sources.Select(s => new SourceConfig
+        {
+            Path = s.Path,
+            Type = s.Type,
+            TargetFolderPath = s.TargetFolderPath.ToList(),
+            MsfPath = s.MsfPath,
+        }).ToList();
+
+        config.Outputs.Add(group);
+        return config;
+    }
+
+    private static string DeriveName(string root)
+    {
+        string name = Path.GetFileName(root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        return string.IsNullOrWhiteSpace(name) ? "Thunderbird" : name;
+    }
+}

--- a/src/Mail2Pst.Core/Mork/MorkReader.cs
+++ b/src/Mail2Pst.Core/Mork/MorkReader.cs
@@ -27,6 +27,17 @@ public static class MorkReader
         return Parse(fs);
     }
 
+    /// <summary>
+    /// Parses a .msf with a live-friendly share mode (<see cref="FileShare.ReadWrite"/>), so a running
+    /// Thunderbird holding the file open does not cause a sharing violation. Use this for conversion-time
+    /// .msf reads; <see cref="Parse(string)"/> keeps ordinary read semantics for all other callers.
+    /// </summary>
+    public static MorkDocument ParseSharedReadWrite(string path)
+    {
+        using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        return Parse(fs);
+    }
+
     public static MorkDocument Parse(Stream stream)
     {
         using var ms = new MemoryStream();

--- a/src/Mail2Pst.Core/Msf/MboxDuplicateIdSet.cs
+++ b/src/Mail2Pst.Core/Msf/MboxDuplicateIdSet.cs
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using Mail2Pst.Core.Models;
+
+namespace Mail2Pst.Core.Msf;
+
+/// <summary>
+/// The set of normalized Message-IDs occurring more than once on the mbox side. Built from a
+/// materialized list (batch Enrich) or from the streaming pre-pass scanner's counts.
+/// </summary>
+internal sealed class MboxDuplicateIdSet
+{
+    private readonly HashSet<string> _dup;
+
+    private MboxDuplicateIdSet(HashSet<string> dup) => _dup = dup;
+
+    public bool Contains(string normalizedId) => _dup.Contains(normalizedId);
+
+    public static MboxDuplicateIdSet FromMessages(IReadOnlyList<MailMessage> messages)
+    {
+        ArgumentNullException.ThrowIfNull(messages);
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (MailMessage mail in messages)
+        {
+            string? key = MessageIdNormalizer.NormalizeForJoin(mail.MessageId);
+            if (key is not null) counts[key] = counts.GetValueOrDefault(key) + 1;
+        }
+        return FromCounts(counts);
+    }
+
+    public static MboxDuplicateIdSet FromCounts(IReadOnlyDictionary<string, int> counts)
+    {
+        ArgumentNullException.ThrowIfNull(counts);
+        var dup = new HashSet<string>(StringComparer.Ordinal);
+        foreach (KeyValuePair<string, int> kv in counts)
+            if (kv.Value > 1) dup.Add(kv.Key);
+        return new MboxDuplicateIdSet(dup);
+    }
+}

--- a/src/Mail2Pst.Core/Msf/MsfEnricher.cs
+++ b/src/Mail2Pst.Core/Msf/MsfEnricher.cs
@@ -25,8 +25,8 @@ public sealed class MsfEnrichmentResult
 }
 
 /// <summary>
-/// Joins .msf rows to MailMessages by uniquely-resolvable normalized Message-ID and applies
-/// the .msf's authoritative flags, junk, and tags. Pure; no I/O or file pairing (SP4 wires that).
+/// Joins .msf rows to MailMessages by uniquely-resolvable normalized Message-ID and applies the
+/// .msf's authoritative flags, junk, and tags. Pure; no I/O or file pairing (SP4b wires that).
 /// </summary>
 public static class MsfEnricher
 {
@@ -36,48 +36,41 @@ public static class MsfEnricher
         ArgumentNullException.ThrowIfNull(messages);
         ArgumentNullException.ThrowIfNull(msf);
         ArgumentNullException.ThrowIfNull(options);
+
         var result = new MsfEnrichmentResult();
-
-        // Index the .msf side by normalized id; mark non-unique keys.
-        var byId = new Dictionary<string, MsfMessage>(StringComparer.Ordinal);
-        var dupMsf = new HashSet<string>(StringComparer.Ordinal);
-        foreach (MsfMessage m in msf.Messages)
-        {
-            string? key = MessageIdNormalizer.NormalizeForJoin(m.MessageId);
-            if (key is null) continue;
-            // On a duplicate, drop the first-seen entry too so byId and dupMsf stay consistent.
-            if (!byId.TryAdd(key, m)) { byId.Remove(key); dupMsf.Add(key); }
-        }
-        // Mark mbox-side duplicate keys too.
-        var mailKeyCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        MsfJoinIndex index = MsfJoinIndex.Build(msf);
+        MboxDuplicateIdSet mboxDuplicates = MboxDuplicateIdSet.FromMessages(messages);
         foreach (MailMessage mail in messages)
-        {
-            string? key = MessageIdNormalizer.NormalizeForJoin(mail.MessageId);
-            if (key is not null) mailKeyCounts[key] = mailKeyCounts.GetValueOrDefault(key) + 1;
-        }
-
-        foreach (MailMessage mail in messages)
-        {
-            string? key = MessageIdNormalizer.NormalizeForJoin(mail.MessageId);
-            if (key is null) { result.SkippedMissingId++; continue; }
-            if (mailKeyCounts[key] > 1 || dupMsf.Contains(key)) { result.SkippedDuplicateId++; continue; }
-            if (!byId.TryGetValue(key, out MsfMessage? row)) { result.NoMsfMatch++; continue; }
-
-            // .msf wins for scalar flags.
-            mail.IsRead = row.IsRead;
-            mail.IsReplied = row.IsReplied;
-            mail.IsForwarded = row.IsForwarded;
-            mail.IsFlagged = row.IsFlagged;
-            mail.IsJunk = row.IsJunk;
-
-            var resolved = new List<string>(options.TagResolver.Resolve(row.Keywords));
-            if (options.JunkHandling == JunkHandlingMode.Category && row.IsJunk) resolved.Add("Junk");
-            MergeCategories(mail.Categories, resolved);
-
-            if (row.IsExpunged) result.ExpungedMatched++;
-            result.Matched++;
-        }
+            TryApply(mail, index, mboxDuplicates, options, result);
         return result;
+    }
+
+    /// <summary>
+    /// Applies one message. Increments EXACTLY ONE of matched/skippedMissingId/skippedDuplicateId/
+    /// noMsfMatch on <paramref name="result"/>; mutates <paramref name="mail"/> only on a unique match.
+    /// </summary>
+    internal static void TryApply(
+        MailMessage mail, MsfJoinIndex index, MboxDuplicateIdSet mboxDuplicates,
+        MsfEnrichmentOptions options, MsfEnrichmentResult result)
+    {
+        string? key = MessageIdNormalizer.NormalizeForJoin(mail.MessageId);
+        if (key is null) { result.SkippedMissingId++; return; }
+        if (mboxDuplicates.Contains(key) || index.IsDuplicateMsfId(key)) { result.SkippedDuplicateId++; return; }
+        if (!index.TryGetUnique(key, out MsfMessage row)) { result.NoMsfMatch++; return; }
+
+        // .msf wins for scalar flags.
+        mail.IsRead = row.IsRead;
+        mail.IsReplied = row.IsReplied;
+        mail.IsForwarded = row.IsForwarded;
+        mail.IsFlagged = row.IsFlagged;
+        mail.IsJunk = row.IsJunk;
+
+        var resolved = new List<string>(options.TagResolver.Resolve(row.Keywords));
+        if (options.JunkHandling == JunkHandlingMode.Category && row.IsJunk) resolved.Add("Junk");
+        MergeCategories(mail.Categories, resolved);
+
+        if (row.IsExpunged) result.ExpungedMatched++;
+        result.Matched++;
     }
 
     // Append new categories to existing, dedupe ordinal, preserve first occurrence; never remove.

--- a/src/Mail2Pst.Core/Msf/MsfJoinIndex.cs
+++ b/src/Mail2Pst.Core/Msf/MsfJoinIndex.cs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Mail2Pst.Core.Msf;
+
+/// <summary>
+/// Indexes the .msf side of the join by normalized Message-ID. Duplicate keys are removed-and-marked
+/// exactly as SP3's Enrich did: a key seen more than once never matches (TryGetUnique false) and is
+/// reported via IsDuplicateMsfId.
+/// </summary>
+internal sealed class MsfJoinIndex
+{
+    private readonly Dictionary<string, MsfMessage> _byId;
+    private readonly HashSet<string> _dup;
+
+    private MsfJoinIndex(Dictionary<string, MsfMessage> byId, HashSet<string> dup)
+    {
+        _byId = byId;
+        _dup = dup;
+    }
+
+    public static MsfJoinIndex Build(MsfReadResult msf)
+    {
+        ArgumentNullException.ThrowIfNull(msf);
+        var byId = new Dictionary<string, MsfMessage>(StringComparer.Ordinal);
+        var dup = new HashSet<string>(StringComparer.Ordinal);
+        foreach (MsfMessage m in msf.Messages)
+        {
+            string? key = MessageIdNormalizer.NormalizeForJoin(m.MessageId);
+            if (key is null) continue;
+            // On a duplicate, drop the first-seen entry too so _byId and _dup stay consistent (SP3 rule).
+            if (!byId.TryAdd(key, m)) { byId.Remove(key); dup.Add(key); }
+        }
+        return new MsfJoinIndex(byId, dup);
+    }
+
+    public bool IsDuplicateMsfId(string normalizedId) => _dup.Contains(normalizedId);
+
+    public bool TryGetUnique(string normalizedId, out MsfMessage row) => _byId.TryGetValue(normalizedId, out row!);
+}

--- a/src/Mail2Pst.Core/Msf/SourceEnrichmentContext.cs
+++ b/src/Mail2Pst.Core/Msf/SourceEnrichmentContext.cs
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Mork;
+using Mail2Pst.Core.Parsing;
+using Mail2Pst.Core.Progress;
+using Mail2Pst.Core.Reporting;
+
+namespace Mail2Pst.Core.Msf;
+
+/// <summary>
+/// Per-source .msf enrichment for the streaming conversion path. TryCreate builds the join index +
+/// mbox-duplicate set, recording the source-level outcome (attempted/enriched/degraded) and any
+/// degradation warning on the report. Optional metadata: ANY .msf failure degrades (warns, no abort);
+/// an mbox pre-pass I/O failure drops the context silently so the parse path reports the source skip
+/// exactly once (no double-report).
+/// </summary>
+internal sealed class SourceEnrichmentContext
+{
+    private readonly MsfJoinIndex _index;
+    private readonly MboxDuplicateIdSet _mboxDuplicates;
+    private readonly MsfEnrichmentOptions _options;
+
+    public MsfEnrichmentResult Result { get; } = new();
+
+    private SourceEnrichmentContext(MsfJoinIndex index, MboxDuplicateIdSet mboxDuplicates, MsfEnrichmentOptions options)
+    {
+        _index = index;
+        _mboxDuplicates = mboxDuplicates;
+        _options = options;
+    }
+
+    public void Apply(MailMessage message) => MsfEnricher.TryApply(message, _index, _mboxDuplicates, _options, Result);
+
+    public static SourceEnrichmentContext? TryCreate(
+        SourceConfig source, MsfEnrichmentOptions options, ConversionReport report,
+        Action<ConversionProgressEvent>? onProgress = null)
+    {
+        string? msfPath = source.MsfPath;
+        if (string.IsNullOrWhiteSpace(msfPath))
+        {
+            report.RecordEnrichmentSource(attempted: false, enriched: false, degraded: false);
+            return null;
+        }
+
+        var sourceRef = new SourceReference { SourcePath = source.Path, Identifier = "(.msf)" };
+
+        if (!File.Exists(msfPath))
+        {
+            Degrade(report, onProgress, sourceRef, $"Paired .msf not found; message flags/tags not applied: {msfPath}");
+            return null;
+        }
+
+        MsfJoinIndex index;
+        try
+        {
+            MorkDocument doc = MorkReader.ParseSharedReadWrite(msfPath);
+            MsfReadResult msf = MsfMessageReader.Read(doc);
+            index = MsfJoinIndex.Build(msf);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or MorkFormatException)
+        {
+            Degrade(report, onProgress, sourceRef, $"Could not read paired .msf; message flags/tags not applied: {ex.Message}");
+            return null;
+        }
+
+        MboxDuplicateIdSet mboxDuplicates;
+        try
+        {
+            mboxDuplicates = MboxMessageIdScanner.ScanDuplicateIds(source.Path);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // The mbox itself is missing/unreadable — NOT an .msf degradation. The normal parse path
+            // records the single authoritative source skip; do not warn or count degraded here.
+            report.RecordEnrichmentSource(attempted: true, enriched: false, degraded: false);
+            return null;
+        }
+
+        report.RecordEnrichmentSource(attempted: true, enriched: true, degraded: false);
+        return new SourceEnrichmentContext(index, mboxDuplicates, options);
+    }
+
+    // An .msf-specific degradation: record on the report AND emit the live WarningEvent so streaming
+    // consumers (CLI/GUI) see it, mirroring how parse warnings are surfaced in ConversionRunner.
+    private static void Degrade(
+        ConversionReport report, Action<ConversionProgressEvent>? onProgress, SourceReference sourceRef, string warning)
+    {
+        report.RecordWarning(sourceRef, warning);
+        onProgress?.Invoke(new WarningEvent(sourceRef.SourcePath, sourceRef.Identifier, warning));
+        report.RecordEnrichmentSource(attempted: true, enriched: false, degraded: true);
+    }
+}

--- a/src/Mail2Pst.Core/Parsing/MboxMessageIdScanner.cs
+++ b/src/Mail2Pst.Core/Parsing/MboxMessageIdScanner.cs
@@ -19,7 +19,7 @@ namespace Mail2Pst.Core.Parsing;
 internal static class MboxMessageIdScanner
 {
     /// <summary>The set of normalized Message-IDs occurring more than once in the mbox.</summary>
-    public static MboxDuplicateIdSet ScanDuplicateIds(string path)
+    internal static MboxDuplicateIdSet ScanDuplicateIds(string path)
     {
         using FileStream stream = File.OpenRead(path); // ordinary read, same as MboxParser
         var counts = new Dictionary<string, int>(StringComparer.Ordinal);

--- a/src/Mail2Pst.Core/Parsing/MboxMessageIdScanner.cs
+++ b/src/Mail2Pst.Core/Parsing/MboxMessageIdScanner.cs
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Msf;
+using MimeKit;
+using MimeKit.Utils;
+
+namespace Mail2Pst.Core.Parsing;
+
+/// <summary>
+/// Headers-only Message-ID pre-pass over an mbox. Reuses MboxParser's boundary engine (boundaries match
+/// Parse exactly) and derives the SAME normalized Message-ID that MimeMessageMapper puts on
+/// MailMessage.MessageId (so duplicate accounting cannot drift). No body/attachment decode.
+/// </summary>
+internal static class MboxMessageIdScanner
+{
+    /// <summary>The set of normalized Message-IDs occurring more than once in the mbox.</summary>
+    public static MboxDuplicateIdSet ScanDuplicateIds(string path)
+    {
+        using FileStream stream = File.OpenRead(path); // ordinary read, same as MboxParser
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (byte[] chunk in MboxParser.EnumerateRawMessages(stream))
+        {
+            string? id;
+            try
+            {
+                id = ExtractNormalizedMessageId(chunk);
+            }
+            catch (Exception ex) when (ex is FormatException or IOException)
+            {
+                // Per-message header parse failure: treat as "no usable Message-ID" and continue —
+                // the pre-pass must be no stricter than the parser, which skips such messages. A
+                // file-level IOException from File.OpenRead above still propagates (no-double-report).
+                continue;
+            }
+            if (id is not null) counts[id] = counts.GetValueOrDefault(id) + 1;
+        }
+        return MboxDuplicateIdSet.FromCounts(counts);
+    }
+
+    private static string? ExtractNormalizedMessageId(byte[] messageBytes)
+    {
+        using var ms = new MemoryStream(messageBytes, writable: false);
+        // Load ONLY the header block (MimeKit stops at the blank line) — no body/attachment decode.
+        HeaderList headers = HeaderList.Load(ms);
+        string? raw = headers["Message-Id"];
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        // Parse the addr-spec the SAME way MimeMessage.MessageId does (strips <>, comments, folding),
+        // then normalize identically to the mapper. This guarantees value parity.
+        string? parsed = MimeUtils.EnumerateReferences(raw).FirstOrDefault();
+        return MessageIdNormalizer.NormalizeForJoin(parsed ?? raw);
+    }
+}

--- a/src/Mail2Pst.Core/Parsing/MboxParser.cs
+++ b/src/Mail2Pst.Core/Parsing/MboxParser.cs
@@ -103,6 +103,14 @@ public class MboxParser : IMailSourceParser
         EnumerateMessageChunks(rawStream, materialize: true, onBytesRead).Select(b => b!);
 
     /// <summary>
+    /// Exposes the raw per-message byte chunks using the EXACT same boundary engine as
+    /// <see cref="Parse"/>/<see cref="CountMessages"/>, so the ID pre-pass
+    /// (<see cref="MboxMessageIdScanner"/>) can never split differently from the real parse.
+    /// </summary>
+    internal static IEnumerable<byte[]> EnumerateRawMessages(Stream rawStream) =>
+        EnumerateMessageChunks(rawStream, materialize: true, onBytesRead: null).Select(b => b!);
+
+    /// <summary>
     /// THE single source of truth for "where do messages begin and end" in an mbox stream.
     /// Walks the stream once, line by line, using the shared <see cref="IsMessageBoundary"/>
     /// rule (a "From " line that is the first line, follows a blank line, or matches the

--- a/src/Mail2Pst.Core/Reporting/ConversionReport.cs
+++ b/src/Mail2Pst.Core/Reporting/ConversionReport.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Msf;
 
 namespace Mail2Pst.Core.Reporting;
 
@@ -20,6 +21,9 @@ public class ConversionReport
     private readonly List<string> _outputFiles = new();
     private readonly List<string> _deletedFiles = new();
     private volatile bool _cancelled;
+
+    private int _enrMatched, _enrMissing, _enrDup, _enrNoMatch, _enrExpunged;
+    private int _srcAttempted, _srcEnriched, _srcDegraded;
 
     public int ConvertedCount => Volatile.Read(ref _convertedCount);
 
@@ -65,6 +69,39 @@ public class ConversionReport
         lock (_lock) _warnings.Add(entry);
     }
 
+    public void RecordEnrichmentSource(bool attempted, bool enriched, bool degraded)
+    {
+        lock (_lock)
+        {
+            if (attempted) _srcAttempted++;
+            if (enriched) _srcEnriched++;
+            if (degraded) _srcDegraded++;
+        }
+    }
+
+    public void RecordEnrichmentCounts(MsfEnrichmentResult result)
+    {
+        lock (_lock)
+        {
+            _enrMatched += result.Matched;
+            _enrMissing += result.SkippedMissingId;
+            _enrDup += result.SkippedDuplicateId;
+            _enrNoMatch += result.NoMsfMatch;
+            _enrExpunged += result.ExpungedMatched;
+        }
+    }
+
+    public MsfEnrichmentSummary EnrichmentSummary
+    {
+        get
+        {
+            lock (_lock)
+                return new MsfEnrichmentSummary(
+                    _enrMatched, _enrMissing, _enrDup, _enrNoMatch, _enrExpunged,
+                    _srcAttempted, _srcEnriched, _srcDegraded);
+        }
+    }
+
     public string ToJson()
     {
         // Single consistent snapshot under the lock, then serialize outside it.
@@ -85,6 +122,7 @@ public class ConversionReport
             converted = ConvertedCount,
             skipped = skipped.Select(s => new { source = s.SourcePath, identifier = s.Identifier, reason = s.Reason }),
             warnings = warnings.Select(w => new { source = w.SourcePath, identifier = w.Identifier, reason = w.Reason }),
+            enrichment = EnrichmentSummary,
         }, options);
     }
 
@@ -112,6 +150,12 @@ public class ConversionReport
         {
             builder.AppendLine($"  WARN {warning.SourcePath} [{warning.Identifier}]: {warning.Reason}");
         }
+
+        MsfEnrichmentSummary enr = EnrichmentSummary;
+        builder.AppendLine(
+            $"Enrichment: matched={enr.Matched} missingId={enr.SkippedMissingId} " +
+            $"duplicateId={enr.SkippedDuplicateId} noMsfMatch={enr.NoMsfMatch} expunged={enr.ExpungedMatched} " +
+            $"(sources attempted={enr.SourcesAttempted} enriched={enr.SourcesEnriched} degraded={enr.SourcesDegraded})");
 
         return builder.ToString();
     }

--- a/src/Mail2Pst.Core/Reporting/MsfEnrichmentSummary.cs
+++ b/src/Mail2Pst.Core/Reporting/MsfEnrichmentSummary.cs
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+namespace Mail2Pst.Core.Reporting;
+
+/// <summary>
+/// Aggregate .msf-enrichment outcome across a conversion. Per-message counts are summed across sources;
+/// SourcesAttempted = sources with a non-blank MsfPath, SourcesEnriched = context built successfully,
+/// SourcesDegraded = .msf-specific failure (missing/locked/malformed). An mbox-read failure is neither.
+/// </summary>
+public sealed record MsfEnrichmentSummary(
+    int Matched, int SkippedMissingId, int SkippedDuplicateId, int NoMsfMatch, int ExpungedMatched,
+    int SourcesAttempted, int SourcesEnriched, int SourcesDegraded);

--- a/tests/Mail2Pst.Core.Tests/Discovery/ConfigFromDiscoveryTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Discovery/ConfigFromDiscoveryTests.cs
@@ -11,7 +11,7 @@ namespace Mail2Pst.Core.Tests.Discovery;
 public class ConfigFromDiscoveryTests
 {
     private static DiscoveryResult Discovery() => new(
-        Root: "/home/user/profile",
+        Root: "/data/tb/profile",
         Layout: "thunderbird-profile",
         Sources: new[]
         {

--- a/tests/Mail2Pst.Core.Tests/Discovery/ConfigFromDiscoveryTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Discovery/ConfigFromDiscoveryTests.cs
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Discovery;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Discovery;
+
+public class ConfigFromDiscoveryTests
+{
+    private static DiscoveryResult Discovery() => new(
+        Root: "/home/user/profile",
+        Layout: "thunderbird-profile",
+        Sources: new[]
+        {
+            new DiscoveredSource("/p/Inbox", "mbox", new[] { "Local Folders", "Inbox" }, "Inbox", 10, "/p/Inbox.msf"),
+            new DiscoveredSource("/p/Sent", "mbox", new[] { "Local Folders", "Sent" }, "Sent", 5, null),
+        },
+        Warnings: Array.Empty<DiscoveryWarning>(),
+        Skipped: Array.Empty<DiscoverySkipped>(),
+        Pairing: new DiscoveryPairingSummary(1, 1, 0));
+
+    [Fact]
+    public void Build_NoTemplate_UsesDefaults_MapsSourcesWithMsfPath()
+    {
+        ConversionConfig cfg = ConfigFromDiscovery.Build(Discovery(), null);
+        OutputGroupConfig g = Assert.Single(cfg.Outputs);
+        Assert.Equal("profile", g.Name);                 // derived from Root directory name
+        Assert.Equal(JunkHandlingMode.Off, cfg.JunkHandling);
+        Assert.Equal(2, g.Sources.Count);
+        Assert.Equal("/p/Inbox.msf", g.Sources[0].MsfPath);
+        Assert.Null(g.Sources[1].MsfPath);
+        Assert.Equal(new List<string> { "Local Folders", "Inbox" }, g.Sources[0].TargetFolderPath);
+    }
+
+    [Fact]
+    public void Build_WithTemplate_CopiesOptions_DiscardsTemplateSources()
+    {
+        var template = new ConversionConfig
+        {
+            JunkHandling = JunkHandlingMode.Category,
+            Outputs =
+            {
+                new OutputGroupConfig
+                {
+                    Name = "MyArchive", MaxSizeMB = 1234, IncludeEmptyFolders = false,
+                    FolderMapping = FolderMappingMode.Flatten,
+                    Sources = { new SourceConfig { Path = "ignored", Type = "mbox" } },
+                },
+            },
+        };
+        ConversionConfig cfg = ConfigFromDiscovery.Build(Discovery(), template);
+        OutputGroupConfig g = Assert.Single(cfg.Outputs);
+        Assert.Equal("MyArchive", g.Name);
+        Assert.Equal(1234, g.MaxSizeMB);
+        Assert.False(g.IncludeEmptyFolders);
+        Assert.Equal(JunkHandlingMode.Category, cfg.JunkHandling);
+        Assert.Equal(2, g.Sources.Count);               // from discovery, not the template's 1
+        Assert.Equal("/p/Inbox", g.Sources[0].Path);
+    }
+
+    [Fact]
+    public void Build_TemplateWithMultipleOutputGroups_Throws()
+    {
+        var template = new ConversionConfig
+        {
+            Outputs = { new OutputGroupConfig { Name = "A" }, new OutputGroupConfig { Name = "B" } },
+        };
+        Assert.Throws<ConfigValidationException>(() => ConfigFromDiscovery.Build(Discovery(), template));
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Mork/MorkReaderSharedReadTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mork/MorkReaderSharedReadTests.cs
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.IO;
+using Mail2Pst.Core.Mork;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Mork;
+
+public class MorkReaderSharedReadTests
+{
+    private const string Msf =
+        "< <(a=c)> (80=ns:msg:db:row:scope:msgs:all)(96=ns:msg:db:table:kind:msgs)(88=flags) >\n" +
+        "{1:^80 {(k^96:c)} [1(^88=1)] }";
+
+    [Fact]
+    public void ParseSharedReadWrite_FileHeldOpenReadWrite_Succeeds()
+    {
+        string path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, Msf);
+            // Simulate a running Thunderbird holding the .msf open read/write with shared read/write.
+            using var holder = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+            MorkDocument doc = MorkReader.ParseSharedReadWrite(path);
+            Assert.True(doc.TryGetSingleTable(
+                "ns:msg:db:row:scope:msgs:all", "ns:msg:db:table:kind:msgs", out _));
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void Parse_FileHeldOpenReadWrite_ThrowsIOException()
+    {
+        // Documents WHY the shared variant exists: plain Parse (File.OpenRead -> FileShare.Read) cannot
+        // open a file another handle holds with write access.
+        string path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, Msf);
+            using var holder = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+            Assert.Throws<IOException>(() => MorkReader.Parse(path));
+        }
+        finally { File.Delete(path); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Msf/MsfJoinIndexTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/MsfJoinIndexTests.cs
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Mork;
+using Mail2Pst.Core.Msf;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Msf;
+
+public class MsfJoinIndexTests
+{
+    private static MorkRow Row(string id, params (string col, string val)[] cells) =>
+        new MorkRow(id, cells.ToDictionary(c => c.col, c => c.val, StringComparer.Ordinal));
+
+    private static MsfReadResult Msf(params MorkRow[] rows)
+    {
+        var dict = rows.ToDictionary(r => r.Id, r => r, StringComparer.Ordinal);
+        var table = new MorkTable("1", MsfMessageReader.MsgsScope, MsfMessageReader.MsgsKind, dict);
+        return MsfMessageReader.Read(new MorkDocument(new[] { table }));
+    }
+
+    [Fact]
+    public void Build_UniqueId_TryGetUniqueTrue()
+    {
+        MsfJoinIndex idx = MsfJoinIndex.Build(Msf(Row("1", ("message-id", "a@h"), ("flags", "1"))));
+        Assert.True(idx.TryGetUnique("<a@h>", out MsfMessage row));
+        Assert.True(row.IsRead);
+        Assert.False(idx.IsDuplicateMsfId("<a@h>"));
+    }
+
+    [Fact]
+    public void Build_DuplicateId_RemovedAndMarked()
+    {
+        MsfJoinIndex idx = MsfJoinIndex.Build(Msf(
+            Row("1", ("message-id", "d@h"), ("flags", "1")),
+            Row("2", ("message-id", "d@h"), ("flags", "1"))));
+        Assert.False(idx.TryGetUnique("<d@h>", out _));
+        Assert.True(idx.IsDuplicateMsfId("<d@h>"));
+    }
+
+    [Fact]
+    public void Build_BlankMessageId_NotIndexed()
+    {
+        MsfJoinIndex idx = MsfJoinIndex.Build(Msf(Row("1", ("flags", "1")))); // no message-id cell
+        Assert.False(idx.TryGetUnique("<x@h>", out _));
+    }
+
+    [Fact]
+    public void MboxDuplicateIdSet_FromMessages_FlagsRepeats()
+    {
+        var set = MboxDuplicateIdSet.FromMessages(new List<MailMessage>
+        {
+            new() { MessageId = "<a@h>" }, new() { MessageId = "<a@h>" }, new() { MessageId = "<b@h>" },
+        });
+        Assert.True(set.Contains("<a@h>"));
+        Assert.False(set.Contains("<b@h>"));
+    }
+
+    [Fact]
+    public void MboxDuplicateIdSet_FromCounts_FlagsGreaterThanOne()
+    {
+        var set = MboxDuplicateIdSet.FromCounts(new Dictionary<string, int>(StringComparer.Ordinal)
+            { ["<a@h>"] = 2, ["<b@h>"] = 1 });
+        Assert.True(set.Contains("<a@h>"));
+        Assert.False(set.Contains("<b@h>"));
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Msf/SourceEnrichmentContextTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/SourceEnrichmentContextTests.cs
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Msf;
+using Mail2Pst.Core.Progress;
+using Mail2Pst.Core.Reporting;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Msf;
+
+public class SourceEnrichmentContextTests
+{
+    private static MsfEnrichmentOptions Opts() =>
+        new() { TagResolver = new DefaultMsfTagResolver(), JunkHandling = JunkHandlingMode.Off };
+
+    // A .msf with one msgs row: message-id=a@h, flags=5 (read+marked).
+    private const string MsfText =
+        "< <(a=c)> (80=ns:msg:db:row:scope:msgs:all)(96=ns:msg:db:table:kind:msgs)(88=flags)(89=message-id) >\n" +
+        "{1:^80 {(k^96:c)} [1(^88=5)(^89=a@h)] }";
+
+    private static string Mbox() =>
+        "From s@e Thu Jan 01 00:00:00 2026\nMessage-ID: <a@h>\nSubject: t\n\nbody\n";
+
+    private static string Write(string content, string ext)
+    {
+        string path = Path.Combine(Path.GetTempPath(), "mail2pst-sec-" + Guid.NewGuid() + ext);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    [Fact]
+    public void TryCreate_BlankMsfPath_ReturnsNull_NotAttempted()
+    {
+        var report = new ConversionReport();
+        var ctx = SourceEnrichmentContext.TryCreate(
+            new SourceConfig { Path = "x.mbox", Type = "mbox", MsfPath = null }, Opts(), report);
+        Assert.Null(ctx);
+        Assert.Equal(0, report.EnrichmentSummary.SourcesAttempted);
+    }
+
+    [Fact]
+    public void TryCreate_MissingMsf_Degrades_WithWarning()
+    {
+        var report = new ConversionReport();
+        var ctx = SourceEnrichmentContext.TryCreate(
+            new SourceConfig { Path = "x.mbox", Type = "mbox", MsfPath = "does-not-exist.msf" }, Opts(), report);
+        Assert.Null(ctx);
+        Assert.Equal(1, report.EnrichmentSummary.SourcesAttempted);
+        Assert.Equal(1, report.EnrichmentSummary.SourcesDegraded);
+        Assert.Equal(1, report.WarningCount);
+    }
+
+    [Fact]
+    public void TryCreate_MalformedMsf_Degrades_WithWarning()
+    {
+        string mbox = Write(Mbox(), ".mbox");
+        string msf = Write("this is not mork", ".msf");
+        var report = new ConversionReport();
+        try
+        {
+            var ctx = SourceEnrichmentContext.TryCreate(
+                new SourceConfig { Path = mbox, Type = "mbox", MsfPath = msf }, Opts(), report);
+            Assert.Null(ctx);
+            Assert.Equal(1, report.EnrichmentSummary.SourcesDegraded);
+            Assert.Equal(1, report.WarningCount);
+        }
+        finally { File.Delete(mbox); File.Delete(msf); }
+    }
+
+    [Fact]
+    public void TryCreate_UnreadableMbox_NoWarning_NotDegraded()
+    {
+        // .msf is valid, but the mbox does not exist: the pre-pass fails -> no context, NO .msf warning,
+        // NOT degraded (the normal parse path will record the source skip elsewhere).
+        string msf = Write(MsfText, ".msf");
+        var report = new ConversionReport();
+        try
+        {
+            var ctx = SourceEnrichmentContext.TryCreate(
+                new SourceConfig { Path = "does-not-exist.mbox", Type = "mbox", MsfPath = msf }, Opts(), report);
+            Assert.Null(ctx);
+            Assert.Equal(1, report.EnrichmentSummary.SourcesAttempted);
+            Assert.Equal(0, report.EnrichmentSummary.SourcesDegraded);
+            Assert.Equal(0, report.WarningCount);
+        }
+        finally { File.Delete(msf); }
+    }
+
+    [Fact]
+    public void TryCreate_Valid_AppliesEnrichment()
+    {
+        string mbox = Write(Mbox(), ".mbox");
+        string msf = Write(MsfText, ".msf");
+        var report = new ConversionReport();
+        try
+        {
+            var ctx = SourceEnrichmentContext.TryCreate(
+                new SourceConfig { Path = mbox, Type = "mbox", MsfPath = msf }, Opts(), report);
+            Assert.NotNull(ctx);
+            Assert.Equal(1, report.EnrichmentSummary.SourcesEnriched);
+
+            var mail = new MailMessage { MessageId = "<a@h>", IsRead = false, IsFlagged = false };
+            ctx!.Apply(mail);
+            Assert.True(mail.IsRead);    // flags=5 -> read
+            Assert.True(mail.IsFlagged); // flags=5 -> marked
+            Assert.Equal(1, ctx.Result.Matched);
+        }
+        finally { File.Delete(mbox); File.Delete(msf); }
+    }
+
+    [Fact]
+    public void TryCreate_MissingMsf_EmitsWarningEvent()
+    {
+        var report = new ConversionReport();
+        var events = new List<ConversionProgressEvent>();
+        var ctx = SourceEnrichmentContext.TryCreate(
+            new SourceConfig { Path = "x.mbox", Type = "mbox", MsfPath = "does-not-exist.msf" },
+            Opts(), report, events.Add);
+        Assert.Null(ctx);
+        WarningEvent w = Assert.Single(events.OfType<WarningEvent>());
+        Assert.Equal("(.msf)", w.Identifier);
+    }
+
+    [Fact]
+    public void TryCreate_LockedMsf_Degrades()
+    {
+        // FileShare.None deterministically blocks the open on Windows (the product's target OS); Unix
+        // file locking is advisory, so this exclusivity does not hold there — guard rather than delete.
+        if (!OperatingSystem.IsWindows()) return;
+
+        // A handle that shares nothing (FileShare.None) makes even the ReadWrite-share open fail.
+        string mbox = Write(Mbox(), ".mbox");
+        string msf = Write(MsfText, ".msf");
+        var report = new ConversionReport();
+        try
+        {
+            using var locker = new FileStream(msf, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            var ctx = SourceEnrichmentContext.TryCreate(
+                new SourceConfig { Path = mbox, Type = "mbox", MsfPath = msf }, Opts(), report);
+            Assert.Null(ctx);
+            Assert.Equal(1, report.EnrichmentSummary.SourcesDegraded);
+            Assert.Equal(1, report.WarningCount);
+        }
+        finally { File.Delete(mbox); File.Delete(msf); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Parsing/MboxMessageIdScannerTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Parsing/MboxMessageIdScannerTests.cs
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Msf;
+using Mail2Pst.Core.Parsing;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Parsing;
+
+public class MboxMessageIdScannerTests
+{
+    // One mbox message: a "From " postmark, headers (incl. optional Message-ID), a blank line, a body.
+    private static string Msg(string? messageIdHeader, string body) =>
+        "From sender@example.com Thu Jan 01 00:00:00 2026\n" +
+        "Subject: t\n" +
+        (messageIdHeader is null ? "" : $"Message-ID: {messageIdHeader}\n") +
+        "\n" + body + "\n";
+
+    private static string WriteMbox(params string[] messages)
+    {
+        string path = Path.Combine(Path.GetTempPath(), "mail2pst-scan-" + System.Guid.NewGuid() + ".mbox");
+        File.WriteAllText(path, string.Concat(messages));
+        return path;
+    }
+
+    [Fact]
+    public void ScanDuplicateIds_FlagsRepeatedIds_NotUniqueOnes()
+    {
+        string path = WriteMbox(Msg("<a@h>", "one"), Msg("<a@h>", "two"), Msg("<b@h>", "three"));
+        try
+        {
+            MboxDuplicateIdSet dup = MboxMessageIdScanner.ScanDuplicateIds(path);
+            Assert.True(dup.Contains("<a@h>"));
+            Assert.False(dup.Contains("<b@h>"));
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ScanDuplicateIds_EmptyMbox_NoDuplicates()
+    {
+        string path = WriteMbox();
+        try
+        {
+            MboxDuplicateIdSet dup = MboxMessageIdScanner.ScanDuplicateIds(path);
+            Assert.False(dup.Contains("<anything@h>"));
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ScanDuplicateIds_MatchesFullParserDerivedDuplicates_ValueParity()
+    {
+        // Includes a comment-bearing id and a missing id to prove VALUE parity with the full parser,
+        // not just boundary parity.
+        string path = WriteMbox(
+            Msg("<a@h>", "first"),
+            Msg("<a@h>", "dup of a"),
+            Msg("<b@h> (a comment)", "with comment"),
+            Msg(null, "no id"));
+        try
+        {
+            // Truth: run the REAL parser, take MailMessage.MessageId, find duplicates.
+            var parserIds = new MboxParser().Parse(path)
+                .Where(r => r.Success).Select(r => r.Message!.MessageId).OfType<string>().ToList();
+            var expectedDup = parserIds.GroupBy(x => x, System.StringComparer.Ordinal)
+                .Where(g => g.Count() > 1).Select(g => g.Key)
+                .ToHashSet(System.StringComparer.Ordinal);
+
+            MboxDuplicateIdSet dup = MboxMessageIdScanner.ScanDuplicateIds(path);
+
+            foreach (string id in parserIds.Distinct())
+                Assert.Equal(expectedDup.Contains(id), dup.Contains(id));
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ScanDuplicateIds_MalformedHeaderChunk_DoesNotAbort()
+    {
+        // A message whose header block is junk must not abort the pre-pass; valid messages still count.
+        string junk = "From s@e Thu Jan 01 00:00:00 2026\n!!! not a header !!!\n\nbody\n";
+        string path = WriteMbox(junk, Msg("<dup@h>", "a"), Msg("<dup@h>", "b"));
+        try
+        {
+            MboxDuplicateIdSet dup = MboxMessageIdScanner.ScanDuplicateIds(path);
+            Assert.True(dup.Contains("<dup@h>"));
+        }
+        finally { File.Delete(path); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Reporting/ConversionReportEnrichmentTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Reporting/ConversionReportEnrichmentTests.cs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using Mail2Pst.Core.Msf;
+using Mail2Pst.Core.Reporting;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Reporting;
+
+public class ConversionReportEnrichmentTests
+{
+    [Fact]
+    public void RecordEnrichment_AccumulatesCountsAndSourceOutcomes()
+    {
+        var report = new ConversionReport();
+        report.RecordEnrichmentSource(attempted: true, enriched: true, degraded: false);
+        report.RecordEnrichmentCounts(new MsfEnrichmentResult { Matched = 3, SkippedDuplicateId = 1 });
+        report.RecordEnrichmentSource(attempted: true, enriched: false, degraded: true);
+
+        MsfEnrichmentSummary s = report.EnrichmentSummary;
+        Assert.Equal(3, s.Matched);
+        Assert.Equal(1, s.SkippedDuplicateId);
+        Assert.Equal(2, s.SourcesAttempted);
+        Assert.Equal(1, s.SourcesEnriched);
+        Assert.Equal(1, s.SourcesDegraded);
+    }
+
+    [Fact]
+    public void ToJsonAndSummary_IncludeEnrichment()
+    {
+        var report = new ConversionReport();
+        report.RecordEnrichmentSource(attempted: true, enriched: true, degraded: false);
+        report.RecordEnrichmentCounts(new MsfEnrichmentResult { Matched = 5 });
+
+        Assert.Contains("enrichment", report.ToJson());
+        Assert.Contains("\"matched\": 5", report.ToJson());
+        Assert.Contains("Enrichment", report.ToSummary());
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/ConversionRunnerEnrichmentTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/ConversionRunnerEnrichmentTests.cs
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Reporting;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests;
+
+public class ConversionRunnerEnrichmentTests
+{
+    // .msf: message-id=a@h, flags=5 (read+marked), junkscore=90, keywords=work.
+    private const string MsfText =
+        "< <(a=c)> (80=ns:msg:db:row:scope:msgs:all)(96=ns:msg:db:table:kind:msgs)" +
+        "(88=flags)(89=message-id)(8A=junkscore)(8B=keywords) >\n" +
+        "{1:^80 {(k^96:c)} [1(^88=5)(^89=a@h)(^8A=90)(^8B=work)] }";
+
+    private static string Msg(string id, string body) =>
+        $"From s@e Thu Jan 01 00:00:00 2026\nMessage-ID: {id}\nSubject: t\n\n{body}\n";
+
+    private static string WriteTemp(string content, string ext)
+    {
+        string p = Path.Combine(Path.GetTempPath(), "mail2pst-cre-" + Guid.NewGuid() + ext);
+        File.WriteAllText(p, content);
+        return p;
+    }
+
+    private static (IReadOnlyList<ReadBackMessage> read, ConversionReport report) Convert(
+        string mboxPath, string? msfPath, string outDir, JunkHandlingMode junk = JunkHandlingMode.Off)
+    {
+        string template = TemplateProvider.ExtractToTempFile();
+        try
+        {
+            var config = new ConversionConfig
+            {
+                JunkHandling = junk,
+                Outputs =
+                {
+                    new OutputGroupConfig
+                    {
+                        Name = "Out",
+                        Sources = { new SourceConfig { Path = mboxPath, Type = "mbox", MsfPath = msfPath } },
+                    },
+                },
+            };
+            var runner = new ConversionRunner(template);
+            ConversionReport report = runner.Run(config, outDir);
+            var read = PstReader.Read(report.OutputFiles).SelectMany(f => f.Messages).ToList();
+            return (read, report);
+        }
+        finally { File.Delete(template); }
+    }
+
+    private static string NewOutDir()
+    {
+        string d = Path.Combine(Path.GetTempPath(), "mail2pst-creo-" + Guid.NewGuid());
+        Directory.CreateDirectory(d);
+        return d;
+    }
+
+    [Fact]
+    public void PairedMsf_EnrichesFlagsAndCategories()
+    {
+        string mbox = WriteTemp(Msg("<a@h>", "one"), ".mbox");
+        string msf = WriteTemp(MsfText, ".msf");
+        string outDir = NewOutDir();
+        try
+        {
+            var (read, report) = Convert(mbox, msf, outDir, JunkHandlingMode.Category);
+            ReadBackMessage m = read.Single(x => x.MessageId == "<a@h>");
+            Assert.True(m.IsRead);
+            Assert.True(m.IsFlagged);
+            Assert.Contains("work", m.Categories);
+            Assert.Contains("Junk", m.Categories); // junkscore 90 + Category mode
+            Assert.Equal(1, report.EnrichmentSummary.Matched);
+            Assert.Equal(1, report.EnrichmentSummary.SourcesEnriched);
+        }
+        finally { File.Delete(mbox); File.Delete(msf); Directory.Delete(outDir, true); }
+    }
+
+    [Fact]
+    public void MissingMsf_Degrades_ConversionSucceeds_NoExtraSkip()
+    {
+        string mbox = WriteTemp(Msg("<a@h>", "one"), ".mbox");
+        string outDir = NewOutDir();
+        try
+        {
+            var (read, report) = Convert(mbox, "no-such.msf", outDir);
+            Assert.Single(read);                      // message still converted
+            Assert.Equal(0, report.SkippedCount);     // no message skips from the degradation
+            Assert.Equal(1, report.EnrichmentSummary.SourcesDegraded);
+            Assert.Equal(1, report.WarningCount);
+        }
+        finally { File.Delete(mbox); Directory.Delete(outDir, true); }
+    }
+
+    [Fact]
+    public void UnreadableMbox_WithMsf_OneSkip_NoMsfWarning_NotDegraded()
+    {
+        string msf = WriteTemp(MsfText, ".msf");
+        string outDir = NewOutDir();
+        try
+        {
+            var (read, report) = Convert("no-such.mbox", msf, outDir);
+            Assert.Empty(read);
+            Assert.Equal(1, report.SkippedCount);     // the single source skip
+            Assert.Equal(0, report.WarningCount);     // no .msf degradation warning
+            Assert.Equal(1, report.EnrichmentSummary.SourcesAttempted);
+            Assert.Equal(0, report.EnrichmentSummary.SourcesDegraded);
+            Assert.Equal(0, report.EnrichmentSummary.SourcesEnriched);
+        }
+        finally { File.Delete(msf); Directory.Delete(outDir, true); }
+    }
+
+    [Fact]
+    public void NoMsf_SourceUnchanged_NoEnrichmentAttempted()
+    {
+        string mbox = WriteTemp(Msg("<a@h>", "one"), ".mbox");
+        string outDir = NewOutDir();
+        try
+        {
+            var (read, report) = Convert(mbox, null, outDir);
+            Assert.Single(read);
+            Assert.Equal(0, report.EnrichmentSummary.SourcesAttempted);
+        }
+        finally { File.Delete(mbox); Directory.Delete(outDir, true); }
+    }
+
+    [Fact]
+    public void MboxSideDuplicateId_StreamingParity_NeitherEnriched()
+    {
+        // Two mbox messages share <a@h>; one .msf row -> neither enriched, both counted duplicate.
+        string mbox = WriteTemp(Msg("<a@h>", "one") + Msg("<a@h>", "two"), ".mbox");
+        string msf = WriteTemp(MsfText, ".msf");
+        string outDir = NewOutDir();
+        try
+        {
+            var (read, report) = Convert(mbox, msf, outDir);
+            Assert.Equal(2, read.Count);
+            Assert.Equal(0, report.EnrichmentSummary.Matched);
+            Assert.Equal(2, report.EnrichmentSummary.SkippedDuplicateId);
+            foreach (ReadBackMessage m in read) Assert.False(m.IsFlagged); // unchanged (mbox default)
+        }
+        finally { File.Delete(mbox); File.Delete(msf); Directory.Delete(outDir, true); }
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/ConvertCommandDoneTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/ConvertCommandDoneTests.cs
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Mail2Pst.Cli;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests;
+
+public class ConvertCommandDoneTests
+{
+    [Fact]
+    public void Convert_DoneJson_IncludesEnrichmentSummary()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "mail2pst-done-" + Guid.NewGuid());
+        Directory.CreateDirectory(dir);
+        string mbox = Path.Combine(dir, "in.mbox");
+        File.WriteAllText(mbox, "From s@e Thu Jan 01 00:00:00 2026\nMessage-ID: <a@h>\nSubject: t\n\nbody\n");
+        string cfg = Path.Combine(dir, "config.json");
+        File.WriteAllText(cfg,
+            "{\"outputs\":[{\"name\":\"Out\",\"sources\":[{\"path\":" +
+            JsonSerializer.Serialize(mbox) + ",\"type\":\"mbox\"}]}]}");
+        string outDir = Path.Combine(dir, "out");
+
+        var sw = new StringWriter();
+        TextWriter original = Console.Out;
+        Console.SetOut(sw);
+        try
+        {
+            int exit = ConvertCommand.Run(new[] { "--config", cfg, "--output", outDir });
+            Assert.Equal(0, exit);
+            // JSON-Lines: the single-line done object carries the additive enrichment summary.
+            string done = sw.ToString().Split('\n').First(l => l.Contains("\"type\":\"done\""));
+            Assert.Contains("\"enrichment\"", done);
+            Assert.Contains("\"sourcesAttempted\"", done);
+        }
+        finally
+        {
+            Console.SetOut(original);
+            Directory.Delete(dir, true);
+        }
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/ConvertInputTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/ConvertInputTests.cs
@@ -47,6 +47,7 @@ public class ConvertInputTests
             Assert.NotNull(r.Config);
             OutputGroupConfig g = Assert.Single(r.Config!.Outputs);
             SourceConfig s = Assert.Single(g.Sources);
+            Assert.NotNull(s.MsfPath);
             Assert.EndsWith("Inbox.msf", s.MsfPath);
             Assert.Equal(profile, r.InputLabel);
         }

--- a/tests/Mail2Pst.Integration.Tests/ConvertInputTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/ConvertInputTests.cs
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.IO;
+using Mail2Pst.Cli;
+using Mail2Pst.Core.Config;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests;
+
+public class ConvertInputTests
+{
+    // Builds a minimal Thunderbird profile dir: <p>/Mail/Local Folders/{Inbox, Inbox.msf}.
+    private static string MakeProfile()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "mail2pst-prof-" + Guid.NewGuid());
+        string acct = Path.Combine(root, "Mail", "Local Folders");
+        Directory.CreateDirectory(acct);
+        File.WriteAllText(Path.Combine(acct, "Inbox"), "");            // 0-byte = valid empty folder
+        File.WriteAllText(Path.Combine(acct, "Inbox.msf"), "x");       // existence-only pairing
+        return root;
+    }
+
+    [Fact]
+    public void Resolve_MissingOutput_Error()
+    {
+        ConvertResolution r = ConvertInput.Resolve(new[] { "--config", "c.json" });
+        Assert.NotNull(r.Error);
+        Assert.Null(r.Config);
+    }
+
+    [Fact]
+    public void Resolve_NeitherConfigNorProfile_Error()
+    {
+        ConvertResolution r = ConvertInput.Resolve(new[] { "--output", "out" });
+        Assert.NotNull(r.Error);
+    }
+
+    [Fact]
+    public void Resolve_ProfileOnly_BuildsConfigWithDiscoveredSources()
+    {
+        string profile = MakeProfile();
+        try
+        {
+            ConvertResolution r = ConvertInput.Resolve(new[] { "--profile", profile, "--output", "out" });
+            Assert.Null(r.Error);
+            Assert.NotNull(r.Config);
+            OutputGroupConfig g = Assert.Single(r.Config!.Outputs);
+            SourceConfig s = Assert.Single(g.Sources);
+            Assert.EndsWith("Inbox.msf", s.MsfPath);
+            Assert.Equal(profile, r.InputLabel);
+        }
+        finally { Directory.Delete(profile, true); }
+    }
+
+    [Fact]
+    public void Resolve_ProfileWithMultiGroupTemplate_Error()
+    {
+        string profile = MakeProfile();
+        string cfg = Path.Combine(Path.GetTempPath(), "mail2pst-tmpl-" + Guid.NewGuid() + ".json");
+        File.WriteAllText(cfg, "{\"outputs\":[{\"name\":\"A\",\"sources\":[]},{\"name\":\"B\",\"sources\":[]}]}");
+        try
+        {
+            ConvertResolution r = ConvertInput.Resolve(new[] { "--profile", profile, "--config", cfg, "--output", "out" });
+            Assert.NotNull(r.Error);
+            Assert.Null(r.Config);
+        }
+        finally { Directory.Delete(profile, true); File.Delete(cfg); }
+    }
+
+    [Fact]
+    public void Resolve_ProfileDirMissing_Error()
+    {
+        ConvertResolution r = ConvertInput.Resolve(new[] { "--profile", "no-such-dir", "--output", "out" });
+        Assert.NotNull(r.Error);
+    }
+
+    [Fact]
+    public void Resolve_UnknownOption_Error()
+    {
+        ConvertResolution r = ConvertInput.Resolve(new[] { "--config", "c.json", "--output", "out", "--weird", "x" });
+        Assert.NotNull(r.Error);
+    }
+
+    [Fact]
+    public void Resolve_ExtraPositionalArg_Error()
+    {
+        ConvertResolution r = ConvertInput.Resolve(new[] { "--config", "c.json", "--output", "out", "extra" });
+        Assert.NotNull(r.Error);
+    }
+
+    [Fact]
+    public void Resolve_FlagMissingValue_Error()
+    {
+        ConvertResolution r = ConvertInput.Resolve(new[] { "--config", "--output", "out" });
+        Assert.NotNull(r.Error);
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/Mail2Pst.Integration.Tests.csproj
+++ b/tests/Mail2Pst.Integration.Tests/Mail2Pst.Integration.Tests.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/Mail2Pst.Core/Mail2Pst.Core.csproj" />
+    <ProjectReference Include="..\..\src\Mail2Pst.Cli\Mail2Pst.Cli.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="../../fixtures/**/*" CopyToOutputDirectory="PreserveNewest" LinkBase="fixtures" />


### PR DESCRIPTION
## Problem

SP2/SP3 built the `.msf` interpreter and the enrichment join, and SP4a paired each mbox with its sibling `.msf`, but nothing applied that enrichment during a real conversion. Converted PSTs therefore did not reflect Thunderbird's read/replied/forwarded/starred/junk/tags for IMAP/EWS accounts (whose mbox exports carry no usable flags).

## Fix

Wire `.msf` enrichment into the streaming conversion pipeline (preserving the producer/consumer memory profile) and add a `convert --profile` mode.

- Refactor `MsfEnricher` into reusable `MsfJoinIndex` / `MboxDuplicateIdSet` / `TryApply`; SP3 join semantics unchanged (the existing `MsfEnricherTests` are the equivalence proof).
- Headers-only `MboxMessageIdScanner` reuses `MboxParser`'s single boundary engine and produces Message-IDs with value parity to the full parser (locked by test).
- `SourceEnrichmentContext` reads each paired `.msf` (`FileShare.ReadWrite` via new `MorkReader.ParseSharedReadWrite`) and applies enrichment per streamed message. Any `.msf` failure (missing/locked/malformed) degrades to mbox-derived flags plus a warning and never aborts; an unreadable mbox is reported exactly once (no double-report).
- `ConversionRunner` folds per-source enrichment counts in a `finally` so they survive early iterator disposal (cancel / split-cap). Enrichment summary added to `ConversionReport` and as an additive `enrichment` field on the `done` JSON.
- `convert --profile <dir> [--config <options.json>] --output <dir>` builds config via `ConfigFromDiscovery`; arg validation rejects unknown/extra/missing-value flags. `--config` alone is unchanged.

## Effect

Pointing `convert` at a Thunderbird profile produces a full-fidelity PST (read/replied/forwarded/starred/junk/tags). Internal until the GUI lands (SP4c); no release is cut here. The CLI JSON-Lines contract change is additive (`schemaVersion` unchanged).

Full suite: 562 passed, 4 skipped (env-gated corpus), 0 failed.