### PR TITLE
feat(core): junk → Folder routing (JunkHandling.Folder)

### DIFF
--- a/src/Mail2Pst.Core/Config/ConfigValidator.cs
+++ b/src/Mail2Pst.Core/Config/ConfigValidator.cs
@@ -17,9 +17,6 @@ public static class ConfigValidator
 {
     public static void Validate(ConversionConfig config)
     {
-        if (config.JunkHandling == JunkHandlingMode.Folder)
-            throw new ConfigValidationException("JunkHandling 'Folder' is not supported until SP4 (junk-folder routing is a pipeline concern). Use 'Off' or 'Category'.");
-
         if (config.Outputs is null || config.Outputs.Count == 0)
             throw new ConfigValidationException("Config has no outputs; at least one output group is required.");
 

--- a/src/Mail2Pst.Core/Config/JunkHandlingMode.cs
+++ b/src/Mail2Pst.Core/Config/JunkHandlingMode.cs
@@ -3,6 +3,7 @@
 #nullable enable
 namespace Mail2Pst.Core.Config;
 
-/// <summary>How .msf junk (junkscore >= 50) is emitted into the PST. Folder is modeled but
-/// not accepted until SP4 (folder routing is a pipeline concern).</summary>
+/// <summary>How .msf junk (junkscore &gt;= 50) is emitted into the PST:
+/// Off = derive IsJunk but emit nothing; Category = add a synthetic "Junk" category;
+/// Folder = route junk messages into a top-level "Junk Email" folder.</summary>
 public enum JunkHandlingMode { Off, Category, Folder }

--- a/src/Mail2Pst.Core/ConversionRunner.cs
+++ b/src/Mail2Pst.Core/ConversionRunner.cs
@@ -155,10 +155,15 @@ public class ConversionRunner
                     MailMessage message = result.Message!;
                     enrichment?.Apply(message);
 
+                    // Route junk into a top-level "Junk Email" folder when JunkHandling.Folder.
+                    // Evaluated AFTER enrichment, which is what makes message.IsJunk authoritative.
+                    IReadOnlyList<string> targetPath = JunkRouting.ResolveTargetFolderPath(
+                        mapping.TargetFolderPath, message.IsJunk, enrichmentOptions.JunkHandling);
+
                     yield return new PlannedMessage
                     {
                         Message = message,
-                        TargetFolderPath = mapping.TargetFolderPath,
+                        TargetFolderPath = targetPath,
                     };
                 }
             }

--- a/src/Mail2Pst.Core/Mapping/JunkRouting.cs
+++ b/src/Mail2Pst.Core/Mapping/JunkRouting.cs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#nullable enable
+using System.Collections.Generic;
+using Mail2Pst.Core.Config;
+
+namespace Mail2Pst.Core.Mapping;
+
+/// <summary>
+/// Pure decision for junk message placement. In <see cref="JunkHandlingMode.Folder"/>, a message
+/// whose .msf enrichment set <c>IsJunk</c> is routed to a single top-level "Junk Email" folder;
+/// otherwise the source's mapped path is returned unchanged. No I/O; trivially unit-testable.
+/// The constant lives here, NOT on MappingEngine (which keeps its own DefaultFlattenFolderName).
+/// </summary>
+internal static class JunkRouting
+{
+    internal const string DefaultJunkFolderName = "Junk Email";
+
+    public static IReadOnlyList<string> ResolveTargetFolderPath(
+        IReadOnlyList<string> mapped, bool isJunk, JunkHandlingMode mode)
+        => mode == JunkHandlingMode.Folder && isJunk
+            ? new[] { DefaultJunkFolderName }
+            : mapped;
+}

