### PR TITLE
feat: import-colours — Thunderbird tag colours into Outlook's master category list

### DIFF
--- a/src/Mail2Pst.Cli/ImportColoursCommand.cs
+++ b/src/Mail2Pst.Cli/ImportColoursCommand.cs
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Mail2Pst.Core.Cli;
+using Mail2Pst.Core.Msf;
+using Mail2Pst.Core.OutlookCategories;
+
+namespace Mail2Pst.Cli;
+
+internal static class ImportColoursCommand
+{
+    private static readonly TimeSpan ApplyTimeout = TimeSpan.FromSeconds(60);
+
+    internal static int Run(string[] args)
+    {
+        ImportColoursInput input = ImportColoursInput.Parse(args);
+        if (input.Error is not null)
+        {
+            Console.Error.WriteLine($"{input.Error}");
+            Console.Error.WriteLine("Usage: continumail-convert import-colours --profile <thunderbird-profile-dir> [--apply]");
+            return 1;
+        }
+
+        string prefsPath = Path.Combine(input.ProfilePath!, "prefs.js");
+        string content = File.Exists(prefsPath) ? File.ReadAllText(prefsPath) : string.Empty;
+        IReadOnlyList<CategoryCandidate> plan =
+            CategoryColorPlan.Build(PrefsTagReader.ParseText(content), PrefsTagReader.ParseColors(content));
+
+        if (!input.Apply)
+        {
+            Emit("preview", outlookAvailable: ProgIdRegistered(), plan);
+            return 0;
+        }
+
+        if (!OperatingSystem.IsWindows() || !ProgIdRegistered())
+        {
+            CliArgs.WriteJsonLine(new { type = "error", stage = "import-colours",
+                message = "Outlook is required for --apply; preview works without it.", fatal = true });
+            Console.Error.WriteLine("Outlook is required for --apply.");
+            return 1;
+        }
+
+        try
+        {
+            IReadOnlyList<CategoryCandidate> applied = RunOnSta(() =>
+            {
+                using var store = new OutlookComCategoryStore();
+                return CategoryColorApplier.Apply(plan, store);
+            }, ApplyTimeout);
+            Emit("apply", outlookAvailable: true, applied);
+            return 0;
+        }
+        catch (TimeoutException)
+        {
+            CliArgs.WriteJsonLine(new { type = "error", stage = "import-colours",
+                message = "Outlook did not respond (a security prompt may be open). Dismiss it / use a trusted context and re-run.",
+                fatal = true });
+            Console.Error.WriteLine("Outlook timed out — dismiss any Outlook security prompt and re-run.");
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            CliArgs.WriteJsonLine(new { type = "error", stage = "import-colours", message = ex.Message, fatal = true });
+            Console.Error.WriteLine($"import-colours failed: {ex.Message}");
+            return 1;
+        }
+    }
+
+    private static bool ProgIdRegistered() =>
+        OperatingSystem.IsWindows() && Type.GetTypeFromProgID("Outlook.Application") is not null;
+
+    private static void Emit(string mode, bool outlookAvailable, IReadOnlyList<CategoryCandidate> categories)
+    {
+        // NOTE: do NOT set schemaVersion here — CliEventSerializer.Serialize injects it (verified: it does
+        // `node["schemaVersion"] = SchemaVersion`). Matches DiscoverCommand, which also omits it.
+        var output = new
+        {
+            type = "importColours",
+            mode,
+            outlookAvailable,
+            categories = categories.Select(c => new { name = c.Name, hex = c.Hex, outlookColor = c.OutlookColor, action = c.Action }),
+        };
+        Console.WriteLine(CliEventSerializer.Serialize(output, indented: true));
+    }
+
+    // Runs the COM interaction on a dedicated STA thread; throws TimeoutException if it doesn't finish in time.
+    private static T RunOnSta<T>(Func<T> work, TimeSpan timeout)
+    {
+        T result = default!;
+        Exception? error = null;
+        var thread = new Thread(() => { try { result = work(); } catch (Exception ex) { error = ex; } });
+        thread.IsBackground = true;
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        if (!thread.Join(timeout)) throw new TimeoutException();
+        if (error is not null) throw error;
+        return result;
+    }
+}

--- a/src/Mail2Pst.Cli/ImportColoursCommand.cs
+++ b/src/Mail2Pst.Cli/ImportColoursCommand.cs
@@ -50,7 +50,9 @@ internal static class ImportColoursCommand
             IReadOnlyList<CategoryCandidate> applied = RunOnSta(() =>
             {
                 using var store = new OutlookComCategoryStore();
-                return CategoryColorApplier.Apply(plan, store);
+                IReadOnlyList<CategoryCandidate> result = CategoryColorApplier.Apply(plan, store);
+                store.Commit(); // atomically persist the buffered adds before Dispose flushes + closes Outlook
+                return result;
             }, ApplyTimeout);
             Emit("apply", outlookAvailable: true, applied);
             return 0;

--- a/src/Mail2Pst.Cli/ImportColoursInput.cs
+++ b/src/Mail2Pst.Cli/ImportColoursInput.cs
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Mail2Pst.Cli;
+
+internal sealed record ImportColoursInput(string? ProfilePath, bool Apply, string? Error)
+{
+    private static readonly HashSet<string> Known = new(StringComparer.Ordinal) { "--profile", "--apply" };
+
+    internal static ImportColoursInput Parse(string[] args)
+    {
+        for (int i = 0; i < args.Length; i++)
+        {
+            string a = args[i];
+            if (!Known.Contains(a)) return new ImportColoursInput(null, false, $"Unknown argument: {a}");
+            if (a == "--profile") i++; // skip its value
+        }
+        string? profile = CliArgs.Flag(args, "--profile");
+        if (string.IsNullOrWhiteSpace(profile))
+            return new ImportColoursInput(null, false, "Missing required --profile <thunderbird-profile-dir>.");
+        return new ImportColoursInput(profile, CliArgs.HasFlag(args, "--apply"), null);
+    }
+}

--- a/src/Mail2Pst.Cli/ImportColoursInput.cs
+++ b/src/Mail2Pst.Cli/ImportColoursInput.cs
@@ -16,7 +16,12 @@ internal sealed record ImportColoursInput(string? ProfilePath, bool Apply, strin
         {
             string a = args[i];
             if (!Known.Contains(a)) return new ImportColoursInput(null, false, $"Unknown argument: {a}");
-            if (a == "--profile") i++; // skip its value
+            if (a == "--profile")
+            {
+                i++;
+                if (i >= args.Length || args[i].StartsWith("--", System.StringComparison.Ordinal))
+                    return new ImportColoursInput(null, false, "--profile requires a value.");
+            }
         }
         string? profile = CliArgs.Flag(args, "--profile");
         if (string.IsNullOrWhiteSpace(profile))

--- a/src/Mail2Pst.Cli/OutlookComCategoryStore.cs
+++ b/src/Mail2Pst.Cli/OutlookComCategoryStore.cs
@@ -100,58 +100,49 @@ internal sealed class OutlookComCategoryStore : IOutlookCategoryStore, IDisposab
             "Could not open the Outlook master category list (CategoryList FAI).", last);
     }
 
-    // Reads the binary RoamingXmlStream as bytes. The COM VARIANT marshals as byte[] in the common case but
-    // can arrive as a 1-D Array of another integral type; null/DBNull (property absent) is an error.
-    private static byte[] ReadBytes(dynamic storage)
-    {
-        object raw = storage.PropertyAccessor.GetProperty(RoamingXmlStreamProp);
-        switch (raw)
-        {
-            case null:
-            case DBNull:
-                throw new InvalidOperationException("The category list stream is empty.");
-            case byte[] b:
-                return b;
-            case Array a:
-                var bytes = new byte[a.Length];
-                for (int i = 0; i < a.Length; i++) bytes[i] = Convert.ToByte(a.GetValue(i));
-                return bytes;
-            default:
-                throw new InvalidOperationException(
-                    $"The category list stream is not binary (got {raw.GetType().Name}).");
-        }
-    }
+    // Reads the binary RoamingXmlStream as bytes via the pure, unit-tested normalizer (handles byte[], an
+    // integral Array marshaling, and null/DBNull).
+    private static byte[] ReadBytes(dynamic storage) =>
+        CategoryStreamBytes.FromVariant((object)storage.PropertyAccessor.GetProperty(RoamingXmlStreamProp));
 
     private static int[] OutlookPids() =>
         Process.GetProcessesByName("OUTLOOK").Select(p => { int id = p.Id; p.Dispose(); return id; }).ToArray();
 
     public void Dispose()
     {
-        // Quit (clean shutdown) flushes our Save to disk; a hard kill would lose it. We never dirtied the OOM
-        // Categories cache, so Outlook won't re-serialize a stale list over the write.
-        try { ((dynamic)_app).Quit(); } catch { /* best-effort */ }
-
-        // Wait for the transient OUTLOOK.EXE we started to exit — that is the flush-complete signal — bounded
-        // so a hung instance can't block the CLI. Wait only on the PIDs we started (not, say, an Outlook the
-        // user launched mid-run).
-        var sw = Stopwatch.StartNew();
-        foreach (int pid in _startedPids)
+        // Only shut Outlook down if we actually started it. _startedPids is empty only if a TOCTOU race had
+        // CreateInstance attach to a pre-existing OUTLOOK.EXE that appeared after the "is Outlook running?"
+        // guard — in that case it is the user's process, so we must NOT Quit it.
+        if (_startedPids.Length > 0)
         {
-            Process? p = null;
-            try
+            // Logoff then Quit (clean shutdown) flushes our Save to disk; a hard kill would lose it. We never
+            // dirtied the OOM Categories cache, so Outlook won't re-serialize a stale list over the write.
+            try { ((dynamic)_session).Logoff(); } catch { /* best-effort */ }
+            try { ((dynamic)_app).Quit(); } catch { /* best-effort */ }
+
+            // Wait for the OUTLOOK.EXE we started to exit — that is the flush-complete signal — bounded so a
+            // hung instance can't block the CLI. (If Logon blocks earlier and the STA Join times out, the
+            // store is abandoned un-Disposed and the started instance can leak; that path emits a clear
+            // "dismiss any Outlook prompt" error and is rare given ShowDialog=false + Outlook-closed.)
+            var sw = Stopwatch.StartNew();
+            foreach (int pid in _startedPids)
             {
-                p = Process.GetProcessById(pid);
-                int remaining = ShutdownWaitMs - (int)sw.ElapsedMilliseconds;
-                if (remaining > 0) p.WaitForExit(remaining);
+                Process? p = null;
+                try
+                {
+                    p = Process.GetProcessById(pid);
+                    int remaining = ShutdownWaitMs - (int)sw.ElapsedMilliseconds;
+                    if (remaining > 0) p.WaitForExit(remaining);
+                }
+                catch { /* already exited / not found */ }
+                finally { p?.Dispose(); }
             }
-            catch { /* already exited / not found */ }
-            finally { p?.Dispose(); }
         }
 
+        // FinalReleaseComObject drops our RCWs; the instance has already exited above, so no extra GC pass is
+        // needed to tear it down.
         try { Marshal.FinalReleaseComObject(_storage); } catch { /* best-effort */ }
         try { Marshal.FinalReleaseComObject(_session); } catch { }
         try { Marshal.FinalReleaseComObject(_app); } catch { }
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
     }
 }

