### PR TITLE
feat(gui): Thunderbird profile parity — discovery, enrichment options, Outlook colour import

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -309,6 +309,16 @@ fn open_folder(app: AppHandle, path: String) -> Result<(), String> {
         .map_err(|e| format!("could not open folder: {e}"))
 }
 
+#[tauri::command]
+fn open_junk_help(app: AppHandle) -> Result<(), String> {
+    app.opener()
+        .open_url(
+            "https://support.mozilla.org/en-US/kb/thunderbird-and-junk-spam-messages",
+            None::<&str>,
+        )
+        .map_err(|e| format!("could not open link: {e}"))
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -326,7 +336,8 @@ pub fn run() {
             start_convert,
             start_scan,
             cancel_convert,
-            open_folder
+            open_folder,
+            open_junk_help
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -74,6 +74,11 @@ async fn scan_sample(app: tauri::AppHandle) -> Result<String, String> {
     .await
 }
 
+#[tauri::command]
+async fn discover_profile(app: tauri::AppHandle, dir: String) -> Result<String, String> {
+    run_sidecar(&app, vec!["discover".to_string(), "--input".to_string(), dir]).await
+}
+
 #[derive(Serialize)]
 struct FileStat {
     path: String,
@@ -315,6 +320,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             check_engine_version,
             scan_sample,
+            discover_profile,
             list_mbox_in_dir,
             stat_files,
             start_convert,

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -35,6 +35,30 @@ fn drain_lines(buf: &mut String) -> Vec<String> {
     out
 }
 
+// Like run_sidecar, but returns stdout even when the sidecar exits nonzero AS LONG AS it printed
+// something — import-colours' handled failures exit 1 while emitting a structured {type:"error"} JSON
+// object the frontend needs. Err only on a spawn failure or a nonzero exit with no stdout.
+async fn run_sidecar_capture(app: &tauri::AppHandle, args: Vec<String>) -> Result<String, String> {
+    let output = app
+        .shell()
+        .sidecar("mail2pst-cli")
+        .map_err(|e| format!("sidecar not found: {e}"))?
+        .args(args)
+        .output()
+        .await
+        .map_err(|e| format!("failed to run engine: {e}"))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    if output.status.success() || !stdout.trim().is_empty() {
+        Ok(stdout)
+    } else {
+        Err(format!(
+            "engine exited with {:?}: {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr)
+        ))
+    }
+}
+
 async fn run_sidecar(app: &tauri::AppHandle, args: Vec<String>) -> Result<String, String> {
     let output = app
         .shell()
@@ -77,6 +101,20 @@ async fn scan_sample(app: tauri::AppHandle) -> Result<String, String> {
 #[tauri::command]
 async fn discover_profile(app: tauri::AppHandle, dir: String) -> Result<String, String> {
     run_sidecar(&app, vec!["discover".to_string(), "--input".to_string(), dir]).await
+}
+
+#[tauri::command]
+async fn preview_colours(app: tauri::AppHandle, dir: String) -> Result<String, String> {
+    run_sidecar_capture(&app, vec!["import-colours".to_string(), "--profile".to_string(), dir]).await
+}
+
+#[tauri::command]
+async fn apply_colours(app: tauri::AppHandle, dir: String) -> Result<String, String> {
+    run_sidecar_capture(
+        &app,
+        vec!["import-colours".to_string(), "--profile".to_string(), dir, "--apply".to_string()],
+    )
+    .await
 }
 
 #[derive(Serialize)]
@@ -337,7 +375,9 @@ pub fn run() {
             start_scan,
             cancel_convert,
             open_folder,
-            open_junk_help
+            open_junk_help,
+            preview_colours,
+            apply_colours
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -150,7 +150,7 @@ export default function App() {
     <ConfirmDialog
       open={confirmSource}
       title="Rescan needed"
-      message="Going back to Source will discard this scan — you'll have to rescan the mbox files."
+      message="Going back to Source will discard this scan — you'll have to rescan the source."
       confirmLabel="Go back"
       cancelLabel="Stay"
       onConfirm={confirmGoToSource}

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -56,7 +56,13 @@ export default function App() {
     return (
       <Shell currentStep={STEP_FOR_PHASE[conv.phase] ?? 0}>
         {conv.phase === "running" && <ConvertView state={conv} />}
-        {conv.phase === "done" && <DoneView state={conv} onConvertAnother={onConvertAnother} />}
+        {conv.phase === "done" && (
+          <DoneView
+            state={conv}
+            profileRoot={f.inputMode === "profile" ? f.profileRoot : null}
+            onConvertAnother={onConvertAnother}
+          />
+        )}
         {conv.phase === "error" && <ErrorView state={conv} onConvertAnother={onConvertAnother} />}
         {conv.phase === "cancelled" && <CancelledView state={conv} onConvertAnother={onConvertAnother} />}
       </Shell>

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -86,8 +86,13 @@ export default function App() {
         <SelectView
           files={f.inputFiles}
           outputPath={f.outputPath}
+          inputMode={f.inputMode}
+          profileRoot={f.profileRoot}
+          sourceError={f.sourceError}
           onFilesChange={flow.setInputFiles}
           onOutputPathChange={flow.setOutputPath}
+          onInputModeChange={flow.setInputMode}
+          onProfileRootChange={flow.setProfileRoot}
           onContinue={flow.continueToScan}
         />
       )}

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -8,6 +8,8 @@ import { SelectView } from "@/components/views/SelectView";
 import { ScanningView } from "@/components/views/ScanningView";
 import { ReviewView } from "@/components/views/ReviewView";
 import { OptionsView } from "@/components/views/OptionsView";
+import { ProfileOptionsView } from "@/components/views/ProfileOptionsView";
+import type { ProfileSourceRow } from "@/lib/types";
 import { ScanErrorView } from "@/components/views/ScanErrorView";
 import { ConvertView } from "@/components/views/ConvertView";
 import { DoneView } from "@/components/views/DoneView";
@@ -113,19 +115,33 @@ export default function App() {
           warnings={f.inputMode === "profile" ? f.discoverWarnings : undefined}
         />
       )}
-      {f.stage === "options" && f.scan && f.outputPath && (
-        <OptionsView
-          scan={f.scan}
-          previewSources={flow.sortedSources}
-          outputPath={f.outputPath}
-          checkedIds={f.checkedIds}
-          skipEmpty={f.skipEmpty}
-          options={f.options}
-          onSetOptions={flow.setOptions}
-          onSetRename={flow.setRename}
-          onStart={start}
-          onBack={flow.backToReview}
-        />
+      {f.stage === "options" && f.outputPath && (
+        f.inputMode === "profile" && f.profileRoot ? (
+          <ProfileOptionsView
+            rows={flow.sortedSources as ProfileSourceRow[]}
+            outputPath={f.outputPath}
+            profileRoot={f.profileRoot}
+            checkedIds={f.checkedIds}
+            skipEmpty={f.skipEmpty}
+            options={f.options}
+            onSetOptions={flow.setOptions}
+            onStart={start}
+            onBack={flow.backToReview}
+          />
+        ) : f.scan ? (
+          <OptionsView
+            scan={f.scan}
+            previewSources={flow.sortedSources}
+            outputPath={f.outputPath}
+            checkedIds={f.checkedIds}
+            skipEmpty={f.skipEmpty}
+            options={f.options}
+            onSetOptions={flow.setOptions}
+            onSetRename={flow.setRename}
+            onStart={start}
+            onBack={flow.backToReview}
+          />
+        ) : null
       )}
       {f.stage === "scanError" && (
         <ScanErrorView message={f.errorMessage ?? "Unknown error"} onBack={flow.back} />

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -109,6 +109,8 @@ export default function App() {
           onSkipEmptyChange={flow.setSkipEmpty}
           onContinue={flow.continueToOptions}
           onBack={requestGoToSource}
+          pairedIds={f.inputMode === "profile" ? flow.pairedIds : undefined}
+          warnings={f.inputMode === "profile" ? f.discoverWarnings : undefined}
         />
       )}
       {f.stage === "options" && f.scan && f.outputPath && (

--- a/desktop/src/components/ui/help-tip.tsx
+++ b/desktop/src/components/ui/help-tip.tsx
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+import { useState, type ReactNode } from "react";
+import { CircleHelp } from "lucide-react";
+
+export function HelpTip({ children, label = "Help" }: { children: ReactNode; label?: string }) {
+  const [clickedOpen, setClickedOpen] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const open = clickedOpen || hovered;
+
+  return (
+    <span
+      className="relative inline-flex"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onKeyDown={(e) => { if (e.key === "Escape") setClickedOpen(false); }}
+      onBlur={(e) => {
+        // Close the click-pinned popover only when focus leaves the whole wrapper —
+        // not merely when the trigger button loses focus to content inside it.
+        if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setClickedOpen(false);
+      }}
+    >
+      <button
+        type="button"
+        aria-label={label}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className="inline-flex text-light-gray transition-colors hover:text-foreground"
+        onClick={() => setClickedOpen((v) => !v)}
+      >
+        <CircleHelp className="size-4" />
+      </button>
+      {open && (
+        <span
+          role="dialog"
+          className="absolute left-0 top-6 z-10 w-72 rounded-lg border border-border bg-popover px-3 py-2 text-xs font-normal text-popover-foreground shadow-lg"
+        >
+          {children}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/desktop/src/components/ui/help-tip.tsx
+++ b/desktop/src/components/ui/help-tip.tsx
@@ -33,6 +33,7 @@ export function HelpTip({ children, label = "Help" }: { children: ReactNode; lab
       {open && (
         <span
           role="dialog"
+          aria-label={label}
           className="absolute left-0 top-6 z-10 w-72 rounded-lg border border-border bg-popover px-3 py-2 text-xs font-normal text-popover-foreground shadow-lg"
         >
           {children}

--- a/desktop/src/components/ui/split-size-control.tsx
+++ b/desktop/src/components/ui/split-size-control.tsx
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { useState } from "react";
+import { SPLIT_PRESETS, resolveCustomGbToMb } from "@/lib/options";
+
+interface SplitSizeControlProps {
+  maxSizeMB: number;
+  allowOversize: boolean;
+  onChange: (maxSizeMB: number) => void;
+  onValidityChange: (ok: boolean) => void;
+}
+
+export function SplitSizeControl({ maxSizeMB, allowOversize, onChange, onValidityChange }: SplitSizeControlProps) {
+  const presetMatch = SPLIT_PRESETS.find((p) => p.mb === maxSizeMB);
+  const [splitMode, setSplitMode] = useState<"preset" | "custom">(presetMatch ? "preset" : "custom");
+  const [customText, setCustomText] = useState<string>(
+    presetMatch ? "" : String(Math.round(maxSizeMB / 1024)),
+  );
+  const [customErr, setCustomErr] = useState<string | null>(null);
+
+  function onSplitSelect(value: string) {
+    if (value === "custom") {
+      setSplitMode("custom");
+      setCustomText(String(Math.round(maxSizeMB / 1024)));
+      setCustomErr(null);
+    } else {
+      setSplitMode("preset");
+      setCustomErr(null);
+      onValidityChange(true);
+      onChange(Number(value));
+    }
+  }
+
+  function onCustomChange(text: string) {
+    setCustomText(text);
+    const r = resolveCustomGbToMb(text, allowOversize);
+    if ("mb" in r) {
+      setCustomErr(null);
+      onValidityChange(true);
+      onChange(r.mb);
+    } else {
+      setCustomErr(r.error);
+      onValidityChange(false);
+    }
+  }
+
+  return (
+    <div>
+      <select
+        className="w-full rounded-lg border border-border bg-card px-2 py-1.5 text-sm text-foreground"
+        value={splitMode === "custom" ? "custom" : String(maxSizeMB)}
+        onChange={(e) => onSplitSelect(e.target.value)}
+      >
+        {SPLIT_PRESETS.map((p) => (
+          <option key={p.mb} value={String(p.mb)}>{p.label}</option>
+        ))}
+        <option value="custom">Custom…</option>
+      </select>
+      {splitMode === "custom" && (
+        <div className="mt-2">
+          <input
+            type="number" min={1} step="0.1"
+            className="w-full rounded-lg border border-border bg-card px-2 py-1.5 text-sm text-foreground"
+            value={customText}
+            onChange={(e) => onCustomChange(e.target.value)}
+            aria-label="Custom split size in GB"
+          />
+          <div className="mt-0.5 text-xs text-light-gray">Size in GB</div>
+          {customErr && <div className="mt-0.5 text-xs text-destructive">{customErr}</div>}
+        </div>
+      )}
+      <p className="mt-1 text-xs text-light-gray">
+        Uses the PST safety limit of 50&nbsp;GB. Very large archives may still be split.
+      </p>
+    </div>
+  );
+}

--- a/desktop/src/components/views/ColourImportCard.tsx
+++ b/desktop/src/components/views/ColourImportCard.tsx
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Palette, TriangleAlert, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { previewColours, applyColours } from "@/lib/engine";
+import { summarizeColourApply } from "@/lib/colourImport";
+import type { ColourCategory } from "@/lib/types";
+
+type Phase =
+  | { k: "loading" }
+  | { k: "ready"; outlookAvailable: boolean; categories: ColourCategory[] }
+  | { k: "applying" }
+  | { k: "applied"; added: number; existing: number }
+  | { k: "error"; message: string; retry: "preview" | "apply" }
+  | { k: "dismissed" };
+
+const ACTION_LABEL: Record<string, string> = {
+  "would-add": "will add",
+  "added": "added",
+  "skipped-existing": "already in Outlook",
+  "skipped-no-colour": "no colour",
+  "skipped-invalid-name": "invalid name",
+};
+
+// Map a raw engine error message to friendly text for the card.
+function errorText(message: string): string {
+  if (/running/i.test(message)) return "Outlook is open — close it completely, then retry.";
+  if (/did not respond|timed out|timeout/i.test(message)) return "Outlook didn't respond — dismiss any Outlook prompt and retry.";
+  return message;
+}
+
+export function ColourImportCard({ profileRoot }: { profileRoot: string }) {
+  const [phase, setPhase] = useState<Phase>({ k: "loading" });
+  const [consent, setConsent] = useState(false);
+  // Guard against setting state after unmount (e.g. user clicks "Convert another" while a one-shot
+  // preview/apply is still running — there is no cancellation, so just drop the late result).
+  const mounted = useRef(true);
+  useEffect(() => () => { mounted.current = false; }, []);
+
+  const runPreview = useCallback(() => {
+    setPhase({ k: "loading" });
+    previewColours(profileRoot)
+      .then((r) => {
+        if (!mounted.current) return;
+        setPhase(
+          r.kind === "error"
+            ? { k: "error", message: r.message, retry: "preview" }
+            : { k: "ready", outlookAvailable: r.outlookAvailable, categories: r.categories },
+        );
+      })
+      .catch((e) => { if (mounted.current) setPhase({ k: "error", message: e instanceof Error ? e.message : String(e), retry: "preview" }); });
+  }, [profileRoot]);
+
+  const runApply = useCallback(() => {
+    setPhase({ k: "applying" });
+    applyColours(profileRoot)
+      .then((r) => {
+        if (!mounted.current) return;
+        if (r.kind === "error") { setPhase({ k: "error", message: r.message, retry: "apply" }); return; }
+        const s = summarizeColourApply(r.categories);
+        setPhase({ k: "applied", added: s.added, existing: s.existing });
+      })
+      .catch((e) => { if (mounted.current) setPhase({ k: "error", message: e instanceof Error ? e.message : String(e), retry: "apply" }); });
+  }, [profileRoot]);
+
+  useEffect(() => { runPreview(); }, [runPreview]);
+
+  if (phase.k === "dismissed") return null;
+
+  const dismiss = () => setPhase({ k: "dismissed" });
+
+  return (
+    <div className="mt-4 overflow-hidden rounded-[11px] border border-border">
+      <div className="flex items-center justify-between border-b border-border bg-card px-3.5 py-2.5">
+        <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+          <Palette className="size-4 text-primary" /> Outlook category colours
+        </div>
+        <span className="rounded-full bg-primary/12 px-2 py-0.5 text-[10px] text-primary">Optional · Windows + Outlook</span>
+      </div>
+
+      <div className="px-3.5 py-3 text-sm">
+        {phase.k === "loading" && (
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2 text-muted-foreground"><Spinner size="sm" /> Checking your tag colours…</div>
+            <Button variant="outline" onClick={dismiss}>Skip</Button>
+          </div>
+        )}
+
+        {phase.k === "applying" && (
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2 text-muted-foreground"><Spinner size="sm" /> Importing… Outlook opens briefly to save the categories.</div>
+            <Button variant="outline" onClick={dismiss}>Hide</Button>
+          </div>
+        )}
+
+        {phase.k === "applied" && (
+          <div>
+            <div className="flex items-start gap-2 text-foreground">
+              <Check className="mt-0.5 size-4 shrink-0 text-primary" />
+              <span>Colours imported. Added {phase.added}, {phase.existing} already existed. Reopen Outlook to see them.</span>
+            </div>
+            <div className="mt-3"><Button variant="outline" onClick={dismiss}>Done</Button></div>
+          </div>
+        )}
+
+        {phase.k === "error" && (
+          <div>
+            <div className="flex items-start gap-2 text-destructive">
+              <TriangleAlert className="mt-0.5 size-4 shrink-0" /> <span>{errorText(phase.message)}</span>
+            </div>
+            <div className="mt-3 flex gap-2.5">
+              <Button onClick={phase.retry === "apply" ? runApply : runPreview}>Retry</Button>
+              <Button variant="outline" onClick={dismiss}>Skip</Button>
+            </div>
+          </div>
+        )}
+
+        {phase.k === "ready" && (() => {
+          const wouldAdd = phase.categories.filter((c) => c.action === "would-add");
+          return (
+            <div>
+              <p className="mb-2 text-xs text-muted-foreground">
+                Your tags became Outlook categories, but Outlook colours them from its own master list. Import your Thunderbird tag colours so they match.
+              </p>
+              <div className="flex flex-col gap-1">
+                {phase.categories.map((c) => (
+                  <div key={c.name} className="flex items-center gap-2.5 text-[13px]">
+                    <span className="size-3.5 shrink-0 rounded border border-black/10" style={{ background: c.hex ?? "transparent" }} />
+                    <span className="flex-1 text-foreground">{c.name}</span>
+                    <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground">{ACTION_LABEL[c.action] ?? c.action}</span>
+                  </div>
+                ))}
+                {phase.categories.length === 0 && <div className="text-xs text-light-gray">No tag colours found in this profile.</div>}
+              </div>
+
+              {!phase.outlookAvailable ? (
+                <div className="mt-3 text-xs text-light-gray">Outlook not detected — install Outlook to import colours.</div>
+              ) : wouldAdd.length === 0 ? (
+                <div className="mt-3 text-xs text-light-gray">Nothing to import — no new Outlook colours are available from this profile.</div>
+              ) : (
+                <>
+                  <div className="mt-3 flex items-start gap-2 rounded-lg border border-[#ecd9a8] bg-[#fbf2dd] px-3 py-2 text-[11.5px] text-[#8a6516]">
+                    <TriangleAlert className="mt-0.5 size-4 shrink-0" />
+                    <span>This adds these categories to Outlook's master list for <strong>all</strong> your Outlook accounts — not just this PST. <strong>Close Outlook before importing.</strong></span>
+                  </div>
+                  <label className="mt-2.5 flex items-center gap-2 text-xs text-foreground">
+                    <input type="checkbox" checked={consent} onChange={(e) => setConsent(e.target.checked)} />
+                    I understand this changes my Outlook categories
+                  </label>
+                </>
+              )}
+
+              <div className="mt-3 flex items-center gap-2.5">
+                {phase.outlookAvailable && wouldAdd.length > 0 && (
+                  <Button disabled={!consent} onClick={runApply}>Import colours to Outlook</Button>
+                )}
+                <Button variant="outline" onClick={dismiss}>Skip</Button>
+              </div>
+            </div>
+          );
+        })()}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/components/views/DoneView.tsx
+++ b/desktop/src/components/views/DoneView.tsx
@@ -9,8 +9,9 @@ import { splitPath } from "@/lib/convert";
 import type { ConvertState } from "@/lib/useConvert";
 import { formatElapsed } from "@/lib/progressStats";
 import { shouldShowEnrichment, formatEnrichmentLine } from "@/lib/doneEnrichment";
+import { ColourImportCard } from "@/components/views/ColourImportCard";
 
-export function DoneView({ state, onConvertAnother }: { state: ConvertState; onConvertAnother: () => void }) {
+export function DoneView({ state, profileRoot, onConvertAnother }: { state: ConvertState; profileRoot?: string | null; onConvertAnother: () => void }) {
   const first = state.outputs[0];
   const folder = first ? splitPath(first).dir : state.outputDir;
   const elapsed = state.elapsedMs != null ? formatElapsed(state.elapsedMs) : "";
@@ -70,6 +71,8 @@ export function DoneView({ state, onConvertAnother }: { state: ConvertState; onC
           )}
         </div>
       )}
+
+      {profileRoot && <ColourImportCard profileRoot={profileRoot} />}
 
       <div className="mt-4 rounded-[10px] border border-dashed border-border bg-card px-3.5 py-3 text-xs text-muted-foreground">
         Keep your original .mbox files until you've opened the PST in Outlook and confirmed everything looks right.

--- a/desktop/src/components/views/DoneView.tsx
+++ b/desktop/src/components/views/DoneView.tsx
@@ -1,13 +1,14 @@
 // SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { Check, Package, FolderOpen } from "lucide-react";
+import { Check, Package, FolderOpen, TriangleAlert } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { StatChip } from "@/components/ui/stat-chip";
 import { openFolder } from "@/lib/engine";
 import { splitPath } from "@/lib/convert";
 import type { ConvertState } from "@/lib/useConvert";
 import { formatElapsed } from "@/lib/progressStats";
+import { shouldShowEnrichment, formatEnrichmentLine } from "@/lib/doneEnrichment";
 
 export function DoneView({ state, onConvertAnother }: { state: ConvertState; onConvertAnother: () => void }) {
   const first = state.outputs[0];
@@ -54,6 +55,21 @@ export function DoneView({ state, onConvertAnother }: { state: ConvertState; onC
         <StatChip label="Skipped" value={state.skipped} />
         <StatChip label="Warnings" value={state.warnings} />
       </div>
+
+      {state.enrichment && shouldShowEnrichment(state.enrichment) && (
+        <div className="mt-4 rounded-[10px] border border-border bg-card px-3.5 py-3 text-xs text-muted-foreground">
+          <div>{formatEnrichmentLine(state.enrichment)}</div>
+          {state.enrichment.sourcesDegraded > 0 && (
+            <div className="mt-1.5 flex items-start gap-2">
+              <TriangleAlert className="mt-0.5 size-4 shrink-0 text-primary" />
+              <span>
+                {state.enrichment.sourcesDegraded} folder{state.enrichment.sourcesDegraded === 1 ? "" : "s"}{" "}
+                couldn't read their .msf — flags/tags not applied there.
+              </span>
+            </div>
+          )}
+        </div>
+      )}
 
       <div className="mt-4 rounded-[10px] border border-dashed border-border bg-card px-3.5 py-3 text-xs text-muted-foreground">
         Keep your original .mbox files until you've opened the PST in Outlook and confirmed everything looks right.

--- a/desktop/src/components/views/OptionsView.tsx
+++ b/desktop/src/components/views/OptionsView.tsx
@@ -4,6 +4,7 @@
 import { useMemo, useState } from "react";
 import { Pencil } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { SplitSizeControl } from "@/components/ui/split-size-control";
 import { deriveOutputTarget, ConvertConfigError } from "@/lib/convert";
 import { formatBytes } from "@/lib/format";
 import {
@@ -11,8 +12,6 @@ import {
   buildConfigFromOptions,
   validateFolderName,
   findDuplicateFolderIds,
-  resolveCustomGbToMb,
-  SPLIT_PRESETS,
   type OptionsState,
 } from "@/lib/options";
 import type { ConversionConfig, SourceRow } from "@/lib/types";
@@ -36,13 +35,7 @@ export function OptionsView({
 }: OptionsViewProps) {
   const [startError, setStartError] = useState<string | null>(null);
   const [editing, setEditing] = useState<string | null>(null);
-
-  const presetMatch = SPLIT_PRESETS.find((p) => p.mb === options.maxSizeMB);
-  const [splitMode, setSplitMode] = useState<"preset" | "custom">(presetMatch ? "preset" : "custom");
-  const [customText, setCustomText] = useState<string>(
-    presetMatch ? "" : String(Math.round(options.maxSizeMB / 1024)),
-  );
-  const [customErr, setCustomErr] = useState<string | null>(null);
+  const [splitOk, setSplitOk] = useState(true);
 
   const pstName = useMemo(() => {
     try { return deriveOutputTarget(outputPath).pstName; } catch { return "Output"; }
@@ -64,26 +57,7 @@ export function OptionsView({
     return m;
   }, [preview.folders, duplicateIds]);
 
-  const canStart = preview.folders.length > 0 && nameErrors.size === 0 && customErr === null;
-
-  function onSplitSelect(value: string) {
-    if (value === "custom") {
-      setSplitMode("custom");
-      setCustomText(String(Math.round(options.maxSizeMB / 1024)));
-      setCustomErr(null);
-    } else {
-      setSplitMode("preset");
-      setCustomErr(null);
-      onSetOptions({ maxSizeMB: Number(value) });
-    }
-  }
-
-  function onCustomChange(text: string) {
-    setCustomText(text);
-    const r = resolveCustomGbToMb(text, options.allowOversize);
-    if ("mb" in r) { setCustomErr(null); onSetOptions({ maxSizeMB: r.mb }); }
-    else setCustomErr(r.error);
-  }
+  const canStart = preview.folders.length > 0 && nameErrors.size === 0 && splitOk;
 
   function onStartClick() {
     try {
@@ -122,32 +96,12 @@ export function OptionsView({
 
           <div>
             <div className="mb-1 text-sm font-medium text-foreground">Split size</div>
-            <select
-              className="w-full rounded-lg border border-border bg-card px-2 py-1.5 text-sm text-foreground"
-              value={splitMode === "custom" ? "custom" : String(options.maxSizeMB)}
-              onChange={(e) => onSplitSelect(e.target.value)}
-            >
-              {SPLIT_PRESETS.map((p) => (
-                <option key={p.mb} value={String(p.mb)}>{p.label}</option>
-              ))}
-              <option value="custom">Custom…</option>
-            </select>
-            {splitMode === "custom" && (
-              <div className="mt-2">
-                <input
-                  type="number" min={1} step="0.1"
-                  className="w-full rounded-lg border border-border bg-card px-2 py-1.5 text-sm text-foreground"
-                  value={customText}
-                  onChange={(e) => onCustomChange(e.target.value)}
-                  aria-label="Custom split size in GB"
-                />
-                <div className="mt-0.5 text-xs text-light-gray">Size in GB</div>
-                {customErr && <div className="mt-0.5 text-xs text-destructive">{customErr}</div>}
-              </div>
-            )}
-            <p className="mt-1 text-xs text-light-gray">
-              Uses the PST safety limit of 50&nbsp;GB. Very large archives may still be split.
-            </p>
+            <SplitSizeControl
+              maxSizeMB={options.maxSizeMB}
+              allowOversize={options.allowOversize}
+              onChange={(mb) => onSetOptions({ maxSizeMB: mb })}
+              onValidityChange={setSplitOk}
+            />
           </div>
         </div>
 

--- a/desktop/src/components/views/ProfileOptionsView.tsx
+++ b/desktop/src/components/views/ProfileOptionsView.tsx
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { HelpTip } from "@/components/ui/help-tip";
 import { SplitSizeControl } from "@/components/ui/split-size-control";
 import { buildProfileConfig } from "@/lib/profileConfig";
 import { effectiveRows } from "@/lib/review";
 import { ConvertConfigError, deriveOutputTarget } from "@/lib/convert";
 import { formatBytes } from "@/lib/format";
+import { openJunkHelp } from "@/lib/engine";
 import type { OptionsState } from "@/lib/options";
 import type { ConversionConfig, ProfileSourceRow } from "@/lib/types";
 
@@ -72,6 +74,53 @@ export function ProfileOptionsView({
             </label>
           </div>
           <div>
+            <div className="mb-1 flex items-center gap-1.5 text-sm font-medium text-foreground">
+              Junk handling
+              <HelpTip>
+                <strong className="text-foreground">Thunderbird junk scores.</strong> Thunderbird's own junk filter
+                scores each message for how spam-like it is, based on what you've marked as junk. That score is
+                separate from which folder a message sits in, so it's <strong className="text-foreground">not</strong>{" "}
+                the same as the contents of your Spam/Junk folder. This option acts on messages Thunderbird scored
+                as junk, wherever they are.{" "}
+                <strong className="text-foreground">"Leave in place" is recommended if unsure.</strong>
+                <button
+                  type="button"
+                  onClick={() => void openJunkHelp()}
+                  className="mt-2 block text-primary underline underline-offset-2 hover:opacity-80"
+                >
+                  Learn more on Mozilla Support
+                </button>
+              </HelpTip>
+            </div>
+            <label className="flex items-center gap-2 text-sm text-foreground">
+              <input type="radio" name="junk" checked={options.junkHandling === "Off"}
+                onChange={() => onSetOptions({ junkHandling: "Off" })} />
+              Leave in place
+            </label>
+            <label className="mt-1 flex items-center gap-2 text-sm text-foreground">
+              <input type="radio" name="junk" checked={options.junkHandling === "Category"}
+                onChange={() => onSetOptions({ junkHandling: "Category" })} />
+              Tag as Junk category
+            </label>
+            <label className="mt-1 flex items-center gap-2 text-sm text-foreground">
+              <input type="radio" name="junk" checked={options.junkHandling === "Folder"}
+                onChange={() => onSetOptions({ junkHandling: "Folder" })} />
+              Move to Junk Email folder
+            </label>
+          </div>
+
+          <div>
+            <label className="flex items-center gap-2 text-sm text-foreground">
+              <input type="checkbox" checked={options.dropExpunged}
+                onChange={(e) => onSetOptions({ dropExpunged: e.target.checked })} />
+              Skip deleted (expunged) messages
+            </label>
+            <p className="ml-6 mt-0.5 text-xs text-light-gray">
+              Permanently leave out messages Thunderbird marked as deleted.
+            </p>
+          </div>
+
+          <div>
             <div className="mb-1 text-sm font-medium text-foreground">Split size</div>
             <SplitSizeControl
               maxSizeMB={options.maxSizeMB}
@@ -101,7 +150,7 @@ export function ProfileOptionsView({
             </div>
           </div>
           <div className="mt-2 rounded-lg border border-border border-l-[3px] border-l-primary bg-card px-3 py-2 text-xs text-muted-foreground">
-            Carried over from Thunderbird automatically: <span className="text-foreground">read/unread, replied, forwarded, starred</span> flags and <span className="text-foreground">tags → Outlook categories</span> (folders with an <span className="text-primary">.msf</span> badge). Junk routing &amp; drop-expunged are coming in a later update.
+            Carried over from Thunderbird automatically: <span className="text-foreground">read/unread, replied, forwarded, starred</span> flags and <span className="text-foreground">tags → Outlook categories</span> (folders with an <span className="text-primary">.msf</span> badge).
           </div>
         </div>
       </div>

--- a/desktop/src/components/views/ProfileOptionsView.tsx
+++ b/desktop/src/components/views/ProfileOptionsView.tsx
@@ -41,7 +41,7 @@ export function ProfileOptionsView({
   function onStartClick() {
     try {
       const { config, outputDir } = buildProfileConfig(
-        rows, checkedIds, skipEmpty, options.folderMapping, options.maxSizeMB, outputPath, profileRoot,
+        rows, checkedIds, skipEmpty, options, outputPath, profileRoot,
       );
       onStart(config, outputDir);
     } catch (e) {

--- a/desktop/src/components/views/ProfileOptionsView.tsx
+++ b/desktop/src/components/views/ProfileOptionsView.tsx
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { SplitSizeControl } from "@/components/ui/split-size-control";
+import { buildProfileConfig } from "@/lib/profileConfig";
+import { effectiveRows } from "@/lib/review";
+import { ConvertConfigError, deriveOutputTarget } from "@/lib/convert";
+import { formatBytes } from "@/lib/format";
+import type { OptionsState } from "@/lib/options";
+import type { ConversionConfig, ProfileSourceRow } from "@/lib/types";
+
+interface ProfileOptionsViewProps {
+  rows: ProfileSourceRow[];
+  outputPath: string;
+  profileRoot: string;
+  checkedIds: Set<string>;
+  skipEmpty: boolean;
+  options: OptionsState;
+  onSetOptions: (patch: Partial<OptionsState>) => void;
+  onStart: (config: ConversionConfig, outputDir: string) => void;
+  onBack: () => void;
+}
+
+export function ProfileOptionsView({
+  rows, outputPath, profileRoot, checkedIds, skipEmpty, options, onSetOptions, onStart, onBack,
+}: ProfileOptionsViewProps) {
+  const [startError, setStartError] = useState<string | null>(null);
+  const [splitOk, setSplitOk] = useState(true);
+
+  const eff = useMemo(
+    () => effectiveRows(rows, checkedIds, skipEmpty) as ProfileSourceRow[],
+    [rows, checkedIds, skipEmpty],
+  );
+  const pstName = useMemo(() => {
+    try { return deriveOutputTarget(outputPath).pstName; } catch { return "Output"; }
+  }, [outputPath]);
+  const totalBytes = eff.reduce((n, r) => n + r.bytes, 0);
+  const canStart = eff.length > 0 && splitOk;
+
+  function onStartClick() {
+    try {
+      const { config, outputDir } = buildProfileConfig(
+        rows, checkedIds, skipEmpty, options.folderMapping, options.maxSizeMB, outputPath, profileRoot,
+      );
+      onStart(config, outputDir);
+    } catch (e) {
+      setStartError(e instanceof ConvertConfigError ? e.message : "Could not start the conversion.");
+    }
+  }
+
+  return (
+    <div className="flex flex-1 flex-col min-h-0">
+      <h1 className="text-xl font-semibold text-foreground">Options</h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Choose how the discovered folders are written and how large each PST may get.
+      </p>
+
+      <div className="mt-4 flex flex-1 gap-6 overflow-hidden">
+        <div className="flex w-64 shrink-0 flex-col gap-5">
+          <div>
+            <div className="mb-1 text-sm font-medium text-foreground">Folder structure</div>
+            <label className="flex items-center gap-2 text-sm text-foreground">
+              <input type="radio" name="mapping" checked={options.folderMapping === "mirror"}
+                onChange={() => onSetOptions({ folderMapping: "mirror" })} />
+              Mirror the Thunderbird tree
+            </label>
+            <label className="mt-1 flex items-center gap-2 text-sm text-foreground">
+              <input type="radio" name="mapping" checked={options.folderMapping === "flatten"}
+                onChange={() => onSetOptions({ folderMapping: "flatten" })} />
+              Flatten into one folder
+            </label>
+          </div>
+          <div>
+            <div className="mb-1 text-sm font-medium text-foreground">Split size</div>
+            <SplitSizeControl
+              maxSizeMB={options.maxSizeMB}
+              allowOversize={options.allowOversize}
+              onChange={(mb) => onSetOptions({ maxSizeMB: mb })}
+              onValidityChange={setSplitOk}
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-1 flex-col overflow-hidden">
+          <div className="mb-1 text-sm font-medium text-foreground">Preview</div>
+          <div className="flex-1 overflow-auto rounded-lg border border-border p-3 text-sm">
+            <div className="font-semibold text-foreground">{pstName}.pst</div>
+            <div className="mt-1 flex flex-col gap-1">
+              {options.folderMapping === "flatten" ? (
+                <div className="pl-3 text-foreground">└ Imported Mail
+                  <span className="ml-2 text-light-gray">{eff.reduce((n, r) => n + r.messages, 0).toLocaleString()} · {formatBytes(totalBytes)}</span>
+                </div>
+              ) : eff.map((r) => (
+                <div key={r.id} className="pl-3 text-foreground">
+                  └ {r.displayName}
+                  <span className="ml-2 text-light-gray">{r.messages.toLocaleString()} · {formatBytes(r.bytes)}</span>
+                </div>
+              ))}
+              {eff.length === 0 && <div className="pl-3 text-xs text-light-gray">No folders selected.</div>}
+            </div>
+          </div>
+          <div className="mt-2 rounded-lg border border-border border-l-[3px] border-l-primary bg-card px-3 py-2 text-xs text-muted-foreground">
+            Carried over from Thunderbird automatically: <span className="text-foreground">read/unread, replied, forwarded, starred</span> flags and <span className="text-foreground">tags → Outlook categories</span> (folders with an <span className="text-primary">.msf</span> badge). Junk routing &amp; drop-expunged are coming in a later update.
+          </div>
+        </div>
+      </div>
+
+      {startError && <p className="mt-3 text-sm text-destructive">{startError}</p>}
+
+      <div className="mt-4 flex items-center justify-end">
+        <div className="flex gap-3">
+          <Button variant="outline" onClick={onBack}>‹ Back</Button>
+          <Button disabled={!canStart} onClick={onStartClick}>Start conversion ›</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/components/views/ReviewView.tsx
+++ b/desktop/src/components/views/ReviewView.tsx
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { useMemo } from "react";
+import { TriangleAlert } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { calculateReviewTotals, nextSort, type SortField, type SortDir, type SortableField } from "@/lib/review";
 import { formatBytes, formatDateRange } from "@/lib/format";
-import type { SourceRow } from "@/lib/types";
+import type { DiscoverWarning, SourceRow } from "@/lib/types";
 
 interface ReviewViewProps {
   sources: SourceRow[];
@@ -18,11 +19,13 @@ interface ReviewViewProps {
   onSkipEmptyChange: (v: boolean) => void;
   onContinue: () => void;
   onBack: () => void;
+  pairedIds?: Set<string>;
+  warnings?: DiscoverWarning[];
 }
 
 export function ReviewView({
   sources, checkedIds, skipEmpty, sortBy, sortDir, onSortChange,
-  onToggle, onSkipEmptyChange, onContinue, onBack,
+  onToggle, onSkipEmptyChange, onContinue, onBack, pairedIds, warnings,
 }: ReviewViewProps) {
   const totals = useMemo(
     () => calculateReviewTotals(sources, checkedIds, skipEmpty),
@@ -51,6 +54,19 @@ export function ReviewView({
       <p className="mt-2 text-xs text-light-gray">
         Click a column header to sort. Sorting changes this view only — it doesn't affect the converted file.
       </p>
+
+      {warnings && warnings.length > 0 && (
+        <div className="mt-2 flex items-start gap-2 rounded-lg border border-border bg-card px-3 py-2 text-xs text-muted-foreground">
+          <TriangleAlert className="mt-0.5 size-4 shrink-0 text-primary" />
+          <div>
+            {warnings.length} discovery warning{warnings.length === 1 ? "" : "s"}
+            <ul className="mt-1 list-disc pl-4">
+              {warnings.slice(0, 5).map((w, i) => <li key={i}>{w.message}</li>)}
+            </ul>
+            {warnings.length > 5 && <div className="mt-0.5">…and {warnings.length - 5} more.</div>}
+          </div>
+        </div>
+      )}
 
       <div className="mt-2 min-h-0 flex-1 overflow-auto rounded-lg border border-border">
         <table className="w-full text-sm">
@@ -97,6 +113,11 @@ export function ReviewView({
                     {s.displayName}
                     {isEmpty && (
                       <span className="ml-2 rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase text-muted-foreground">empty</span>
+                    )}
+                    {pairedIds && (
+                      pairedIds.has(s.id)
+                        ? <span className="ml-2 rounded bg-primary/15 px-1.5 py-0.5 text-[10px] uppercase text-primary">.msf</span>
+                        : <span className="ml-2 rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase text-muted-foreground">no .msf</span>
                     )}
                   </td>
                   <td className="px-2 py-1.5 text-right">{s.messages.toLocaleString()}</td>

--- a/desktop/src/components/views/SelectView.tsx
+++ b/desktop/src/components/views/SelectView.tsx
@@ -93,6 +93,7 @@ export function SelectView({
       <div className="mt-4 inline-flex overflow-hidden rounded-md border border-border">
         <button
           type="button"
+          aria-pressed={inputMode === "profile"}
           onClick={() => onInputModeChange("profile")}
           className={"px-4 py-1.5 text-sm " + (inputMode === "profile" ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-muted")}
         >
@@ -100,6 +101,7 @@ export function SelectView({
         </button>
         <button
           type="button"
+          aria-pressed={inputMode === "files"}
           onClick={() => onInputModeChange("files")}
           className={"px-4 py-1.5 text-sm " + (inputMode === "files" ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-muted")}
         >

--- a/desktop/src/components/views/SelectView.tsx
+++ b/desktop/src/components/views/SelectView.tsx
@@ -12,13 +12,19 @@ import type { FileStat } from "@/lib/types";
 interface SelectViewProps {
   files: FileStat[];
   outputPath: string | null;
+  inputMode: "files" | "profile";
+  profileRoot: string | null;
+  sourceError?: string | null;
   onFilesChange: (files: FileStat[]) => void;
   onOutputPathChange: (path: string | null) => void;
+  onInputModeChange: (m: "files" | "profile") => void;
+  onProfileRootChange: (path: string | null) => void;
   onContinue: () => void;
 }
 
 export function SelectView({
-  files, outputPath, onFilesChange, onOutputPathChange, onContinue,
+  files, outputPath, inputMode, profileRoot, sourceError,
+  onFilesChange, onOutputPathChange, onInputModeChange, onProfileRootChange, onContinue,
 }: SelectViewProps) {
   // Picker errors are transient and screen-local (e.g. "no .mbox in folder").
   // Parent owns the durable file/output state; this does NOT belong there.
@@ -50,6 +56,12 @@ export function SelectView({
     await addFiles(found);
   }
 
+  async function onChooseProfile() {
+    setPickerError(null);
+    const dir = await pickFolder();
+    if (dir) onProfileRootChange(dir);
+  }
+
   async function onChooseOutput() {
     setPickerError(null);
     const path = await pickOutputPst();
@@ -67,50 +79,85 @@ export function SelectView({
   }
 
   const totalBytes = files.reduce((sum, f) => sum + f.size, 0);
-  const canContinue = files.length > 0 && outputPath !== null;
+  const canContinue =
+    outputPath !== null &&
+    (inputMode === "files" ? files.length > 0 : profileRoot !== null);
 
   return (
     <div className="flex flex-1 flex-col">
-      <h1 className="text-xl font-semibold text-foreground">Choose your mbox files</h1>
+      <h1 className="text-xl font-semibold text-foreground">Choose what to convert</h1>
       <p className="mt-1 text-sm text-muted-foreground">
-        Select a folder that contains <code>.mbox</code> files, or pick individual <code>.mbox</code> files.
+        Select a Thunderbird profile or pick individual <code>.mbox</code> files.
       </p>
 
-      <div className="mt-4 flex gap-3">
-        <Button onClick={onChooseFiles}>
-          <FileText /> Choose .mbox files…
-        </Button>
-        <Button variant="outline" onClick={onChooseFolder}>
-          <FolderOpen /> Select folder…
-        </Button>
+      <div className="mt-4 inline-flex overflow-hidden rounded-md border border-border">
+        <button
+          type="button"
+          onClick={() => onInputModeChange("profile")}
+          className={"px-4 py-1.5 text-sm " + (inputMode === "profile" ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-muted")}
+        >
+          Thunderbird profile
+        </button>
+        <button
+          type="button"
+          onClick={() => onInputModeChange("files")}
+          className={"px-4 py-1.5 text-sm " + (inputMode === "files" ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-muted")}
+        >
+          .mbox files
+        </button>
       </div>
 
-      {files.length > 0 && (
+      {inputMode === "profile" && (
         <div className="mt-4">
-          <div className="text-xs text-light-gray">
-            {files.length} mbox file{files.length === 1 ? "" : "s"} · {formatBytes(totalBytes)}
-          </div>
-          <div className="mt-2 flex max-h-40 flex-col gap-1.5 overflow-auto">
-            {files.map((f) => (
-              <div
-                key={f.path}
-                className="flex items-center gap-3 rounded-lg border border-border bg-card px-3 py-1.5 text-sm text-foreground"
-              >
-                <span className="truncate">{splitPath(f.path).base}</span>
-                <span className="ml-auto shrink-0 text-light-gray">{formatBytes(f.size)}</span>
-                <button
-                  type="button"
-                  onClick={() => removeFile(f.path)}
-                  aria-label={`Remove ${splitPath(f.path).base}`}
-                  title="Remove"
-                  className="shrink-0 rounded p-0.5 text-light-gray transition-colors hover:text-destructive"
-                >
-                  <X className="size-4" />
-                </button>
-              </div>
-            ))}
-          </div>
+          <Button onClick={onChooseProfile}>
+            <FolderOpen /> {profileRoot ? splitPath(profileRoot).base : "Choose profile / mail folder…"}
+          </Button>
+          {profileRoot && <div className="mt-1 text-xs text-light-gray">{profileRoot}</div>}
+          <p className="mt-2 text-xs text-light-gray">
+            Point at a Thunderbird profile, a Mail/ImapMail store, or a single account folder. Nested folders and tags/flags are detected automatically.
+          </p>
         </div>
+      )}
+
+      {inputMode === "files" && (
+        <>
+          <div className="mt-4 flex gap-3">
+            <Button onClick={onChooseFiles}>
+              <FileText /> Choose .mbox files…
+            </Button>
+            <Button variant="outline" onClick={onChooseFolder}>
+              <FolderOpen /> Select folder…
+            </Button>
+          </div>
+
+          {files.length > 0 && (
+            <div className="mt-4">
+              <div className="text-xs text-light-gray">
+                {files.length} mbox file{files.length === 1 ? "" : "s"} · {formatBytes(totalBytes)}
+              </div>
+              <div className="mt-2 flex max-h-40 flex-col gap-1.5 overflow-auto">
+                {files.map((f) => (
+                  <div
+                    key={f.path}
+                    className="flex items-center gap-3 rounded-lg border border-border bg-card px-3 py-1.5 text-sm text-foreground"
+                  >
+                    <span className="truncate">{splitPath(f.path).base}</span>
+                    <span className="ml-auto shrink-0 text-light-gray">{formatBytes(f.size)}</span>
+                    <button
+                      type="button"
+                      onClick={() => removeFile(f.path)}
+                      aria-label={`Remove ${splitPath(f.path).base}`}
+                      title="Remove"
+                      className="shrink-0 rounded p-0.5 text-light-gray transition-colors hover:text-destructive"
+                    >
+                      <X className="size-4" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </>
       )}
 
       <div className="mt-5">
@@ -134,7 +181,9 @@ export function SelectView({
         {outputPath && <div className="mt-1 text-xs text-light-gray">{splitPath(outputPath).dir}</div>}
       </div>
 
-      {pickerError && <p className="mt-4 text-sm text-destructive">{pickerError}</p>}
+      {(pickerError || sourceError) && (
+        <p className="mt-4 text-sm text-destructive">{pickerError ?? sourceError}</p>
+      )}
 
       <div className="mt-auto flex items-center justify-end pt-5">
         <Button disabled={!canContinue} onClick={onContinue}>

--- a/desktop/src/lib/colourImport.test.ts
+++ b/desktop/src/lib/colourImport.test.ts
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+import { describe, it, expect } from "vitest";
+import { parseColourImport, summarizeColourApply } from "./colourImport";
+import type { ColourCategory } from "./types";
+
+const preview = JSON.stringify({
+  type: "importColours", mode: "preview", outlookAvailable: true, schemaVersion: 1,
+  categories: [
+    { name: "Work", hex: "#FF9900", outlookColor: 2, action: "would-add" },
+    { name: "Important", hex: "#FF0000", outlookColor: 1, action: "skipped-existing" },
+  ],
+});
+
+describe("parseColourImport", () => {
+  it("parses a preview object", () => {
+    const r = parseColourImport(preview);
+    expect(r.kind).toBe("result");
+    if (r.kind !== "result") return;
+    expect(r.mode).toBe("preview");
+    expect(r.outlookAvailable).toBe(true);
+    expect(r.categories).toHaveLength(2);
+    expect(r.categories[0]).toEqual({ name: "Work", hex: "#FF9900", outlookColor: 2, action: "would-add" });
+  });
+
+  it("parses an apply object", () => {
+    const r = parseColourImport(JSON.stringify({ type: "importColours", mode: "apply", outlookAvailable: true, categories: [] }));
+    expect(r.kind === "result" && r.mode === "apply").toBe(true);
+  });
+
+  it("maps a handled error object (nonzero exit) to kind:error with its message", () => {
+    const r = parseColourImport(JSON.stringify({ type: "error", stage: "import-colours", message: "Outlook is running. Close Outlook completely, then re-run import-colours --apply.", fatal: true }));
+    expect(r.kind).toBe("error");
+    if (r.kind !== "error") return;
+    expect(r.message).toContain("Outlook is running");
+  });
+
+  it("returns empty categories result when none", () => {
+    const r = parseColourImport(JSON.stringify({ type: "importColours", mode: "preview", outlookAvailable: false, categories: [] }));
+    expect(r.kind === "result" && r.categories.length === 0 && r.outlookAvailable === false).toBe(true);
+  });
+
+  it("returns all rows for a skipped-only preview (none would-add → drives the 'nothing to import' card state)", () => {
+    const r = parseColourImport(JSON.stringify({ type: "importColours", mode: "preview", outlookAvailable: true, categories: [
+      { name: "Important", hex: "#FF0000", outlookColor: 1, action: "skipped-existing" },
+      { name: "NoColour", hex: null, outlookColor: null, action: "skipped-no-colour" },
+    ] }));
+    expect(r.kind).toBe("result");
+    if (r.kind !== "result") return;
+    expect(r.categories).toHaveLength(2);
+    expect(r.categories.some((c) => c.action === "would-add")).toBe(false);
+  });
+
+  it("returns a generic error for unrecognized/non-JSON output (never throws)", () => {
+    expect(parseColourImport("not json at all")).toEqual({ kind: "error", message: "Could not read colour-import result." });
+    expect(parseColourImport("")).toEqual({ kind: "error", message: "Could not read colour-import result." });
+  });
+});
+
+describe("summarizeColourApply", () => {
+  it("counts added vs already-existing", () => {
+    const cats: ColourCategory[] = [
+      { name: "a", hex: "#1", outlookColor: 1, action: "added" },
+      { name: "b", hex: "#2", outlookColor: 2, action: "added" },
+      { name: "c", hex: "#3", outlookColor: 3, action: "skipped-existing" },
+      { name: "d", hex: null, outlookColor: null, action: "skipped-no-colour" },
+    ];
+    expect(summarizeColourApply(cats)).toEqual({ added: 2, existing: 1 });
+  });
+});

--- a/desktop/src/lib/colourImport.ts
+++ b/desktop/src/lib/colourImport.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { extractJsonObjects, isRecord } from "./parse";
+import type { ColourCategory } from "./types";
+
+export type ColourImportParse =
+  | { kind: "result"; mode: "preview" | "apply"; outlookAvailable: boolean; categories: ColourCategory[] }
+  | { kind: "error"; message: string };
+
+/** Parse the one-shot import-colours stdout into a result or a typed error.
+ * Never throws on engine/user output: unrecognized/malformed → a generic error. */
+export function parseColourImport(stdout: string): ColourImportParse {
+  const obj = extractJsonObjects(stdout).find(
+    (o) => isRecord(o) && (o.type === "importColours" || o.type === "error"),
+  ) as Record<string, unknown> | undefined;
+
+  if (!obj) return { kind: "error", message: "Could not read colour-import result." };
+
+  if (obj.type === "error") {
+    const message = typeof obj.message === "string" && obj.message.length > 0 ? obj.message : "Colour import failed.";
+    return { kind: "error", message };
+  }
+
+  return {
+    kind: "result",
+    mode: obj.mode === "apply" ? "apply" : "preview",
+    outlookAvailable: obj.outlookAvailable === true,
+    categories: Array.isArray(obj.categories) ? (obj.categories as ColourCategory[]) : [],
+  };
+}
+
+/** Count an apply result's outcomes for the success line. */
+export function summarizeColourApply(categories: ColourCategory[]): { added: number; existing: number } {
+  let added = 0;
+  let existing = 0;
+  for (const c of categories) {
+    if (c.action === "added") added++;
+    else if (c.action === "skipped-existing") existing++;
+  }
+  return { added, existing };
+}

--- a/desktop/src/lib/discover.test.ts
+++ b/desktop/src/lib/discover.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect } from "vitest";
 import { parseDiscover } from "./discover";
+import { EngineParseError } from "./parse";
 
 const SAMPLE = JSON.stringify({
   type: "discovery",
@@ -51,6 +52,6 @@ describe("parseDiscover", () => {
   });
 
   it("throws when no discovery object is present", () => {
-    expect(() => parseDiscover("not json at all")).toThrow();
+    expect(() => parseDiscover("not json at all")).toThrow(EngineParseError);
   });
 });

--- a/desktop/src/lib/discover.test.ts
+++ b/desktop/src/lib/discover.test.ts
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, it, expect } from "vitest";
+import { parseDiscover } from "./discover";
+
+const SAMPLE = JSON.stringify({
+  type: "discovery",
+  schemaVersion: 1,
+  root: "C:/profile",
+  layout: "thunderbird",
+  sources: [
+    { path: "C:/p/Inbox", type: "mbox", targetFolderPath: ["Account", "Inbox"],
+      displayName: "Inbox", sourceBytes: 100, msfPath: "C:/p/Inbox.msf" },
+    { path: "C:/p/Work", type: "mbox", targetFolderPath: ["Work", "Inbox"],
+      displayName: "Inbox", sourceBytes: 50, msfPath: null },
+  ],
+  warnings: [
+    { code: "duplicate-target-folder-path", path: "C:/p/Inbox", targetFolderPath: ["Account", "Inbox"],
+      segment: null, segmentIndex: null, relatedPaths: ["C:/p/Inbox"], message: "dup" },
+  ],
+  skipped: [{ code: "symlink-skipped", path: "C:/p/link", reason: "symlink" }],
+  pairing: { pairedMsfCount: 1, unpairedMboxCount: 1, orphanMsfCount: 0 },
+});
+
+describe("parseDiscover", () => {
+  it("parses a discovery object with nested sources, pairing, warnings, skipped", () => {
+    const r = parseDiscover(SAMPLE);
+    expect(r.root).toBe("C:/profile");
+    expect(r.layout).toBe("thunderbird");
+    expect(r.sources).toHaveLength(2);
+    expect(r.sources[0].targetFolderPath).toEqual(["Account", "Inbox"]);
+    expect(r.sources[0].msfPath).toBe("C:/p/Inbox.msf");
+    expect(r.sources[1].msfPath).toBeNull();
+    expect(r.warnings[0].code).toBe("duplicate-target-folder-path");
+    expect(r.skipped[0].code).toBe("symlink-skipped");
+    expect(r.pairing.pairedMsfCount).toBe(1);
+  });
+
+  it("tolerates surrounding noise (dev build) around the object", () => {
+    const r = parseDiscover("warning: dev build\n" + SAMPLE + "\n");
+    expect(r.sources).toHaveLength(2);
+  });
+
+  it("defaults missing arrays to empty", () => {
+    const r = parseDiscover(JSON.stringify({ type: "discovery", root: "x", layout: "empty" }));
+    expect(r.sources).toEqual([]);
+    expect(r.warnings).toEqual([]);
+    expect(r.skipped).toEqual([]);
+    expect(r.pairing).toEqual({ pairedMsfCount: 0, unpairedMboxCount: 0, orphanMsfCount: 0 });
+  });
+
+  it("throws when no discovery object is present", () => {
+    expect(() => parseDiscover("not json at all")).toThrow();
+  });
+});

--- a/desktop/src/lib/discover.ts
+++ b/desktop/src/lib/discover.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { extractJsonObjects, isRecord, EngineParseError } from "./parse";
+import type {
+  DiscoverResult, DiscoveredSource, DiscoverWarning, DiscoverSkipped, DiscoverPairing,
+} from "./types";
+
+/** Parse the engine's single pretty-printed `discovery` object (tolerates dev-build
+ * noise around it). Throws EngineParseError when no discovery object is present. */
+export function parseDiscover(stdout: string): DiscoverResult {
+  const obj = extractJsonObjects(stdout).find(
+    (o) => isRecord(o) && o.type === "discovery",
+  ) as Record<string, unknown> | undefined;
+  if (!obj) throw new EngineParseError("No discovery object in engine output");
+
+  const sources = (Array.isArray(obj.sources) ? obj.sources : []).map(
+    (s) => s as DiscoveredSource,
+  );
+  const warnings = (Array.isArray(obj.warnings) ? obj.warnings : []).map(
+    (w) => w as DiscoverWarning,
+  );
+  const skipped = (Array.isArray(obj.skipped) ? obj.skipped : []).map(
+    (s) => s as DiscoverSkipped,
+  );
+  const p = isRecord(obj.pairing) ? obj.pairing : {};
+  const pairing: DiscoverPairing = {
+    pairedMsfCount: Number(p.pairedMsfCount ?? 0),
+    unpairedMboxCount: Number(p.unpairedMboxCount ?? 0),
+    orphanMsfCount: Number(p.orphanMsfCount ?? 0),
+  };
+
+  return {
+    root: String(obj.root ?? ""),
+    layout: String(obj.layout ?? ""),
+    sources,
+    warnings,
+    skipped,
+    pairing,
+    schemaVersion: obj.schemaVersion as number | undefined,
+  };
+}

--- a/desktop/src/lib/doneEnrichment.test.ts
+++ b/desktop/src/lib/doneEnrichment.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { shouldShowEnrichment, formatEnrichmentLine } from "./doneEnrichment";
+import type { EnrichmentSummary } from "./types";
+
+const base: EnrichmentSummary = {
+  matched: 0, skippedMissingId: 0, skippedDuplicateId: 0, noMsfMatch: 0,
+  expungedMatched: 0, expungedDropped: 0, sourcesAttempted: 0, sourcesEnriched: 0, sourcesDegraded: 0,
+};
+
+describe("shouldShowEnrichment", () => {
+  it("false for null", () => expect(shouldShowEnrichment(null)).toBe(false));
+  it("false when nothing enriched or degraded", () => expect(shouldShowEnrichment(base)).toBe(false));
+  it("true when a folder enriched", () => expect(shouldShowEnrichment({ ...base, sourcesEnriched: 1 })).toBe(true));
+  it("true when a folder degraded (none enriched)", () => expect(shouldShowEnrichment({ ...base, sourcesDegraded: 2 })).toBe(true));
+});
+
+describe("formatEnrichmentLine", () => {
+  it("formats folders + matched", () => {
+    expect(formatEnrichmentLine({ ...base, sourcesAttempted: 3, sourcesEnriched: 3, matched: 10 }))
+      .toBe("Thunderbird data applied to 3 of 3 folders · 10 messages matched");
+  });
+  it("appends expunged clause only when >0", () => {
+    expect(formatEnrichmentLine({ ...base, sourcesAttempted: 1, sourcesEnriched: 1, matched: 4, expungedDropped: 2 }))
+      .toBe("Thunderbird data applied to 1 of 1 folders · 4 messages matched · 2 expunged dropped");
+  });
+  it("degraded-only: formats honestly without implying enrichment", () => {
+    expect(formatEnrichmentLine({ ...base, sourcesAttempted: 2, sourcesEnriched: 0, sourcesDegraded: 2, matched: 0 }))
+      .toBe("Thunderbird data applied to 0 of 2 folders · 0 messages matched");
+  });
+});

--- a/desktop/src/lib/doneEnrichment.test.ts
+++ b/desktop/src/lib/doneEnrichment.test.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import { describe, it, expect } from "vitest";
 import { shouldShowEnrichment, formatEnrichmentLine } from "./doneEnrichment";
 import type { EnrichmentSummary } from "./types";

--- a/desktop/src/lib/doneEnrichment.ts
+++ b/desktop/src/lib/doneEnrichment.ts
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import type { EnrichmentSummary } from "./types";
+
+/** Show the Done enrichment block only when there is something meaningful to
+ * report — at least one folder was enriched from .msf, or at least one degraded
+ * (could not read its .msf). Hidden for file-mode / no-.msf conversions. */
+export function shouldShowEnrichment(e: EnrichmentSummary | null): boolean {
+  return !!e && (e.sourcesEnriched > 0 || e.sourcesDegraded > 0);
+}
+
+/** Compact one-line summary. Reports enriched/attempted folders + matched
+ * messages honestly (a degraded-only run shows "0 of N folders"); appends the
+ * expunged-dropped clause only when any were dropped. */
+export function formatEnrichmentLine(e: EnrichmentSummary): string {
+  let line =
+    `Thunderbird data applied to ${e.sourcesEnriched} of ${e.sourcesAttempted} folders` +
+    ` · ${e.matched.toLocaleString()} messages matched`;
+  if (e.expungedDropped > 0) line += ` · ${e.expungedDropped.toLocaleString()} expunged dropped`;
+  return line;
+}

--- a/desktop/src/lib/engine.ts
+++ b/desktop/src/lib/engine.ts
@@ -144,3 +144,7 @@ export function cancelConvert(): Promise<void> {
 export function openFolder(path: string): Promise<void> {
   return invoke<void>("open_folder", { path });
 }
+
+export function openJunkHelp(): Promise<void> {
+  return invoke<void>("open_junk_help");
+}

--- a/desktop/src/lib/engine.ts
+++ b/desktop/src/lib/engine.ts
@@ -6,7 +6,8 @@ import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { parseEngineOutput, type VersionResult, type ScanResult } from "./parse";
 import { parseScanLine } from "./scan";
-import type { ConversionConfig, FileStat } from "./types";
+import { parseDiscover } from "./discover";
+import type { ConversionConfig, FileStat, DiscoverResult } from "./types";
 
 export async function checkEngineVersion(): Promise<VersionResult> {
   const stdout = await invoke<string>("check_engine_version");
@@ -20,6 +21,12 @@ export async function scanSample(): Promise<ScanResult> {
   const result = parseEngineOutput(stdout);
   if (result.kind !== "scan") throw new Error("Expected a scan response from the engine");
   return result;
+}
+
+/** Run engine discovery on a Thunderbird profile / mail folder (one-shot). */
+export async function discoverProfile(dir: string): Promise<DiscoverResult> {
+  const stdout = await invoke<string>("discover_profile", { dir });
+  return parseDiscover(stdout);
 }
 
 /** Scan arbitrary user-selected mbox paths. Spawns the sidecar via `start_scan`

--- a/desktop/src/lib/engine.ts
+++ b/desktop/src/lib/engine.ts
@@ -7,6 +7,7 @@ import { open, save } from "@tauri-apps/plugin-dialog";
 import { parseEngineOutput, type VersionResult, type ScanResult } from "./parse";
 import { parseScanLine } from "./scan";
 import { parseDiscover } from "./discover";
+import { parseColourImport, type ColourImportParse } from "./colourImport";
 import type { ConversionConfig, FileStat, DiscoverResult } from "./types";
 
 export async function checkEngineVersion(): Promise<VersionResult> {
@@ -147,4 +148,14 @@ export function openFolder(path: string): Promise<void> {
 
 export function openJunkHelp(): Promise<void> {
   return invoke<void>("open_junk_help");
+}
+
+/** Preview the Thunderbird→Outlook colour import (Outlook-free). */
+export async function previewColours(dir: string): Promise<ColourImportParse> {
+  return parseColourImport(await invoke<string>("preview_colours", { dir }));
+}
+
+/** Apply the colour import to Outlook's master list (Windows + Outlook, Outlook must be closed). */
+export async function applyColours(dir: string): Promise<ColourImportParse> {
+  return parseColourImport(await invoke<string>("apply_colours", { dir }));
 }

--- a/desktop/src/lib/options.test.ts
+++ b/desktop/src/lib/options.test.ts
@@ -258,3 +258,11 @@ describe("validateFolderName parity table (mirror of FolderNameValidatorTests.cs
     expect(validateFolderName(name)).not.toBeNull();
   });
 });
+
+describe("defaultOptions enrichment defaults", () => {
+  it("defaults junkHandling to Off and dropExpunged to false", () => {
+    const o = defaultOptions();
+    expect(o.junkHandling).toBe("Off");
+    expect(o.dropExpunged).toBe(false);
+  });
+});

--- a/desktop/src/lib/options.ts
+++ b/desktop/src/lib/options.ts
@@ -17,6 +17,8 @@ export interface OptionsState {
   allowOversize: boolean;
   renames: Record<string, string>; // sourceId -> folder name (Mirror)
   flattenFolderName: string;
+  junkHandling: "Off" | "Category" | "Folder";
+  dropExpunged: boolean;
 }
 
 /** Fresh default options (factory, so callers never share a mutable object). */
@@ -27,6 +29,8 @@ export function defaultOptions(): OptionsState {
     allowOversize: false,
     renames: {},
     flattenFolderName: FLATTEN_DEFAULT_NAME,
+    junkHandling: "Off",
+    dropExpunged: false,
   };
 }
 

--- a/desktop/src/lib/parse.ts
+++ b/desktop/src/lib/parse.ts
@@ -9,14 +9,14 @@ export type VersionResult = { kind: "version"; version: string; schemaVersion?: 
 export type ScanResult = { kind: "scan"; totals: ScanTotals; sources: SourceRow[]; schemaVersion?: number };
 export type EngineResult = VersionResult | ScanResult;
 
-function isRecord(v: unknown): v is Record<string, unknown> {
+export function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null;
 }
 
 // Extract every top-level {...} JSON object from arbitrary text (tolerates
 // leading/trailing noise, multi-line objects, and multiple objects). Strings are
 // respected so braces inside string values don't confuse the depth counter.
-function extractJsonObjects(text: string): unknown[] {
+export function extractJsonObjects(text: string): unknown[] {
   const objects: unknown[] = [];
   let depth = 0;
   let start = -1;

--- a/desktop/src/lib/profileConfig.test.ts
+++ b/desktop/src/lib/profileConfig.test.ts
@@ -6,6 +6,7 @@ import { mergeProfileSources, buildProfileConfig } from "./profileConfig";
 import type { DiscoveredSource, ProfileSourceRow } from "./types";
 import type { ScanResult } from "./parse";
 import { ConvertConfigError } from "./convert";
+import { defaultOptions } from "./options";
 
 const disc = (path: string, tfp: string[], msf: string | null): DiscoveredSource => ({
   path, type: "mbox", targetFolderPath: tfp, displayName: tfp[tfp.length - 1], sourceBytes: 1, msfPath: msf,
@@ -19,6 +20,8 @@ const scan: ScanResult = {
     { id: "scan-2", path: "C:/p/B", displayName: "B", messages: 3, bytes: 300, sourceBytes: 30, dateFrom: null, dateTo: null, warnings: 0, skipped: 0 },
   ],
 };
+
+const opts = (over: Partial<import("./options").OptionsState> = {}) => ({ ...defaultOptions(), ...over });
 
 describe("mergeProfileSources", () => {
   it("joins by path, sets id=path and displayName=joined targetFolderPath, takes counts from scan", () => {
@@ -54,7 +57,7 @@ describe("buildProfileConfig", () => {
   const checked = new Set(["C:/p/A", "C:/p/B"]);
 
   it("mirror: emits targetFolderPath + msfPath verbatim, profilePath set", () => {
-    const { config } = buildProfileConfig(rows, checked, true, "mirror", 5120, "C:/out/Gmail.pst", "C:/p");
+    const { config } = buildProfileConfig(rows, checked, true, opts({ folderMapping: "mirror", maxSizeMB: 5120 }), "C:/out/Gmail.pst", "C:/p");
     expect(config.profilePath).toBe("C:/p");
     expect(config.outputs[0].folderMapping).toBe("mirror");
     expect(config.outputs[0].maxSizeMB).toBe(5120);
@@ -67,13 +70,13 @@ describe("buildProfileConfig", () => {
       { ...rows[0], id: "C:/x/A/Inbox", path: "C:/x/A/Inbox", targetFolderPath: ["A", "Inbox"], displayName: "A / Inbox" },
       { ...rows[1], id: "C:/x/B/Inbox", path: "C:/x/B/Inbox", targetFolderPath: ["B", "Inbox"], displayName: "B / Inbox", msfPath: null },
     ];
-    const { config } = buildProfileConfig(dupRows, new Set(["C:/x/A/Inbox", "C:/x/B/Inbox"]), true, "mirror", 5120, "C:/out/X.pst", "C:/x");
+    const { config } = buildProfileConfig(dupRows, new Set(["C:/x/A/Inbox", "C:/x/B/Inbox"]), true, opts({ folderMapping: "mirror", maxSizeMB: 5120 }), "C:/out/X.pst", "C:/x");
     expect(config.outputs[0].sources).toHaveLength(2);
     expect(config.outputs[0].sources.map((s) => s.targetFolderPath)).toEqual([["A", "Inbox"], ["B", "Inbox"]]);
   });
 
   it("flatten: folderMapping flatten, no targetFolderPath, no targetFolder, msfPath + profilePath kept", () => {
-    const { config } = buildProfileConfig(rows, checked, true, "flatten", 5120, "C:/out/Gmail.pst", "C:/p");
+    const { config } = buildProfileConfig(rows, checked, true, opts({ folderMapping: "flatten", maxSizeMB: 5120 }), "C:/out/Gmail.pst", "C:/p");
     expect(config.outputs[0].folderMapping).toBe("flatten");
     expect(config.profilePath).toBe("C:/p");
     for (const s of config.outputs[0].sources) {
@@ -85,18 +88,36 @@ describe("buildProfileConfig", () => {
 
   it("honors skipEmpty and checked selection", () => {
     const withEmpty: ProfileSourceRow[] = [...rows, { ...rows[0], id: "C:/p/E", path: "C:/p/E", messages: 0, targetFolderPath: ["E"], displayName: "E", msfPath: null }];
-    const { config } = buildProfileConfig(withEmpty, new Set(["C:/p/A", "C:/p/E"]), true, "mirror", 5120, "C:/out/G.pst", "C:/p");
+    const { config } = buildProfileConfig(withEmpty, new Set(["C:/p/A", "C:/p/E"]), true, opts({ folderMapping: "mirror", maxSizeMB: 5120 }), "C:/out/G.pst", "C:/p");
     // A is checked+non-empty; E is checked but empty (skipped); B not checked.
     expect(config.outputs[0].sources.map((s) => s.path)).toEqual(["C:/p/A"]);
   });
 
   it("throws ConvertConfigError when no folders are effective", () => {
-    expect(() => buildProfileConfig(rows, new Set(), true, "mirror", 5120, "C:/out/G.pst", "C:/p")).toThrow(ConvertConfigError);
+    expect(() => buildProfileConfig(rows, new Set(), true, opts({ folderMapping: "mirror", maxSizeMB: 5120 }), "C:/out/G.pst", "C:/p")).toThrow(ConvertConfigError);
   });
 
   it("derives outputDir + pstName from the .pst path", () => {
-    const { outputDir, pstName } = buildProfileConfig(rows, checked, true, "mirror", 5120, "C:/out/Gmail.pst", "C:/p");
+    const { outputDir, pstName } = buildProfileConfig(rows, checked, true, opts({ folderMapping: "mirror", maxSizeMB: 5120 }), "C:/out/Gmail.pst", "C:/p");
     expect(pstName).toBe("Gmail");
     expect(outputDir).toBe("C:/out");
+  });
+
+  it("writes junkHandling + dropExpunged top-level (defaults Off/false) in mirror", () => {
+    const { config } = buildProfileConfig(rows, checked, true, opts({ folderMapping: "mirror" }), "C:/out/G.pst", "C:/p");
+    expect(config.junkHandling).toBe("Off");
+    expect(config.dropExpunged).toBe(false);
+  });
+
+  it("carries non-default junkHandling + dropExpunged in mirror AND flatten", () => {
+    for (const folderMapping of ["mirror", "flatten"] as const) {
+      const { config } = buildProfileConfig(
+        rows, checked, true, opts({ folderMapping, junkHandling: "Folder", dropExpunged: true }), "C:/out/G.pst", "C:/p",
+      );
+      expect(config.outputs[0].folderMapping).toBe(folderMapping); // folderMapping stays on the output group
+      expect(config).not.toHaveProperty("folderMapping");           // not duplicated at top level
+      expect(config.junkHandling).toBe("Folder");                   // junk/expunged ARE top-level
+      expect(config.dropExpunged).toBe(true);
+    }
   });
 });

--- a/desktop/src/lib/profileConfig.test.ts
+++ b/desktop/src/lib/profileConfig.test.ts
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, it, expect } from "vitest";
+import { mergeProfileSources, buildProfileConfig } from "./profileConfig";
+import type { DiscoveredSource, ProfileSourceRow } from "./types";
+import type { ScanResult } from "./parse";
+
+const disc = (path: string, tfp: string[], msf: string | null): DiscoveredSource => ({
+  path, type: "mbox", targetFolderPath: tfp, displayName: tfp[tfp.length - 1], sourceBytes: 1, msfPath: msf,
+});
+
+const scan: ScanResult = {
+  kind: "scan",
+  totals: { messages: 0, bytes: 0, sourceBytes: 0, sources: 0 },
+  sources: [
+    { id: "scan-1", path: "C:/p/A", displayName: "A", messages: 5, bytes: 500, sourceBytes: 50, dateFrom: null, dateTo: null, warnings: 0, skipped: 0 },
+    { id: "scan-2", path: "C:/p/B", displayName: "B", messages: 3, bytes: 300, sourceBytes: 30, dateFrom: null, dateTo: null, warnings: 0, skipped: 0 },
+  ],
+};
+
+describe("mergeProfileSources", () => {
+  it("joins by path, sets id=path and displayName=joined targetFolderPath, takes counts from scan", () => {
+    const rows = mergeProfileSources(
+      [disc("C:/p/A", ["Account", "Inbox"], "C:/p/A.msf"), disc("C:/p/B", ["Work", "Inbox"], null)],
+      scan,
+    );
+    expect(rows[0].id).toBe("C:/p/A");
+    expect(rows[0].displayName).toBe("Account / Inbox");
+    expect(rows[0].messages).toBe(5);
+    expect(rows[0].msfPath).toBe("C:/p/A.msf");
+    expect(rows[1].msfPath).toBeNull();
+  });
+
+  it("uses zero counts for a discovered source with no scan row", () => {
+    const rows = mergeProfileSources([disc("C:/p/Z", ["Z"], null)], scan);
+    expect(rows[0].messages).toBe(0);
+    expect(rows[0].id).toBe("C:/p/Z");
+  });
+
+  it("ignores scan rows absent from discovery (discovery is the source of truth)", () => {
+    // scan has C:/p/A and C:/p/B; discovery only has A → B must not appear.
+    const rows = mergeProfileSources([disc("C:/p/A", ["Account", "Inbox"], null)], scan);
+    expect(rows.map((r) => r.path)).toEqual(["C:/p/A"]);
+  });
+});
+
+describe("buildProfileConfig", () => {
+  const rows: ProfileSourceRow[] = [
+    { id: "C:/p/A", path: "C:/p/A", displayName: "Account / Inbox", messages: 5, bytes: 500, sourceBytes: 50, dateFrom: null, dateTo: null, warnings: 0, skipped: 0, targetFolderPath: ["Account", "Inbox"], msfPath: "C:/p/A.msf" },
+    { id: "C:/p/B", path: "C:/p/B", displayName: "Work / Inbox", messages: 3, bytes: 300, sourceBytes: 30, dateFrom: null, dateTo: null, warnings: 0, skipped: 0, targetFolderPath: ["Work", "Inbox"], msfPath: null },
+  ];
+  const checked = new Set(["C:/p/A", "C:/p/B"]);
+
+  it("mirror: emits targetFolderPath + msfPath verbatim, profilePath set", () => {
+    const { config } = buildProfileConfig(rows, checked, true, "mirror", 5120, "C:/out/Gmail.pst", "C:/p");
+    expect(config.profilePath).toBe("C:/p");
+    expect(config.outputs[0].folderMapping).toBe("mirror");
+    expect(config.outputs[0].maxSizeMB).toBe(5120);
+    expect(config.outputs[0].sources[0]).toEqual({ path: "C:/p/A", type: "mbox", targetFolderPath: ["Account", "Inbox"], msfPath: "C:/p/A.msf" });
+    expect(config.outputs[0].sources[1]).toEqual({ path: "C:/p/B", type: "mbox", targetFolderPath: ["Work", "Inbox"] }); // unpaired → no msfPath
+  });
+
+  it("mirror: allows duplicate leaf names under different parents (no error)", () => {
+    const dupRows: ProfileSourceRow[] = [
+      { ...rows[0], id: "C:/x/A/Inbox", path: "C:/x/A/Inbox", targetFolderPath: ["A", "Inbox"], displayName: "A / Inbox" },
+      { ...rows[1], id: "C:/x/B/Inbox", path: "C:/x/B/Inbox", targetFolderPath: ["B", "Inbox"], displayName: "B / Inbox", msfPath: null },
+    ];
+    const { config } = buildProfileConfig(dupRows, new Set(["C:/x/A/Inbox", "C:/x/B/Inbox"]), true, "mirror", 5120, "C:/out/X.pst", "C:/x");
+    expect(config.outputs[0].sources).toHaveLength(2);
+    expect(config.outputs[0].sources.map((s) => s.targetFolderPath)).toEqual([["A", "Inbox"], ["B", "Inbox"]]);
+  });
+
+  it("flatten: folderMapping flatten, no targetFolderPath, no targetFolder, msfPath + profilePath kept", () => {
+    const { config } = buildProfileConfig(rows, checked, true, "flatten", 5120, "C:/out/Gmail.pst", "C:/p");
+    expect(config.outputs[0].folderMapping).toBe("flatten");
+    expect(config.profilePath).toBe("C:/p");
+    for (const s of config.outputs[0].sources) {
+      expect(s.targetFolderPath).toBeUndefined();
+      expect(s.targetFolder).toBeUndefined();
+    }
+    expect(config.outputs[0].sources[0].msfPath).toBe("C:/p/A.msf");
+  });
+
+  it("honors skipEmpty and checked selection", () => {
+    const withEmpty: ProfileSourceRow[] = [...rows, { ...rows[0], id: "C:/p/E", path: "C:/p/E", messages: 0, targetFolderPath: ["E"], displayName: "E", msfPath: null }];
+    const { config } = buildProfileConfig(withEmpty, new Set(["C:/p/A", "C:/p/E"]), true, "mirror", 5120, "C:/out/G.pst", "C:/p");
+    // A is checked+non-empty; E is checked but empty (skipped); B not checked.
+    expect(config.outputs[0].sources.map((s) => s.path)).toEqual(["C:/p/A"]);
+  });
+
+  it("throws ConvertConfigError when no folders are effective", () => {
+    expect(() => buildProfileConfig(rows, new Set(), true, "mirror", 5120, "C:/out/G.pst", "C:/p")).toThrow();
+  });
+
+  it("derives outputDir + pstName from the .pst path", () => {
+    const { outputDir, pstName } = buildProfileConfig(rows, checked, true, "mirror", 5120, "C:/out/Gmail.pst", "C:/p");
+    expect(pstName).toBe("Gmail");
+    expect(outputDir).toBe("C:/out");
+  });
+});

--- a/desktop/src/lib/profileConfig.test.ts
+++ b/desktop/src/lib/profileConfig.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect } from "vitest";
 import { mergeProfileSources, buildProfileConfig } from "./profileConfig";
 import type { DiscoveredSource, ProfileSourceRow } from "./types";
 import type { ScanResult } from "./parse";
+import { ConvertConfigError } from "./convert";
 
 const disc = (path: string, tfp: string[], msf: string | null): DiscoveredSource => ({
   path, type: "mbox", targetFolderPath: tfp, displayName: tfp[tfp.length - 1], sourceBytes: 1, msfPath: msf,
@@ -90,7 +91,7 @@ describe("buildProfileConfig", () => {
   });
 
   it("throws ConvertConfigError when no folders are effective", () => {
-    expect(() => buildProfileConfig(rows, new Set(), true, "mirror", 5120, "C:/out/G.pst", "C:/p")).toThrow();
+    expect(() => buildProfileConfig(rows, new Set(), true, "mirror", 5120, "C:/out/G.pst", "C:/p")).toThrow(ConvertConfigError);
   });
 
   it("derives outputDir + pstName from the .pst path", () => {

--- a/desktop/src/lib/profileConfig.ts
+++ b/desktop/src/lib/profileConfig.ts
@@ -3,6 +3,7 @@
 
 import type { DiscoveredSource, ProfileSourceRow, ConversionConfig, SourceConfigEntry } from "./types";
 import type { ScanResult } from "./parse";
+import type { OptionsState } from "./options";
 import { effectiveRows } from "./review";
 import { deriveOutputTarget, ConvertConfigError } from "./convert";
 
@@ -35,17 +36,18 @@ export function mergeProfileSources(
  * targetFolderPath + msfPath verbatim (NO leaf-name dedupe — same leaf under
  * different parents is valid). Flatten omits targetFolderPath and sets
  * folderMapping:"flatten" so the engine routes to "Imported Mail"; msfPath and
- * top-level profilePath are kept in both modes so enrichment + tag names apply. */
+ * top-level profilePath are kept in both modes so enrichment + tag names apply.
+ * junkHandling + dropExpunged are always written at the top-level config. */
 export function buildProfileConfig(
   rows: ProfileSourceRow[],
   checkedIds: Set<string>,
   skipEmpty: boolean,
-  folderMapping: "mirror" | "flatten",
-  maxSizeMB: number,
+  options: OptionsState,
   outputPstPath: string,
   profileRoot: string,
 ): { config: ConversionConfig; outputDir: string; pstName: string } {
   const { outputDir, pstName } = deriveOutputTarget(outputPstPath);
+  const folderMapping = options.folderMapping;
   const eff = effectiveRows(rows, checkedIds, skipEmpty) as ProfileSourceRow[];
   if (eff.length === 0) {
     throw new ConvertConfigError("Select at least one folder to convert.");
@@ -63,9 +65,11 @@ export function buildProfileConfig(
     pstName,
     config: {
       profilePath: profileRoot,
+      junkHandling: options.junkHandling,
+      dropExpunged: options.dropExpunged,
       outputs: [{
         name: pstName,
-        maxSizeMB,
+        maxSizeMB: options.maxSizeMB,
         folderMapping,
         includeEmptyFolders: !skipEmpty,
         sources,

--- a/desktop/src/lib/profileConfig.ts
+++ b/desktop/src/lib/profileConfig.ts
@@ -54,7 +54,7 @@ export function buildProfileConfig(
   const sources: SourceConfigEntry[] = eff.map((r) => {
     const entry: SourceConfigEntry = { path: r.path, type: "mbox" };
     if (folderMapping === "mirror") entry.targetFolderPath = r.targetFolderPath;
-    if (r.msfPath) entry.msfPath = r.msfPath;
+    if (r.msfPath != null) entry.msfPath = r.msfPath;
     return entry;
   });
 

--- a/desktop/src/lib/profileConfig.ts
+++ b/desktop/src/lib/profileConfig.ts
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import type { DiscoveredSource, ProfileSourceRow, ConversionConfig, SourceConfigEntry } from "./types";
+import type { ScanResult } from "./parse";
+import { effectiveRows } from "./review";
+import { deriveOutputTarget, ConvertConfigError } from "./convert";
+
+/** Merge discovery sources with scan counts. Identity = discovered `path`; the
+ * scan row's id is ignored (it is scan-local). displayName = joined nested path. */
+export function mergeProfileSources(
+  discovered: DiscoveredSource[], scan: ScanResult,
+): ProfileSourceRow[] {
+  const byPath = new Map(scan.sources.map((s) => [s.path, s]));
+  return discovered.map((d) => {
+    const s = byPath.get(d.path);
+    return {
+      id: d.path,
+      path: d.path,
+      displayName: d.targetFolderPath.join(" / "),
+      messages: s?.messages ?? 0,
+      bytes: s?.bytes ?? 0,
+      sourceBytes: s?.sourceBytes ?? d.sourceBytes,
+      dateFrom: s?.dateFrom ?? null,
+      dateTo: s?.dateTo ?? null,
+      warnings: s?.warnings ?? 0,
+      skipped: s?.skipped ?? 0,
+      targetFolderPath: d.targetFolderPath,
+      msfPath: d.msfPath,
+    };
+  });
+}
+
+/** Build a full profile-mode ConversionConfig. Mirror emits each source's
+ * targetFolderPath + msfPath verbatim (NO leaf-name dedupe — same leaf under
+ * different parents is valid). Flatten omits targetFolderPath and sets
+ * folderMapping:"flatten" so the engine routes to "Imported Mail"; msfPath and
+ * top-level profilePath are kept in both modes so enrichment + tag names apply. */
+export function buildProfileConfig(
+  rows: ProfileSourceRow[],
+  checkedIds: Set<string>,
+  skipEmpty: boolean,
+  folderMapping: "mirror" | "flatten",
+  maxSizeMB: number,
+  outputPstPath: string,
+  profileRoot: string,
+): { config: ConversionConfig; outputDir: string; pstName: string } {
+  const { outputDir, pstName } = deriveOutputTarget(outputPstPath);
+  const eff = effectiveRows(rows, checkedIds, skipEmpty) as ProfileSourceRow[];
+  if (eff.length === 0) {
+    throw new ConvertConfigError("Select at least one folder to convert.");
+  }
+
+  const sources: SourceConfigEntry[] = eff.map((r) => {
+    const entry: SourceConfigEntry = { path: r.path, type: "mbox" };
+    if (folderMapping === "mirror") entry.targetFolderPath = r.targetFolderPath;
+    if (r.msfPath) entry.msfPath = r.msfPath;
+    return entry;
+  });
+
+  return {
+    outputDir,
+    pstName,
+    config: {
+      profilePath: profileRoot,
+      outputs: [{
+        name: pstName,
+        maxSizeMB,
+        folderMapping,
+        includeEmptyFolders: !skipEmpty,
+        sources,
+      }],
+    },
+  };
+}

--- a/desktop/src/lib/types.ts
+++ b/desktop/src/lib/types.ts
@@ -25,6 +25,8 @@ export interface SourceConfigEntry {
   path: string;
   type: "mbox";
   targetFolder?: string;
+  targetFolderPath?: string[];
+  msfPath?: string;
 }
 
 export interface OutputGroupConfig {
@@ -37,6 +39,7 @@ export interface OutputGroupConfig {
 
 export interface ConversionConfig {
   outputs: OutputGroupConfig[];
+  profilePath?: string;
 }
 
 export interface FileStat {
@@ -81,3 +84,51 @@ export type ConvertEvent = (
       elapsedMs?: number;
     }
 ) & Versioned;
+
+export interface DiscoveredSource {
+  path: string;
+  type: string;
+  targetFolderPath: string[];
+  displayName: string;
+  sourceBytes: number;
+  msfPath: string | null;
+}
+
+export interface DiscoverWarning {
+  code: string;
+  path: string;
+  targetFolderPath: string[] | null;
+  segment: string | null;
+  segmentIndex: number | null;
+  relatedPaths: string[] | null;
+  message: string;
+}
+
+export interface DiscoverSkipped {
+  code: string;
+  path: string;
+  reason: string;
+}
+
+export interface DiscoverPairing {
+  pairedMsfCount: number;
+  unpairedMboxCount: number;
+  orphanMsfCount: number;
+}
+
+export interface DiscoverResult {
+  root: string;
+  layout: string;
+  sources: DiscoveredSource[];
+  warnings: DiscoverWarning[];
+  skipped: DiscoverSkipped[];
+  pairing: DiscoverPairing;
+  schemaVersion?: number;
+}
+
+/** A discovery source merged with its scan counts. `id` is the source `path`
+ * (profile-mode identity); `displayName` is the joined nested target path. */
+export interface ProfileSourceRow extends SourceRow {
+  targetFolderPath: string[];
+  msfPath: string | null;
+}

--- a/desktop/src/lib/types.ts
+++ b/desktop/src/lib/types.ts
@@ -40,11 +40,25 @@ export interface OutputGroupConfig {
 export interface ConversionConfig {
   outputs: OutputGroupConfig[];
   profilePath?: string;
+  junkHandling?: "Off" | "Category" | "Folder";
+  dropExpunged?: boolean;
 }
 
 export interface FileStat {
   path: string;
   size: number;
+}
+
+export interface EnrichmentSummary {
+  matched: number;
+  skippedMissingId: number;
+  skippedDuplicateId: number;
+  noMsfMatch: number;
+  expungedMatched: number;
+  expungedDropped: number;
+  sourcesAttempted: number;
+  sourcesEnriched: number;
+  sourcesDegraded: number;
 }
 
 export type Versioned = { schemaVersion?: number };
@@ -72,6 +86,7 @@ export type ConvertEvent = (
       outputDirectory?: string;
       report?: string;
       elapsedMs: number;
+      enrichment?: EnrichmentSummary;
     }
   | { type: "error"; stage?: string; message: string; fatal: boolean }
   | {

--- a/desktop/src/lib/types.ts
+++ b/desktop/src/lib/types.ts
@@ -147,3 +147,10 @@ export interface ProfileSourceRow extends SourceRow {
   targetFolderPath: string[];
   msfPath: string | null;
 }
+
+export interface ColourCategory {
+  name: string;
+  hex: string | null;
+  outlookColor: number | null;
+  action: string;
+}

--- a/desktop/src/lib/useConvert.test.ts
+++ b/desktop/src/lib/useConvert.test.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, it, expect } from "vitest";
+import { reduceConvert, initialConvertState } from "./useConvert";
+import type { ConvertEvent, EnrichmentSummary } from "./types";
+
+const enr: EnrichmentSummary = {
+  matched: 10, skippedMissingId: 0, skippedDuplicateId: 0, noMsfMatch: 0,
+  expungedMatched: 2, expungedDropped: 2, sourcesAttempted: 3, sourcesEnriched: 3, sourcesDegraded: 0,
+};
+
+const running = { ...initialConvertState, phase: "running" as const };
+
+describe("reduceConvert enrichment capture", () => {
+  it("stores enrichment from a done event", () => {
+    const done: ConvertEvent = { type: "done", converted: 10, skipped: 0, warnings: 0, outputs: ["x.pst"], elapsedMs: 5, enrichment: enr };
+    expect(reduceConvert(running, done).enrichment).toEqual(enr);
+  });
+
+  it("defaults enrichment to null when the done event omits it", () => {
+    const done: ConvertEvent = { type: "done", converted: 1, skipped: 0, warnings: 0, outputs: [], elapsedMs: 1 };
+    expect(reduceConvert(running, done).enrichment).toBeNull();
+  });
+
+  it("initial state has null enrichment", () => {
+    expect(initialConvertState.enrichment).toBeNull();
+  });
+});

--- a/desktop/src/lib/useConvert.ts
+++ b/desktop/src/lib/useConvert.ts
@@ -6,7 +6,7 @@ import { listen } from "@tauri-apps/api/event";
 import { parseConvertLine, appendWarningCapped, convertExitError, type WarningItem } from "./convert";
 import { startConvert } from "./engine";
 import { checkSchemaVersion } from "./schema";
-import type { ConversionConfig, ConvertEvent } from "./types";
+import type { ConversionConfig, ConvertEvent, EnrichmentSummary } from "./types";
 
 export type ConvertPhase = "idle" | "running" | "done" | "error" | "cancelled";
 
@@ -25,9 +25,10 @@ export interface ConvertState {
   outputDir: string;
   errorMessage: string | null;
   elapsedMs: number | null;
+  enrichment: EnrichmentSummary | null;
 }
 
-const initial: ConvertState = {
+export const initialConvertState: ConvertState = {
   phase: "idle",
   total: 0,
   converted: 0,
@@ -42,9 +43,10 @@ const initial: ConvertState = {
   outputDir: "",
   errorMessage: null,
   elapsedMs: null,
+  enrichment: null,
 };
 
-function reduce(state: ConvertState, ev: ConvertEvent): ConvertState {
+export function reduceConvert(state: ConvertState, ev: ConvertEvent): ConvertState {
   // Only process events during an active run. This blocks both already-terminal
   // states AND a stray late event arriving after `reset()` (idle) — which would
   // otherwise wrongly flip idle → running.
@@ -87,6 +89,7 @@ function reduce(state: ConvertState, ev: ConvertEvent): ConvertState {
         warnings: ev.warnings,
         outputs: ev.outputs,
         elapsedMs: ev.elapsedMs,
+        enrichment: ev.enrichment ?? null,
       };
     case "error":
       return { ...state, phase: "error", errorMessage: ev.message };
@@ -106,7 +109,7 @@ function reduce(state: ConvertState, ev: ConvertEvent): ConvertState {
 }
 
 export function useConvert() {
-  const [state, setState] = useState<ConvertState>(initial);
+  const [state, setState] = useState<ConvertState>(initialConvertState);
   const phaseRef = useRef<ConvertPhase>("idle");
   phaseRef.current = state.phase;
   const schemaWarnedRef = useRef(false);
@@ -120,7 +123,7 @@ export function useConvert() {
         const msg = checkSchemaVersion(ev.schemaVersion);
         if (msg) console.warn(`[mail2pst] ${msg}`);
       }
-      setState((s) => reduce(s, ev));
+      setState((s) => reduceConvert(s, ev));
     });
     const unlistenExit = listen<number | null>("convert://exit", async (e) => {
       // Let a convert://line handler already queued ahead of this exit run first
@@ -141,7 +144,7 @@ export function useConvert() {
 
   const start = useCallback(async (config: ConversionConfig, outputDir: string) => {
     schemaWarnedRef.current = false;
-    setState({ ...initial, phase: "running", outputDir, startedAtMs: Date.now() });
+    setState({ ...initialConvertState, phase: "running", outputDir, startedAtMs: Date.now() });
     try {
       await startConvert(config, outputDir);
     } catch (err) {
@@ -150,7 +153,7 @@ export function useConvert() {
     }
   }, []);
 
-  const reset = useCallback(() => setState(initial), []);
+  const reset = useCallback(() => setState(initialConvertState), []);
 
   return { state, start, reset };
 }

--- a/desktop/src/lib/useScan.ts
+++ b/desktop/src/lib/useScan.ts
@@ -7,7 +7,7 @@ import { mergeProfileSources } from "./profileConfig";
 import { checkSchemaVersion } from "./schema";
 import { defaultOptions, type OptionsState, FLATTEN_SOURCE_ID } from "./options";
 import { sortSources, type SortField, type SortDir } from "./review";
-import type { FileStat, SourceRow, ProfileSourceRow, DiscoverWarning } from "./types";
+import type { FileStat, SourceRow, ProfileSourceRow, DiscoverWarning, DiscoverResult } from "./types";
 import type { ScanResult } from "./parse";
 
 export type FlowStage = "select" | "scanning" | "review" | "options" | "scanError";
@@ -83,7 +83,7 @@ export function useScan() {
 
       // Discovery failure / empty discovery is a SOURCE-selection problem → return to Source with
       // sourceError. Only a scan failure AFTER successful discovery goes to the ScanError view.
-      let disc;
+      let disc: DiscoverResult;
       try {
         disc = await discoverProfile(state.profileRoot);
       } catch (e) {

--- a/desktop/src/lib/useScan.ts
+++ b/desktop/src/lib/useScan.ts
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { useCallback, useMemo, useState } from "react";
-import { scan as runScan } from "./engine";
+import { scan as runScan, discoverProfile } from "./engine";
+import { mergeProfileSources } from "./profileConfig";
 import { checkSchemaVersion } from "./schema";
 import { defaultOptions, type OptionsState, FLATTEN_SOURCE_ID } from "./options";
 import { sortSources, type SortField, type SortDir } from "./review";
-import type { FileStat, SourceRow } from "./types";
+import type { FileStat, SourceRow, ProfileSourceRow, DiscoverWarning } from "./types";
 import type { ScanResult } from "./parse";
 
 export type FlowStage = "select" | "scanning" | "review" | "options" | "scanError";
@@ -23,6 +24,11 @@ export interface PreConvertState {
   scanProgress: { bytes: number; totalBytes: number } | null;
   sortBy: SortField;
   sortDir: SortDir;
+  inputMode: "files" | "profile";
+  profileRoot: string | null;
+  profileRows: ProfileSourceRow[];
+  discoverWarnings: DiscoverWarning[];
+  sourceError: string | null; // parent-owned discover-time error, shown on the Source screen
 }
 
 function initialState(): PreConvertState {
@@ -38,6 +44,11 @@ function initialState(): PreConvertState {
     scanProgress: null,
     sortBy: "default",
     sortDir: "desc",
+    inputMode: "files",
+    profileRoot: null,
+    profileRows: [],
+    discoverWarnings: [],
+    sourceError: null,
   };
 }
 
@@ -53,13 +64,73 @@ export function useScan() {
     [],
   );
 
+  const setInputMode = useCallback(
+    (inputMode: "files" | "profile") => setState((s) => ({ ...s, inputMode, sourceError: null })),
+    [],
+  );
+  const setProfileRoot = useCallback(
+    (profileRoot: string | null) => setState((s) => ({ ...s, profileRoot, sourceError: null })),
+    [],
+  );
+
   const continueToScan = useCallback(async () => {
+    if (state.inputMode === "profile") {
+      if (!state.profileRoot) {
+        setState((s) => ({ ...s, sourceError: "Choose a Thunderbird profile or mail folder." }));
+        return;
+      }
+      setState((s) => ({ ...s, stage: "scanning", sourceError: null, errorMessage: null, scanProgress: null }));
+
+      // Discovery failure / empty discovery is a SOURCE-selection problem → return to Source with
+      // sourceError. Only a scan failure AFTER successful discovery goes to the ScanError view.
+      let disc;
+      try {
+        disc = await discoverProfile(state.profileRoot);
+      } catch (e) {
+        const sourceError = e instanceof Error ? e.message : String(e);
+        setState((s) => ({ ...s, stage: "select", sourceError, scanProgress: null }));
+        return;
+      }
+      if (disc.sources.length === 0) {
+        setState((s) => ({ ...s, stage: "select", sourceError: "No mail folders found in that location.", scanProgress: null }));
+        return;
+      }
+
+      try {
+        const paths = disc.sources.map((d) => d.path);
+        const result = await runScan(paths, (p) =>
+          setState((s) => (s.stage === "scanning" ? { ...s, scanProgress: p } : s)),
+        );
+        const schemaMsg = checkSchemaVersion(result.schemaVersion);
+        if (schemaMsg) console.warn(`[mail2pst] ${schemaMsg}`);
+        const profileRows = mergeProfileSources(disc.sources, result);
+        setState((s) => ({
+          ...s,
+          stage: "review",
+          scan: result,
+          profileRows,
+          discoverWarnings: disc.warnings,
+          checkedIds: new Set(profileRows.map((r) => r.id)),
+          skipEmpty: true,
+          options: defaultOptions(),
+          scanProgress: null,
+          sortBy: "default",
+          sortDir: "desc",
+        }));
+      } catch (e) {
+        const errorMessage = e instanceof Error ? e.message : String(e);
+        setState((s) => ({ ...s, stage: "scanError", errorMessage, scanProgress: null }));
+      }
+      return;
+    }
+
+    // --- file mode (unchanged) ---
     const paths = state.inputFiles.map((f) => f.path);
     if (paths.length === 0) {
       setState((s) => ({ ...s, errorMessage: "Select at least one .mbox file." }));
       return;
     }
-    setState((s) => ({ ...s, stage: "scanning", errorMessage: null, scanProgress: null }));
+    setState((s) => ({ ...s, stage: "scanning", sourceError: null, errorMessage: null, scanProgress: null }));
     try {
       // Guard the progress update on stage so a late/queued event after the scan
       // resolves can't leak a bar into Review or ScanError.
@@ -73,6 +144,8 @@ export function useScan() {
         ...s,
         stage: "review",
         scan: result,
+        profileRows: [],
+        discoverWarnings: [],
         checkedIds: new Set(result.sources.map((x) => x.id)),
         skipEmpty: true,
         options: defaultOptions(),
@@ -84,7 +157,7 @@ export function useScan() {
       const errorMessage = e instanceof Error ? e.message : String(e);
       setState((s) => ({ ...s, stage: "scanError", errorMessage, scanProgress: null }));
     }
-  }, [state.inputFiles]);
+  }, [state.inputMode, state.profileRoot, state.inputFiles]);
 
   const toggleChecked = useCallback((id: string) => {
     setState((s) => {
@@ -125,25 +198,33 @@ export function useScan() {
   const backToReview = useCallback(() => setState((s) => ({ ...s, stage: "review" })), []);
 
   const back = useCallback(
-    () => setState((s) => ({ ...s, stage: "select", scan: null, errorMessage: null, scanProgress: null })),
+    () => setState((s) => ({ ...s, stage: "select", scan: null, profileRows: [], discoverWarnings: [], errorMessage: null, sourceError: null, scanProgress: null })),
     [],
   );
   const resetFlow = useCallback(() => setState(initialState()), []);
 
-  const sortedSources: SourceRow[] = useMemo(
-    () => (state.scan ? sortSources(state.scan.sources, state.sortBy, state.sortDir) : []),
-    [state.scan, state.sortBy, state.sortDir],
+  const sortedSources: SourceRow[] = useMemo(() => {
+    if (state.inputMode === "profile") return sortSources(state.profileRows, state.sortBy, state.sortDir);
+    return state.scan ? sortSources(state.scan.sources, state.sortBy, state.sortDir) : [];
+  }, [state.inputMode, state.profileRows, state.scan, state.sortBy, state.sortDir]);
+
+  const pairedIds: Set<string> = useMemo(
+    () => new Set(state.profileRows.filter((r) => r.msfPath).map((r) => r.id)),
+    [state.profileRows],
   );
 
   return {
     state,
     setInputFiles,
     setOutputPath,
+    setInputMode,
+    setProfileRoot,
     continueToScan,
     toggleChecked,
     setSkipEmpty,
     setSort,
     sortedSources,
+    pairedIds,
     setOptions,
     setRename,
     continueToOptions,

--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -19,6 +19,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": { "@/*": ["./src/*"] }
   },


### PR DESCRIPTION
Brings the desktop GUI to near-parity with the CLI for the Thunderbird → PST → Outlook flow, in three layers (18 commits). No engine/CLI behavior change — all GUI wiring on top of existing capabilities, plus small Tauri commands.

## A — Profile mode (discovery + nested folders + auto enrichment)
- New "Thunderbird profile" input mode alongside the `.mbox` file picker (segmented toggle on Source).
- New `discover_profile` Tauri command runs the engine's `discover`; the GUI parses it, scans the discovered paths, and merges by path.
- Review shows the nested folder tree with per-folder counts, an `.msf`-pairing badge, and discovery warnings.
- Mirror-the-tree or flatten; builds a profile config carrying `profilePath` + per-source `targetFolderPath` + `msfPath`, so the engine auto-applies read/flag state + tags→categories.

## B — Enrichment options + Done summary
- Junk handling (Off/Category/Folder, opt-in, default Off) with a junk-score help tip + Mozilla link; skip-expunged toggle.
- `buildProfileConfig` writes top-level `junkHandling`/`dropExpunged`.
- Done screen shows an enrichment summary (folders enriched/matched/expunged-dropped) when non-trivial, with a degraded-`.msf` warning.

## C — Outlook colour import (optional, post-convert)
- Optional Done-screen card (profile mode) that wraps `import-colours`: an Outlook-free preview (colour swatches + actions) and a consent-gated Import that writes Thunderbird tag colours into Outlook's master category list.
- Two narrow Tauri commands (`preview_colours`, `apply_colours`) via a capture helper that returns the CLI's structured JSON even on handled nonzero exits; Import gated by consent + Outlook-available + something-to-add; Outlook-closed/retry handling.

## Testing
- Full Vitest suite green (147 tests; new pure parsers/helpers + flow logic covered), `npm run build` (tsc + vite) clean. Each sub-project had per-task + Opus whole-branch reviews.

## Known follow-ups (not blocking)
- The paired `.msf` badge reads as warning-coloured (terracotta); will be restyled to a clearer positive treatment.
- The colour-import preview re-spawns the CLI (cold-start latency); planned to fold the preview into the convert `done` event so it's instant.
- Interactive GUI e2e (real profile + Outlook) still to be done manually.