--- a/src/Mail2Pst.Core/Mapping/JunkRouting.cs
+++ b/src/Mail2Pst.Core/Mapping/JunkRouting.cs
@@ -17,7 +17,7 @@ internal static class JunkRouting
 {
     internal const string DefaultJunkFolderName = "Junk Email";
 
-    public static IReadOnlyList<string> ResolveTargetFolderPath(
+    internal static IReadOnlyList<string> ResolveTargetFolderPath(
         IReadOnlyList<string> mapped, bool isJunk, JunkHandlingMode mode)
         => mode == JunkHandlingMode.Folder && isJunk
             ? new[] { DefaultJunkFolderName }

--- a/tests/Mail2Pst.Core.Tests/Config/ConfigLoaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Config/ConfigLoaderTests.cs
@@ -97,4 +97,21 @@ public class ConfigLoaderTests
         }
         finally { File.Delete(tempPath); }
     }
+
+    [Fact]
+    public void Load_ParsesJunkHandlingFolder()
+    {
+        string json = """
+        { "junkHandling": "Folder", "outputs": [ { "name": "Out", "maxSizeMB": 100,
+          "folderMapping": "mirror", "sources": [ { "path": "a.mbox", "type": "mbox" } ] } ] }
+        """;
+        string tempPath = Path.GetTempFileName();
+        File.WriteAllText(tempPath, json);
+        try
+        {
+            ConversionConfig config = ConfigLoader.Load(tempPath);
+            Assert.Equal(JunkHandlingMode.Folder, config.JunkHandling);
+        }
+        finally { File.Delete(tempPath); }
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Config/JunkHandlingConfigTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Config/JunkHandlingConfigTests.cs
@@ -25,13 +25,7 @@ public class JunkHandlingConfigTests
     [Theory]
     [InlineData(JunkHandlingMode.Off)]
     [InlineData(JunkHandlingMode.Category)]
-    public void OffAndCategory_AreAccepted(JunkHandlingMode junk)
+    [InlineData(JunkHandlingMode.Folder)]
+    public void AllModes_AreAccepted(JunkHandlingMode junk)
         => ConfigValidator.Validate(Base(junk)); // does not throw
-
-    [Fact]
-    public void Folder_IsRejected_UntilSp4()
-    {
-        var ex = Assert.Throws<ConfigValidationException>(() => ConfigValidator.Validate(Base(JunkHandlingMode.Folder)));
-        Assert.Contains("Folder", ex.Message);
-    }
 }

--- a/tests/Mail2Pst.Core.Tests/Mapping/JunkRoutingTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mapping/JunkRoutingTests.cs
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Mapping;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Mapping;
+
+public class JunkRoutingTests
+{
+    private static readonly string[] Mapped = { "Accounts", "Work", "Inbox" };
+
+    [Theory]
+    [InlineData(JunkHandlingMode.Off, true)]
+    [InlineData(JunkHandlingMode.Off, false)]
+    [InlineData(JunkHandlingMode.Category, true)]
+    [InlineData(JunkHandlingMode.Category, false)]
+    [InlineData(JunkHandlingMode.Folder, false)]
+    public void NonRouting_ReturnsMappedPathUnchanged(JunkHandlingMode mode, bool isJunk)
+    {
+        var result = JunkRouting.ResolveTargetFolderPath(Mapped, isJunk, mode);
+        Assert.Same(Mapped, result); // same reference, no allocation on the common path
+    }
+
+    [Fact]
+    public void FolderModeAndJunk_RoutesToJunkEmail()
+    {
+        var result = JunkRouting.ResolveTargetFolderPath(Mapped, isJunk: true, JunkHandlingMode.Folder);
+        Assert.Equal(new[] { "Junk Email" }, result);
+    }
+
+    [Fact]
+    public void DefaultJunkFolderName_IsJunkEmail()
+        => Assert.Equal("Junk Email", JunkRouting.DefaultJunkFolderName);
+}

--- a/tests/Mail2Pst.Core.Tests/Msf/MsfEnricherTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/MsfEnricherTests.cs
@@ -132,4 +132,15 @@ public class MsfEnricherTests
         MsfEnricher.Enrich(new[] { mail }, msf, Opts());
         Assert.Equal(new[] { "work", "keep", "newtag" }, mail.Categories);
     }