--- a/src/Mail2Pst.Cli/OutlookComCategoryStore.cs
+++ b/src/Mail2Pst.Cli/OutlookComCategoryStore.cs
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Mail2Pst.Core.OutlookCategories;
+
+namespace Mail2Pst.Cli;
+
+/// <summary>
+/// IOutlookCategoryStore backed by Outlook via LATE-BOUND COM (no Microsoft.Office.Interop reference). MUST
+/// be constructed and used on an STA thread (see ImportColoursCommand). Disposes the COM objects to avoid a
+/// ghosted OUTLOOK.EXE. Throws InvalidOperationException if Outlook is unavailable.
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal sealed class OutlookComCategoryStore : IOutlookCategoryStore, IDisposable
+{
+    private readonly object _app;
+    private readonly object _session;
+    private readonly dynamic _categories;
+
+    internal OutlookComCategoryStore()
+    {
+        Type? t = Type.GetTypeFromProgID("Outlook.Application");
+        if (t is null) throw new InvalidOperationException("Outlook is not installed (ProgID not registered).");
+        _app = Activator.CreateInstance(t)
+               ?? throw new InvalidOperationException("Could not start Outlook.");
+        dynamic app = _app;
+        _session = app.GetNamespace("MAPI");
+        _categories = ((dynamic)_session).Categories;
+    }
+
+    public IReadOnlySet<string> ExistingNames()
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (dynamic c in _categories) names.Add((string)c.Name);
+        return names;
+    }
+
+    public void Add(string name, int outlookColorIndex) =>
+        _categories.Add(name, outlookColorIndex, 0); // OlCategoryShortcutKey.olCategoryShortcutKeyNone = 0
+
+    public void Dispose()
+    {
+        try { Marshal.ReleaseComObject(_categories); } catch { /* best-effort */ }
+        try { Marshal.ReleaseComObject(_session); } catch { }
+        try { Marshal.ReleaseComObject(_app); } catch { }
+    }
+}

--- a/src/Mail2Pst.Cli/OutlookComCategoryStore.cs
+++ b/src/Mail2Pst.Cli/OutlookComCategoryStore.cs
@@ -3,49 +3,162 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using System.Text;
+using System.Xml;
 using Mail2Pst.Core.OutlookCategories;
 
 namespace Mail2Pst.Cli;
 
 /// <summary>
 /// IOutlookCategoryStore backed by Outlook via LATE-BOUND COM (no Microsoft.Office.Interop reference). MUST
-/// be constructed and used on an STA thread (see ImportColoursCommand). Disposes the COM objects to avoid a
-/// ghosted OUTLOOK.EXE. Throws InvalidOperationException if Outlook is unavailable.
+/// be constructed and used on an STA thread (see ImportColoursCommand).
+///
+/// It does NOT use the Outlook Object Model's <c>Categories.Add</c> — that commits the master category list
+/// lazily and racily, persisting only a nondeterministic subset of a batch (verified across ~10 experiments:
+/// 1/7, 2/3, 3/7, 4/7 survivors with every teardown variant). Instead it edits the master list's backing
+/// XML directly: the Calendar folder's <c>IPM.Configuration.CategoryList</c> associated (FAI) message carries
+/// the whole list as a UTF-8 <c>PidTagRoamingXmlStream</c> (MS-OXOCFG §2.2.5.1.1). We read that XML, append
+/// one &lt;category&gt; node per buffered Add, and write it back in a single <c>StorageItem.Save</c> — one
+/// atomic commit, no per-add race (verified deterministic: 4/4 runs persisted 7/7).
+///
+/// Requires Outlook to be CLOSED: we start a transient instance, never touch its in-memory Categories cache
+/// (so it cannot re-serialize a stale list over our write), and on Dispose call Quit so the store flushes to
+/// disk (a hard kill loses the Save). A user's already-running Outlook caches the list and could overwrite or
+/// not see our change until restart, so we refuse to run against it.
 /// </summary>
 [SupportedOSPlatform("windows")]
 internal sealed class OutlookComCategoryStore : IOutlookCategoryStore, IDisposable
 {
+    private const string RoamingXmlStreamProp = "http://schemas.microsoft.com/mapi/proptag/0x7C080102";
+    private const int OlFolderCalendar = 9;
+    private const int ShutdownWaitMs = 30_000;
+
     private readonly object _app;
     private readonly object _session;
-    private readonly dynamic _categories;
+    private readonly dynamic _storage;     // the IPM.Configuration.CategoryList FAI StorageItem
+    private readonly XmlDocument _doc;
+    private readonly XmlElement _root;
+    private readonly string _nsUri;
+    private readonly HashSet<string> _existing = new(StringComparer.OrdinalIgnoreCase);
+    private readonly List<(string Name, int OutlookColor)> _pending = new();
 
     internal OutlookComCategoryStore()
     {
+        if (Process.GetProcessesByName("OUTLOOK").Length != 0)
+            throw new InvalidOperationException(
+                "Outlook is running. Close Outlook completely, then re-run import-colours --apply.");
+
         Type? t = Type.GetTypeFromProgID("Outlook.Application");
         if (t is null) throw new InvalidOperationException("Outlook is not installed (ProgID not registered).");
-        _app = Activator.CreateInstance(t)
-               ?? throw new InvalidOperationException("Could not start Outlook.");
+        _app = Activator.CreateInstance(t) ?? throw new InvalidOperationException("Could not start Outlook.");
         dynamic app = _app;
-        _session = app.GetNamespace("MAPI");
-        _categories = ((dynamic)_session).Categories;
+        dynamic session = app.GetNamespace("MAPI");
+        session.Logon(null, null, false, false); // ShowDialog=false, NewSession=false: silent default-profile session
+        _session = session;
+
+        _storage = OpenCategoryListStorage(session);
+        _doc = new XmlDocument { PreserveWhitespace = true };
+        _doc.LoadXml(ReadXml(_storage));
+        _root = _doc.DocumentElement ?? throw new InvalidOperationException("CategoryList XML has no root element.");
+        _nsUri = _root.NamespaceURI;
+        foreach (XmlNode node in _root.ChildNodes)
+            if (node is XmlElement el && el.LocalName == "category")
+            {
+                string name = el.GetAttribute("name");
+                if (!string.IsNullOrEmpty(name)) _existing.Add(name);
+            }
     }
 
-    public IReadOnlySet<string> ExistingNames()
+    public IReadOnlySet<string> ExistingNames() => _existing;
+
+    public void Add(string name, int outlookColorIndex)
     {
-        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (dynamic c in _categories) names.Add((string)c.Name);
-        return names;
+        _pending.Add((name, outlookColorIndex));
+        _existing.Add(name);
     }
 
-    public void Add(string name, int outlookColorIndex) =>
-        _categories.Add(name, outlookColorIndex, 0); // OlCategoryShortcutKey.olCategoryShortcutKeyNone = 0
+    public void Commit()
+    {
+        if (_pending.Count == 0) return;
+
+        foreach ((string name, int outlookColor) in _pending)
+        {
+            XmlElement cat = _doc.CreateElement("category", _nsUri);
+            cat.SetAttribute("name", name);
+            // The XML 'color' is the 0-based MS-OXOCFG index; OlCategoryColor (1-25) is that index + 1.
+            cat.SetAttribute("color", (outlookColor - 1).ToString(CultureInfo.InvariantCulture));
+            cat.SetAttribute("keyboardShortcut", "0");
+            cat.SetAttribute("usageCount", "0");
+            cat.SetAttribute("guid", "{" + Guid.NewGuid().ToString().ToUpperInvariant() + "}");
+            _root.AppendChild(cat);
+        }
+        _root.SetAttribute("lastSavedTime",
+            DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff", CultureInfo.InvariantCulture));
+
+        dynamic pa = _storage.PropertyAccessor;
+        pa.SetProperty(RoamingXmlStreamProp, Serialize(_doc));
+        _storage.Save(); // single atomic commit of the FAI message
+        _pending.Clear();
+    }
+
+    // Opens the CategoryList FAI by its identity. olIdentifyByMessageClass (1) is the documented value but
+    // errors on this Outlook build; by-subject (2) reliably returns the existing item (its subject equals its
+    // message class). Try message-class first for forward-compat, then subject; reject an item that carries no
+    // XML stream (some identifier types fabricate an empty StorageItem instead of failing).
+    private static dynamic OpenCategoryListStorage(dynamic session)
+    {
+        dynamic calendar = session.GetDefaultFolder(OlFolderCalendar);
+        foreach (int idType in new[] { 1, 2 })
+        {
+            dynamic? candidate = null;
+            try { candidate = calendar.GetStorage("IPM.Configuration.CategoryList", idType); }
+            catch { continue; } // identifier not supported on this build
+            try { _ = candidate!.PropertyAccessor.GetProperty(RoamingXmlStreamProp); return candidate; }
+            catch { /* no XML stream on this item — try the next identifier */ }
+        }
+        throw new InvalidOperationException("Could not open the Outlook master category list (CategoryList FAI).");
+    }
+
+    private static string ReadXml(dynamic storage) =>
+        Encoding.UTF8.GetString((byte[])storage.PropertyAccessor.GetProperty(RoamingXmlStreamProp));
+
+    private static byte[] Serialize(XmlDocument doc)
+    {
+        var settings = new XmlWriterSettings { Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false) };
+        using var ms = new MemoryStream();
+        using (XmlWriter w = XmlWriter.Create(ms, settings)) doc.Save(w);
+        return ms.ToArray();
+    }
 
     public void Dispose()
     {
-        try { Marshal.ReleaseComObject(_categories); } catch { /* best-effort */ }
-        try { Marshal.ReleaseComObject(_session); } catch { }
-        try { Marshal.ReleaseComObject(_app); } catch { }
+        // Quit (clean shutdown) flushes our Save to disk; a hard kill would lose it. We never dirtied the OOM
+        // Categories cache, so Outlook won't re-serialize a stale list over the write.
+        try { ((dynamic)_app).Quit(); } catch { /* best-effort */ }
+
+        // Wait for the transient OUTLOOK.EXE to exit — that is the flush-complete signal — bounded so a hung
+        // instance can't block the CLI. We required Outlook closed at startup, so any instance now is ours.
+        var sw = Stopwatch.StartNew();
+        foreach (Process p in Process.GetProcessesByName("OUTLOOK"))
+        {
+            try
+            {
+                int remaining = ShutdownWaitMs - (int)sw.ElapsedMilliseconds;
+                if (remaining > 0) p.WaitForExit(remaining);
+            }
+            catch { /* already exited / access denied */ }
+            finally { p.Dispose(); }
+        }
+
+        try { Marshal.FinalReleaseComObject(_storage); } catch { /* best-effort */ }
+        try { Marshal.FinalReleaseComObject(_session); } catch { }
+        try { Marshal.FinalReleaseComObject(_app); } catch { }
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
     }
 }

