### PR TITLE
feat(core): prefs.js-backed tag display-names (SP4d)

### DIFF
--- a/src/Mail2Pst.Core/Config/ConversionConfig.cs
+++ b/src/Mail2Pst.Core/Config/ConversionConfig.cs
@@ -11,4 +11,5 @@ public class ConversionConfig
     public List<OutputGroupConfig> Outputs { get; set; } = new();
     public JunkHandlingMode JunkHandling { get; set; } = JunkHandlingMode.Off;
     public bool DropExpunged { get; set; }
+    public string? ProfilePath { get; set; }
 }

--- a/src/Mail2Pst.Core/ConversionRunner.cs
+++ b/src/Mail2Pst.Core/ConversionRunner.cs
@@ -41,7 +41,7 @@ public class ConversionRunner
 
         var enrichmentOptions = new MsfEnrichmentOptions
         {
-            TagResolver = new DefaultMsfTagResolver(),
+            TagResolver = MsfTagResolverFactory.Create(config.ProfilePath),
             JunkHandling = config.JunkHandling,
             DropExpunged = config.DropExpunged,
         };

--- a/src/Mail2Pst.Core/Discovery/ConfigFromDiscovery.cs
+++ b/src/Mail2Pst.Core/Discovery/ConfigFromDiscovery.cs
@@ -53,6 +53,8 @@ public static class ConfigFromDiscovery
             MsfPath = s.MsfPath,
         }).ToList();
 
+        config.ProfilePath = discovery.Root;   // --profile root is authoritative (ignores any template ProfilePath)
+
         config.Outputs.Add(group);
         return config;
     }

--- a/src/Mail2Pst.Core/Msf/MsfTagDefaults.cs
+++ b/src/Mail2Pst.Core/Msf/MsfTagDefaults.cs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Mail2Pst.Core.Msf;
+
+/// <summary>
+/// Shared tag-resolution defaults used by both DefaultMsfTagResolver and PrefsJsTagResolver:
+/// internal junk tokens to drop, and the five built-in $labelN English fallback names.
+/// (Thunderbird lets users rename/localize these; prefs.js is authoritative when present.)
+/// </summary>
+internal static class MsfTagDefaults
+{
+    internal static readonly IReadOnlySet<string> Filtered =
+        new HashSet<string>(StringComparer.Ordinal) { "NonJunk" };
+
+    internal static readonly IReadOnlyDictionary<string, string> BuiltinLabels =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["$label1"] = "Important", ["$label2"] = "Work", ["$label3"] = "Personal",
+            ["$label4"] = "To Do",     ["$label5"] = "Later",
+        };
+}