+
+    [Fact]
+    public void JunkFolderMode_SetsJunk_NoJunkCategory_KeepsTags()
+    {
+        var mail = new MailMessage { MessageId = "<jf@h>" };
+        MsfReadResult msf = Msf(Row("1", ("message-id", "jf@h"), ("junkscore", "90"), ("keywords", "work")));
+        MsfEnricher.Enrich(new[] { mail }, msf, Opts(JunkHandlingMode.Folder));
+        Assert.True(mail.IsJunk);
+        Assert.DoesNotContain("Junk", mail.Categories); // synthetic "Junk" is Category-mode only
+        Assert.Contains("work", mail.Categories);        // user tag still becomes a category
+    }
 }

--- a/tests/Mail2Pst.Integration.Tests/JunkFolderRoutingTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/JunkFolderRoutingTests.cs
@@ -88,4 +88,41 @@ public class JunkFolderRoutingTests
         }
         finally { File.Delete(mbox); File.Delete(msf); Directory.Delete(outDir, true); }
     }
+
+    [Fact]
+    public void FolderMode_MsfDegrades_NoRouting_NoJunkCategory_StillWarns()
+    {
+        // .msf present but unreadable -> enrichment degrades -> IsJunk never set -> behaves like Off.
+        string mbox = WriteTemp(Msg("<a@h>", "one"), ".mbox");
+        string outDir = NewOutDir();
+        try
+        {
+            var (folders, report) = Convert(mbox, "no-such.msf", outDir, JunkHandlingMode.Folder);
+
+            Assert.DoesNotContain(folders, f => f.DisplayPath == "Junk Email");
+            ReadFolder inbox = folders.Single(f => f.DisplayPath == "Inbox");
+            ReadBackMessage m = Assert.Single(inbox.Messages);
+            Assert.Equal("<a@h>", m.MessageId);
+            Assert.DoesNotContain("Junk", m.Categories);
+            Assert.Equal(1, report.EnrichmentSummary.SourcesDegraded);
+            Assert.Equal(1, report.WarningCount);
+        }
+        finally { File.Delete(mbox); Directory.Delete(outDir, true); }
+    }
+
+    [Fact]
+    public void FolderMode_NoJunk_DoesNotPreCreateJunkEmail()
+    {
+        // No .msf -> nothing is junk. IncludeEmptyFolders defaults true (pre-creates mapped folders only).
+        string mbox = WriteTemp(Msg("<a@h>", "one"), ".mbox");
+        string outDir = NewOutDir();
+        try
+        {
+            var (folders, _) = Convert(mbox, null, outDir, JunkHandlingMode.Folder);
+
+            Assert.Contains(folders, f => f.DisplayPath == "Inbox");            // mapped folder present
+            Assert.DoesNotContain(folders, f => f.DisplayPath == "Junk Email"); // never pre-created
+        }
+        finally { File.Delete(mbox); Directory.Delete(outDir, true); }
+    }
 }

