### PR TITLE
feat(core): expunged-drop option (DropExpunged)

### DIFF
--- a/src/Mail2Pst.Core/Config/ConversionConfig.cs
+++ b/src/Mail2Pst.Core/Config/ConversionConfig.cs
@@ -10,4 +10,5 @@ public class ConversionConfig
 {
     public List<OutputGroupConfig> Outputs { get; set; } = new();
     public JunkHandlingMode JunkHandling { get; set; } = JunkHandlingMode.Off;
+    public bool DropExpunged { get; set; }
 }

--- a/src/Mail2Pst.Core/ConversionRunner.cs
+++ b/src/Mail2Pst.Core/ConversionRunner.cs
@@ -154,7 +154,16 @@ public class ConversionRunner
                     }
 
                     MailMessage message = result.Message!;
-                    enrichment?.Apply(message);
+                    bool keep = enrichment?.Apply(message) ?? true;
+                    if (!keep)
+                    {
+                        // Expunged-dropped: never yielded, so it never reaches the writer's finally
+                        // (PstWriter.WritePlan) that disposes attachment streams per dequeued message —
+                        // dispose here in the producer so the dropped message's streams don't leak.
+                        foreach (MailAttachment attachment in message.Attachments)
+                            attachment.Content.Dispose();
+                        continue;
+                    }
 
                     // Route junk into a top-level "Junk Email" folder when JunkHandling.Folder.
                     // Evaluated AFTER enrichment, which is what makes message.IsJunk authoritative.

--- a/src/Mail2Pst.Core/ConversionRunner.cs
+++ b/src/Mail2Pst.Core/ConversionRunner.cs
@@ -43,6 +43,7 @@ public class ConversionRunner
         {
             TagResolver = new DefaultMsfTagResolver(),
             JunkHandling = config.JunkHandling,
+            DropExpunged = config.DropExpunged,
         };
 
         // Validate source types eagerly so an unsupported type fails loudly

--- a/src/Mail2Pst.Core/Discovery/ConfigFromDiscovery.cs
+++ b/src/Mail2Pst.Core/Discovery/ConfigFromDiscovery.cs
@@ -30,6 +30,7 @@ public static class ConfigFromDiscovery
                     $"found {template.Outputs.Count}.");
 
             config.JunkHandling = template.JunkHandling;
+            config.DropExpunged = template.DropExpunged;
 
             if (template.Outputs.Count == 1)
             {

--- a/src/Mail2Pst.Core/Msf/MsfEnricher.cs
+++ b/src/Mail2Pst.Core/Msf/MsfEnricher.cs
@@ -42,8 +42,10 @@ public static class MsfEnricher
         var result = new MsfEnrichmentResult();
         MsfJoinIndex index = MsfJoinIndex.Build(msf);
         MboxDuplicateIdSet mboxDuplicates = MboxDuplicateIdSet.FromMessages(messages);
+        // Batch mode keeps every message: the per-message keep return (used by the streaming
+        // path to drop expunged messages) is intentionally discarded here.
         foreach (MailMessage mail in messages)
-            TryApply(mail, index, mboxDuplicates, options, result);
+            _ = TryApply(mail, index, mboxDuplicates, options, result);
         return result;
     }
 

--- a/src/Mail2Pst.Core/Msf/MsfEnricher.cs
+++ b/src/Mail2Pst.Core/Msf/MsfEnricher.cs
@@ -13,6 +13,7 @@ public sealed class MsfEnrichmentOptions
 {
     public IMsfTagResolver TagResolver { get; set; } = new DefaultMsfTagResolver();
     public JunkHandlingMode JunkHandling { get; set; } = JunkHandlingMode.Off;
+    public bool DropExpunged { get; set; }
 }
 
 public sealed class MsfEnrichmentResult
@@ -22,6 +23,7 @@ public sealed class MsfEnrichmentResult
     public int SkippedDuplicateId { get; set; }
     public int NoMsfMatch { get; set; }
     public int ExpungedMatched { get; set; }