--- a/src/Mail2Pst.Cli/OutlookComCategoryStore.cs
+++ b/src/Mail2Pst.Cli/OutlookComCategoryStore.cs
@@ -4,12 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
-using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
-using System.Xml;
 using Mail2Pst.Core.OutlookCategories;
 
 namespace Mail2Pst.Cli;
@@ -22,9 +20,9 @@ namespace Mail2Pst.Cli;
 /// lazily and racily, persisting only a nondeterministic subset of a batch (verified across ~10 experiments:
 /// 1/7, 2/3, 3/7, 4/7 survivors with every teardown variant). Instead it edits the master list's backing
 /// XML directly: the Calendar folder's <c>IPM.Configuration.CategoryList</c> associated (FAI) message carries
-/// the whole list as a UTF-8 <c>PidTagRoamingXmlStream</c> (MS-OXOCFG §2.2.5.1.1). We read that XML, append
-/// one &lt;category&gt; node per buffered Add, and write it back in a single <c>StorageItem.Save</c> — one
-/// atomic commit, no per-add race (verified deterministic: 4/4 runs persisted 7/7).
+/// the whole list as a UTF-8 <c>PidTagRoamingXmlStream</c>. We read that XML (<see cref="CategoryListXml"/>),
+/// append one node per buffered Add, and write it back in a single <c>StorageItem.Save</c> — one atomic
+/// commit, no per-add race (verified deterministic: 4/4 runs persisted 7/7).
 ///
 /// Requires Outlook to be CLOSED: we start a transient instance, never touch its in-memory Categories cache
 /// (so it cannot re-serialize a stale list over our write), and on Dispose call Quit so the store flushes to
@@ -41,67 +39,43 @@ internal sealed class OutlookComCategoryStore : IOutlookCategoryStore, IDisposab
     private readonly object _app;
     private readonly object _session;
     private readonly dynamic _storage;     // the IPM.Configuration.CategoryList FAI StorageItem
-    private readonly XmlDocument _doc;
-    private readonly XmlElement _root;
-    private readonly string _nsUri;
-    private readonly HashSet<string> _existing = new(StringComparer.OrdinalIgnoreCase);
+    private readonly string _originalXml;
+    private readonly IReadOnlySet<string> _existing;
     private readonly List<(string Name, int OutlookColor)> _pending = new();
+    private readonly int[] _startedPids;   // OUTLOOK.EXE PIDs that appeared when we created the instance
 
     internal OutlookComCategoryStore()
     {
-        if (Process.GetProcessesByName("OUTLOOK").Length != 0)
+        int[] before = OutlookPids();
+        if (before.Length != 0)
             throw new InvalidOperationException(
                 "Outlook is running. Close Outlook completely, then re-run import-colours --apply.");
 
         Type? t = Type.GetTypeFromProgID("Outlook.Application");
         if (t is null) throw new InvalidOperationException("Outlook is not installed (ProgID not registered).");
         _app = Activator.CreateInstance(t) ?? throw new InvalidOperationException("Could not start Outlook.");
+        _startedPids = OutlookPids().Except(before).ToArray(); // the transient instance(s) we just started
+
         dynamic app = _app;
         dynamic session = app.GetNamespace("MAPI");
         session.Logon(null, null, false, false); // ShowDialog=false, NewSession=false: silent default-profile session
         _session = session;
 
         _storage = OpenCategoryListStorage(session);
-        _doc = new XmlDocument { PreserveWhitespace = true };
-        _doc.LoadXml(ReadXml(_storage));
-        _root = _doc.DocumentElement ?? throw new InvalidOperationException("CategoryList XML has no root element.");
-        _nsUri = _root.NamespaceURI;
-        foreach (XmlNode node in _root.ChildNodes)
-            if (node is XmlElement el && el.LocalName == "category")
-            {
-                string name = el.GetAttribute("name");
-                if (!string.IsNullOrEmpty(name)) _existing.Add(name);
-            }
+        _originalXml = Encoding.UTF8.GetString(ReadBytes(_storage));
+        _existing = CategoryListXml.ReadNames(_originalXml);
     }
 
     public IReadOnlySet<string> ExistingNames() => _existing;
 
-    public void Add(string name, int outlookColorIndex)
-    {
-        _pending.Add((name, outlookColorIndex));
-        _existing.Add(name);
-    }
+    public void Add(string name, int outlookColorIndex) => _pending.Add((name, outlookColorIndex));
 
     public void Commit()
     {
         if (_pending.Count == 0) return;
-
-        foreach ((string name, int outlookColor) in _pending)
-        {
-            XmlElement cat = _doc.CreateElement("category", _nsUri);
-            cat.SetAttribute("name", name);
-            // The XML 'color' is the 0-based MS-OXOCFG index; OlCategoryColor (1-25) is that index + 1.
-            cat.SetAttribute("color", (outlookColor - 1).ToString(CultureInfo.InvariantCulture));
-            cat.SetAttribute("keyboardShortcut", "0");
-            cat.SetAttribute("usageCount", "0");
-            cat.SetAttribute("guid", "{" + Guid.NewGuid().ToString().ToUpperInvariant() + "}");
-            _root.AppendChild(cat);
-        }
-        _root.SetAttribute("lastSavedTime",
-            DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff", CultureInfo.InvariantCulture));
-
+        string newXml = CategoryListXml.Append(_originalXml, _pending);
         dynamic pa = _storage.PropertyAccessor;
-        pa.SetProperty(RoamingXmlStreamProp, Serialize(_doc));
+        pa.SetProperty(RoamingXmlStreamProp, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false).GetBytes(newXml));
         _storage.Save(); // single atomic commit of the FAI message
         _pending.Clear();
     }
@@ -109,31 +83,47 @@ internal sealed class OutlookComCategoryStore : IOutlookCategoryStore, IDisposab
     // Opens the CategoryList FAI by its identity. olIdentifyByMessageClass (1) is the documented value but
     // errors on this Outlook build; by-subject (2) reliably returns the existing item (its subject equals its
     // message class). Try message-class first for forward-compat, then subject; reject an item that carries no
-    // XML stream (some identifier types fabricate an empty StorageItem instead of failing).
+    // binary XML stream (some identifier types fabricate an empty StorageItem instead of failing).
     private static dynamic OpenCategoryListStorage(dynamic session)
     {
         dynamic calendar = session.GetDefaultFolder(OlFolderCalendar);
+        Exception? last = null;
         foreach (int idType in new[] { 1, 2 })
         {
-            dynamic? candidate = null;
+            dynamic candidate;
             try { candidate = calendar.GetStorage("IPM.Configuration.CategoryList", idType); }
-            catch { continue; } // identifier not supported on this build
-            try { _ = candidate!.PropertyAccessor.GetProperty(RoamingXmlStreamProp); return candidate; }
-            catch { /* no XML stream on this item — try the next identifier */ }
+            catch (Exception ex) { last = ex; continue; } // identifier not supported on this build
+            try { _ = ReadBytes(candidate); return candidate; }
+            catch (Exception ex) { last = ex; }            // no usable XML stream — try the next identifier
         }
-        throw new InvalidOperationException("Could not open the Outlook master category list (CategoryList FAI).");
+        throw new InvalidOperationException(
+            "Could not open the Outlook master category list (CategoryList FAI).", last);
     }
 
