### PR TITLE
perf(core): batch folder.SaveChanges to checkpoints

### DIFF
--- a/src/Mail2Pst.Core/Writing/PstPartManager.cs
+++ b/src/Mail2Pst.Core/Writing/PstPartManager.cs
@@ -32,6 +32,7 @@ internal sealed class PstPartManager
 
     private readonly List<string> _outputFiles = new();
     private readonly Dictionary<string, PSTFolder> _folders = new();
+    private readonly HashSet<PSTFolder> _dirtyFolders = new(ReferenceEqualityComparer.Instance);
     private PSTFile? _file;
     private string _currentPath = "";
     private int _partNumber = 1;
@@ -77,6 +78,7 @@ internal sealed class PstPartManager
     /// <summary>Predictive split: flushes the current part, then starts the next.</summary>
     public void FlushAndSplit()
     {
+        SaveDirtyFolders();
         _file!.EndSavingChanges();
         StartNextPartAfterFlush();
     }
@@ -85,6 +87,7 @@ internal sealed class PstPartManager
     {
         PSTFolder folder = GetOrCreateFolder(path);
         _writeMessage(_file!, folder, message);
+        _dirtyFolders.Add(folder);
     }
 
     public void OnWritten(long messageSize)
@@ -94,8 +97,24 @@ internal sealed class PstPartManager
         _messagesSinceCheck++;
     }
 
-    /// <summary>EndSavingChanges only — the checkpoint path flushes here so progress can emit before the size decision.</summary>
-    public void Flush() => _file!.EndSavingChanges();
+    // Flush every folder that received a message since the last save. The vendored library
+    // requires folder.SaveChanges() before file.EndSavingChanges() or the contents-table
+    // update is lost — batching the per-folder save to each flush boundary (instead of per
+    // message) avoids rewriting a folder's whole contents table on every single message.
+    // An empty dirty set is a no-op (empty PSTs, pre-created-only folders, finish-with-no-writes).
+    private void SaveDirtyFolders()
+    {
+        foreach (PSTFolder folder in _dirtyFolders)
+            folder.SaveChanges();
+        _dirtyFolders.Clear();
+    }
+
+    /// <summary>Saves dirty folders, then EndSavingChanges — the checkpoint path flushes here so progress can emit before the size decision.</summary>
+    public void Flush()
+    {
+        SaveDirtyFolders();
+        _file!.EndSavingChanges();
+    }
 
     /// <summary>
     /// PRECONDITION: Flush() was just called. Splits if the part reached the cap (returns
@@ -115,7 +134,11 @@ internal sealed class PstPartManager
         return false;
     }
 
-    public void Finish() => _file!.EndSavingChanges();
+    public void Finish()
+    {
+        SaveDirtyFolders();
+        _file!.EndSavingChanges();
+    }
 
     /// <summary>Closes the current handle. Idempotent: nulls the field so a double Close() is a no-op.</summary>
     public void Close()
@@ -167,6 +190,7 @@ internal sealed class PstPartManager
             _file = nextFile;
             nextFile = null;   // ownership transferred to _file
             _folders.Clear();
+            _dirtyFolders.Clear();
             _estimatedContentBytes = 0;
             _messagesSinceCheck = 0;
             _messagesInCurrentPart = 0;

--- a/src/Mail2Pst.Core/Writing/PstWriter.cs
+++ b/src/Mail2Pst.Core/Writing/PstWriter.cs
@@ -484,7 +484,9 @@ public class PstWriter
 
         note.SaveChanges();
         folder.AddMessage(note);
-        folder.SaveChanges();
+        // folder.SaveChanges() is intentionally NOT called per message: PstPartManager batches it
+        // (SaveDirtyFolders) to each checkpoint/split/finish flush, before EndSavingChanges. Saving
+        // a folder's whole contents table per message is ~O(n^2); batching is the E3 perf win.
     }
 
     private static void WriteAttachment(PSTFile file, Note note, MailAttachment a)