+    public int ExpungedDropped { get; set; }
 }
 
 /// <summary>

--- a/src/Mail2Pst.Core/Msf/MsfEnricher.cs
+++ b/src/Mail2Pst.Core/Msf/MsfEnricher.cs
@@ -50,15 +50,17 @@ public static class MsfEnricher
     /// <summary>
     /// Applies one message. Increments EXACTLY ONE of matched/skippedMissingId/skippedDuplicateId/
     /// noMsfMatch on <paramref name="result"/>; mutates <paramref name="mail"/> only on a unique match.
+    /// Returns false ONLY for a unique match where the row is expunged and options.DropExpunged is set
+    /// (the message should be dropped, not written); true in every other case.
     /// </summary>
-    internal static void TryApply(
+    internal static bool TryApply(
         MailMessage mail, MsfJoinIndex index, MboxDuplicateIdSet mboxDuplicates,
         MsfEnrichmentOptions options, MsfEnrichmentResult result)
     {
         string? key = MessageIdNormalizer.NormalizeForJoin(mail.MessageId);
-        if (key is null) { result.SkippedMissingId++; return; }
-        if (mboxDuplicates.Contains(key) || index.IsDuplicateMsfId(key)) { result.SkippedDuplicateId++; return; }
-        if (!index.TryGetUnique(key, out MsfMessage row)) { result.NoMsfMatch++; return; }
+        if (key is null) { result.SkippedMissingId++; return true; }
+        if (mboxDuplicates.Contains(key) || index.IsDuplicateMsfId(key)) { result.SkippedDuplicateId++; return true; }
+        if (!index.TryGetUnique(key, out MsfMessage row)) { result.NoMsfMatch++; return true; }
 
         // .msf wins for scalar flags.
         mail.IsRead = row.IsRead;
@@ -71,8 +73,17 @@ public static class MsfEnricher
         if (options.JunkHandling == JunkHandlingMode.Category && row.IsJunk) resolved.Add("Junk");
         MergeCategories(mail.Categories, resolved);
 
-        if (row.IsExpunged) result.ExpungedMatched++;
         result.Matched++;
+        if (row.IsExpunged)
+        {
+            result.ExpungedMatched++;
+            if (options.DropExpunged)
+            {
+                result.ExpungedDropped++;
+                return false;
+            }
+        }
+        return true;
     }
 
     // Append new categories to existing, dedupe ordinal, preserve first occurrence; never remove.

--- a/src/Mail2Pst.Core/Msf/SourceEnrichmentContext.cs
+++ b/src/Mail2Pst.Core/Msf/SourceEnrichmentContext.cs
@@ -34,7 +34,7 @@ internal sealed class SourceEnrichmentContext
         _options = options;
     }
 
-    public void Apply(MailMessage message) => MsfEnricher.TryApply(message, _index, _mboxDuplicates, _options, Result);
+    public bool Apply(MailMessage message) => MsfEnricher.TryApply(message, _index, _mboxDuplicates, _options, Result);
 
     public static SourceEnrichmentContext? TryCreate(
         SourceConfig source, MsfEnrichmentOptions options, ConversionReport report,

--- a/src/Mail2Pst.Core/Reporting/ConversionReport.cs
+++ b/src/Mail2Pst.Core/Reporting/ConversionReport.cs
@@ -22,7 +22,7 @@ public class ConversionReport
     private readonly List<string> _deletedFiles = new();
     private volatile bool _cancelled;
 
-    private int _enrMatched, _enrMissing, _enrDup, _enrNoMatch, _enrExpunged;
+    private int _enrMatched, _enrMissing, _enrDup, _enrNoMatch, _enrExpunged, _enrDropped;
     private int _srcAttempted, _srcEnriched, _srcDegraded;
 
     public int ConvertedCount => Volatile.Read(ref _convertedCount);
@@ -88,6 +88,7 @@ public class ConversionReport
             _enrDup += result.SkippedDuplicateId;
             _enrNoMatch += result.NoMsfMatch;
             _enrExpunged += result.ExpungedMatched;
+            _enrDropped += result.ExpungedDropped;
         }
     }
 