--- a/src/Mail2Pst.Core/Msf/MsfTagResolver.cs
+++ b/src/Mail2Pst.Core/Msf/MsfTagResolver.cs
@@ -19,21 +19,14 @@ public interface IMsfTagResolver
 /// </summary>
 public sealed class DefaultMsfTagResolver : IMsfTagResolver
 {
-    private static readonly HashSet<string> Filtered = new(StringComparer.Ordinal) { "NonJunk" };
-    private static readonly Dictionary<string, string> Labels = new(StringComparer.Ordinal)
-    {
-        ["$label1"] = "Important", ["$label2"] = "Work", ["$label3"] = "Personal",
-        ["$label4"] = "To Do",     ["$label5"] = "Later",
-    };
-
     public IReadOnlyList<string> Resolve(IReadOnlyList<string> keywords)
     {
         var result = new List<string>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
         foreach (string kw in keywords)
         {
-            if (Filtered.Contains(kw)) continue;
-            string name = Labels.TryGetValue(kw, out string? mapped) ? mapped : kw;
+            if (MsfTagDefaults.Filtered.Contains(kw)) continue;
+            string name = MsfTagDefaults.BuiltinLabels.TryGetValue(kw, out string? mapped) ? mapped : kw;
             if (seen.Add(name)) result.Add(name);
         }
         return result;

--- a/src/Mail2Pst.Core/Msf/MsfTagResolverFactory.cs
+++ b/src/Mail2Pst.Core/Msf/MsfTagResolverFactory.cs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System.Collections.Generic;
+using System.IO;
+
+namespace Mail2Pst.Core.Msf;
+
+/// <summary>
+/// Selects the tag resolver for a conversion. With a profile directory containing a prefs.js that has
+/// tag-name prefs, returns a PrefsJsTagResolver; otherwise (null/blank path, no prefs.js, unreadable, or
+/// no tag prefs) silently falls back to DefaultMsfTagResolver. Best-effort category naming — never warns
+/// and never affects .msf enrichment counts.
+/// </summary>
+public static class MsfTagResolverFactory
+{
+    public static IMsfTagResolver Create(string? profilePath)
+    {
+        if (string.IsNullOrWhiteSpace(profilePath))
+            return new DefaultMsfTagResolver();
+
+        IReadOnlyDictionary<string, string> prefs = PrefsTagReader.Read(Path.Combine(profilePath, "prefs.js"));
+        return prefs.Count > 0 ? new PrefsJsTagResolver(prefs) : new DefaultMsfTagResolver();
+    }
+}

--- a/src/Mail2Pst.Core/Msf/PrefsJsTagResolver.cs
+++ b/src/Mail2Pst.Core/Msf/PrefsJsTagResolver.cs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Mail2Pst.Core.Msf;
+
+/// <summary>
+/// Resolves .msf tag keys to category names using prefs.js display-names layered over the built-in
+/// defaults. Per keyword: drop NonJunk; else prefs name; else built-in $labelN; else the key verbatim.
+/// Dedupe ordinal, first occurrence wins (same contract as DefaultMsfTagResolver when prefs is empty).
+/// </summary>
+public sealed class PrefsJsTagResolver : IMsfTagResolver
+{
+    private readonly Dictionary<string, string> _prefs;
+
+    public PrefsJsTagResolver(IReadOnlyDictionary<string, string> prefsNames)
+    {
+        ArgumentNullException.ThrowIfNull(prefsNames);
+        _prefs = new Dictionary<string, string>(prefsNames, StringComparer.Ordinal); // defensive ordinal copy
+    }
+
+    public IReadOnlyList<string> Resolve(IReadOnlyList<string> keywords)
+    {
+        var result = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (string kw in keywords)
+        {
+            if (MsfTagDefaults.Filtered.Contains(kw)) continue;
+            string name = _prefs.TryGetValue(kw, out string? pref) ? pref
+                : MsfTagDefaults.BuiltinLabels.TryGetValue(kw, out string? builtin) ? builtin
+                : kw;
+            if (seen.Add(name)) result.Add(name);
+        }
+        return result;
+    }
+}

--- a/src/Mail2Pst.Core/Msf/PrefsTagReader.cs
+++ b/src/Mail2Pst.Core/Msf/PrefsTagReader.cs
@@ -39,7 +39,7 @@ public static class PrefsTagReader
     public static IReadOnlyDictionary<string, string> ParseText(string content)
     {
         var map = new Dictionary<string, string>(StringComparer.Ordinal);
-        foreach (string line in content.Split('\n'))
+        foreach (string line in content.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None))
         {
             Match m = TagPrefRegex.Match(line);
             if (!m.Success) continue;

--- a/src/Mail2Pst.Core/Msf/PrefsTagReader.cs
+++ b/src/Mail2Pst.Core/Msf/PrefsTagReader.cs
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Mail2Pst.Core.Msf;
+
+/// <summary>
+/// Reads Thunderbird tag display-names from a profile's prefs.js — the `mailnews.tags.&lt;key&gt;.tag`
+/// prefs only (colour is out of scope). Line-oriented recognition of user_pref(...) text; does NOT
+/// execute JavaScript. ParseText is pure; Read adds file I/O and returns an empty map when the file is
+/// missing/unreadable.
+/// </summary>
+public static class PrefsTagReader
+{
+    // Anchored per line so a "// user_pref(...)" comment line does not match. Value allows escaped
+    // chars (\\ and \") inside; key is the lazy segment between "mailnews.tags." and the ".tag" suffix.
+    private static readonly Regex TagPrefRegex = new(
+        "^\\s*user_pref\\s*\\(\\s*\"mailnews\\.tags\\.(?<key>.+?)\\.tag\"\\s*,\\s*\"(?<val>(?:\\\\.|[^\"\\\\])*)\"\\s*\\)\\s*;?\\s*$",
+        RegexOptions.CultureInvariant);
+
+    public static IReadOnlyDictionary<string, string> Read(string prefsJsPath)
+    {
+        try
+        {
+            return ParseText(File.ReadAllText(prefsJsPath));
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return new Dictionary<string, string>(StringComparer.Ordinal);
+        }
+    }
+
+    public static IReadOnlyDictionary<string, string> ParseText(string content)
+    {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (string line in content.Split('\n'))
+        {
+            Match m = TagPrefRegex.Match(line);
+            if (!m.Success) continue;
+            if (!TryUnescape(m.Groups["val"].Value, out string name)) continue; // bad escape -> skip line
+            if (name.Length == 0) continue;                                       // empty name -> skip line
+            map[m.Groups["key"].Value] = name;                                    // later duplicate wins
+        }
+        return map;
+    }
+
+    private static bool TryUnescape(string raw, out string result)
+    {
+        var sb = new StringBuilder(raw.Length);
+        for (int i = 0; i < raw.Length; i++)
+        {
+            char c = raw[i];
+            if (c != '\\') { sb.Append(c); continue; }
+            i++;
+            if (i >= raw.Length) { result = ""; return false; } // dangling backslash
+            switch (raw[i])
+            {
+                case '\\': sb.Append('\\'); break;
+                case '"': sb.Append('"'); break;
+                case 'n': sb.Append('\n'); break;
+                case 'r': sb.Append('\r'); break;
+                case 't': sb.Append('\t'); break;
+                case 'u':
+                    if (i + 4 >= raw.Length) { result = ""; return false; }
+                    if (!ushort.TryParse(raw.Substring(i + 1, 4), NumberStyles.HexNumber,
+                            CultureInfo.InvariantCulture, out ushort code)) { result = ""; return false; }
+                    sb.Append((char)code);
+                    i += 4;
+                    break;
+                default: result = ""; return false; // unknown escape -> skip line
+            }
+        }
+        result = sb.ToString();
+        return true;
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Config/ConfigLoaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Config/ConfigLoaderTests.cs
@@ -135,4 +135,25 @@ public class ConfigLoaderTests
         }
         finally { File.Delete(tempPath); }
     }
+
+    [Fact]
+    public void ProfilePath_DefaultsToNull()
+        => Assert.Null(new ConversionConfig().ProfilePath);
+
+    [Fact]
+    public void Load_ParsesProfilePath()
+    {
+        string json = """
+        { "profilePath": "/data/tb/profile", "outputs": [ { "name": "Out", "maxSizeMB": 100,
+          "folderMapping": "mirror", "sources": [ { "path": "a.mbox", "type": "mbox" } ] } ] }
+        """;
+        string tempPath = Path.GetTempFileName();
+        File.WriteAllText(tempPath, json);
+        try
+        {
+            ConversionConfig config = ConfigLoader.Load(tempPath);
+            Assert.Equal("/data/tb/profile", config.ProfilePath);
+        }
+        finally { File.Delete(tempPath); }
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Discovery/ConfigFromDiscoveryTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Discovery/ConfigFromDiscoveryTests.cs
@@ -34,6 +34,15 @@ public class ConfigFromDiscoveryTests
         Assert.Equal("/p/Inbox.msf", g.Sources[0].MsfPath);
         Assert.Null(g.Sources[1].MsfPath);
         Assert.Equal(new List<string> { "Local Folders", "Inbox" }, g.Sources[0].TargetFolderPath);
+        Assert.Equal("/data/tb/profile", cfg.ProfilePath);   // == discovery.Root
+    }
+
+    [Fact]
+    public void Build_WithTemplateProfilePath_DiscoveryRootWins()
+    {
+        var template = new ConversionConfig { ProfilePath = "/some/other/place" };
+        ConversionConfig cfg = ConfigFromDiscovery.Build(Discovery(), template);
+        Assert.Equal("/data/tb/profile", cfg.ProfilePath);   // discovery.Root, not the template value
     }
 
     [Fact]

--- a/tests/Mail2Pst.Core.Tests/Msf/MsfTagResolverFactoryTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/MsfTagResolverFactoryTests.cs
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.IO;
+using Mail2Pst.Core.Msf;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Msf;
+
+public class MsfTagResolverFactoryTests
+{
+    private static string NewDir()
+    {
+        string d = Path.Combine(Path.GetTempPath(), "mail2pst-prof-" + Guid.NewGuid());
+        Directory.CreateDirectory(d);
+        return d;
+    }
+
+    [Fact]
+    public void NullPath_ReturnsDefaultResolver()
+        => Assert.IsType<DefaultMsfTagResolver>(MsfTagResolverFactory.Create(null));
+
+    [Fact]
+    public void DirWithoutPrefsJs_ReturnsDefaultResolver()
+    {
+        string dir = NewDir();
+        try { Assert.IsType<DefaultMsfTagResolver>(MsfTagResolverFactory.Create(dir)); }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void DirWithTagBearingPrefsJs_ReturnsPrefsResolver()
+    {
+        string dir = NewDir();
+        File.WriteAllText(Path.Combine(dir, "prefs.js"),
+            "user_pref(\"mailnews.tags.$label1.tag\", \"Critique\");\n");
+        try
+        {
+            IMsfTagResolver r = MsfTagResolverFactory.Create(dir);
+            Assert.IsType<PrefsJsTagResolver>(r);
+            Assert.Equal(new[] { "Critique" }, r.Resolve(new[] { "$label1" }));
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void DirWithPrefsJsButNoTagNames_ReturnsDefaultResolver()
+    {
+        // prefs.js exists but has only a .color pref + unrelated prefs -> empty tag-name map -> fallback.
+        string dir = NewDir();
+        File.WriteAllText(Path.Combine(dir, "prefs.js"),
+            "user_pref(\"mailnews.tags.$label1.color\", \"#FF0000\");\n" +
+            "user_pref(\"mail.server.server1.check_new_mail\", true);\n");
+        try { Assert.IsType<DefaultMsfTagResolver>(MsfTagResolverFactory.Create(dir)); }
+        finally { Directory.Delete(dir, true); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Msf/PrefsJsTagResolverTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/PrefsJsTagResolverTests.cs
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using Mail2Pst.Core.Msf;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Msf;
+
+public class PrefsJsTagResolverTests
+{
+    private static PrefsJsTagResolver Resolver(params (string key, string name)[] prefs)
+    {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var (k, n) in prefs) map[k] = n;
+        return new PrefsJsTagResolver(map);
+    }
+
+    [Fact]
+    public void PrefsOverridesBuiltin()
+    {
+        var r = Resolver(("$label1", "Critique"));
+        Assert.Equal(new[] { "Critique" }, r.Resolve(new[] { "$label1" }));
+    }
+
+    [Fact]
+    public void BuiltinFallback_WhenPrefsLacksLabel()
+    {
+        var r = Resolver(); // empty prefs
+        Assert.Equal(new[] { "Important" }, r.Resolve(new[] { "$label1" }));
+    }
+
+    [Fact]
+    public void CustomKey_UsesPrefsName()
+    {
+        var r = Resolver(("custom", "Client X"));
+        Assert.Equal(new[] { "Client X" }, r.Resolve(new[] { "custom" }));
+    }
+
+    [Fact]
+    public void UnknownKey_PassesThrough()
+    {
+        var r = Resolver();
+        Assert.Equal(new[] { "weirdkey" }, r.Resolve(new[] { "weirdkey" }));
+    }
+
+    [Fact]
+    public void NonJunk_IsFiltered()
+    {
+        var r = Resolver(("$label1", "Critique"));
+        Assert.Equal(new[] { "Critique" }, r.Resolve(new[] { "NonJunk", "$label1" }));
+    }
+
+    [Fact]
+    public void Dedupe_PreservesFirstOccurrence_OnCollision()
+    {
+        // prefs renames $label2 to "Work"; a custom key also named "Work" collides -> first wins, one entry.
+        var r = Resolver(("$label2", "Work"), ("dup", "Work"));
+        Assert.Equal(new[] { "Work" }, r.Resolve(new[] { "$label2", "dup" }));
+    }
+
+    [Fact]
+    public void RenamedBuiltin_AndCustom_InOnePass()
+    {
+        var r = Resolver(("$label1", "Critique"), ("custom", "Client X"));
+        Assert.Equal(new[] { "Critique", "Client X" }, r.Resolve(new[] { "$label1", "custom" }));
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Msf/PrefsTagReaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/PrefsTagReaderTests.cs
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Collections.Generic;
+using System.IO;
+using Mail2Pst.Core.Msf;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Msf;
+
+public class PrefsTagReaderTests
+{
+    [Fact]
+    public void ParsesBuiltinAndCustomTagNames()
+    {
+        string text =
+            "user_pref(\"mailnews.tags.$label1.tag\", \"Critique\");\n" +
+            "user_pref(\"mailnews.tags.custom.tag\", \"Client X\");\n";
+        var map = PrefsTagReader.ParseText(text);
+        Assert.Equal("Critique", map["$label1"]);
+        Assert.Equal("Client X", map["custom"]);
+        Assert.Equal(2, map.Count);
+    }
+
+    [Fact]
+    public void IgnoresColorAndUnrelatedPrefs()
+    {
+        string text =
+            "user_pref(\"mailnews.tags.$label1.tag\", \"Important\");\n" +
+            "user_pref(\"mailnews.tags.$label1.color\", \"#FF0000\");\n" +
+            "user_pref(\"mail.server.server1.check_new_mail\", true);\n";
+        var map = PrefsTagReader.ParseText(text);
+        Assert.Equal(new[] { "$label1" }, new List<string>(map.Keys));
+    }
+
+    [Fact]
+    public void SkipsCommentAndMalformedLines()
+    {
+        string text =
+            "// user_pref(\"mailnews.tags.$label1.tag\", \"Commented\");\n" +
+            "user_pref(\"mailnews.tags.$label2.tag\",\n" +   // truncated/malformed line
+            "user_pref(\"mailnews.tags.$label3.tag\", \"Personal\");\n";
+        var map = PrefsTagReader.ParseText(text);
+        Assert.False(map.ContainsKey("$label1"));
+        Assert.False(map.ContainsKey("$label2"));
+        Assert.Equal("Personal", map["$label3"]);
+    }
+
+    [Fact]
+    public void ToleratesWhitespace()
+    {
+        string text = "   user_pref( \"mailnews.tags.$label1.tag\" ,  \"Important\" ) ;  \n";
+        var map = PrefsTagReader.ParseText(text);
+        Assert.Equal("Important", map["$label1"]);
+    }
+
+    [Fact]
+    public void UnescapesStringLiterals()
+    {
+        string text =
+            "user_pref(\"mailnews.tags.a.tag\", \"q\\\"q\");\n" +        // q"q
+            "user_pref(\"mailnews.tags.b.tag\", \"x\\\\y\");\n" +       // x\y
+            "user_pref(\"mailnews.tags.c.tag\", \"u\\u00e9\");\n" +     // ué
+            "user_pref(\"mailnews.tags.d.tag\", \"g\\nhi\\rj\\tk\");\n"; // g<LF>hi<CR>j<TAB>k
+        var map = PrefsTagReader.ParseText(text);
+        Assert.Equal("q\"q", map["a"]);
+        Assert.Equal("x\\y", map["b"]);
+        Assert.Equal("ué", map["c"]);
+        Assert.Equal("g\nhi\rj\tk", map["d"]);
+    }
+
+    [Fact]
+    public void DoesNotNormalizeKey()
+    {
+        string text = "user_pref(\"mailnews.tags.Custom-Key_1.tag\", \"Name\");\n";
+        var map = PrefsTagReader.ParseText(text);
+        Assert.Equal("Name", map["Custom-Key_1"]); // key kept verbatim, no lowercase/trim/normalize
+    }
+
+    [Fact]
+    public void SkipsLineWithUnparseableEscape()
+    {
+        string text =
+            "user_pref(\"mailnews.tags.bad.tag\", \"x\\q\");\n" +    // \q is not a known escape
+            "user_pref(\"mailnews.tags.ok.tag\", \"Fine\");\n";
+        var map = PrefsTagReader.ParseText(text);
+        Assert.False(map.ContainsKey("bad"));
+        Assert.Equal("Fine", map["ok"]);
+    }
+
+    [Fact]
+    public void SkipsEmptyDisplayName()
+    {
+        string text = "user_pref(\"mailnews.tags.foo.tag\", \"\");\n";
+        var map = PrefsTagReader.ParseText(text);
+        Assert.False(map.ContainsKey("foo"));
+    }
+
+    [Fact]
+    public void LaterDuplicateWins_IncludingEarlierMalformed()
+    {
+        string text =
+            "user_pref(\"mailnews.tags.$label1.tag\", \"First\");\n" +
+            "user_pref(\"mailnews.tags.$label1.tag\", \"Second\");\n" +
+            "user_pref(\"mailnews.tags.dup.tag\", \"x\\q\");\n" +   // malformed -> skipped
+            "user_pref(\"mailnews.tags.dup.tag\", \"Valid\");\n";
+        var map = PrefsTagReader.ParseText(text);
+        Assert.Equal("Second", map["$label1"]);
+        Assert.Equal("Valid", map["dup"]);
+    }
+
+    [Fact]
+    public void Read_MissingFile_ReturnsEmptyMap()
+    {
+        var map = PrefsTagReader.Read(Path.Combine(Path.GetTempPath(), "no-such-" + System.Guid.NewGuid() + ".js"));
+        Assert.Empty(map);
+    }
+
+    [Fact]
+    public void Read_PresentFile_Parses()
+    {
+        string p = Path.Combine(Path.GetTempPath(), "prefs-" + System.Guid.NewGuid() + ".js");
+        File.WriteAllText(p, "user_pref(\"mailnews.tags.$label1.tag\", \"Important\");\n");
+        try { Assert.Equal("Important", PrefsTagReader.Read(p)["$label1"]); }
+        finally { File.Delete(p); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Msf/PrefsTagReaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/PrefsTagReaderTests.cs
@@ -123,4 +123,15 @@ public class PrefsTagReaderTests
         try { Assert.Equal("Important", PrefsTagReader.Read(p)["$label1"]); }
         finally { File.Delete(p); }
     }
+
+    [Fact]
+    public void HandlesCrlfLineEndings()
+    {
+        string text =
+            "user_pref(\"mailnews.tags.$label1.tag\", \"Important\");\r\n" +
+            "user_pref(\"mailnews.tags.custom.tag\", \"Client X\");\r\n";
+        var map = PrefsTagReader.ParseText(text);
+        Assert.Equal("Important", map["$label1"]);
+        Assert.Equal("Client X", map["custom"]);
+    }
 }

--- a/tests/Mail2Pst.Integration.Tests/PrefsTagNameRoundTripTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/PrefsTagNameRoundTripTests.cs
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Reporting;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests;
+
+public class PrefsTagNameRoundTripTests
+{
+    // .msf: message-id=a@h, keywords="$label1 custom" ($ is Mork-escaped as $24).
+    private const string MsfText =
+        "< <(a=c)> (80=ns:msg:db:row:scope:msgs:all)(96=ns:msg:db:table:kind:msgs)" +
+        "(89=message-id)(8B=keywords) >\n" +
+        "{1:^80 {(k^96:c)} [1(^89=a@h)(^8B=$24label1 custom)] }";
+
+    private static string Msg(string id) =>
+        $"From s@e Thu Jan 01 00:00:00 2026\nMessage-ID: {id}\nSubject: t\n\nbody\n";
+
+    private static string NewDir(string tag)
+    {
+        string d = Path.Combine(Path.GetTempPath(), "mail2pst-" + tag + "-" + Guid.NewGuid());
+        Directory.CreateDirectory(d);
+        return d;
+    }
+
+    private static IReadOnlyList<string> Convert(string? profilePath)
+    {
+        string profileDir = profilePath ?? NewDir("noprof");
+        string mbox = Path.Combine(profileDir, "Inbox");
+        File.WriteAllText(mbox, Msg("<a@h>"));
+        File.WriteAllText(Path.Combine(profileDir, "Inbox.msf"), MsfText);
+        string outDir = NewDir("out");
+        string template = TemplateProvider.ExtractToTempFile();
+        try
+        {
+            var config = new ConversionConfig
+            {
+                ProfilePath = profilePath,
+                Outputs =
+                {
+                    new OutputGroupConfig
+                    {
+                        Name = "Out",
+                        Sources = { new SourceConfig
+                            { Path = mbox, Type = "mbox", MsfPath = Path.Combine(profileDir, "Inbox.msf"),
+                              TargetFolder = "Inbox" } },
+                    },
+                },
+            };
+            ConversionReport report = new ConversionRunner(template).Run(config, outDir);
+            ReadBackMessage m = PstReader.Read(report.OutputFiles).SelectMany(f => f.Messages).Single();
+            return m.Categories;
+        }
+        finally
+        {
+            File.Delete(template);
+            Directory.Delete(outDir, true);
+            if (profilePath is null) Directory.Delete(profileDir, true);
+        }
+    }
+
+    [Fact]
+    public void PrefsJs_RenamedBuiltinAndCustom_AppliedToCategories()
+    {
+        string profile = NewDir("prof");
+        File.WriteAllText(Path.Combine(profile, "prefs.js"),
+            "user_pref(\"mailnews.tags.$label1.tag\", \"Critique\");\n" +
+            "user_pref(\"mailnews.tags.custom.tag\", \"Client X\");\n");
+        try
+        {
+            IReadOnlyList<string> categories = Convert(profile);
+            Assert.Equal(new[] { "Critique", "Client X" }, categories);
+        }
+        finally { Directory.Delete(profile, true); }
+    }
+
+    [Fact]
+    public void NoPrefsJs_FallsBackToBuiltinNames()
+    {
+        // No ProfilePath -> DefaultMsfTagResolver: $label1 -> "Important", custom passes through.
+        IReadOnlyList<string> categories = Convert(profilePath: null);
+        Assert.Equal(new[] { "Important", "custom" }, categories);
+    }
+}


### PR DESCRIPTION
## Problem
`.msf` tags became Outlook categories using *guessed* English names (`$label1`→"Important") and raw custom-tag *keys*. The user's real display-names live in the profile's `prefs.js` (`mailnews.tags.<key>.tag`), so renamed built-ins and custom tags showed the wrong text.

## Fix
Read `prefs.js` and use the user's actual tag display-names.

- New `PrefsTagReader` (`ParseText` pure + `Read` file I/O) parses `mailnews.tags.<key>.tag` lines (ignores `.color`/unrelated/comments; handles `\ \" \n \r \t \uXXXX`; later-duplicate-wins; key not normalized).
- New `PrefsJsTagResolver` layers prefs over the built-ins: drop `NonJunk` → prefs name → built-in `$labelN` → passthrough; dedupe ordinal first-wins. Shared `MsfTagDefaults` keeps `DefaultMsfTagResolver` behavior identical.
- `MsfTagResolverFactory.Create(profilePath)` picks the resolver; **silent fallback** to `DefaultMsfTagResolver` when `prefs.js` is absent/unreadable/has no tag prefs (no warning, no effect on `.msf` enrichment counts).
- `ConversionConfig.ProfilePath` (profile *directory*); `ConfigFromDiscovery` sets it from the `--profile` root (authoritative over any template); `ConversionRunner` builds the resolver via the factory.

**Colour deferred** (parse only `.tag`). No CLI flag, no JSON-contract change.

## Effect
`convert --profile` produces categories with the user's real tag names — the main win being custom tags and renamed built-ins. Localized built-ins never customized by the user keep the English defaults (documented limitation). Full suite: 616 pass / 4 skipped.