-    private static string ReadXml(dynamic storage) =>
-        Encoding.UTF8.GetString((byte[])storage.PropertyAccessor.GetProperty(RoamingXmlStreamProp));
-
-    private static byte[] Serialize(XmlDocument doc)
+    // Reads the binary RoamingXmlStream as bytes. The COM VARIANT marshals as byte[] in the common case but
+    // can arrive as a 1-D Array of another integral type; null/DBNull (property absent) is an error.
+    private static byte[] ReadBytes(dynamic storage)
     {
-        var settings = new XmlWriterSettings { Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false) };
-        using var ms = new MemoryStream();
-        using (XmlWriter w = XmlWriter.Create(ms, settings)) doc.Save(w);
-        return ms.ToArray();
+        object raw = storage.PropertyAccessor.GetProperty(RoamingXmlStreamProp);
+        switch (raw)
+        {
+            case null:
+            case DBNull:
+                throw new InvalidOperationException("The category list stream is empty.");
+            case byte[] b:
+                return b;
+            case Array a:
+                var bytes = new byte[a.Length];
+                for (int i = 0; i < a.Length; i++) bytes[i] = Convert.ToByte(a.GetValue(i));
+                return bytes;
+            default:
+                throw new InvalidOperationException(
+                    $"The category list stream is not binary (got {raw.GetType().Name}).");
+        }
     }
+
+    private static int[] OutlookPids() =>
+        Process.GetProcessesByName("OUTLOOK").Select(p => { int id = p.Id; p.Dispose(); return id; }).ToArray();
 
     public void Dispose()
     {
@@ -141,18 +131,21 @@ internal sealed class OutlookComCategoryStore : IOutlookCategoryStore, IDisposab
         // Categories cache, so Outlook won't re-serialize a stale list over the write.
         try { ((dynamic)_app).Quit(); } catch { /* best-effort */ }
 
-        // Wait for the transient OUTLOOK.EXE to exit — that is the flush-complete signal — bounded so a hung
-        // instance can't block the CLI. We required Outlook closed at startup, so any instance now is ours.
+        // Wait for the transient OUTLOOK.EXE we started to exit — that is the flush-complete signal — bounded
+        // so a hung instance can't block the CLI. Wait only on the PIDs we started (not, say, an Outlook the
+        // user launched mid-run).
         var sw = Stopwatch.StartNew();
-        foreach (Process p in Process.GetProcessesByName("OUTLOOK"))
+        foreach (int pid in _startedPids)
         {
+            Process? p = null;
             try
             {
+                p = Process.GetProcessById(pid);
                 int remaining = ShutdownWaitMs - (int)sw.ElapsedMilliseconds;
                 if (remaining > 0) p.WaitForExit(remaining);
             }
-            catch { /* already exited / access denied */ }
-            finally { p.Dispose(); }
+            catch { /* already exited / not found */ }
+            finally { p?.Dispose(); }
         }
 
         try { Marshal.FinalReleaseComObject(_storage); } catch { /* best-effort */ }

--- a/src/Mail2Pst.Cli/Program.cs
+++ b/src/Mail2Pst.Cli/Program.cs
@@ -13,6 +13,7 @@ if (args.Length == 0)
     Console.Error.WriteLine("  continumail-convert convert  --profile <dir> [--config <options.json>] --output <dir>");
     Console.Error.WriteLine("  continumail-convert scan     --input <path> [--input <path> ...] [--type mbox]");
     Console.Error.WriteLine("  continumail-convert discover --input <dir>");
+    Console.Error.WriteLine("  continumail-convert import-colours --profile <thunderbird-profile-dir> [--apply]");
     return 1;
 }
 
@@ -21,6 +22,7 @@ return args[0] switch
     "convert"            => ConvertCommand.Run(args[1..]),
     "scan"               => ScanCommand.Run(args[1..]),
     "discover"           => DiscoverCommand.Run(args[1..]),
+    "import-colours"     => ImportColoursCommand.Run(args[1..]),
     "version" or "--version" or "-v" => PrintVersion(),
     _                    => PrintUnknownCommand(args[0]),
 };
@@ -39,6 +41,6 @@ static int PrintVersion()
 
 static int PrintUnknownCommand(string cmd)
 {
-    Console.Error.WriteLine($"Unknown command '{cmd}'. Use 'convert', 'scan', or 'discover'.");
+    Console.Error.WriteLine($"Unknown command '{cmd}'. Use 'convert', 'scan', 'discover', or 'import-colours'.");
     return 1;
 }

--- a/src/Mail2Pst.Core/Msf/MsfTagDefaults.cs
+++ b/src/Mail2Pst.Core/Msf/MsfTagDefaults.cs
@@ -22,4 +22,11 @@ internal static class MsfTagDefaults
             ["$label1"] = "Important", ["$label2"] = "Work", ["$label3"] = "Personal",
             ["$label4"] = "To Do",     ["$label5"] = "Later",
         };
+
+    internal static readonly IReadOnlyDictionary<string, string> BuiltinColors =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["$label1"] = "#FF0000", ["$label2"] = "#FF9900", ["$label3"] = "#009900",
+            ["$label4"] = "#3333FF", ["$label5"] = "#993399",
+        };
 }

--- a/src/Mail2Pst.Core/Msf/PrefsTagReader.cs
+++ b/src/Mail2Pst.Core/Msf/PrefsTagReader.cs
@@ -24,6 +24,11 @@ public static class PrefsTagReader
         "^\\s*user_pref\\s*\\(\\s*\"mailnews\\.tags\\.(?<key>.+?)\\.tag\"\\s*,\\s*\"(?<val>(?:\\\\.|[^\"\\\\])*)\"\\s*\\)\\s*;?\\s*$",
         RegexOptions.CultureInvariant);
 
+    // Like TagPrefRegex but for `.color` with a strict #RRGGBB value (6 hex digits, optional leading #).
+    private static readonly Regex ColorPrefRegex = new(
+        "^\\s*user_pref\\s*\\(\\s*\"mailnews\\.tags\\.(?<key>.+?)\\.color\"\\s*,\\s*\"(?<val>#?[0-9A-Fa-f]{6})\"\\s*\\)\\s*;?\\s*$",
+        RegexOptions.CultureInvariant);
+
     public static IReadOnlyDictionary<string, string> Read(string prefsJsPath)
     {
         try
@@ -46,6 +51,20 @@ public static class PrefsTagReader
             if (!TryUnescape(m.Groups["val"].Value, out string name)) continue; // bad escape -> skip line
             if (name.Length == 0) continue;                                       // empty name -> skip line
             map[m.Groups["key"].Value] = name;                                    // later duplicate wins
+        }
+        return map;
+    }
+
+    public static IReadOnlyDictionary<string, string> ParseColors(string content)
+    {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (string line in content.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None))
+        {
+            Match m = ColorPrefRegex.Match(line);
+            if (!m.Success) continue;
+            string hex = m.Groups["val"].Value;
+            if (hex[0] != '#') hex = "#" + hex;     // normalize to leading #
+            map[m.Groups["key"].Value] = hex;       // later duplicate wins
         }
         return map;
     }

--- a/src/Mail2Pst.Core/OutlookCategories/CategoryCandidate.cs
+++ b/src/Mail2Pst.Core/OutlookCategories/CategoryCandidate.cs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+namespace Mail2Pst.Core.OutlookCategories;
+
+/// <summary>One resolved category for the colour import. Action is a plan action (would-add /
+/// skipped-no-colour / skipped-invalid-name) before apply, replaced by the final action after apply
+/// (added / skipped-existing). OutlookColor is the OlCategoryColor int (1-25), null when no colour resolved.</summary>
+public sealed record CategoryCandidate(string Name, string? Hex, int? OutlookColor, string Action);

--- a/src/Mail2Pst.Core/OutlookCategories/CategoryColorApplier.cs
+++ b/src/Mail2Pst.Core/OutlookCategories/CategoryColorApplier.cs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+namespace Mail2Pst.Core.OutlookCategories;
+
+/// <summary>Applies a candidate plan to an IOutlookCategoryStore: would-add becomes added (store.Add) or
+/// skipped-existing (name already present, case-insensitive, never overwritten); already-skipped candidates
+/// pass through unchanged. Pure orchestration — no Outlook types.</summary>
+public static class CategoryColorApplier
+{
+    public static IReadOnlyList<CategoryCandidate> Apply(
+        IReadOnlyList<CategoryCandidate> plan, IOutlookCategoryStore store)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(store);
+
+        IReadOnlySet<string> existing = store.ExistingNames();
+        var results = new List<CategoryCandidate>(plan.Count);
+        foreach (CategoryCandidate c in plan)
+        {
+            if (c.Action != "would-add") { results.Add(c); continue; }
+            if (existing.Contains(c.Name)) { results.Add(c with { Action = "skipped-existing" }); continue; }
+            store.Add(c.Name, c.OutlookColor!.Value);
+            results.Add(c with { Action = "added" });
+        }
+        return results;
+    }
+}

--- a/src/Mail2Pst.Core/OutlookCategories/CategoryColorPlan.cs
+++ b/src/Mail2Pst.Core/OutlookCategories/CategoryColorPlan.cs
@@ -25,11 +25,13 @@ public static class CategoryColorPlan
         // Deterministic order: the five built-ins first, then any other key (ordinal-sorted), distinct.
         var keys = new List<string>();
         var seenKey = new HashSet<string>(StringComparer.Ordinal);
-        foreach (string k in MsfTagDefaults.BuiltinLabels.Keys) { if (seenKey.Add(k)) keys.Add(k); }
+        foreach (string k in MsfTagDefaults.BuiltinLabels.Keys)
+            if (!MsfTagDefaults.Filtered.Contains(k) && seenKey.Add(k)) keys.Add(k);
         foreach (string k in tagNames.Keys.Concat(tagColors.Keys).OrderBy(k => k, StringComparer.Ordinal))
