### PR TITLE
fix(core): key Mork tables by (scope, id) so the msgs table survives id reuse

### DIFF
--- a/src/Mail2Pst.Core/Mork/MorkReader.cs
+++ b/src/Mail2Pst.Core/Mork/MorkReader.cs
@@ -116,6 +116,10 @@ internal sealed class MorkAssembler
     /// <summary>Mutable working state for a single table during assembly.</summary>
     private sealed class WorkingTable
     {
+        // The table's own id (the numeric id from { <id>:^scope … }). The working-table
+        // dictionary is keyed by the composite (scope, id) — see ReadTable — so Id is kept
+        // here to emit the final MorkTable with its real id.
+        public string Id { get; set; } = "";
         public string? Scope { get; set; }
         public string? Kind { get; set; }
         // rowId -> (cells dict, or null if the row has been cut and not re-added)
@@ -163,9 +167,9 @@ internal sealed class MorkAssembler
 
         // Build the final immutable MorkDocument from accumulated working state.
         var tables = new List<MorkTable>(_workingTables.Count);
-        foreach (string tableId in _tableOrder)
+        foreach (string tableKey in _tableOrder)
         {
-            var wt = _workingTables[tableId];
+            var wt = _workingTables[tableKey];
             var rows = new Dictionary<string, MorkRow>(StringComparer.Ordinal);
             foreach (var kv in wt.Rows)
             {
@@ -173,7 +177,8 @@ internal sealed class MorkAssembler
                 if (kv.Value is not null)
                     rows[kv.Key] = new MorkRow(kv.Key, kv.Value);
             }
-            tables.Add(new MorkTable(tableId, wt.Scope, wt.Kind, rows));
+            // Emit the table's real id (wt.Id), not the composite (scope, id) working key.
+            tables.Add(new MorkTable(wt.Id, wt.Scope, wt.Kind, rows));
         }
 
         return new MorkDocument(tables);
@@ -441,16 +446,25 @@ internal sealed class MorkAssembler
         string scopeAtomId = ExpectAtomRefId();
         string scope = ResolveColumnAtom(scopeAtomId);
 
-        // Get-or-create the working table for this id.
-        if (!_workingTables.TryGetValue(tableId, out var wt))
+        // Mork table identity is (id, scope), NOT id alone: real Thunderbird .msf reuses a small
+        // numeric id across DIFFERENT scopes (e.g. id "1" for both the msgs table ^80 and the
+        // dbfolderinfo table ^9F). Keying by id alone collapses them — the later statement clobbers
+        // the earlier table's scope/kind (last-write-wins) and merges their row bags, which loses the
+        // msgs table. Key by the composite (scope, id) so distinct tables stay distinct. (A space
+        // cannot appear in a scope string or hex table id, so it is a safe separator.) Every table statement in
+        // real .msf carries :^scope (the parser requires it), so the key is always well-defined.
+        string tableKey = scope + " " + tableId;
+
+        // Get-or-create the working table for this (scope, id).
+        if (!_workingTables.TryGetValue(tableKey, out var wt))
         {
-            wt = new WorkingTable { Scope = scope };
-            _workingTables[tableId] = wt;
-            _tableOrder.Add(tableId);
+            wt = new WorkingTable { Id = tableId, Scope = scope };
+            _workingTables[tableKey] = wt;
+            _tableOrder.Add(tableKey);
         }
         else
         {
-            // Re-statement: update scope (last-write-wins) but keep existing rows.
+            // Re-statement of the SAME (scope, id): scope is identical by construction; keep rows.
             wt.Scope = scope;
         }
 

--- a/tests/Mail2Pst.Core.Tests/Mork/MorkParseTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mork/MorkParseTests.cs
@@ -134,6 +134,35 @@ public class MorkParseTests
         Assert.Equal("5", t.Rows["1"].Cells["flags"]);
     }
 