--- a/tests/Mail2Pst.Integration.Tests/JunkFolderRoutingTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/JunkFolderRoutingTests.cs
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Reporting;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests;
+
+public class JunkFolderRoutingTests
+{
+    // .msf: message-id=a@h, flags=5 (read+marked), junkscore=90 (junk), keywords=work.
+    private const string MsfText =
+        "< <(a=c)> (80=ns:msg:db:row:scope:msgs:all)(96=ns:msg:db:table:kind:msgs)" +
+        "(88=flags)(89=message-id)(8A=junkscore)(8B=keywords) >\n" +
+        "{1:^80 {(k^96:c)} [1(^88=5)(^89=a@h)(^8A=90)(^8B=work)] }";
+
+    private static string Msg(string id, string body) =>
+        $"From s@e Thu Jan 01 00:00:00 2026\nMessage-ID: {id}\nSubject: t\n\n{body}\n";
+
+    private static string WriteTemp(string content, string ext)
+    {
+        string p = Path.Combine(Path.GetTempPath(), "mail2pst-jfr-" + Guid.NewGuid() + ext);
+        File.WriteAllText(p, content);
+        return p;
+    }
+
+    private static string NewOutDir()
+    {
+        string d = Path.Combine(Path.GetTempPath(), "mail2pst-jfro-" + Guid.NewGuid());
+        Directory.CreateDirectory(d);
+        return d;
+    }
+
+    private static (IReadOnlyList<ReadFolder> folders, ConversionReport report) Convert(
+        string mboxPath, string? msfPath, string outDir, JunkHandlingMode junk)
+    {
+        string template = TemplateProvider.ExtractToTempFile();
+        try
+        {
+            var config = new ConversionConfig
+            {
+                JunkHandling = junk,
+                Outputs =
+                {
+                    new OutputGroupConfig
+                    {
+                        Name = "Out",
+                        Sources = { new SourceConfig
+                            { Path = mboxPath, Type = "mbox", MsfPath = msfPath, TargetFolder = "Inbox" } },
+                    },
+                },
+            };
+            var runner = new ConversionRunner(template);
+            ConversionReport report = runner.Run(config, outDir);
+            return (PstReader.Read(report.OutputFiles), report);
+        }
+        finally { File.Delete(template); }
+    }
+
+    [Fact]
+    public void FolderMode_RoutesJunkToJunkEmail_PreservesTags_NonJunkStays()
+    {
+        // <a@h> = junk (junkscore 90) + keyword "work"; <b@h> = no .msf row -> not junk.
+        string mbox = WriteTemp(Msg("<a@h>", "one") + Msg("<b@h>", "two"), ".mbox");
+        string msf = WriteTemp(MsfText, ".msf");
+        string outDir = NewOutDir();
+        try
+        {
+            var (folders, _) = Convert(mbox, msf, outDir, JunkHandlingMode.Folder);
+
+            ReadFolder junk = folders.Single(f => f.DisplayPath == "Junk Email");
+            ReadFolder inbox = folders.Single(f => f.DisplayPath == "Inbox");
+
+            ReadBackMessage routed = Assert.Single(junk.Messages);
+            Assert.Equal("<a@h>", routed.MessageId);
+            Assert.True(routed.IsRead);                        // .msf flags=5 applied -> enrich ran BEFORE routing
+            Assert.True(routed.IsFlagged);
+            Assert.Contains("work", routed.Categories);       // user tag preserved
+            Assert.DoesNotContain("Junk", routed.Categories); // synthetic category suppressed in Folder mode
+
+            ReadBackMessage stayed = Assert.Single(inbox.Messages);
+            Assert.Equal("<b@h>", stayed.MessageId);
+        }
+        finally { File.Delete(mbox); File.Delete(msf); Directory.Delete(outDir, true); }
+    }
+}


### PR DESCRIPTION
## Problem
`JunkHandlingMode.Folder` was modeled but rejected by `ConfigValidator`. Junk messages could only be tagged with a synthetic "Junk" category (`Category` mode), never moved into a junk folder.

## Fix
Accept `Folder` mode and route `.msf`-flagged junk (junkscore ≥ 50) into a single top-level `"Junk Email"` folder per output PST.

- New pure `JunkRouting.ResolveTargetFolderPath(mapped, isJunk, mode)` helper; `ConversionRunner.EnumeratePlannedMessages` calls it **after** `.msf` enrichment sets `MailMessage.IsJunk`, before yielding the `PlannedMessage` (enrich → route → yield).
- Routing fires solely on `IsJunk` — no heuristics. With no/unreadable `.msf`, Folder mode degrades to Off-behaviour per source.
- Folder mode suppresses only the synthetic `"Junk"` category; Thunderbird tags still map to Outlook categories.
- `"Junk Email"` is a normal PST folder created on demand — never pre-created by `IncludeEmptyFolders`, no Outlook special-folder metadata.
- Config-JSON only (`"junkHandling": "Folder"` / `--profile` template); no new CLI flag.

## Effect
A `convert --profile` run with `junkHandling: Folder` relocates junk into a recognizable top-level Junk Email folder instead of tagging it. Non-junk mail and explicit folder mappings are unchanged.

Full suite: 576 pass / 4 skipped / 0 fail (clean Release build).