@@ -98,6 +99,7 @@ public class ConversionReport
             lock (_lock)
                 return new MsfEnrichmentSummary(
                     _enrMatched, _enrMissing, _enrDup, _enrNoMatch, _enrExpunged,
+                    _enrDropped,
                     _srcAttempted, _srcEnriched, _srcDegraded);
         }
     }
@@ -155,6 +157,7 @@ public class ConversionReport
         builder.AppendLine(
             $"Enrichment: matched={enr.Matched} missingId={enr.SkippedMissingId} " +
             $"duplicateId={enr.SkippedDuplicateId} noMsfMatch={enr.NoMsfMatch} expunged={enr.ExpungedMatched} " +
+            $"dropped={enr.ExpungedDropped} " +
             $"(sources attempted={enr.SourcesAttempted} enriched={enr.SourcesEnriched} degraded={enr.SourcesDegraded})");
 
         return builder.ToString();

--- a/src/Mail2Pst.Core/Reporting/MsfEnrichmentSummary.cs
+++ b/src/Mail2Pst.Core/Reporting/MsfEnrichmentSummary.cs
@@ -10,4 +10,5 @@ namespace Mail2Pst.Core.Reporting;
 /// </summary>
 public sealed record MsfEnrichmentSummary(
     int Matched, int SkippedMissingId, int SkippedDuplicateId, int NoMsfMatch, int ExpungedMatched,
+    int ExpungedDropped,
     int SourcesAttempted, int SourcesEnriched, int SourcesDegraded);

--- a/tests/Mail2Pst.Core.Tests/Config/ConfigLoaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Config/ConfigLoaderTests.cs
@@ -114,4 +114,25 @@ public class ConfigLoaderTests
         }
         finally { File.Delete(tempPath); }
     }