+    [Fact]
+    public void Parse_SameTableIdDifferentScopes_KeptDistinct()
+    {
+        // Regression for the real-profile BUG-1: Thunderbird reuses a small table id across
+        // DIFFERENT scopes — the msgs table {1:^80} and the dbfolderinfo table {1:^9F} both use
+        // id "1". Mork identity is (id, scope), so they are DISTINCT tables. The dbfolderinfo
+        // statement appears LATER in the file; if the assembler keys tables by id alone it
+        // clobbers the msgs table's scope/kind (last-write-wins) and merges the row bags, so
+        // GetTables(msgs, msgs) returns 0 — exactly the live INBOX.msf failure.
+        const string columnDict =
+            "< <(a=c)> (80=ns:msg:db:row:scope:msgs:all)(96=ns:msg:db:table:kind:msgs)"
+            + "(9F=ns:msg:db:row:scope:dbfolderinfo:all)(A0=ns:msg:db:table:kind:dbfolderinfo)(88=flags) >\n";
+        const string msgsTable = "{1:^80 {(k^96:c)} [m1(^88=5)] }\n";        // id 1, msgs
+        const string dbfTable  = "{1:^9F {(k^A0:c)} [d1(^88=1)] }";           // id 1, dbfolderinfo (LATER)
+        MorkDocument doc = MorkReader.ParseString(columnDict + msgsTable + dbfTable);
+
+        Assert.True(
+            doc.TryGetSingleTable("ns:msg:db:row:scope:msgs:all", "ns:msg:db:table:kind:msgs", out MorkTable msgs),
+            $"msgs table lost to id collision — actual tables: [{string.Join(", ", doc.Tables.Select(x => $"id={x.Id} scope={x.Scope} kind={x.Kind}"))}]");
+        Assert.True(msgs.Rows.ContainsKey("m1"));
+        Assert.Equal("5", msgs.Rows["m1"].Cells["flags"]);
+        Assert.False(msgs.Rows.ContainsKey("d1")); // row bags must not cross-merge
+
+        Assert.True(
+            doc.TryGetSingleTable("ns:msg:db:row:scope:dbfolderinfo:all", "ns:msg:db:table:kind:dbfolderinfo", out MorkTable dbf),
+            "dbfolderinfo table missing");
+        Assert.True(dbf.Rows.ContainsKey("d1"));
+    }
+
     // Builds: "< <(a=c)> (f=iso-8859-1)(80=ns:...:msgs:all)(96=ns:...:kind:msgs)(81=subject) >{1:^80 {(k^96:c)} [1(^81=<0xE6>)]}"
     // with the subject value being the single raw byte 0xE6 (NOT $-escaped) to exercise the byte path.
     private static byte[] BuildLatin1Fixture()


### PR DESCRIPTION
## Problem

Real Thunderbird `.msf` files reuse the same numeric table id across different scopes — id `1` is both the **msgs** table (scope `^80` = `ns:msg:db:row:scope:msgs:all`) and the **dbfolderinfo** table (scope `^9F`). Mork table identity is `(id, scope)`, but `MorkAssembler` keyed its working-table map by **id alone**. The dbfolderinfo statement appears later in the file, so last-write-wins clobbered the msgs table's scope/kind (and merged the two row bags). Result: `MorkDocument.GetTables(msgs, msgs)` returned 0 on real profiles — `MsfMessageReader.Read` threw `Expected exactly one Thunderbird msgs table, found 0`, wiping `.msf` enrichment for major folders (including a 16,325-message Gmail INBOX).

Synthetic test fixtures never collided ids, so this only surfaced on real-profile data.

## Fix

Key working tables by the composite `(scope, id)` instead of `id` alone. Every table statement in real `.msf` carries `:^scope` (the parser already requires it), so the key is always well-defined; distinct tables that share an id across scopes stay distinct.

## Verification

- New regression test (`Parse_SameTableIdDifferentScopes_KeptDistinct`) reproduces the cross-scope id collision: fails before, passes after.
- Env-gated corpus tests (`MorkCorpusTests`/`MsfCorpusTests`) against a real live `INBOX.msf`: failed with `found 0` before, pass after.
- End-to-end INBOX conversion: enrichment went from 0 matched / 1 degraded / warning to 16,281 matched / 0 degraded / 0 warnings (16,325 messages).
- Full suite: 563 passed, 4 skipped, 0 failed.