-            if (seenKey.Add(k)) keys.Add(k);
+            if (!MsfTagDefaults.Filtered.Contains(k) && seenKey.Add(k)) keys.Add(k);
 
         var result = new List<CategoryCandidate>();
+        // OrdinalIgnoreCase (not E4's Ordinal): Outlook category names are case-insensitive.
         var seenName = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (string key in keys)
         {

--- a/src/Mail2Pst.Core/OutlookCategories/CategoryColorPlan.cs
+++ b/src/Mail2Pst.Core/OutlookCategories/CategoryColorPlan.cs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mail2Pst.Core.Msf;
+
+namespace Mail2Pst.Core.OutlookCategories;
+
+/// <summary>
+/// Builds the colour-import candidate list from a profile's prefs.js tag names + colours. Candidate set =
+/// the five built-in $labelN keys plus every key seen in names/colours. Name resolution matches the E4
+/// resolver (prefs name -> built-in $labelN default -> key). Colour = prefs .color -> built-in default for
+/// $labelN -> none. Names are validated against Outlook rules. Pure; Outlook-free.
+/// </summary>
+public static class CategoryColorPlan
+{
+    public static IReadOnlyList<CategoryCandidate> Build(
+        IReadOnlyDictionary<string, string> tagNames, IReadOnlyDictionary<string, string> tagColors)
+    {
+        ArgumentNullException.ThrowIfNull(tagNames);
+        ArgumentNullException.ThrowIfNull(tagColors);
+
+        // Deterministic order: the five built-ins first, then any other key (ordinal-sorted), distinct.
+        var keys = new List<string>();
+        var seenKey = new HashSet<string>(StringComparer.Ordinal);
+        foreach (string k in MsfTagDefaults.BuiltinLabels.Keys) { if (seenKey.Add(k)) keys.Add(k); }
+        foreach (string k in tagNames.Keys.Concat(tagColors.Keys).OrderBy(k => k, StringComparer.Ordinal))
+            if (seenKey.Add(k)) keys.Add(k);
+
+        var result = new List<CategoryCandidate>();
+        var seenName = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string key in keys)
+        {
+            string name = tagNames.TryGetValue(key, out string? pref) ? pref
+                : MsfTagDefaults.BuiltinLabels.TryGetValue(key, out string? builtin) ? builtin
+                : key;
+            if (!seenName.Add(name)) continue; // ordinal-ignore-case de-dupe across keys
+
+            string? hex = tagColors.TryGetValue(key, out string? c) ? c
+                : MsfTagDefaults.BuiltinColors.TryGetValue(key, out string? bc) ? bc
+                : null;
+
+            if (name.Length == 0 || name.Length > 255 || name.Contains(','))
+            { result.Add(new CategoryCandidate(name, hex, null, "skipped-invalid-name")); continue; }
+
+            if (hex is null || !OlCategoryColorMap.TryNearestIndex(hex, out int color))
+            { result.Add(new CategoryCandidate(name, hex, null, "skipped-no-colour")); continue; }
+
+            result.Add(new CategoryCandidate(name, hex, color, "would-add"));
+        }
+        return result;
+    }
+}

--- a/src/Mail2Pst.Core/OutlookCategories/CategoryListXml.cs
+++ b/src/Mail2Pst.Core/OutlookCategories/CategoryListXml.cs
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Xml;
+
+namespace Mail2Pst.Core.OutlookCategories;
+
+/// <summary>
+/// Pure string transforms over the Outlook master category list XML — the CategoryList FAI's
+/// <c>PidTagRoamingXmlStream</c> (MS-OXOCFG §2.2.5.1.1). No COM/Outlook types, so it is fully unit-testable;
+/// the CLI's late-bound COM shim handles only the binary read/write of that stream.
+/// </summary>
+public static class CategoryListXml
+{
+    private const string DefaultNamespace = "CategoryList.xsd";
+    private const char Bom = '﻿';
+
+    /// <summary>Category names present in the list, compared OrdinalIgnoreCase. Empty/whitespace input
+    /// yields an empty set. Throws <see cref="FormatException"/> on malformed (non-empty) XML.</summary>
+    public static IReadOnlySet<string> ReadNames(string xml)
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        XmlElement? root = Load(xml).DocumentElement;
+        if (root is null) return names;
+        foreach (XmlNode node in root.ChildNodes)
+            if (node is XmlElement el && el.LocalName == "category")
+            {
+                string name = el.GetAttribute("name");
+                if (!string.IsNullOrEmpty(name)) names.Add(name);
+            }
+        return names;
+    }
+
+    /// <summary>Appends one &lt;category&gt; node per addition (name + OlCategoryColor 1-25) and returns the
+    /// new XML as a string with a BOM-free <c>&lt;?xml version="1.0"?&gt;</c> declaration (the format Outlook
+    /// expects). Empty/whitespace input starts a fresh list. Refreshes <c>lastSavedTime</c>. Throws
+    /// <see cref="FormatException"/> on malformed (non-empty) XML.</summary>
+    public static string Append(string xml, IReadOnlyList<(string Name, int OutlookColor)> additions)
+    {
+        ArgumentNullException.ThrowIfNull(additions);
+        XmlDocument doc = Load(xml);
+        XmlElement root = doc.DocumentElement!;
+        string ns = root.NamespaceURI;
+
+        foreach ((string name, int outlookColor) in additions)
+        {
+            XmlElement cat = doc.CreateElement("category", ns);
+            cat.SetAttribute("name", name); // SetAttribute escapes &, <, ", and any unicode safely
+            // The XML 'color' is the 0-based MS-OXOCFG index; OlCategoryColor (1-25) is that index + 1.
+            cat.SetAttribute("color", (outlookColor - 1).ToString(CultureInfo.InvariantCulture));
+            cat.SetAttribute("keyboardShortcut", "0");
+            cat.SetAttribute("usageCount", "0");
+            cat.SetAttribute("guid", Guid.NewGuid().ToString("B").ToUpperInvariant()); // {XXXXXXXX-....}
+            root.AppendChild(cat);
+        }
+        root.SetAttribute("lastSavedTime",
+            DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff", CultureInfo.InvariantCulture));
+        return Serialize(doc);
+    }
+
+    // Loads the XML, tolerating a leading UTF-8 BOM / surrounding whitespace, and synthesizing a fresh
+    // <categories> root for empty input. Wraps parse failures in FormatException so callers report a clear,
+    // actionable error rather than a raw XmlException.
+    private static XmlDocument Load(string xml)
+    {
+        var doc = new XmlDocument { PreserveWhitespace = true };
+        string trimmed = (xml ?? string.Empty).Trim(Bom, ' ', '\t', '\r', '\n');
+        if (trimmed.Length == 0)
+        {
+            doc.AppendChild(doc.CreateXmlDeclaration("1.0", null, null));
+            doc.AppendChild(doc.CreateElement("categories", DefaultNamespace));
+            return doc;
+        }
+        try { doc.LoadXml(trimmed); }
+        catch (XmlException ex) { throw new FormatException("The Outlook category list XML is malformed.", ex); }
+        if (doc.DocumentElement is null)
+            throw new FormatException("The Outlook category list XML has no root element.");
+        return doc;
+    }
+
+    private static string Serialize(XmlDocument doc)
+    {
+        // The document carries an <?xml version="1.0"?> declaration with no encoding attribute, so emitting to
+        // a UTF-8-reporting writer keeps the declaration encoding-free (no spurious utf-16/utf-8 attribute that
+        // would contradict the UTF-8 bytes the caller writes to the stream).
+        var settings = new XmlWriterSettings { OmitXmlDeclaration = false };
+        var sw = new Utf8StringWriter();
+        using (XmlWriter w = XmlWriter.Create(sw, settings)) doc.Save(w);
+        return sw.ToString();
+    }
+
+    private sealed class Utf8StringWriter : StringWriter
+    {
+        public override Encoding Encoding => Encoding.UTF8;
+    }
+}

--- a/src/Mail2Pst.Core/OutlookCategories/CategoryListXml.cs
+++ b/src/Mail2Pst.Core/OutlookCategories/CategoryListXml.cs
@@ -54,10 +54,13 @@ public static class CategoryListXml
             // The XML 'color' is the 0-based MS-OXOCFG index; OlCategoryColor (1-25) is that index + 1.
             cat.SetAttribute("color", (outlookColor - 1).ToString(CultureInfo.InvariantCulture));
             cat.SetAttribute("keyboardShortcut", "0");
-            cat.SetAttribute("usageCount", "0");
+            cat.SetAttribute("usageCount", "0"); // present on Outlook-written nodes; new categories start unused
             cat.SetAttribute("guid", Guid.NewGuid().ToString("B").ToUpperInvariant()); // {XXXXXXXX-....}
             root.AppendChild(cat);
         }