+
+    [Fact]
+    public void DropExpunged_DefaultsToFalse()
+        => Assert.False(new ConversionConfig().DropExpunged);
+
+    [Fact]
+    public void Load_ParsesDropExpunged()
+    {
+        string json = """
+        { "dropExpunged": true, "outputs": [ { "name": "Out", "maxSizeMB": 100,
+          "folderMapping": "mirror", "sources": [ { "path": "a.mbox", "type": "mbox" } ] } ] }
+        """;
+        string tempPath = Path.GetTempFileName();
+        File.WriteAllText(tempPath, json);
+        try
+        {
+            ConversionConfig config = ConfigLoader.Load(tempPath);
+            Assert.True(config.DropExpunged);
+        }
+        finally { File.Delete(tempPath); }
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Discovery/ConfigFromDiscoveryTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Discovery/ConfigFromDiscoveryTests.cs
@@ -29,6 +29,7 @@ public class ConfigFromDiscoveryTests
         OutputGroupConfig g = Assert.Single(cfg.Outputs);
         Assert.Equal("profile", g.Name);                 // derived from Root directory name
         Assert.Equal(JunkHandlingMode.Off, cfg.JunkHandling);
+        Assert.False(cfg.DropExpunged);
         Assert.Equal(2, g.Sources.Count);
         Assert.Equal("/p/Inbox.msf", g.Sources[0].MsfPath);
         Assert.Null(g.Sources[1].MsfPath);
@@ -41,6 +42,7 @@ public class ConfigFromDiscoveryTests
         var template = new ConversionConfig
         {
             JunkHandling = JunkHandlingMode.Category,
+            DropExpunged = true,
             Outputs =
             {
                 new OutputGroupConfig
@@ -57,6 +59,7 @@ public class ConfigFromDiscoveryTests
         Assert.Equal(1234, g.MaxSizeMB);
         Assert.False(g.IncludeEmptyFolders);
         Assert.Equal(JunkHandlingMode.Category, cfg.JunkHandling);
+        Assert.True(cfg.DropExpunged);
         Assert.Equal(2, g.Sources.Count);               // from discovery, not the template's 1
         Assert.Equal("/p/Inbox", g.Sources[0].Path);
     }

--- a/tests/Mail2Pst.Core.Tests/Msf/MsfEnricherTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/MsfEnricherTests.cs
@@ -25,8 +25,76 @@ public class MsfEnricherTests
         return MsfMessageReader.Read(new MorkDocument(new[] { table }));
     }
 
-    private static MsfEnrichmentOptions Opts(JunkHandlingMode junk = JunkHandlingMode.Off) =>
-        new() { TagResolver = new DefaultMsfTagResolver(), JunkHandling = junk };
+    private static MsfEnrichmentOptions Opts(JunkHandlingMode junk = JunkHandlingMode.Off, bool dropExpunged = false) =>
+        new() { TagResolver = new DefaultMsfTagResolver(), JunkHandling = junk, DropExpunged = dropExpunged };
+
+    // Calls TryApply directly to observe the keep return for a single message.
+    private static (bool keep, MsfEnrichmentResult result) ApplyOne(
+        MailMessage mail, MsfReadResult msf, MsfEnrichmentOptions opts)
+    {
+        var result = new MsfEnrichmentResult();
+        bool keep = MsfEnricher.TryApply(
+            mail, MsfJoinIndex.Build(msf), MboxDuplicateIdSet.FromMessages(new[] { mail }), opts, result);
+        return (keep, result);
+    }
+
+    [Fact]
+    public void DropExpunged_True_UniqueExpungedMatch_DropsAndCounts()
+    {
+        var mail = new MailMessage { MessageId = "<x@h>" };
+        MsfReadResult msf = Msf(Row("1", ("message-id", "x@h"), ("flags", "8"))); // 0x8 = expunged
+        var (keep, result) = ApplyOne(mail, msf, Opts(dropExpunged: true));
+        Assert.False(keep);
+        Assert.Equal(1, result.Matched);
+        Assert.Equal(1, result.ExpungedMatched);
+        Assert.Equal(1, result.ExpungedDropped);
+    }
+
+    [Fact]
+    public void DropExpunged_False_UniqueExpungedMatch_KeptAndNotDropped()
+    {
+        var mail = new MailMessage { MessageId = "<x@h>" };
+        MsfReadResult msf = Msf(Row("1", ("message-id", "x@h"), ("flags", "8")));
+        var (keep, result) = ApplyOne(mail, msf, Opts(dropExpunged: false));
+        Assert.True(keep);
+        Assert.Equal(1, result.ExpungedMatched);
+        Assert.Equal(0, result.ExpungedDropped);
+    }
+
+    [Fact]
+    public void DropExpunged_True_NonExpungedMatch_Kept()
+    {
+        var mail = new MailMessage { MessageId = "<x@h>" };
+        MsfReadResult msf = Msf(Row("1", ("message-id", "x@h"), ("flags", "1"))); // read, not expunged
+        var (keep, result) = ApplyOne(mail, msf, Opts(dropExpunged: true));
+        Assert.True(keep);
+        Assert.Equal(0, result.ExpungedDropped);
+    }
+
+    [Fact]
+    public void DropExpunged_True_UnmatchedMissingId_Kept()
+    {
+        var mail = new MailMessage { MessageId = null };
+        MsfReadResult msf = Msf(Row("1", ("message-id", "x@h"), ("flags", "8")));
+        var (keep, result) = ApplyOne(mail, msf, Opts(dropExpunged: true));
+        Assert.True(keep);
+        Assert.Equal(1, result.SkippedMissingId);
+        Assert.Equal(0, result.ExpungedDropped);
+    }
+
+    [Fact]
+    public void DropExpunged_True_DuplicateMsfId_Kept()
+    {
+        // Two .msf rows share the id (both expunged); a non-unique match must NOT drop.
+        var mail = new MailMessage { MessageId = "<dup@h>" };
+        MsfReadResult msf = Msf(
+            Row("1", ("message-id", "dup@h"), ("flags", "8")),
+            Row("2", ("message-id", "dup@h"), ("flags", "8")));
+        var (keep, result) = ApplyOne(mail, msf, Opts(dropExpunged: true));
+        Assert.True(keep);
+        Assert.Equal(1, result.SkippedDuplicateId);
+        Assert.Equal(0, result.ExpungedDropped);
+    }
 
     [Fact]
     public void UniqueMatch_OverridesFlags_SetsJunk_AddsCategories()

--- a/tests/Mail2Pst.Integration.Tests/ExpungedDropTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/ExpungedDropTests.cs
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Reporting;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests;
+
+public class ExpungedDropTests
+{
+    // .msf: message-id=a@h, flags=8 (expunged). One column header, one row.
+    private const string MsfExpungedA =
+        "< <(a=c)> (80=ns:msg:db:row:scope:msgs:all)(96=ns:msg:db:table:kind:msgs)(88=flags)(89=message-id) >\n" +
+        "{1:^80 {(k^96:c)} [1(^88=8)(^89=a@h)] }";
+
+    // .msf: message-id=c@h, flags=8 (expunged).
+    private const string MsfExpungedC =
+        "< <(a=c)> (80=ns:msg:db:row:scope:msgs:all)(96=ns:msg:db:table:kind:msgs)(88=flags)(89=message-id) >\n" +
+        "{1:^80 {(k^96:c)} [1(^88=8)(^89=c@h)] }";
+
+    private static string Msg(string id, string body) =>
+        $"From s@e Thu Jan 01 00:00:00 2026\nMessage-ID: {id}\nSubject: t\n\n{body}\n";
+
+    private static string MsgWithAttachment(string id) =>
+        "From s@e Thu Jan 01 00:00:00 2026\n" +
+        $"Message-ID: {id}\n" +
+        "Subject: t\n" +
+        "MIME-Version: 1.0\n" +
+        "Content-Type: multipart/mixed; boundary=\"b\"\n\n" +
+        "--b\nContent-Type: text/plain\n\nbody\n" +
+        "--b\nContent-Type: application/octet-stream\n" +
+        "Content-Disposition: attachment; filename=\"f.bin\"\n" +
+        "Content-Transfer-Encoding: base64\n\nZGF0YQ==\n" +
+        "--b--\n";
+
+    private static string WriteTemp(string content, string ext)
+    {
+        string p = Path.Combine(Path.GetTempPath(), "mail2pst-exp-" + Guid.NewGuid() + ext);
+        File.WriteAllText(p, content);
+        return p;
+    }
+
+    private static string NewOutDir()
+    {
+        string d = Path.Combine(Path.GetTempPath(), "mail2pst-expo-" + Guid.NewGuid());
+        Directory.CreateDirectory(d);
+        return d;
+    }
+
+    private static (IReadOnlyList<ReadBackMessage> read, ConversionReport report) Convert(
+        string mboxPath, string? msfPath, string outDir, bool dropExpunged)
+    {
+        string template = TemplateProvider.ExtractToTempFile();
+        try
+        {
+            var config = new ConversionConfig
+            {
+                DropExpunged = dropExpunged,
+                Outputs =
+                {
+                    new OutputGroupConfig
+                    {
+                        Name = "Out",
+                        Sources = { new SourceConfig { Path = mboxPath, Type = "mbox", MsfPath = msfPath } },
+                    },
+                },
+            };
+            ConversionReport report = new ConversionRunner(template).Run(config, outDir);
+            return (PstReader.Read(report.OutputFiles).SelectMany(f => f.Messages).ToList(), report);
+        }
+        finally { File.Delete(template); }
+    }
+
+    [Fact]
+    public void DropExpunged_True_DropsExpungedMatch_KeepsUnmatched()
+    {
+        // <a@h> = expunged in .msf -> dropped; <b@h> = no .msf row -> kept.
+        string mbox = WriteTemp(Msg("<a@h>", "one") + Msg("<b@h>", "two"), ".mbox");
+        string msf = WriteTemp(MsfExpungedA, ".msf");
+        string outDir = NewOutDir();
+        try
+        {
+            var (read, report) = Convert(mbox, msf, outDir, dropExpunged: true);
+            Assert.Single(read);
+            Assert.Equal("<b@h>", read[0].MessageId);
+            Assert.Equal(1, report.EnrichmentSummary.ExpungedMatched); // observability: matched + expunged
+            Assert.Equal(1, report.EnrichmentSummary.ExpungedDropped); // actioned: actually suppressed
+            Assert.Equal(1, report.ConvertedCount);
+            Assert.Equal(0, report.SkippedCount);     // a drop is not a skip
+        }
+        finally { File.Delete(mbox); File.Delete(msf); Directory.Delete(outDir, true); }
+    }
+
+    [Fact]
+    public void DropExpunged_False_KeepsExpunged()
+    {
+        string mbox = WriteTemp(Msg("<a@h>", "one") + Msg("<b@h>", "two"), ".mbox");
+        string msf = WriteTemp(MsfExpungedA, ".msf");
+        string outDir = NewOutDir();
+        try
+        {
+            var (read, report) = Convert(mbox, msf, outDir, dropExpunged: false);
+            Assert.Equal(2, read.Count);
+            Assert.Contains(read, m => m.MessageId == "<a@h>");
+            Assert.Equal(0, report.EnrichmentSummary.ExpungedDropped);
+            Assert.Equal(1, report.EnrichmentSummary.ExpungedMatched);
+        }
+        finally { File.Delete(mbox); File.Delete(msf); Directory.Delete(outDir, true); }
+    }
+
+    [Fact]
+    public void DropExpunged_True_WithAttachment_DisposesAndCompletes()
+    {
+        // The only message is expunged + has an attachment -> dropped; conversion completes,
+        // and the runner disposes the dropped message's attachment stream (no leak/crash).
+        string mbox = WriteTemp(MsgWithAttachment("<c@h>"), ".mbox");
+        string msf = WriteTemp(MsfExpungedC, ".msf");
+        string outDir = NewOutDir();
+        try
+        {
+            var (read, report) = Convert(mbox, msf, outDir, dropExpunged: true);
+            Assert.Empty(read);
+            Assert.Equal(0, report.ConvertedCount);
+            Assert.Equal(1, report.EnrichmentSummary.ExpungedDropped);
+        }
+        finally { File.Delete(mbox); File.Delete(msf); Directory.Delete(outDir, true); }
+    }
+}


### PR DESCRIPTION
## Problem
Messages flagged deleted-but-not-yet-compacted in a Thunderbird `.msf` (expunged) were always carried into the PST. There was no way to drop them.

## Fix
Add `ConversionConfig.DropExpunged` (bool, default `false`). When `true`, a message whose **unique** `.msf` match has `IsExpunged` is dropped — not written — instead of kept.

- `MsfEnricher.TryApply` returns `bool keep`; `false` **only** for a unique matched-expunged row when `DropExpunged` (incrementing `Matched` + `ExpungedMatched` + new `ExpungedDropped`). Missing/duplicate/no-match messages are always kept (expunged state is unknowable without the deferred `msgOffset` fallback).
- `ConversionRunner` disposes the dropped message's attachment streams (it never reaches the writer's `finally`) and skips it **before** junk routing/yield.
- Dropped ≠ skipped: `SkippedCount` is untouched; drops surface only via `enrichment.expungedDropped` (additive `done` JSON field, `schemaVersion` unchanged).
- Config-JSON only (`"dropExpunged": true` / `--profile` template); no CLI flag. Default `false` preserves current PST/write behavior.

Scope note: the `msgOffset` fallback join (the other half originally bundled into E2) is **deferred** — Message-ID already covers ~99.7% and `msgOffset` carries silent-mis-enrichment risk.

## Effect
Pointing `convert --profile` at a profile with `dropExpunged: true` omits expunged messages from the output PST. Full suite: 586 pass / 4 skipped.