--- a/tests/Mail2Pst.Integration.Tests/MultiFolderCheckpointTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/MultiFolderCheckpointTests.cs
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Mapping;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Reporting;
+using Mail2Pst.Core.Writing;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests;
+
+public class MultiFolderCheckpointTests
+{
+    private static string NewOutDir()
+    {
+        string d = Path.Combine(Path.GetTempPath(), "mail2pst-mfc-" + Guid.NewGuid());
+        Directory.CreateDirectory(d);
+        return d;
+    }
+
+    // Interleave messages across the given folders so every folder is dirty at the same time.
+    private static List<PlannedMessage> Interleave(int perFolder, params string[] folders)
+    {
+        var planned = new List<PlannedMessage>();
+        for (int i = 0; i < perFolder; i++)
+            foreach (string f in folders)
+                planned.Add(new PlannedMessage
+                {
+                    Message = new MailMessage { MessageId = $"<{f}-{i}@h>", Subject = $"{f}-{i}" },
+                    TargetFolderPath = new[] { f },
+                });
+        return planned;
+    }
+
+    private static IReadOnlyList<ReadFolder> WriteAndRead(
+        IEnumerable<PlannedMessage> planned, string outDir, int checkIntervalMessages)
+    {
+        var plan = new PstOutputPlan { Name = "P", MaxSizeBytes = 1000L * 1024 * 1024, IncludeEmptyFolders = true };
+        var report = new ConversionReport();
+        var outputs = new PstWriter(RoundTripHarness.TemplatePath, checkIntervalMessages)
+            .WritePlan(plan, planned, outDir, report);
+        return PstReader.Read(outputs);
+    }
+
+    [Fact]
+    public void MultipleFolders_SinglePart_BelowCheckpoint_AllSavedAtFinish()
+    {
+        // 3 folders x 3 = 9 messages, default checkInterval 500 -> no checkpoint; only Finish() flushes.
+        var planned = Interleave(perFolder: 3, "A", "B", "C");
+        string outDir = NewOutDir();
+        try
+        {
+            IReadOnlyList<ReadFolder> folders = WriteAndRead(planned, outDir, checkIntervalMessages: 500);
+            foreach (string name in new[] { "A", "B", "C" })
+            {
+                ReadFolder f = folders.Single(x => x.DisplayPath == name);
+                Assert.Equal(
+                    new[] { $"<{name}-0@h>", $"<{name}-1@h>", $"<{name}-2@h>" },
+                    f.Messages.Select(m => m.MessageId).OrderBy(s => s, StringComparer.Ordinal));
+            }
+        }
+        finally { Directory.Delete(outDir, true); }
+    }
+
+    [Fact]
+    public void MultipleFolders_AcrossCheckpoint_AllSurvive()
+    {
+        // 2 folders x 6 = 12 messages, checkInterval 5 -> checkpoint Flush fires mid-run with BOTH dirty.
+        var planned = Interleave(perFolder: 6, "A", "B");
+        string outDir = NewOutDir();
+        try
+        {
+            IReadOnlyList<ReadFolder> folders = WriteAndRead(planned, outDir, checkIntervalMessages: 5);
+            foreach (string name in new[] { "A", "B" })
+            {
+                ReadFolder f = folders.Single(x => x.DisplayPath == name);
+                Assert.Equal(6, f.Messages.Count);
+                Assert.Equal(
+                    Enumerable.Range(0, 6).Select(i => $"<{name}-{i}@h>"),
+                    f.Messages.Select(m => m.MessageId).OrderBy(s => s, StringComparer.Ordinal));
+            }
+        }
+        finally { Directory.Delete(outDir, true); }
+    }
+}


### PR DESCRIPTION
## Problem
`PstWriter.WriteMessage` called `folder.SaveChanges()` once per message. That rewrites the folder's entire contents table every time, so writing a folder is ~O(n²) in its message count — the dominant cost on large folders (e.g. a 16k-message INBOX).

## Fix
Batch the folder contents-table flush to the existing checkpoint cadence.

- `PstPartManager` tracks a per-part set of *dirty* folders (`HashSet<PSTFolder>` with explicit `ReferenceEqualityComparer.Instance`); `Write` marks a folder dirty after a successful message write.
- New `SaveDirtyFolders()` saves each dirty folder once and runs immediately **before** every `EndSavingChanges` (the three flush sites: checkpoint `Flush`, predictive `FlushAndSplit`, `Finish`) — honoring the vendored "SaveChanges before EndSavingChanges" requirement. The dirty set is cleared on split.
- `PstWriter.WriteMessage` drops the per-message `folder.SaveChanges()` (keeps `note.SaveChanges()` + `folder.AddMessage(note)`).

`folder.SaveChanges()` now runs ~once per dirty folder per checkpoint window (default 500) instead of once per message. Behavior-preserving: no config/CLI/JSON-contract change; empty folders, split durability, on-disk size checks, and cancel/delete-in-progress-part are unchanged.

## Effect
A large single-folder conversion does ~500× fewer contents-table rewrites. New multi-folder round-trip tests pin that all dirty folders are saved at `Finish` and across a mid-run checkpoint. Full suite: 588 pass / 4 skipped.