+        // Refresh lastSavedTime; lastSavedSession is intentionally left untouched — it (with lastSavedTime)
+        // lets a *running* Outlook decide its cached list is stale, which only matters if we ever support
+        // applying against an open Outlook. Today --apply requires Outlook closed, so there is no cache.
         root.SetAttribute("lastSavedTime",
             DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff", CultureInfo.InvariantCulture));
         return Serialize(doc);
@@ -85,9 +88,10 @@ public static class CategoryListXml
 
     private static string Serialize(XmlDocument doc)
     {
-        // The document carries an <?xml version="1.0"?> declaration with no encoding attribute, so emitting to
-        // a UTF-8-reporting writer keeps the declaration encoding-free (no spurious utf-16/utf-8 attribute that
-        // would contradict the UTF-8 bytes the caller writes to the stream).
+        // The writer reports UTF-8, so the declaration is emitted as <?xml version="1.0" encoding="utf-8"?> —
+        // which AGREES with the UTF-8 bytes the caller writes to the stream. The StringWriter default reports
+        // UTF-16, which would emit encoding="utf-16" and contradict those bytes (Outlook's reader then fails);
+        // overriding Encoding is what avoids that trap.
         var settings = new XmlWriterSettings { OmitXmlDeclaration = false };
         var sw = new Utf8StringWriter();
         using (XmlWriter w = XmlWriter.Create(sw, settings)) doc.Save(w);

--- a/src/Mail2Pst.Core/OutlookCategories/CategoryStreamBytes.cs
+++ b/src/Mail2Pst.Core/OutlookCategories/CategoryStreamBytes.cs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Globalization;
+
+namespace Mail2Pst.Core.OutlookCategories;
+
+/// <summary>
+/// Normalizes the binary value a COM <c>PropertyAccessor</c> returns for the CategoryList FAI's
+/// <c>PidTagRoamingXmlStream</c> into a <c>byte[]</c>. Pure (no COM types), so it is unit-testable; the CLI's
+/// shim only hands it the boxed VARIANT. PT_BINARY usually marshals as <c>byte[]</c>, but some Outlook builds
+/// yield a 1-D <c>Array</c> of another integral element type (e.g. <c>sbyte[]</c>, VT_I1).
+/// </summary>
+public static class CategoryStreamBytes
+{
+    public static byte[] FromVariant(object? raw)
+    {
+        switch (raw)
+        {
+            case null:
+            case DBNull:
+                throw new InvalidOperationException("The category list stream is empty or missing.");
+            case byte[] b:
+                return b;
+            case Array a:
+                // Reinterpret each element's low 8 bits. Convert.ToByte would throw OverflowException for any
+                // sbyte < 0 (i.e. any source byte >= 0x80, which non-ASCII UTF-8 — like "ÆØÅ" — guarantees).
+                var bytes = new byte[a.Length];
+                for (int i = 0; i < a.Length; i++)
+                    bytes[i] = unchecked((byte)Convert.ToInt64(a.GetValue(i), CultureInfo.InvariantCulture));
+                return bytes;
+            default:
+                throw new InvalidOperationException(
+                    $"The category list stream is not binary (got {raw.GetType().Name}).");
+        }
+    }
+}

--- a/src/Mail2Pst.Core/OutlookCategories/IOutlookCategoryStore.cs
+++ b/src/Mail2Pst.Core/OutlookCategories/IOutlookCategoryStore.cs
@@ -10,6 +10,10 @@ public interface IOutlookCategoryStore
 {
     /// <summary>Existing master-list category names, compared case-insensitively (OrdinalIgnoreCase).</summary>
     IReadOnlySet<string> ExistingNames();
-    /// <summary>Add a category with the given OlCategoryColor integer (1-25).</summary>
+    /// <summary>Buffer a category with the given OlCategoryColor integer (1-25) for addition. Not persisted
+    /// until <see cref="Commit"/> is called — the master list must be written in a single atomic operation
+    /// (Outlook commits per-add writes lazily and racily, losing all but the first).</summary>
     void Add(string name, int outlookColorIndex);
+    /// <summary>Atomically persist all buffered <see cref="Add"/>s. No-op when nothing was buffered.</summary>
+    void Commit();
 }

--- a/src/Mail2Pst.Core/OutlookCategories/IOutlookCategoryStore.cs
+++ b/src/Mail2Pst.Core/OutlookCategories/IOutlookCategoryStore.cs
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System.Collections.Generic;
+namespace Mail2Pst.Core.OutlookCategories;
+
+/// <summary>Abstraction over the Outlook master category list. No MS/COM types — pure string/int — so Core
+/// stays Outlook-free; the only implementation is the CLI's late-bound COM shim.</summary>
+public interface IOutlookCategoryStore
+{
+    /// <summary>Existing master-list category names, compared case-insensitively (OrdinalIgnoreCase).</summary>
+    IReadOnlySet<string> ExistingNames();
+    /// <summary>Add a category with the given OlCategoryColor integer (1-25).</summary>
+    void Add(string name, int outlookColorIndex);
+}

--- a/src/Mail2Pst.Core/OutlookCategories/OlCategoryColorMap.cs
+++ b/src/Mail2Pst.Core/OutlookCategories/OlCategoryColorMap.cs
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Globalization;
+
+namespace Mail2Pst.Core.OutlookCategories;
+
+/// <summary>
+/// Maps a #RRGGBB hex to the nearest Outlook category colour by Euclidean RGB distance. The returned
+/// integer is the OlCategoryColor enum value (1=Red .. 25=DarkMaroon; 0=None is never returned). RGBs are
+/// the canonical MS-OXOCFG §2.2.5.1.1 base colours; OlCategoryColor = MS-OXOCFG index + 1.
+/// </summary>
+public static class OlCategoryColorMap
+{
+    // index 0 of this array = OlCategoryColor 1 (Red). 25 entries.
+    private static readonly (byte R, byte G, byte B)[] Palette =
+    {
+        (214, 37, 46),  (240, 108, 21), (255, 202, 76), (255, 254, 61), (74, 182, 63),
+        (64, 189, 149), (133, 154, 82), (50, 103, 184), (97, 61, 180),  (163, 78, 120),
+        (196, 204, 221),(140, 156, 189),(196, 196, 196),(165, 165, 165),(28, 28, 28),
+        (175, 30, 37),  (177, 79, 13),  (171, 123, 5),  (153, 148, 0),  (53, 121, 43),
+        (46, 125, 100), (95, 108, 58),  (42, 81, 145),  (80, 50, 143),  (130, 55, 95),
+    };
+
+    public static bool TryNearestIndex(string hex, out int olCategoryColor)
+    {
+        olCategoryColor = 0;
+        if (!TryParseHex(hex, out int r, out int g, out int b)) return false;
+
+        int bestIdx = 0;
+        long bestDist = long.MaxValue;
+        for (int i = 0; i < Palette.Length; i++)
+        {
+            long dr = r - Palette[i].R, dg = g - Palette[i].G, db = b - Palette[i].B;
+            long dist = dr * dr + dg * dg + db * db;
+            if (dist < bestDist) { bestDist = dist; bestIdx = i; }
+        }
+        olCategoryColor = bestIdx + 1; // OlCategoryColor is 1-based
+        return true;
+    }
+
+    private static bool TryParseHex(string hex, out int r, out int g, out int b)
+    {
+        r = g = b = 0;
+        if (string.IsNullOrEmpty(hex)) return false;
+        string h = hex[0] == '#' ? hex.Substring(1) : hex;
+        if (h.Length != 6) return false;
+        return TryByte(h, 0, out r) && TryByte(h, 2, out g) && TryByte(h, 4, out b);
+    }
+
+    private static bool TryByte(string h, int pos, out int value) =>
+        int.TryParse(h.AsSpan(pos, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out value);
+}

--- a/tests/Mail2Pst.Core.Tests/Msf/PrefsTagReaderColorTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/PrefsTagReaderColorTests.cs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using Mail2Pst.Core.Msf;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Msf;
+
+public class PrefsTagReaderColorTests
+{
+    [Fact]
+    public void ParsesColorPrefs_IgnoringTagAndUnrelated()
+    {
+        string text =
+            "user_pref(\"mailnews.tags.$label1.color\", \"#FF0000\");\n" +
+            "user_pref(\"mailnews.tags.custom.color\", \"#12ab9C\");\n" +
+            "user_pref(\"mailnews.tags.$label1.tag\", \"Important\");\n" +    // .tag ignored
+            "user_pref(\"mail.server.server1.color\", \"#000000\");\n";       // unrelated ignored
+        var map = PrefsTagReader.ParseColors(text);
+        Assert.Equal("#FF0000", map["$label1"]);
+        Assert.Equal("#12ab9C", map["custom"]);
+        Assert.Equal(2, map.Count);
+    }
+
+    [Fact]
+    public void SkipsMalformedHex()
+    {
+        string text =
+            "user_pref(\"mailnews.tags.a.color\", \"red\");\n" +       // not hex
+            "user_pref(\"mailnews.tags.b.color\", \"#F00\");\n" +      // 3-digit, not 6
+            "user_pref(\"mailnews.tags.c.color\", \"#00FF00\");\n";
+        var map = PrefsTagReader.ParseColors(text);
+        Assert.False(map.ContainsKey("a"));
+        Assert.False(map.ContainsKey("b"));
+        Assert.Equal("#00FF00", map["c"]);
+    }
+
+    [Fact]
+    public void MissingPrefs_EmptyMap()
+        => Assert.Empty(PrefsTagReader.ParseColors(""));
+}

--- a/tests/Mail2Pst.Core.Tests/OutlookCategories/CategoryColorApplierTests.cs
+++ b/tests/Mail2Pst.Core.Tests/OutlookCategories/CategoryColorApplierTests.cs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Collections.Generic;
+using System.Linq;
+using Mail2Pst.Core.OutlookCategories;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.OutlookCategories;
+
+public class CategoryColorApplierTests
+{
+    private sealed class FakeStore : IOutlookCategoryStore
+    {
+        private readonly HashSet<string> _existing;
+        public readonly List<(string Name, int Color)> Added = new();
+        public FakeStore(params string[] existing) =>
+            _existing = new HashSet<string>(existing, System.StringComparer.OrdinalIgnoreCase);
+        public IReadOnlySet<string> ExistingNames() => _existing;
+        public void Add(string name, int outlookColorIndex) { Added.Add((name, outlookColorIndex)); _existing.Add(name); }
+    }
+
+    [Fact]
+    public void AddsNew_AndCarriesColor()
+    {
+        var plan = new List<CategoryCandidate> { new("Critique", "#FF0000", 1, "would-add") };
+        var store = new FakeStore();
+        var results = CategoryColorApplier.Apply(plan, store);
+        Assert.Equal("added", results.Single().Action);
+        Assert.Equal(("Critique", 1), store.Added.Single());
+    }
+
+    [Fact]
+    public void SkipsExisting_CaseInsensitive_NoOverwrite()
+    {
+        var plan = new List<CategoryCandidate> { new("Critique", "#FF0000", 1, "would-add") };
+        var store = new FakeStore("critique"); // different case already present
+        var results = CategoryColorApplier.Apply(plan, store);
+        Assert.Equal("skipped-existing", results.Single().Action);
+        Assert.Empty(store.Added);
+    }
+
+    [Fact]
+    public void PassesThroughSkippedCandidates_WithoutCallingStore()
+    {
+        var plan = new List<CategoryCandidate>
+        {
+            new("NoColour", null, null, "skipped-no-colour"),
+            new("Foo, Bar", "#FF0000", null, "skipped-invalid-name"),
+        };
+        var store = new FakeStore();
+        var results = CategoryColorApplier.Apply(plan, store);
+        Assert.Equal(new[] { "skipped-no-colour", "skipped-invalid-name" }, results.Select(r => r.Action));
+        Assert.Empty(store.Added);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/OutlookCategories/CategoryColorApplierTests.cs
+++ b/tests/Mail2Pst.Core.Tests/OutlookCategories/CategoryColorApplierTests.cs
@@ -15,8 +15,10 @@ public class CategoryColorApplierTests
         public readonly List<(string Name, int Color)> Added = new();
         public FakeStore(params string[] existing) =>
             _existing = new HashSet<string>(existing, System.StringComparer.OrdinalIgnoreCase);
+        public int CommitCount { get; private set; }
         public IReadOnlySet<string> ExistingNames() => _existing;
         public void Add(string name, int outlookColorIndex) { Added.Add((name, outlookColorIndex)); _existing.Add(name); }
+        public void Commit() => CommitCount++;
     }
 
     [Fact]

--- a/tests/Mail2Pst.Core.Tests/OutlookCategories/CategoryColorPlanTests.cs
+++ b/tests/Mail2Pst.Core.Tests/OutlookCategories/CategoryColorPlanTests.cs
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Collections.Generic;
+using System.Linq;
+using Mail2Pst.Core.OutlookCategories;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.OutlookCategories;
+
+public class CategoryColorPlanTests
+{
+    private static Dictionary<string, string> D(params (string k, string v)[] kv)
+    {
+        var d = new Dictionary<string, string>(System.StringComparer.Ordinal);
+        foreach (var (k, v) in kv) d[k] = v;
+        return d;
+    }
+
+    [Fact]
+    public void BuiltinLabels_AlwaysPresent_WithDefaultColours_WhenNoPrefs()
+    {
+        var plan = CategoryColorPlan.Build(D(), D());
+        CategoryCandidate label1 = plan.Single(c => c.Name == "Important");
+        Assert.Equal("would-add", label1.Action);
+        Assert.Equal(1, label1.OutlookColor);   // #FF0000 -> Red
+        Assert.Contains(plan, c => c.Name == "Later" && c.OutlookColor == 10); // #993399 -> Maroon
+    }
+
+    [Fact]
+    public void PrefsName_And_PrefsColour_Override_Builtin()
+    {
+        var plan = CategoryColorPlan.Build(D(("$label1", "Critique")), D(("$label1", "#00FF00")));
+        CategoryCandidate c = plan.Single(x => x.Name == "Critique");
+        Assert.Equal("would-add", c.Action);
+        Assert.Equal(5, c.OutlookColor);   // #00FF00 (0,255,0) nearest -> Green(5)
+        Assert.DoesNotContain(plan, x => x.Name == "Important"); // $label1 resolved to Critique, not Important
+    }
+
+    [Fact]
+    public void CustomTag_WithColour_Included()
+    {
+        var plan = CategoryColorPlan.Build(D(("proj", "Client X")), D(("proj", "#3333FF")));
+        Assert.Contains(plan, c => c.Name == "Client X" && c.OutlookColor == 8 && c.Action == "would-add");
+    }
+
+    [Fact]
+    public void CustomTag_NameButNoColour_SkippedNoColour()
+    {
+        var plan = CategoryColorPlan.Build(D(("proj", "Client X")), D());
+        CategoryCandidate c = plan.Single(x => x.Name == "Client X");
+        Assert.Equal("skipped-no-colour", c.Action);
+        Assert.Null(c.OutlookColor);
+    }
+
+    [Fact]
+    public void NameWithComma_SkippedInvalidName()
+    {
+        var plan = CategoryColorPlan.Build(D(("proj", "Foo, Bar")), D(("proj", "#FF0000")));
+        Assert.Equal("skipped-invalid-name", plan.Single(x => x.Name == "Foo, Bar").Action);
+    }
+
+    [Fact]
+    public void NameTooLong_SkippedInvalidName()
+    {
+        string longName = new string('x', 256);
+        var plan = CategoryColorPlan.Build(D(("proj", longName)), D(("proj", "#FF0000")));
+        Assert.Equal("skipped-invalid-name", plan.Single(x => x.Name == longName).Action);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/OutlookCategories/CategoryColorPlanTests.cs
+++ b/tests/Mail2Pst.Core.Tests/OutlookCategories/CategoryColorPlanTests.cs
@@ -66,4 +66,11 @@ public class CategoryColorPlanTests
         var plan = CategoryColorPlan.Build(D(("proj", longName)), D(("proj", "#FF0000")));
         Assert.Equal("skipped-invalid-name", plan.Single(x => x.Name == longName).Action);
     }
+
+    [Fact]
+    public void NonJunk_IsFiltered_NotACandidate()
+    {
+        var plan = CategoryColorPlan.Build(D(("NonJunk", "NonJunk")), D(("NonJunk", "#FF0000")));
+        Assert.DoesNotContain(plan, c => c.Name == "NonJunk");
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/OutlookCategories/CategoryListXmlTests.cs
+++ b/tests/Mail2Pst.Core.Tests/OutlookCategories/CategoryListXmlTests.cs
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mail2Pst.Core.OutlookCategories;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.OutlookCategories;
+
+public class CategoryListXmlTests
+{
+    // Shape mirrors the real IPM.Configuration.CategoryList stream: a default-namespaced root with categories
+    // whose 'color' is the 0-based MS-OXOCFG index.
+    private const string Sample =
+        "<?xml version=\"1.0\"?>\r\n" +
+        "<categories default=\"\" lastSavedSession=\"2\" lastSavedTime=\"2026-06-21T18:05:45.683\" xmlns=\"CategoryList.xsd\">\r\n" +
+        "\t<category name=\"Red category\" color=\"0\" keyboardShortcut=\"0\" guid=\"{FCBD6427-68FB-40ED-A698-3D4A66062ECC}\"/>\r\n" +
+        "\t<category name=\"Yellow category\" color=\"3\" keyboardShortcut=\"0\" guid=\"{A6983171-BCC5-4F6C-B8A3-DA06AE1B1A25}\"/>\r\n" +
+        "</categories>";
+
+    [Fact]
+    public void ReadNames_ReturnsExisting_CaseInsensitive()
+    {
+        IReadOnlySet<string> names = CategoryListXml.ReadNames(Sample);
+        Assert.Equal(2, names.Count);
+        Assert.Contains("Red category", names);
+        Assert.Contains("yellow CATEGORY", names); // OrdinalIgnoreCase
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   \r\n\t ")]
+    public void ReadNames_EmptyOrWhitespace_ReturnsEmpty(string xml) =>
+        Assert.Empty(CategoryListXml.ReadNames(xml));
+
+    [Fact]
+    public void ReadNames_Bom_IsTolerated()
+    {
+        IReadOnlySet<string> names = CategoryListXml.ReadNames('﻿' + Sample);
+        Assert.Contains("Red category", names);
+    }
+
+    [Fact]
+    public void ReadNames_Malformed_ThrowsFormatException() =>
+        Assert.Throws<FormatException>(() => CategoryListXml.ReadNames("<categories><not closed"));
+
+    [Fact]
+    public void Append_AddsNodes_PreservesExisting_AndRoundTrips()
+    {
+        string result = CategoryListXml.Append(Sample, new[] { ("Work", 2), ("To Do", 8) });
+        IReadOnlySet<string> names = CategoryListXml.ReadNames(result);
+        Assert.Equal(new[] { "Red category", "To Do", "Work", "Yellow category" }, names.OrderBy(n => n).ToArray());
+    }
+
+    [Theory]
+    [InlineData(1, "0")]   // Red
+    [InlineData(2, "1")]   // Orange
+    [InlineData(8, "7")]   // Blue
+    [InlineData(25, "24")] // DarkMaroon
+    public void Append_MapsOlCategoryColorToZeroBasedXmlColor(int outlookColor, string expectedXmlColor)
+    {
+        string result = CategoryListXml.Append(Sample, new[] { ("Foo", outlookColor) });
+        var doc = new System.Xml.XmlDocument();
+        doc.LoadXml(result);
+        var ns = new System.Xml.XmlNamespaceManager(doc.NameTable);
+        ns.AddNamespace("c", "CategoryList.xsd");
+        var node = doc.SelectSingleNode("//c:category[@name='Foo']", ns);
+        Assert.Equal(expectedXmlColor, node!.Attributes!["color"]!.Value);
+    }
+
+    [Fact]
+    public void Append_NewNode_HasGuidInBraceUpperForm_AndShortcutZero()
+    {
+        string result = CategoryListXml.Append(Sample, new[] { ("Foo", 2) });
+        var doc = new System.Xml.XmlDocument();
+        doc.LoadXml(result);
+        var ns = new System.Xml.XmlNamespaceManager(doc.NameTable);
+        ns.AddNamespace("c", "CategoryList.xsd");
+        var node = doc.SelectSingleNode("//c:category[@name='Foo']", ns)!;
+        string guid = node.Attributes!["guid"]!.Value;
+        Assert.Matches("^\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}$", guid);
+        Assert.Equal("0", node.Attributes!["keyboardShortcut"]!.Value);
+    }
+
+    [Fact]
+    public void Append_EscapesSpecialChars_AndPreservesUnicode()
+    {
+        string result = CategoryListXml.Append(Sample, new[] { ("A & B <\"x\"> ÆØÅ", 4) });
+        // Raw markup must be escaped, the unicode must survive verbatim, and it must round-trip to the literal.
+        Assert.DoesNotContain("A & B", result);
+        Assert.Contains("ÆØÅ", result);
+        Assert.Contains("A & B <\"x\"> ÆØÅ", CategoryListXml.ReadNames(result));
+    }
+
+    [Fact]
+    public void Append_NewNode_InheritsDefaultNamespace_NoEmptyXmlns()
+    {
+        string result = CategoryListXml.Append(Sample, new[] { ("Work", 2) });
+        Assert.DoesNotContain("xmlns=\"\"", result); // a wrong namespace would emit this on the new node
+    }
+
+    [Fact]
+    public void Append_DeclarationEncodingMatchesUtf8Bytes_AndIsBomFree()
+    {
+        // The caller writes the result as UTF-8 (no BOM); the declaration must agree, not contradict it.
+        // utf-16 here would be the classic StringWriter bug that breaks Outlook's reader.
+        string result = CategoryListXml.Append(Sample, new[] { ("Work", 2) });
+        Assert.StartsWith("<?xml version=\"1.0\" encoding=\"utf-8\"?>", result);
+        Assert.DoesNotContain("utf-16", result, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain('﻿', result);
+    }
+
+    [Fact]
+    public void Append_EmptyInput_StartsFreshList()
+    {
+        string result = CategoryListXml.Append("", new[] { ("Work", 2) });
+        Assert.Equal(new[] { "Work" }, CategoryListXml.ReadNames(result).ToArray());
+        Assert.DoesNotContain("xmlns=\"\"", result);
+    }
+
+    [Fact]
+    public void Append_NoAdditions_IsValidNoOpRoundTrip()
+    {
+        string result = CategoryListXml.Append(Sample, Array.Empty<(string, int)>());
+        Assert.Equal(2, CategoryListXml.ReadNames(result).Count);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/OutlookCategories/CategoryStreamBytesTests.cs
+++ b/tests/Mail2Pst.Core.Tests/OutlookCategories/CategoryStreamBytesTests.cs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using Mail2Pst.Core.OutlookCategories;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.OutlookCategories;
+
+public class CategoryStreamBytesTests
+{
+    [Fact]
+    public void ByteArray_PassesThroughUnchanged()
+    {
+        var input = new byte[] { 0x3C, 0x3F, 0xFF, 0x80, 0x00 };
+        Assert.Same(input, CategoryStreamBytes.FromVariant(input));
+    }
+
+    [Fact]
+    public void SByteArray_ReinterpretsHighBitBytes_NoOverflow()
+    {
+        // VT_I1 marshaling: source bytes 0x00, 0x7F, 0x80, 0xFF arrive as sbyte 0, 127, -128, -1.
+        var input = new sbyte[] { 0, 127, -128, -1 };
+        Assert.Equal(new byte[] { 0x00, 0x7F, 0x80, 0xFF }, CategoryStreamBytes.FromVariant(input));
+    }
+
+    [Fact]
+    public void ShortArray_ReinterpretsLowByte()
+    {
+        var input = new short[] { 0x00C6, 0x00D8 }; // Æ, Ø low bytes
+        Assert.Equal(new byte[] { 0xC6, 0xD8 }, CategoryStreamBytes.FromVariant(input));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    public void NullOrDbNull_Throws(object? raw)
+    {
+        Assert.Throws<InvalidOperationException>(() => CategoryStreamBytes.FromVariant(raw));
+        Assert.Throws<InvalidOperationException>(() => CategoryStreamBytes.FromVariant(DBNull.Value));
+    }
+
+    [Fact]
+    public void NonBinary_Throws() =>
+        Assert.Throws<InvalidOperationException>(() => CategoryStreamBytes.FromVariant("not bytes"));
+}

--- a/tests/Mail2Pst.Core.Tests/OutlookCategories/OlCategoryColorMapTests.cs
+++ b/tests/Mail2Pst.Core.Tests/OutlookCategories/OlCategoryColorMapTests.cs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using Mail2Pst.Core.OutlookCategories;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.OutlookCategories;
+
+public class OlCategoryColorMapTests
+{
+    [Theory]
+    [InlineData("#FF0000", 1)]   // TB Important -> Red
+    [InlineData("#FF9900", 2)]   // TB Work     -> Orange
+    [InlineData("#009900", 20)]  // TB Personal -> Dark green (nearest-RGB, not Green)
+    [InlineData("#3333FF", 8)]   // TB To Do    -> Blue
+    [InlineData("#993399", 10)]  // TB Later    -> Maroon (nearest-RGB, not Purple)
+    [InlineData("#D6252E", 1)]   // exact palette Red (214,37,46) -> Red
+    [InlineData("#1c1c1c", 15)]  // near-black -> Black (case-insensitive, no leading-issue)
+    public void MapsHexToNearestOlCategoryColor(string hex, int expected)
+        => Assert.Equal(expected, NearestOrFail(hex));
+
+    [Fact]
+    public void NeverReturnsNone()
+        => Assert.NotEqual(0, NearestOrFail("#FFFFFF")); // white -> nearest real swatch, not None(0)
+
+    [Theory]
+    [InlineData("red")]
+    [InlineData("#F00")]
+    [InlineData("")]
+    [InlineData("#GGGGGG")]
+    public void RejectsInvalidHex(string hex)
+        => Assert.False(OlCategoryColorMap.TryNearestIndex(hex, out _));
+
+    private static int NearestOrFail(string hex)
+    {
+        Assert.True(OlCategoryColorMap.TryNearestIndex(hex, out int idx));
+        return idx;
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/ImportColoursInputTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/ImportColoursInputTests.cs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using Mail2Pst.Cli;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests;
+
+public class ImportColoursInputTests
+{
+    [Fact]
+    public void ParsesProfileAndApply()
+    {
+        var input = ImportColoursInput.Parse(new[] { "--profile", "/p", "--apply" });
+        Assert.Null(input.Error);
+        Assert.Equal("/p", input.ProfilePath);
+        Assert.True(input.Apply);
+    }
+
+    [Fact]
+    public void DefaultsToPreview_WhenNoApply()
+    {
+        var input = ImportColoursInput.Parse(new[] { "--profile", "/p" });
+        Assert.Null(input.Error);
+        Assert.False(input.Apply);
+    }
+
+    [Fact]
+    public void MissingProfile_IsError()
+    {
+        var input = ImportColoursInput.Parse(new[] { "--apply" });
+        Assert.NotNull(input.Error);
+    }
+
+    [Fact]
+    public void UnknownFlag_IsError()
+    {
+        var input = ImportColoursInput.Parse(new[] { "--profile", "/p", "--bogus" });
+        Assert.NotNull(input.Error);
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/ImportColoursInputTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/ImportColoursInputTests.cs
@@ -37,4 +37,18 @@ public class ImportColoursInputTests
         var input = ImportColoursInput.Parse(new[] { "--profile", "/p", "--bogus" });
         Assert.NotNull(input.Error);
     }
+
+    [Fact]
+    public void ProfileWithoutValue_IsError()
+    {
+        var input = ImportColoursInput.Parse(new[] { "--profile", "--apply" });
+        Assert.NotNull(input.Error);
+    }
+
+    [Fact]
+    public void ProfileFlagLast_NoValue_IsError()
+    {
+        var input = ImportColoursInput.Parse(new[] { "--profile" });
+        Assert.NotNull(input.Error);
+    }
 }


### PR DESCRIPTION
## What

Adds an **optional, Outlook-only** `import-colours` CLI helper to the converter. It reads Thunderbird tag names + colours (from `prefs.js`, with built-in `$labelN` defaults) and imports them into Outlook's **master category list**, so the category keywords written onto converted mail show with the right colour swatch in Outlook.

- `import-colours --profile <tb-profile>` → **preview** (Outlook-free): the resolved candidates, names, hex, mapped `OlCategoryColor`, and action.
- `import-colours --profile <tb-profile> --apply` → writes them to Outlook's master list. **Requires Outlook to be closed** (errors clearly if it's running). Preview path needs no Outlook.

## How (and why the approach changed mid-branch)

The first implementation used the Outlook Object Model `Categories.Add`. Real-data testing proved that path **commits the master list lazily and racily**: a transient automation Outlook persisted only a nondeterministic subset of a batch (observed 1/7, 2/3, 3/7, 4/7 survivors across every teardown variant — Logon, clean Quit, dwell, even a visible UI).

The shipped approach writes the backing store directly: the Calendar folder's `IPM.Configuration.CategoryList` associated (FAI) message holds the whole list as a UTF-8 `PidTagRoamingXmlStream` (MS-OXOCFG §2.2.5.1.1). We read that XML, append one `<category>` node per add, and write it back in a **single `StorageItem.Save`** — one atomic commit, no per-add race. **Verified deterministic** (4/4 prototype runs at 7/7; clean end-to-end CLI run added 6 categories + skipped 1 existing, all persisted with correct colours).

Core stays Outlook-free: the XML transform (`CategoryListXml`) and binary-stream normalizer (`CategoryStreamBytes`) are pure BCL; all late-bound COM lives in the CLI's `OutlookComCategoryStore`.

## Testing

- Full suite **668 tests green** (incl. 21 new unit tests for the XML transform and binary-stream normalizer: namespace inheritance, colour off-by-one, special-char/unicode escaping, BOM/empty/malformed handling, utf-8 declaration vs the StringWriter utf-16 trap, and high-bit `sbyte[]` marshaling).
- End-to-end validated against a real Thunderbird Gmail profile: 7 categories (incl. the unicode `ÆØÅ`) imported with correct colours.

## Review

Two Opus review rounds; all Critical/Important findings resolved (atomic-write race eliminated, `sbyte[]` overflow fixed, `Quit()` scoped to instances we started, robust empty/garbage XML handling).