### PR TITLE
feat(gui): v0.2.0 GUI polish & Thunderbird profile onboarding

### DIFF
--- a/.githooks/leak-check-allowlist.txt
+++ b/.githooks/leak-check-allowlist.txt
@@ -11,6 +11,10 @@
 @x.com
 @b.com
 
+# Synthetic addresses used in profile_scan_tests fixtures (Rust unit tests — no real PII).
+alice@gmail.com
+bob@work.com
+
 # Legitimate third-party references that may appear in tracked files
 noreply@github.com
 

--- a/.githooks/leak-check-allowlist.txt
+++ b/.githooks/leak-check-allowlist.txt
@@ -5,15 +5,12 @@
 @example.com
 @example.net
 @example.org
+@example.test
 
 # Synthetic placeholder domains used throughout the unit-test suite (not real recipients).
 # (Migrating these tests to @example.* would let us drop these two — minor future cleanup.)
 @x.com
 @b.com
-
-# Synthetic addresses used in profile_scan_tests fixtures (Rust unit tests — no real PII).
-alice@gmail.com
-bob@work.com
 
 # Legitimate third-party references that may appear in tracked files
 noreply@github.com

--- a/.githooks/leak-check-allowlist.txt
+++ b/.githooks/leak-check-allowlist.txt
@@ -11,7 +11,6 @@
 # (Migrating these tests to @example.* would let us drop these two — minor future cleanup.)
 @x.com
 @b.com
-@y.com
 
 # Legitimate third-party references that may appear in tracked files
 noreply@github.com

--- a/.githooks/leak-check-allowlist.txt
+++ b/.githooks/leak-check-allowlist.txt
@@ -11,6 +11,7 @@
 # (Migrating these tests to @example.* would let us drop these two — minor future cleanup.)
 @x.com
 @b.com
+@y.com
 
 # Legitimate third-party references that may appear in tracked files
 noreply@github.com

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -117,6 +117,29 @@ async fn apply_colours(app: tauri::AppHandle, dir: String) -> Result<String, Str
     .await
 }
 
+/// Writes the supplied colour plan to a temp file and runs `import-colours --apply --plan-file`,
+/// then removes the temp file (mirrors start_convert's temp-config cleanup).
+#[tauri::command]
+async fn apply_colours_plan(app: AppHandle, plan: serde_json::Value) -> Result<String, String> {
+    let unique = format!(
+        "{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    );
+    let plan_path = std::env::temp_dir().join(format!("continumail-colourplan-{unique}.json"));
+    std::fs::write(&plan_path, serde_json::to_string(&plan).map_err(|e| e.to_string())?)
+        .map_err(|e| format!("cannot write plan: {e}"))?;
+    let path_str = plan_path.to_string_lossy().to_string();
+    let result = run_sidecar_capture(&app, vec![
+        "import-colours".into(), "--plan-file".into(), path_str, "--apply".into(),
+    ]).await;
+    let _ = std::fs::remove_file(&plan_path); // best-effort cleanup
+    result
+}
+
 #[derive(Serialize)]
 struct FileStat {
     path: String,
@@ -471,6 +494,7 @@ pub fn run() {
             open_junk_help,
             preview_colours,
             apply_colours,
+            apply_colours_plan,
             default_thunderbird_profiles_dir,
             list_thunderbird_profiles
         ])

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -357,6 +357,88 @@ fn open_junk_help(app: AppHandle) -> Result<(), String> {
         .map_err(|e| format!("could not open link: {e}"))
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ProfileEntry {
+    name: String,
+    path: String,
+    is_default: bool,
+}
+
+/// Parse profiles.ini. `tb_root` = the Thunderbird dir (parent of Profiles/). Pure + testable.
+fn parse_profiles_ini(content: &str, tb_root: &std::path::Path) -> Vec<ProfileEntry> {
+    let mut defaults: Vec<String> = Vec::new();
+    let mut profiles: Vec<(String, String, bool, Option<String>)> = Vec::new();
+    let mut sec = String::new();
+    let (mut name, mut path, mut is_rel, mut sec_default) =
+        (None::<String>, None::<String>, true, None::<String>);
+
+    for line in content.lines() {
+        let l = line.trim();
+        if l.starts_with('[') && l.ends_with(']') {
+            if sec.starts_with("Profile") {
+                if let (Some(n), Some(p)) = (name.take(), path.take()) {
+                    profiles.push((n, p, is_rel, sec_default.take()));
+                }
+            }
+            sec = l[1..l.len() - 1].to_string();
+            name = None;
+            path = None;
+            is_rel = true;
+            sec_default = None;
+            continue;
+        }
+        let Some((k, v)) = l.split_once('=') else {
+            continue;
+        };
+        let (k, v) = (k.trim(), v.trim());
+        if sec.starts_with("Install") && k == "Default" {
+            defaults.push(v.replace('\\', "/"));
+        } else if sec.starts_with("Profile") {
+            match k {
+                "Name" => name = Some(v.to_string()),
+                "Path" => path = Some(v.to_string()),
+                "IsRelative" => is_rel = v == "1",
+                "Default" if v == "1" => sec_default = Some("1".into()),
+                _ => {}
+            }
+        }
+    }
+    if sec.starts_with("Profile") {
+        if let (Some(n), Some(p)) = (name.take(), path.take()) {
+            profiles.push((n, p, is_rel, sec_default.take()));
+        }
+    }
+
+    profiles
+        .into_iter()
+        .map(|(name, raw, is_rel, sd)| {
+            let abs = if is_rel {
+                tb_root.join(&raw).to_string_lossy().to_string()
+            } else {
+                raw.clone()
+            };
+            let norm = raw.replace('\\', "/");
+            let is_default = sd.is_some() || defaults.iter().any(|d| d.as_str() == norm);
+            ProfileEntry { name, path: abs, is_default }
+        })
+        .collect()
+}
+
+#[tauri::command]
+fn list_thunderbird_profiles() -> Result<Vec<ProfileEntry>, String> {
+    let appdata = match std::env::var_os("APPDATA") {
+        Some(v) => std::path::PathBuf::from(v),
+        None => return Ok(vec![]),
+    };
+    let tb = appdata.join("Thunderbird");
+    let ini = tb.join("profiles.ini");
+    match std::fs::read_to_string(&ini) {
+        Ok(content) => Ok(parse_profiles_ini(&content, &tb)),
+        Err(_) => Ok(vec![]),
+    }
+}
+
 /// Returns %APPDATA%\Thunderbird\Profiles when it exists, else None. Windows-only app.
 #[tauri::command]
 fn default_thunderbird_profiles_dir() -> Result<Option<String>, String> {
@@ -389,10 +471,46 @@ pub fn run() {
             open_junk_help,
             preview_colours,
             apply_colours,
-            default_thunderbird_profiles_dir
+            default_thunderbird_profiles_dir,
+            list_thunderbird_profiles
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod profiles_ini_tests {
+    use super::*;
+    use std::path::Path;
+
+    const INI: &str = "\
+[Install4F96D1932A9F858E]\n\
+Default=Profiles/abc.default-release\n\
+\n\
+[Profile0]\n\
+Name=default-release\n\
+IsRelative=1\n\
+Path=Profiles/abc.default-release\n\
+\n\
+[Profile1]\n\
+Name=dev\n\
+IsRelative=1\n\
+Path=Profiles/xyz.dev\n";
+
+    #[test]
+    fn parses_profiles_and_marks_default() {
+        let out = parse_profiles_ini(INI, Path::new("C:/TB"));
+        assert_eq!(out.len(), 2);
+        let def = out.iter().find(|p| p.is_default).unwrap();
+        assert_eq!(def.name, "default-release");
+        assert!(def.path.ends_with("Profiles/abc.default-release") || def.path.ends_with("Profiles\\abc.default-release"));
+        assert!(!out.iter().find(|p| p.name == "dev").unwrap().is_default);
+    }
+
+    #[test]
+    fn empty_content_yields_empty() {
+        assert!(parse_profiles_ini("", Path::new("C:/x")).is_empty());
+    }
 }
 
 #[cfg(test)]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -386,6 +386,8 @@ struct ProfileEntry {
     name: String,
     path: String,
     is_default: bool,
+    accounts: Vec<String>,
+    convertible: bool,
 }
 
 /// Parse profiles.ini. `tb_root` = the Thunderbird dir (parent of Profiles/). Pure + testable.
@@ -443,9 +445,89 @@ fn parse_profiles_ini(content: &str, tb_root: &std::path::Path) -> Vec<ProfileEn
             };
             let norm = raw.replace('\\', "/");
             let is_default = sd.is_some() || defaults.iter().any(|d| d.as_str() == norm);
-            ProfileEntry { name, path: abs, is_default }
+            ProfileEntry { name, path: abs, is_default, accounts: Vec::new(), convertible: false }
         })
         .collect()
+}
+
+/// Parse mail.identity.*.useremail values from prefs.js. Pure. Case-insensitive dedupe, keep first.
+fn parse_identity_emails(prefs: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for line in prefs.lines() {
+        let l = line.trim_start();
+        if !l.starts_with("user_pref(") { continue; }
+        let Some((key_raw, val_raw)) = two_quoted(l) else { continue; };
+        if !(key_raw.starts_with("mail.identity.") && key_raw.ends_with(".useremail")) { continue; }
+        let mid = &key_raw["mail.identity.".len()..key_raw.len() - ".useremail".len()];
+        if mid.is_empty() || mid.contains('.') { continue; }
+        let Some(v) = prefs_unescape(&val_raw) else { continue; };
+        let v = v.trim().to_string();
+        if v.is_empty() { continue; }
+        if seen.insert(v.to_lowercase()) { out.push(v); }
+    }
+    out
+}
+
+/// Raw contents (escapes intact) of the first two double-quoted strings on a line, or None.
+fn two_quoted(s: &str) -> Option<(String, String)> {
+    let chars: Vec<char> = s.chars().collect();
+    let mut found: Vec<String> = Vec::new();
+    let mut i = 0;
+    while i < chars.len() && found.len() < 2 {
+        if chars[i] != '"' { i += 1; continue; }
+        i += 1;
+        let mut buf = String::new();
+        loop {
+            if i >= chars.len() { return None; }
+            let c = chars[i];
+            if c == '\\' {
+                if i + 1 >= chars.len() { return None; }
+                buf.push(c); buf.push(chars[i + 1]); i += 2; continue;
+            }
+            if c == '"' { i += 1; break; }
+            buf.push(c); i += 1;
+        }
+        found.push(buf);
+    }
+    if found.len() == 2 { Some((found.remove(0), found.remove(0))) } else { None }
+}
+
+/// Unescape a prefs.js double-quoted value. None on dangling/unknown escape.
+fn prefs_unescape(raw: &str) -> Option<String> {
+    let mut s = String::with_capacity(raw.len());
+    let mut it = raw.chars().peekable();
+    while let Some(ch) = it.next() {
+        if ch != '\\' { s.push(ch); continue; }
+        match it.next()? {
+            '\\' => s.push('\\'), '"' => s.push('"'),
+            'n' => s.push('\n'), 'r' => s.push('\r'), 't' => s.push('\t'),
+            'u' => {
+                let hex: String = (0..4).map(|_| it.next()).collect::<Option<String>>()?;
+                let cp = u32::from_str_radix(&hex, 16).ok()?;
+                s.push(char::from_u32(cp)?);
+            }
+            _ => return None,
+        }
+    }
+    Some(s)
+}
+
+fn is_convertible(email_count: usize, has_mail_store: bool) -> bool { email_count > 0 || has_mail_store }
+
+/// True if Mail/ or ImapMail/ recursively contains a non-dir, non-.msf file.
+fn has_mail_store(profile_dir: &std::path::Path) -> bool {
+    ["Mail", "ImapMail"].iter().any(|s| dir_has_mailbox_file(&profile_dir.join(s)))
+}
+
+fn dir_has_mailbox_file(dir: &std::path::Path) -> bool {
+    let Ok(rd) = std::fs::read_dir(dir) else { return false; };
+    for entry in rd.flatten() {
+        let p = entry.path();
+        if p.is_dir() { if dir_has_mailbox_file(&p) { return true; } }
+        else if p.extension().and_then(|e| e.to_str()) != Some("msf") { return true; }
+    }
+    false
 }
 
 #[tauri::command]
@@ -456,10 +538,20 @@ fn list_thunderbird_profiles() -> Result<Vec<ProfileEntry>, String> {
     };
     let tb = appdata.join("Thunderbird");
     let ini = tb.join("profiles.ini");
-    match std::fs::read_to_string(&ini) {
-        Ok(content) => Ok(parse_profiles_ini(&content, &tb)),
-        Err(_) => Ok(vec![]),
+    let content = match std::fs::read_to_string(&ini) {
+        Ok(c) => c,
+        Err(_) => return Ok(vec![]),
+    };
+    let mut out = Vec::new();
+    for e in parse_profiles_ini(&content, &tb) {
+        let dir = std::path::Path::new(&e.path);
+        let accounts = std::fs::read_to_string(dir.join("prefs.js"))
+            .map(|p| parse_identity_emails(&p))
+            .unwrap_or_default();
+        let convertible = is_convertible(accounts.len(), has_mail_store(dir));
+        out.push(ProfileEntry { name: e.name, path: e.path, is_default: e.is_default, accounts, convertible });
     }
+    Ok(out)
 }
 
 /// Returns %APPDATA%\Thunderbird\Profiles when it exists, else None. Windows-only app.
@@ -500,6 +592,59 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod profile_scan_tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn parse_emails_dedupes_case_insensitively_keeping_first() {
+        let p = "\
+user_pref(\"mail.identity.id1.useremail\", \"Alice@GMAIL.com\");\n\
+user_pref(\"mail.identity.id2.useremail\", \"alice@gmail.com\");\n\
+user_pref(\"mail.identity.id3.useremail\", \"bob@work.com\");\n\
+user_pref(\"mail.identity.id4.fullName\", \"Not An Email\");\n";
+        assert_eq!(parse_identity_emails(p), vec!["Alice@GMAIL.com", "bob@work.com"]);
+    }
+
+    #[test]
+    fn parse_emails_unescapes_and_skips_malformed() {
+        let p = "\
+user_pref(\"mail.identity.id1.useremail\", \"al\\u00e6ce@example.com\");\n\
+user_pref(\"mail.identity.id2.useremail\", \"bad\\xZZ@example.com\");\n\
+user_pref(\"mail.identity.id3.useremail\", \"   \");\n";
+        assert_eq!(parse_identity_emails(p), vec!["alæce@example.com"]); // id2 skipped (bad escape), id3 empty
+    }
+
+    #[test]
+    fn convertible_truth_table() {
+        assert!(is_convertible(1, false));
+        assert!(is_convertible(0, true));
+        assert!(!is_convertible(0, false));
+    }
+
+    #[test]
+    fn mail_store_detection() {
+        let root = std::env::temp_dir().join(format!("cm-mailstore-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        let a = root.join("a"); fs::create_dir_all(a.join("Mail/Local Folders")).unwrap();
+        fs::write(a.join("Mail/Local Folders/Inbox"), b"x").unwrap();
+        assert!(has_mail_store(&a));
+        let b = root.join("b"); fs::create_dir_all(b.join("Mail/Local Folders")).unwrap();
+        fs::write(b.join("Mail/Local Folders/Inbox.msf"), b"x").unwrap();
+        assert!(!has_mail_store(&b));
+        let c = root.join("c"); fs::create_dir_all(c.join("Mail/Local Folders/Archives.sbd")).unwrap();
+        fs::write(c.join("Mail/Local Folders/Archives.sbd/2024"), b"x").unwrap();
+        assert!(has_mail_store(&c));
+        let d = root.join("d"); fs::create_dir_all(d.join("ImapMail/acct")).unwrap();
+        fs::write(d.join("ImapMail/acct/INBOX"), b"x").unwrap();
+        assert!(has_mail_store(&d));
+        let e = root.join("e"); fs::create_dir_all(e.join("Mail")).unwrap(); fs::create_dir_all(e.join("ImapMail")).unwrap();
+        assert!(!has_mail_store(&e));
+        let _ = fs::remove_dir_all(&root);
+    }
 }
 
 #[cfg(test)]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -357,6 +357,17 @@ fn open_junk_help(app: AppHandle) -> Result<(), String> {
         .map_err(|e| format!("could not open link: {e}"))
 }
 
+/// Returns %APPDATA%\Thunderbird\Profiles when it exists, else None. Windows-only app.
+#[tauri::command]
+fn default_thunderbird_profiles_dir() -> Result<Option<String>, String> {
+    let appdata = match std::env::var_os("APPDATA") {
+        Some(v) => std::path::PathBuf::from(v),
+        None => return Ok(None),
+    };
+    let dir = appdata.join("Thunderbird").join("Profiles");
+    Ok(if dir.is_dir() { Some(dir.to_string_lossy().to_string()) } else { None })
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -377,7 +388,8 @@ pub fn run() {
             open_folder,
             open_junk_help,
             preview_colours,
-            apply_colours
+            apply_colours,
+            default_thunderbird_profiles_dir
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -602,11 +602,11 @@ mod profile_scan_tests {
     #[test]
     fn parse_emails_dedupes_case_insensitively_keeping_first() {
         let p = "\
-user_pref(\"mail.identity.id1.useremail\", \"Alice@GMAIL.com\");\n\
-user_pref(\"mail.identity.id2.useremail\", \"alice@gmail.com\");\n\
-user_pref(\"mail.identity.id3.useremail\", \"bob@work.com\");\n\
+user_pref(\"mail.identity.id1.useremail\", \"Alice@EXAMPLE.com\");\n\
+user_pref(\"mail.identity.id2.useremail\", \"alice@example.com\");\n\
+user_pref(\"mail.identity.id3.useremail\", \"bob@example.test\");\n\
 user_pref(\"mail.identity.id4.fullName\", \"Not An Email\");\n";
-        assert_eq!(parse_identity_emails(p), vec!["Alice@GMAIL.com", "bob@work.com"]);
+        assert_eq!(parse_identity_emails(p), vec!["Alice@EXAMPLE.com", "bob@example.test"]);
     }
 
     #[test]

--- a/desktop/src/components/views/ColourImportCard.tsx
+++ b/desktop/src/components/views/ColourImportCard.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
 // SPDX-License-Identifier: GPL-3.0-or-later
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Palette, TriangleAlert, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
@@ -37,8 +37,7 @@ export function ColourImportCard({ plan }: { plan: ColourPlanEntry[] }) {
   // Guard against setting state after unmount (e.g. user clicks "Convert another" while
   // apply is still running — there is no cancellation, so just drop the late result).
   const mounted = useRef(true);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useCallback(() => () => { mounted.current = false; }, [])();
+  useEffect(() => () => { mounted.current = false; }, []);
 
   const runApply = useCallback(() => {
     setPhase({ k: "applying" });

--- a/desktop/src/components/views/ColourImportCard.tsx
+++ b/desktop/src/components/views/ColourImportCard.tsx
@@ -1,19 +1,18 @@
 // SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
 // SPDX-License-Identifier: GPL-3.0-or-later
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { Palette, TriangleAlert, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
-import { previewColours, applyColours } from "@/lib/engine";
+import { applyColoursPlan } from "@/lib/engine";
 import { summarizeColourApply } from "@/lib/colourImport";
-import type { ColourCategory } from "@/lib/types";
+import type { ColourPlanEntry } from "@/lib/types";
 
 type Phase =
-  | { k: "loading" }
-  | { k: "ready"; outlookAvailable: boolean; categories: ColourCategory[] }
+  | { k: "ready" }
   | { k: "applying" }
   | { k: "applied"; added: number; existing: number }
-  | { k: "error"; message: string; retry: "preview" | "apply" }
+  | { k: "error"; message: string }
   | { k: "dismissed" };
 
 const ACTION_LABEL: Record<string, string> = {
@@ -31,41 +30,27 @@ function errorText(message: string): string {
   return message;
 }
 
-export function ColourImportCard({ profileRoot }: { profileRoot: string }) {
-  const [phase, setPhase] = useState<Phase>({ k: "loading" });
+export function ColourImportCard({ plan }: { plan: ColourPlanEntry[] }) {
+  const wouldAdd = plan.filter((c) => c.action === "would-add");
+  const [phase, setPhase] = useState<Phase>({ k: "ready" });
   const [consent, setConsent] = useState(false);
-  // Guard against setting state after unmount (e.g. user clicks "Convert another" while a one-shot
-  // preview/apply is still running — there is no cancellation, so just drop the late result).
+  // Guard against setting state after unmount (e.g. user clicks "Convert another" while
+  // apply is still running — there is no cancellation, so just drop the late result).
   const mounted = useRef(true);
-  useEffect(() => () => { mounted.current = false; }, []);
-
-  const runPreview = useCallback(() => {
-    setPhase({ k: "loading" });
-    previewColours(profileRoot)
-      .then((r) => {
-        if (!mounted.current) return;
-        setPhase(
-          r.kind === "error"
-            ? { k: "error", message: r.message, retry: "preview" }
-            : { k: "ready", outlookAvailable: r.outlookAvailable, categories: r.categories },
-        );
-      })
-      .catch((e) => { if (mounted.current) setPhase({ k: "error", message: e instanceof Error ? e.message : String(e), retry: "preview" }); });
-  }, [profileRoot]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useCallback(() => () => { mounted.current = false; }, [])();
 
   const runApply = useCallback(() => {
     setPhase({ k: "applying" });
-    applyColours(profileRoot)
+    applyColoursPlan(plan)
       .then((r) => {
         if (!mounted.current) return;
-        if (r.kind === "error") { setPhase({ k: "error", message: r.message, retry: "apply" }); return; }
+        if (r.kind === "error") { setPhase({ k: "error", message: r.message }); return; }
         const s = summarizeColourApply(r.categories);
         setPhase({ k: "applied", added: s.added, existing: s.existing });
       })
-      .catch((e) => { if (mounted.current) setPhase({ k: "error", message: e instanceof Error ? e.message : String(e), retry: "apply" }); });
-  }, [profileRoot]);
-
-  useEffect(() => { runPreview(); }, [runPreview]);
+      .catch((e) => { if (mounted.current) setPhase({ k: "error", message: e instanceof Error ? e.message : String(e) }); });
+  }, [plan]);
 
   if (phase.k === "dismissed") return null;
 
@@ -81,13 +66,6 @@ export function ColourImportCard({ profileRoot }: { profileRoot: string }) {
       </div>
 
       <div className="px-3.5 py-3 text-sm">
-        {phase.k === "loading" && (
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex items-center gap-2 text-muted-foreground"><Spinner size="sm" /> Checking your tag colours…</div>
-            <Button variant="outline" onClick={dismiss}>Skip</Button>
-          </div>
-        )}
-
         {phase.k === "applying" && (
           <div className="flex items-center justify-between gap-2">
             <div className="flex items-center gap-2 text-muted-foreground"><Spinner size="sm" /> Importing… Outlook opens briefly to save the categories.</div>
@@ -111,56 +89,50 @@ export function ColourImportCard({ profileRoot }: { profileRoot: string }) {
               <TriangleAlert className="mt-0.5 size-4 shrink-0" /> <span>{errorText(phase.message)}</span>
             </div>
             <div className="mt-3 flex gap-2.5">
-              <Button onClick={phase.retry === "apply" ? runApply : runPreview}>Retry</Button>
+              <Button onClick={runApply}>Retry</Button>
               <Button variant="outline" onClick={dismiss}>Skip</Button>
             </div>
           </div>
         )}
 
-        {phase.k === "ready" && (() => {
-          const wouldAdd = phase.categories.filter((c) => c.action === "would-add");
-          return (
-            <div>
-              <p className="mb-2 text-xs text-muted-foreground">
-                Your tags became Outlook categories, but Outlook colours them from its own master list. Import your Thunderbird tag colours so they match.
-              </p>
-              <div className="flex flex-col gap-1">
-                {phase.categories.map((c) => (
-                  <div key={c.name} className="flex items-center gap-2.5 text-[13px]">
-                    <span className="size-3.5 shrink-0 rounded border border-black/10" style={{ background: c.hex ?? "transparent" }} />
-                    <span className="flex-1 text-foreground">{c.name}</span>
-                    <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground">{ACTION_LABEL[c.action] ?? c.action}</span>
-                  </div>
-                ))}
-                {phase.categories.length === 0 && <div className="text-xs text-light-gray">No tag colours found in this profile.</div>}
-              </div>
-
-              {!phase.outlookAvailable ? (
-                <div className="mt-3 text-xs text-light-gray">Outlook not detected — install Outlook to import colours.</div>
-              ) : wouldAdd.length === 0 ? (
-                <div className="mt-3 text-xs text-light-gray">Nothing to import — no new Outlook colours are available from this profile.</div>
-              ) : (
-                <>
-                  <div className="mt-3 flex items-start gap-2 rounded-lg border border-[#ecd9a8] bg-[#fbf2dd] px-3 py-2 text-[11.5px] text-[#8a6516]">
-                    <TriangleAlert className="mt-0.5 size-4 shrink-0" />
-                    <span>This adds these categories to Outlook's master list for <strong>all</strong> your Outlook accounts — not just this PST. <strong>Close Outlook before importing.</strong></span>
-                  </div>
-                  <label className="mt-2.5 flex items-center gap-2 text-xs text-foreground">
-                    <input type="checkbox" checked={consent} onChange={(e) => setConsent(e.target.checked)} />
-                    I understand this changes my Outlook categories
-                  </label>
-                </>
-              )}
-
-              <div className="mt-3 flex items-center gap-2.5">
-                {phase.outlookAvailable && wouldAdd.length > 0 && (
-                  <Button disabled={!consent} onClick={runApply}>Import colours to Outlook</Button>
-                )}
-                <Button variant="outline" onClick={dismiss}>Skip</Button>
-              </div>
+        {phase.k === "ready" && (
+          <div>
+            <p className="mb-2 text-xs text-muted-foreground">
+              Your tags became Outlook categories, but Outlook colours them from its own master list. Import your Thunderbird tag colours so they match.
+            </p>
+            <div className="flex flex-col gap-1">
+              {plan.map((c) => (
+                <div key={c.name} className="flex items-center gap-2.5 text-[13px]">
+                  <span className="size-3.5 shrink-0 rounded border border-black/10" style={{ background: c.hex ?? "transparent" }} />
+                  <span className="flex-1 text-foreground">{c.name}</span>
+                  <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground">{ACTION_LABEL[c.action] ?? c.action}</span>
+                </div>
+              ))}
             </div>
-          );
-        })()}
+
+            {wouldAdd.length === 0 ? (
+              <div className="mt-3 text-xs text-light-gray">Nothing to import — no new Outlook colours are available from this profile.</div>
+            ) : (
+              <>
+                <div className="mt-3 flex items-start gap-2 rounded-lg border border-[#ecd9a8] bg-[#fbf2dd] px-3 py-2 text-[11.5px] text-[#8a6516]">
+                  <TriangleAlert className="mt-0.5 size-4 shrink-0" />
+                  <span>This adds these categories to Outlook's master list for <strong>all</strong> your Outlook accounts — not just this PST. <strong>Close Outlook before importing.</strong></span>
+                </div>
+                <label className="mt-2.5 flex items-center gap-2 text-xs text-foreground">
+                  <input type="checkbox" checked={consent} onChange={(e) => setConsent(e.target.checked)} />
+                  I understand this changes my Outlook categories
+                </label>
+              </>
+            )}
+
+            <div className="mt-3 flex items-center gap-2.5">
+              {wouldAdd.length > 0 && (
+                <Button disabled={!consent} onClick={runApply}>Import colours to Outlook</Button>
+              )}
+              <Button variant="outline" onClick={dismiss}>Skip</Button>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/desktop/src/components/views/DoneView.tsx
+++ b/desktop/src/components/views/DoneView.tsx
@@ -58,14 +58,16 @@ export function DoneView({ state, profileRoot, onConvertAnother }: { state: Conv
       </div>
 
       {state.enrichment && shouldShowEnrichment(state.enrichment) && (
-        <div className="mt-4 rounded-[10px] border border-border bg-card px-3.5 py-3 text-xs text-muted-foreground">
-          <div>{formatEnrichmentLine(state.enrichment)}</div>
+        <div className="mt-4 rounded-[10px] border border-border bg-card px-3.5 py-3 text-xs">
+          <div className="flex items-center gap-2 text-foreground">
+            <span className="text-data-present font-bold">✓</span>
+            {formatEnrichmentLine(state.enrichment)}
+          </div>
           {state.enrichment.sourcesDegraded > 0 && (
-            <div className="mt-1.5 flex items-start gap-2">
+            <div className="mt-1.5 flex items-start gap-2 text-muted-foreground">
               <TriangleAlert className="mt-0.5 size-4 shrink-0 text-primary" />
               <span>
-                {state.enrichment.sourcesDegraded} folder{state.enrichment.sourcesDegraded === 1 ? "" : "s"}{" "}
-                couldn't read their .msf — flags/tags not applied there.
+                {state.enrichment.sourcesDegraded} folder{state.enrichment.sourcesDegraded === 1 ? "" : "s"} couldn't read their .msf — flags/tags not applied there.
               </span>
             </div>
           )}

--- a/desktop/src/components/views/DoneView.tsx
+++ b/desktop/src/components/views/DoneView.tsx
@@ -74,7 +74,9 @@ export function DoneView({ state, profileRoot, onConvertAnother }: { state: Conv
         </div>
       )}
 
-      {profileRoot && <ColourImportCard profileRoot={profileRoot} />}
+      {profileRoot && state.colourPlan && state.colourPlan.length > 0 && (
+        <ColourImportCard plan={state.colourPlan} />
+      )}
 
       <div className="mt-4 rounded-[10px] border border-dashed border-border bg-card px-3.5 py-3 text-xs text-muted-foreground">
         Keep your original .mbox files until you've opened the PST in Outlook and confirmed everything looks right.

--- a/desktop/src/components/views/ReviewView.tsx
+++ b/desktop/src/components/views/ReviewView.tsx
@@ -116,7 +116,7 @@ export function ReviewView({
                     )}
                     {pairedIds && (
                       pairedIds.has(s.id)
-                        ? <span className="ml-2 rounded bg-primary/15 px-1.5 py-0.5 text-[10px] uppercase text-primary">.msf</span>
+                        ? <span className="ml-2 rounded bg-data-present/15 px-1.5 py-0.5 text-[10px] uppercase text-data-present">✓ .msf</span>
                         : <span className="ml-2 rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase text-muted-foreground">no .msf</span>
                     )}
                   </td>

--- a/desktop/src/components/views/SelectView.tsx
+++ b/desktop/src/components/views/SelectView.tsx
@@ -1,10 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { useState, useEffect } from "react";
-import { FileText, FolderOpen, Save, X } from "lucide-react";
+import { useState } from "react";
+import { FileText, FolderOpen, Save, Search, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import { pickMboxFiles, pickFolder, listMboxInDir, statFiles, pickOutputPst, listThunderbirdProfiles } from "@/lib/engine";
+import { visibleProfiles, hiddenNote, profilePrimaryLabel, profileSubtext, pickDefaultProfile } from "@/lib/profiles";
 import { splitPath } from "@/lib/convert";
 import { formatBytes } from "@/lib/format";
 import type { FileStat, ProfileEntry } from "@/lib/types";
@@ -29,24 +31,25 @@ export function SelectView({
   // Picker errors are transient and screen-local (e.g. "no .mbox in folder").
   // Parent owns the durable file/output state; this does NOT belong there.
   const [pickerError, setPickerError] = useState<string | null>(null);
-  const [detectedProfiles, setDetectedProfiles] = useState<ProfileEntry[]>([]);
 
-  // Load profiles.ini entries on mount (or when switching to profile mode).
-  useEffect(() => {
-    if (inputMode !== "profile") return;
-    let cancelled = false;
-    listThunderbirdProfiles().then((profiles) => {
-      if (cancelled) return;
-      setDetectedProfiles(profiles);
-      // Only preselect the default when the user hasn't already chosen a path.
-      if (profileRoot === null) {
-        const def = profiles.find((p) => p.isDefault) ?? profiles[0];
-        if (def) onProfileRootChange(def.path);
-      }
-    });
-    return () => { cancelled = true; };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [inputMode]);
+  const [scan, setScan] = useState<
+    | { k: "idle" }
+    | { k: "scanning" }
+    | { k: "done"; entries: ProfileEntry[] }
+    | { k: "error" }
+  >({ k: "idle" });
+
+  async function runScan() {
+    setScan({ k: "scanning" });
+    try {
+      const entries = await listThunderbirdProfiles();
+      setScan({ k: "done", entries });
+      const pick = pickDefaultProfile(entries, profileRoot);
+      if (pick) onProfileRootChange(pick);
+    } catch {
+      setScan({ k: "error" });
+    }
+  }
 
   async function addFiles(paths: string[]) {
     if (paths.length === 0) return;
@@ -101,6 +104,9 @@ export function SelectView({
     outputPath !== null &&
     (inputMode === "files" ? files.length > 0 : profileRoot !== null);
 
+  // For the "manual path shown when not a detected profile" check.
+  const scannedEntries = scan.k === "done" ? scan.entries : [];
+
   return (
     <div className="flex flex-1 flex-col">
       <h1 className="text-xl font-semibold text-foreground">Choose what to convert</h1>
@@ -129,41 +135,81 @@ export function SelectView({
 
       {inputMode === "profile" && (
         <div className="mt-4">
-          {detectedProfiles.length > 0 && (
-            <div className="mb-3 flex flex-col gap-1.5">
-              {detectedProfiles.map((p) => (
-                <label
-                  key={p.path}
-                  className={
-                    "flex cursor-pointer items-start gap-3 rounded-lg border px-3 py-2 text-sm transition-colors " +
-                    (profileRoot === p.path
-                      ? "border-primary bg-primary/10 text-foreground"
-                      : "border-border bg-card text-foreground hover:bg-muted")
-                  }
-                >
-                  <input
-                    type="radio"
-                    name="profile"
-                    value={p.path}
-                    checked={profileRoot === p.path}
-                    onChange={() => { setPickerError(null); onProfileRootChange(p.path); }}
-                    className="mt-0.5 accent-primary shrink-0"
-                  />
-                  <div className="min-w-0">
-                    <span className="font-medium">{p.name}</span>
-                    {p.isDefault && (
-                      <span className="ml-2 rounded bg-primary/15 px-1.5 py-0.5 text-xs text-primary">default</span>
-                    )}
-                    <div className="truncate text-xs text-light-gray">{p.path}</div>
-                  </div>
-                </label>
-              ))}
+          {scan.k === "scanning" && (
+            <div className="mb-3 flex items-center gap-2 text-sm text-muted-foreground">
+              <Spinner size="sm" />
+              Scanning for Thunderbird profiles…
             </div>
           )}
-          <Button variant="outline" onClick={onChooseProfile}>
-            <FolderOpen /> Browse manually…
-          </Button>
-          {profileRoot && detectedProfiles.every((p) => p.path !== profileRoot) && (
+
+          {scan.k === "error" && (
+            <p className="mb-3 text-sm text-destructive">
+              Could not scan Thunderbird profiles — use Browse manually…
+            </p>
+          )}
+
+          {scan.k === "done" && (() => {
+            const vis = visibleProfiles(scan.entries);
+            const note = hiddenNote(scan.entries);
+            if (vis.length === 0) {
+              return (
+                <p className="mb-3 text-sm text-muted-foreground">
+                  No Thunderbird profiles with mail found — use Browse manually… to point at a profile or folder.
+                </p>
+              );
+            }
+            return (
+              <div className="mb-3">
+                <div className="flex flex-col gap-1.5">
+                  {vis.map((e) => (
+                    <label
+                      key={e.path}
+                      className={
+                        "flex cursor-pointer items-start gap-3 rounded-lg border px-3 py-2 text-sm transition-colors " +
+                        (profileRoot === e.path
+                          ? "border-primary bg-primary/10 text-foreground"
+                          : "border-border bg-card text-foreground hover:bg-muted")
+                      }
+                    >
+                      <input
+                        type="radio"
+                        name="profile"
+                        value={e.path}
+                        checked={profileRoot === e.path}
+                        onChange={() => { setPickerError(null); onProfileRootChange(e.path); }}
+                        className="mt-0.5 accent-primary shrink-0"
+                      />
+                      <div className="min-w-0">
+                        <span className="font-medium">{profilePrimaryLabel(e)}</span>
+                        {e.isDefault && (
+                          <span className="ml-2 rounded bg-primary/15 px-1.5 py-0.5 text-xs text-primary">default</span>
+                        )}
+                        <div className="truncate text-xs text-light-gray">{profileSubtext(e)}</div>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+                {note && (
+                  <p className="mt-1 text-xs italic text-light-gray">{note}</p>
+                )}
+              </div>
+            );
+          })()}
+
+          <div className="flex gap-3">
+            <Button variant="outline" onClick={onChooseProfile}>
+              <FolderOpen /> Browse manually…
+            </Button>
+            <Button
+              variant="outline"
+              onClick={runScan}
+              disabled={scan.k === "scanning"}
+            >
+              <Search /> {scan.k === "idle" ? "Scan for Thunderbird profiles" : "Rescan"}
+            </Button>
+          </div>
+
+          {profileRoot && scannedEntries.every((e) => e.path !== profileRoot) && (
             <div className="mt-1 text-xs text-light-gray">{profileRoot}</div>
           )}
           <p className="mt-2 text-xs text-light-gray">

--- a/desktop/src/components/views/SelectView.tsx
+++ b/desktop/src/components/views/SelectView.tsx
@@ -104,7 +104,7 @@ export function SelectView({
     outputPath !== null &&
     (inputMode === "files" ? files.length > 0 : profileRoot !== null);
 
-  // For the "manual path shown when not a detected profile" check.
+  // For the "manual path shown when not a scanned profile" check.
   const scannedEntries = scan.k === "done" ? scan.entries : [];
 
   return (
@@ -205,7 +205,7 @@ export function SelectView({
               onClick={runScan}
               disabled={scan.k === "scanning"}
             >
-              <Search /> {scan.k === "idle" ? "Scan for Thunderbird profiles" : "Rescan"}
+              <Search /> {scan.k === "idle" ? "Scan for Thunderbird profiles" : scan.k === "scanning" ? "Scanning…" : "Rescan"}
             </Button>
           </div>
 

--- a/desktop/src/components/views/SelectView.tsx
+++ b/desktop/src/components/views/SelectView.tsx
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { FileText, FolderOpen, Save, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { pickMboxFiles, pickFolder, listMboxInDir, statFiles, pickOutputPst } from "@/lib/engine";
+import { pickMboxFiles, pickFolder, listMboxInDir, statFiles, pickOutputPst, listThunderbirdProfiles } from "@/lib/engine";
 import { splitPath } from "@/lib/convert";
 import { formatBytes } from "@/lib/format";
-import type { FileStat } from "@/lib/types";
+import type { FileStat, ProfileEntry } from "@/lib/types";
 
 interface SelectViewProps {
   files: FileStat[];
@@ -29,6 +29,24 @@ export function SelectView({
   // Picker errors are transient and screen-local (e.g. "no .mbox in folder").
   // Parent owns the durable file/output state; this does NOT belong there.
   const [pickerError, setPickerError] = useState<string | null>(null);
+  const [detectedProfiles, setDetectedProfiles] = useState<ProfileEntry[]>([]);
+
+  // Load profiles.ini entries on mount (or when switching to profile mode).
+  useEffect(() => {
+    if (inputMode !== "profile") return;
+    let cancelled = false;
+    listThunderbirdProfiles().then((profiles) => {
+      if (cancelled) return;
+      setDetectedProfiles(profiles);
+      // Only preselect the default when the user hasn't already chosen a path.
+      if (profileRoot === null) {
+        const def = profiles.find((p) => p.isDefault) ?? profiles[0];
+        if (def) onProfileRootChange(def.path);
+      }
+    });
+    return () => { cancelled = true; };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inputMode]);
 
   async function addFiles(paths: string[]) {
     if (paths.length === 0) return;
@@ -111,10 +129,43 @@ export function SelectView({
 
       {inputMode === "profile" && (
         <div className="mt-4">
-          <Button onClick={onChooseProfile}>
-            <FolderOpen /> {profileRoot ? splitPath(profileRoot).base : "Choose profile / mail folder…"}
+          {detectedProfiles.length > 0 && (
+            <div className="mb-3 flex flex-col gap-1.5">
+              {detectedProfiles.map((p) => (
+                <label
+                  key={p.path}
+                  className={
+                    "flex cursor-pointer items-start gap-3 rounded-lg border px-3 py-2 text-sm transition-colors " +
+                    (profileRoot === p.path
+                      ? "border-primary bg-primary/10 text-foreground"
+                      : "border-border bg-card text-foreground hover:bg-muted")
+                  }
+                >
+                  <input
+                    type="radio"
+                    name="profile"
+                    value={p.path}
+                    checked={profileRoot === p.path}
+                    onChange={() => { setPickerError(null); onProfileRootChange(p.path); }}
+                    className="mt-0.5 accent-primary shrink-0"
+                  />
+                  <div className="min-w-0">
+                    <span className="font-medium">{p.name}</span>
+                    {p.isDefault && (
+                      <span className="ml-2 rounded bg-primary/15 px-1.5 py-0.5 text-xs text-primary">default</span>
+                    )}
+                    <div className="truncate text-xs text-light-gray">{p.path}</div>
+                  </div>
+                </label>
+              ))}
+            </div>
+          )}
+          <Button variant="outline" onClick={onChooseProfile}>
+            <FolderOpen /> Browse manually…
           </Button>
-          {profileRoot && <div className="mt-1 text-xs text-light-gray">{profileRoot}</div>}
+          {profileRoot && detectedProfiles.every((p) => p.path !== profileRoot) && (
+            <div className="mt-1 text-xs text-light-gray">{profileRoot}</div>
+          )}
           <p className="mt-2 text-xs text-light-gray">
             Point at a Thunderbird profile, a Mail/ImapMail store, or a single account folder. Nested folders and tags/flags are detected automatically.
           </p>

--- a/desktop/src/lib/engine.ts
+++ b/desktop/src/lib/engine.ts
@@ -8,7 +8,7 @@ import { parseEngineOutput, type VersionResult, type ScanResult } from "./parse"
 import { parseScanLine } from "./scan";
 import { parseDiscover } from "./discover";
 import { parseColourImport, type ColourImportParse } from "./colourImport";
-import type { ConversionConfig, FileStat, DiscoverResult } from "./types";
+import type { ConversionConfig, FileStat, DiscoverResult, ProfileEntry } from "./types";
 
 export async function checkEngineVersion(): Promise<VersionResult> {
   const stdout = await invoke<string>("check_engine_version");
@@ -165,4 +165,13 @@ export async function previewColours(dir: string): Promise<ColourImportParse> {
 /** Apply the colour import to Outlook's master list (Windows + Outlook, Outlook must be closed). */
 export async function applyColours(dir: string): Promise<ColourImportParse> {
   return parseColourImport(await invoke<string>("apply_colours", { dir }));
+}
+
+/** List installed Thunderbird profiles from profiles.ini. Returns [] if none found or on error. */
+export async function listThunderbirdProfiles(): Promise<ProfileEntry[]> {
+  try {
+    return await invoke<ProfileEntry[]>("list_thunderbird_profiles");
+  } catch {
+    return [];
+  }
 }

--- a/desktop/src/lib/engine.ts
+++ b/desktop/src/lib/engine.ts
@@ -114,7 +114,14 @@ export async function pickMboxFiles(): Promise<string[]> {
 
 /** Returns a chosen folder path, or null if cancelled. */
 export async function pickFolder(): Promise<string | null> {
-  const result = await open({ multiple: false, directory: true });
+  let defaultPath: string | undefined;
+  try {
+    const d = await invoke<string | null>("default_thunderbird_profiles_dir");
+    defaultPath = d ?? undefined;
+  } catch {
+    defaultPath = undefined; // never block the picker on this
+  }
+  const result = await open({ multiple: false, directory: true, defaultPath });
   return typeof result === "string" ? result : null;
 }
 

--- a/desktop/src/lib/engine.ts
+++ b/desktop/src/lib/engine.ts
@@ -172,11 +172,7 @@ export async function applyColoursPlan(plan: ColourPlanEntry[]): Promise<ColourI
   return parseColourImport(await invoke<string>("apply_colours_plan", { plan }));
 }
 
-/** List installed Thunderbird profiles from profiles.ini. Returns [] if none found or on error. */
+/** List installed Thunderbird profiles from profiles.ini. Resolves [] if none found; rejects on unexpected failure. */
 export async function listThunderbirdProfiles(): Promise<ProfileEntry[]> {
-  try {
-    return await invoke<ProfileEntry[]>("list_thunderbird_profiles");
-  } catch {
-    return [];
-  }
+  return invoke<ProfileEntry[]>("list_thunderbird_profiles");
 }

--- a/desktop/src/lib/engine.ts
+++ b/desktop/src/lib/engine.ts
@@ -8,7 +8,7 @@ import { parseEngineOutput, type VersionResult, type ScanResult } from "./parse"
 import { parseScanLine } from "./scan";
 import { parseDiscover } from "./discover";
 import { parseColourImport, type ColourImportParse } from "./colourImport";
-import type { ConversionConfig, FileStat, DiscoverResult, ProfileEntry } from "./types";
+import type { ConversionConfig, FileStat, DiscoverResult, ProfileEntry, ColourPlanEntry } from "./types";
 
 export async function checkEngineVersion(): Promise<VersionResult> {
   const stdout = await invoke<string>("check_engine_version");
@@ -165,6 +165,11 @@ export async function previewColours(dir: string): Promise<ColourImportParse> {
 /** Apply the colour import to Outlook's master list (Windows + Outlook, Outlook must be closed). */
 export async function applyColours(dir: string): Promise<ColourImportParse> {
   return parseColourImport(await invoke<string>("apply_colours", { dir }));
+}
+
+/** Apply a pre-computed colour plan (from done.colourPlan) via a temp plan file. Outlook must be closed. */
+export async function applyColoursPlan(plan: ColourPlanEntry[]): Promise<ColourImportParse> {
+  return parseColourImport(await invoke<string>("apply_colours_plan", { plan }));
 }
 
 /** List installed Thunderbird profiles from profiles.ini. Returns [] if none found or on error. */

--- a/desktop/src/lib/profiles.test.ts
+++ b/desktop/src/lib/profiles.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { visibleProfiles, hiddenProfiles, hiddenNote, profilePrimaryLabel, profileSubtext, pickDefaultProfile } from "./profiles";
+import type { ProfileEntry } from "./types";
+
+const p = (o: Partial<ProfileEntry>): ProfileEntry =>
+  ({ name: "default", path: "/p/default", isDefault: false, accounts: [], convertible: true, ...o });
+
+describe("labels", () => {
+  it("one email", () => expect(profilePrimaryLabel(p({ accounts: ["a@x.com"] }))).toBe("a@x.com"));
+  it("+N more", () => expect(profilePrimaryLabel(p({ accounts: ["a@x.com", "b@y.com"] }))).toBe("a@x.com +1 more"));
+  it("falls back to raw name", () => expect(profilePrimaryLabel(p({ name: "work", accounts: [] }))).toBe("work"));
+  it("subtext is name · path", () => expect(profileSubtext(p({ name: "work", path: "/p/w" }))).toBe("work · /p/w"));
+});
+
+describe("filter + note", () => {
+  const list = [p({ name: "a", path: "/a", accounts: ["a@x.com"], convertible: true }),
+                p({ name: "default-esr", path: "/esr", convertible: false })];
+  it("visible = convertible only", () => expect(visibleProfiles(list).map((x) => x.name)).toEqual(["a"]));
+  it("hidden = non-convertible", () => expect(hiddenProfiles(list).map((x) => x.name)).toEqual(["default-esr"]));
+  it("note (singular) uses raw name, no path", () => expect(hiddenNote(list)).toBe("“default-esr” was hidden — no convertible mail found in it."));
+  it("note null when none hidden", () => expect(hiddenNote([list[0]])).toBeNull());
+  it("note (plural)", () => expect(hiddenNote([p({ name: "x", convertible: false }), p({ name: "y", convertible: false })]))
+    .toBe("2 profiles were hidden — no convertible mail found."));
+});
+
+describe("pickDefaultProfile", () => {
+  it("returns null (no change) when a profile is already selected", () =>
+    expect(pickDefaultProfile([p({ path: "/a", convertible: true })], "/already")).toBeNull());
+  it("single convertible -> its path", () =>
+    expect(pickDefaultProfile([p({ path: "/a", convertible: true })], null)).toBe("/a"));
+  it("first isDefault convertible wins", () =>
+    expect(pickDefaultProfile([p({ path: "/a", convertible: true }), p({ path: "/b", isDefault: true, convertible: true })], null)).toBe("/b"));
+  it("never picks a non-convertible default", () =>
+    expect(pickDefaultProfile([p({ path: "/esr", isDefault: true, convertible: false }), p({ path: "/a", convertible: true })], null)).toBe("/a"));
+  it("multiple convertible defaults -> first in order", () =>
+    expect(pickDefaultProfile([p({ path: "/a", isDefault: true, convertible: true }), p({ path: "/b", isDefault: true, convertible: true })], null)).toBe("/a"));
+});

--- a/desktop/src/lib/profiles.test.ts
+++ b/desktop/src/lib/profiles.test.ts
@@ -7,7 +7,7 @@ const p = (o: Partial<ProfileEntry>): ProfileEntry =>
 
 describe("labels", () => {
   it("one email", () => expect(profilePrimaryLabel(p({ accounts: ["a@x.com"] }))).toBe("a@x.com"));
-  it("+N more", () => expect(profilePrimaryLabel(p({ accounts: ["a@x.com", "b@y.com"] }))).toBe("a@x.com +1 more"));
+  it("+N more", () => expect(profilePrimaryLabel(p({ accounts: ["a@x.com", "b@example.com"] }))).toBe("a@x.com +1 more"));
   it("falls back to raw name", () => expect(profilePrimaryLabel(p({ name: "work", accounts: [] }))).toBe("work"));
   it("subtext is name · path", () => expect(profileSubtext(p({ name: "work", path: "/p/w" }))).toBe("work · /p/w"));
 });

--- a/desktop/src/lib/profiles.ts
+++ b/desktop/src/lib/profiles.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+import type { ProfileEntry } from "./types";
+
+export const visibleProfiles = (entries: ProfileEntry[]): ProfileEntry[] => entries.filter((e) => e.convertible);
+export const hiddenProfiles = (entries: ProfileEntry[]): ProfileEntry[] => entries.filter((e) => !e.convertible);
+
+export function hiddenNote(entries: ProfileEntry[]): string | null {
+  const hidden = hiddenProfiles(entries);
+  if (hidden.length === 0) return null;
+  if (hidden.length === 1) return `“${hidden[0].name}” was hidden — no convertible mail found in it.`;
+  return `${hidden.length} profiles were hidden — no convertible mail found.`;
+}
+
+export function profilePrimaryLabel(e: ProfileEntry): string {
+  if (e.accounts.length === 0) return e.name;
+  const extra = e.accounts.length - 1;
+  return extra > 0 ? `${e.accounts[0]} +${extra} more` : e.accounts[0];
+}
+
+export const profileSubtext = (e: ProfileEntry): string => `${e.name} · ${e.path}`;
+
+/** Path to preselect, or null to change nothing. Never overrides an existing selection. */
+export function pickDefaultProfile(entries: ProfileEntry[], currentProfileRoot: string | null): string | null {
+  if (currentProfileRoot !== null) return null;
+  const conv = visibleProfiles(entries);
+  if (conv.length === 0) return null;
+  if (conv.length === 1) return conv[0].path;
+  return (conv.find((e) => e.isDefault) ?? null)?.path ?? null;
+}

--- a/desktop/src/lib/profiles.ts
+++ b/desktop/src/lib/profiles.ts
@@ -26,5 +26,5 @@ export function pickDefaultProfile(entries: ProfileEntry[], currentProfileRoot: 
   const conv = visibleProfiles(entries);
   if (conv.length === 0) return null;
   if (conv.length === 1) return conv[0].path;
-  return (conv.find((e) => e.isDefault) ?? null)?.path ?? null;
+  return conv.find((e) => e.isDefault)?.path ?? null;
 }

--- a/desktop/src/lib/types.ts
+++ b/desktop/src/lib/types.ts
@@ -158,8 +158,4 @@ export interface ColourCategory {
 
 export type ColourPlanEntry = Pick<ColourCategory, "name" | "hex" | "outlookColor" | "action">;
 
-export interface ProfileEntry {
-  name: string;
-  path: string;
-  isDefault: boolean;
-}
+export interface ProfileEntry { name: string; path: string; isDefault: boolean; accounts: string[]; convertible: boolean }

--- a/desktop/src/lib/types.ts
+++ b/desktop/src/lib/types.ts
@@ -87,6 +87,7 @@ export type ConvertEvent = (
       report?: string;
       elapsedMs: number;
       enrichment?: EnrichmentSummary;
+      colourPlan?: ColourPlanEntry[];
     }
   | { type: "error"; stage?: string; message: string; fatal: boolean }
   | {
@@ -154,6 +155,8 @@ export interface ColourCategory {
   outlookColor: number | null;
   action: string;
 }
+
+export type ColourPlanEntry = Pick<ColourCategory, "name" | "hex" | "outlookColor" | "action">;
 
 export interface ProfileEntry {
   name: string;

--- a/desktop/src/lib/types.ts
+++ b/desktop/src/lib/types.ts
@@ -154,3 +154,9 @@ export interface ColourCategory {
   outlookColor: number | null;
   action: string;
 }
+
+export interface ProfileEntry {
+  name: string;
+  path: string;
+  isDefault: boolean;
+}

--- a/desktop/src/lib/useConvert.test.ts
+++ b/desktop/src/lib/useConvert.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, it, expect } from "vitest";
 import { reduceConvert, initialConvertState } from "./useConvert";
-import type { ConvertEvent, EnrichmentSummary } from "./types";
+import type { ConvertEvent, EnrichmentSummary, ColourPlanEntry } from "./types";
 
 const enr: EnrichmentSummary = {
   matched: 10, skippedMissingId: 0, skippedDuplicateId: 0, noMsfMatch: 0,
@@ -25,5 +25,25 @@ describe("reduceConvert enrichment capture", () => {
 
   it("initial state has null enrichment", () => {
     expect(initialConvertState.enrichment).toBeNull();
+  });
+});
+
+describe("reduceConvert colourPlan capture", () => {
+  it("captures colourPlan from the done event", () => {
+    const plan: ColourPlanEntry[] = [{ name: "Important", hex: "#FF0000", outlookColor: 6, action: "would-add" }];
+    const next = reduceConvert(running, {
+      type: "done", converted: 1, skipped: 0, warnings: 0, outputs: ["a.pst"],
+      elapsedMs: 5, colourPlan: plan,
+    } as ConvertEvent);
+    expect(next.colourPlan).toEqual(plan);
+  });
+
+  it("defaults colourPlan to null when the done event omits it", () => {
+    const done: ConvertEvent = { type: "done", converted: 1, skipped: 0, warnings: 0, outputs: [], elapsedMs: 1 };
+    expect(reduceConvert(running, done).colourPlan).toBeNull();
+  });
+
+  it("initial state has null colourPlan", () => {
+    expect(initialConvertState.colourPlan).toBeNull();
   });
 });

--- a/desktop/src/lib/useConvert.ts
+++ b/desktop/src/lib/useConvert.ts
@@ -6,7 +6,7 @@ import { listen } from "@tauri-apps/api/event";
 import { parseConvertLine, appendWarningCapped, convertExitError, type WarningItem } from "./convert";
 import { startConvert } from "./engine";
 import { checkSchemaVersion } from "./schema";
-import type { ConversionConfig, ConvertEvent, EnrichmentSummary } from "./types";
+import type { ConversionConfig, ConvertEvent, EnrichmentSummary, ColourPlanEntry } from "./types";
 
 export type ConvertPhase = "idle" | "running" | "done" | "error" | "cancelled";
 
@@ -26,6 +26,7 @@ export interface ConvertState {
   errorMessage: string | null;
   elapsedMs: number | null;
   enrichment: EnrichmentSummary | null;
+  colourPlan: ColourPlanEntry[] | null;
 }
 
 export const initialConvertState: ConvertState = {
@@ -44,6 +45,7 @@ export const initialConvertState: ConvertState = {
   errorMessage: null,
   elapsedMs: null,
   enrichment: null,
+  colourPlan: null,
 };
 
 export function reduceConvert(state: ConvertState, ev: ConvertEvent): ConvertState {
@@ -90,6 +92,7 @@ export function reduceConvert(state: ConvertState, ev: ConvertEvent): ConvertSta
         outputs: ev.outputs,
         elapsedMs: ev.elapsedMs,
         enrichment: ev.enrichment ?? null,
+        colourPlan: ev.colourPlan ?? null,
       };
     case "error":
       return { ...state, phase: "error", errorMessage: ev.message };

--- a/desktop/src/styles/globals.css
+++ b/desktop/src/styles/globals.css
@@ -33,9 +33,11 @@
   --dark-cream: #d1c9bf;
   --error: #db0000;
   --error-light: #fef0f0;
+  --data-present: #2f6f5e; /* sage-teal: ".msf present" / confirmed (NOT terracotta, NOT success-green) */
 }
 
 .dark {
+  --data-present: #2f6f5e;
   --background: #2a2b2f;
   --foreground: #fef9ef;
   --card: #3a3b3f;
@@ -94,6 +96,7 @@
   --color-dark-cream: var(--dark-cream);
   --color-error: var(--error);
   --color-error-light: var(--error-light);
+  --color-data-present: var(--data-present);
 }
 
 @layer base {

--- a/src/Mail2Pst.Cli/ConvertCommand.cs
+++ b/src/Mail2Pst.Cli/ConvertCommand.cs
@@ -3,11 +3,14 @@
 
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Mail2Pst.Core;
 using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Msf;
+using Mail2Pst.Core.OutlookCategories;
 using Mail2Pst.Core.Progress;
 
 namespace Mail2Pst.Cli;
@@ -133,6 +136,8 @@ internal static class ConvertCommand
             string reportTxtPath = Path.Combine(outputDir, "conversion-report.txt");
             File.WriteAllText(reportTxtPath, report.ToSummary());
 
+            var colourPlan = BuildColourPlan(config.ProfilePath);
+
             CliArgs.WriteJsonLine(new
             {
                 type = "done",
@@ -144,6 +149,7 @@ internal static class ConvertCommand
                 report = reportJsonPath,
                 elapsedMs = stopwatch.ElapsedMilliseconds,
                 enrichment = report.EnrichmentSummary,
+                colourPlan = colourPlan,
             });
 
             return 0;
@@ -164,5 +170,25 @@ internal static class ConvertCommand
         {
             try { File.Delete(templatePath); } catch { /* best-effort temp cleanup */ }
         }
+    }
+
+    private static object[] BuildColourPlan(string? profilePath)
+    {
+        if (string.IsNullOrEmpty(profilePath)) return Array.Empty<object>();
+        string prefsPath = Path.Combine(profilePath, "prefs.js");
+        if (!File.Exists(prefsPath)) return Array.Empty<object>();
+        string content;
+        try { content = File.ReadAllText(prefsPath); }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        { return Array.Empty<object>(); }
+
+        var plan = CategoryColorPlan.Build(
+            PrefsTagReader.ParseText(content),
+            PrefsTagReader.ParseColors(content));
+
+        var list = new List<object>();
+        foreach (var c in plan)
+            list.Add(new { name = c.Name, hex = c.Hex, outlookColor = c.OutlookColor, action = c.Action });
+        return list.ToArray();
     }
 }

--- a/src/Mail2Pst.Cli/ImportColoursCommand.cs
+++ b/src/Mail2Pst.Cli/ImportColoursCommand.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using Mail2Pst.Core.Cli;
 using Mail2Pst.Core.Msf;
@@ -23,13 +24,30 @@ internal static class ImportColoursCommand
         {
             Console.Error.WriteLine($"{input.Error}");
             Console.Error.WriteLine("Usage: continumail-convert import-colours --profile <thunderbird-profile-dir> [--apply]");
+            Console.Error.WriteLine("       continumail-convert import-colours --plan-file <path> [--apply]");
             return 1;
         }
 
-        string prefsPath = Path.Combine(input.ProfilePath!, "prefs.js");
-        string content = File.Exists(prefsPath) ? File.ReadAllText(prefsPath) : string.Empty;
-        IReadOnlyList<CategoryCandidate> plan =
-            CategoryColorPlan.Build(PrefsTagReader.ParseText(content), PrefsTagReader.ParseColors(content));
+        IReadOnlyList<CategoryCandidate> plan;
+        if (input.PlanFile is not null)
+        {
+            try
+            {
+                plan = LoadPlanFromFile(input.PlanFile);
+            }
+            catch (Exception ex)
+            {
+                CliArgs.WriteJsonLine(new { type = "error", stage = "import-colours", message = $"Could not load plan file: {ex.Message}", fatal = true });
+                Console.Error.WriteLine($"import-colours failed: {ex.Message}");
+                return 1;
+            }
+        }
+        else
+        {
+            string prefsPath = Path.Combine(input.ProfilePath!, "prefs.js");
+            string content = File.Exists(prefsPath) ? File.ReadAllText(prefsPath) : string.Empty;
+            plan = CategoryColorPlan.Build(PrefsTagReader.ParseText(content), PrefsTagReader.ParseColors(content));
+        }
 
         if (!input.Apply)
         {
@@ -71,6 +89,45 @@ internal static class ImportColoursCommand
             Console.Error.WriteLine($"import-colours failed: {ex.Message}");
             return 1;
         }
+    }
+
+    // Reads a colour plan JSON array (shape: [{name,hex,outlookColor,action}]) and normalises
+    // the action field so a would-add with no colour is safely downgraded to skipped-no-colour.
+    internal static IReadOnlyList<CategoryCandidate> LoadPlanFromFile(string path)
+    {
+        string json = File.ReadAllText(path);
+        using JsonDocument doc = JsonDocument.Parse(json);
+        JsonElement root = doc.RootElement;
+        if (root.ValueKind != JsonValueKind.Array)
+            throw new FormatException("Plan file must be a JSON array.");
+
+        var result = new List<CategoryCandidate>();
+        foreach (JsonElement el in root.EnumerateArray())
+        {
+            string name = el.GetProperty("name").GetString() ?? string.Empty;
+            string? hex = el.TryGetProperty("hex", out JsonElement hexEl) ? hexEl.GetString() : null;
+            int? outlookColor = el.TryGetProperty("outlookColor", out JsonElement ocEl) && ocEl.ValueKind == JsonValueKind.Number
+                ? ocEl.GetInt32()
+                : null;
+            string? rawAction = el.TryGetProperty("action", out JsonElement actEl) ? actEl.GetString() : null;
+
+            // Safe normalisation:
+            // - action present → use it, but demote would-add with null colour
+            // - action absent + colour present → would-add
+            // - action absent + colour absent → skipped-no-colour
+            string action;
+            if (rawAction is not null)
+            {
+                action = (rawAction == "would-add" && outlookColor is null) ? "skipped-no-colour" : rawAction;
+            }
+            else
+            {
+                action = outlookColor is not null ? "would-add" : "skipped-no-colour";
+            }
+
+            result.Add(new CategoryCandidate(name, hex, outlookColor, action));
+        }
+        return result;
     }
 
     private static bool ProgIdRegistered() =>

--- a/src/Mail2Pst.Cli/ImportColoursInput.cs
+++ b/src/Mail2Pst.Cli/ImportColoursInput.cs
@@ -6,9 +6,9 @@ using System.Collections.Generic;
 
 namespace Mail2Pst.Cli;
 
-internal sealed record ImportColoursInput(string? ProfilePath, bool Apply, string? Error)
+internal sealed record ImportColoursInput(string? ProfilePath, bool Apply, string? Error, string? PlanFile = null)
 {
-    private static readonly HashSet<string> Known = new(StringComparer.Ordinal) { "--profile", "--apply" };
+    private static readonly HashSet<string> Known = new(StringComparer.Ordinal) { "--profile", "--apply", "--plan-file" };
 
     internal static ImportColoursInput Parse(string[] args)
     {
@@ -16,16 +16,23 @@ internal sealed record ImportColoursInput(string? ProfilePath, bool Apply, strin
         {
             string a = args[i];
             if (!Known.Contains(a)) return new ImportColoursInput(null, false, $"Unknown argument: {a}");
-            if (a == "--profile")
+            if (a == "--profile" || a == "--plan-file")
             {
                 i++;
                 if (i >= args.Length || args[i].StartsWith("--", System.StringComparison.Ordinal))
-                    return new ImportColoursInput(null, false, "--profile requires a value.");
+                    return new ImportColoursInput(null, false, $"{a} requires a value.");
             }
         }
         string? profile = CliArgs.Flag(args, "--profile");
-        if (string.IsNullOrWhiteSpace(profile))
-            return new ImportColoursInput(null, false, "Missing required --profile <thunderbird-profile-dir>.");
-        return new ImportColoursInput(profile, CliArgs.HasFlag(args, "--apply"), null);
+        string? planFile = CliArgs.Flag(args, "--plan-file");
+        bool apply = CliArgs.HasFlag(args, "--apply");
+
+        if (profile is not null && planFile is not null)
+            return new ImportColoursInput(null, false, "--profile and --plan-file are mutually exclusive; specify exactly one.");
+
+        if (profile is null && planFile is null)
+            return new ImportColoursInput(null, false, "Missing required --profile <thunderbird-profile-dir> or --plan-file <path>.");
+
+        return new ImportColoursInput(profile, apply, null, planFile);
     }
 }

--- a/tests/Mail2Pst.Integration.Tests/ConsoleCaptureCollection.cs
+++ b/tests/Mail2Pst.Integration.Tests/ConsoleCaptureCollection.cs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests;
+
+/// <summary>
+/// Tests that redirect the process-global Console.Out (via Console.SetOut) to capture CLI stdout
+/// must not run in parallel with each other or other collections, or the global redirect races.
+/// </summary>
+[CollectionDefinition("ConsoleCapture", DisableParallelization = true)]
+public sealed class ConsoleCaptureCollection { }

--- a/tests/Mail2Pst.Integration.Tests/ConvertCommandColourPlanTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/ConvertCommandColourPlanTests.cs
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Mail2Pst.Cli;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests;
+
+public class ConvertCommandColourPlanTests
+{
+    private static string CreateMinimalMbox(string dir)
+    {
+        string mbox = Path.Combine(dir, "in.mbox");
+        File.WriteAllText(mbox, "From s@e Thu Jan 01 00:00:00 2026\nMessage-ID: <a@h>\nSubject: t\n\nbody\n");
+        return mbox;
+    }
+
+    private static string CreateConfig(string dir, string mbox, string? profilePath = null)
+    {
+        string cfg = Path.Combine(dir, "config.json");
+        string profilePart = profilePath is not null
+            ? ",\"profilePath\":" + JsonSerializer.Serialize(profilePath)
+            : "";
+        File.WriteAllText(cfg,
+            "{\"outputs\":[{\"name\":\"Out\",\"sources\":[{\"path\":" +
+            JsonSerializer.Serialize(mbox) + ",\"type\":\"mbox\"}]}]" +
+            profilePart + "}");
+        return cfg;
+    }
+
+    [Fact]
+    public void Convert_WithProfilePathAndColouredTag_DoneHasColourPlanEntry()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "mail2pst-colour-" + Guid.NewGuid());
+        Directory.CreateDirectory(dir);
+        string profileDir = Path.Combine(dir, "profile");
+        Directory.CreateDirectory(profileDir);
+
+        // Write a minimal prefs.js with one coloured tag
+        File.WriteAllText(Path.Combine(profileDir, "prefs.js"),
+            "user_pref(\"mailnews.tags.$label1.tag\", \"Important\");\n" +
+            "user_pref(\"mailnews.tags.$label1.color\", \"#FF0000\");\n");
+
+        string mbox = CreateMinimalMbox(dir);
+        string cfg = CreateConfig(dir, mbox, profileDir);
+        string outDir = Path.Combine(dir, "out");
+
+        var sw = new StringWriter();
+        TextWriter original = Console.Out;
+        Console.SetOut(sw);
+        try
+        {
+            int exit = ConvertCommand.Run(new[] { "--config", cfg, "--output", outDir });
+            Assert.Equal(0, exit);
+
+            string done = sw.ToString().Split('\n').First(l => l.Contains("\"type\":\"done\""));
+            using var doc = JsonDocument.Parse(done);
+            var root = doc.RootElement;
+
+            Assert.True(root.TryGetProperty("colourPlan", out JsonElement plan), "done must have colourPlan");
+            Assert.Equal(JsonValueKind.Array, plan.ValueKind);
+
+            // Find the Important entry
+            var entry = plan.EnumerateArray().FirstOrDefault(e =>
+                e.TryGetProperty("name", out var n) && n.GetString() == "Important");
+            Assert.NotEqual(default, entry);
+            Assert.Equal("#FF0000", entry.GetProperty("hex").GetString());
+            Assert.Equal("would-add", entry.GetProperty("action").GetString());
+        }
+        finally
+        {
+            Console.SetOut(original);
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void Convert_WithoutProfilePath_DoneHasEmptyColourPlan()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "mail2pst-colour-" + Guid.NewGuid());
+        Directory.CreateDirectory(dir);
+
+        string mbox = CreateMinimalMbox(dir);
+        string cfg = CreateConfig(dir, mbox, profilePath: null);
+        string outDir = Path.Combine(dir, "out");
+
+        var sw = new StringWriter();
+        TextWriter original = Console.Out;
+        Console.SetOut(sw);
+        try
+        {
+            int exit = ConvertCommand.Run(new[] { "--config", cfg, "--output", outDir });
+            Assert.Equal(0, exit);
+
+            string done = sw.ToString().Split('\n').First(l => l.Contains("\"type\":\"done\""));
+            using var doc = JsonDocument.Parse(done);
+            var root = doc.RootElement;
+
+            Assert.True(root.TryGetProperty("colourPlan", out JsonElement plan), "done must have colourPlan");
+            Assert.Equal(JsonValueKind.Array, plan.ValueKind);
+            Assert.Equal(0, plan.GetArrayLength());
+        }
+        finally
+        {
+            Console.SetOut(original);
+            Directory.Delete(dir, true);
+        }
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/ConvertCommandColourPlanTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/ConvertCommandColourPlanTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace Mail2Pst.Integration.Tests;
 
+[Collection("ConsoleCapture")]
 public class ConvertCommandColourPlanTests
 {
     private static string CreateMinimalMbox(string dir)

--- a/tests/Mail2Pst.Integration.Tests/ConvertCommandDoneTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/ConvertCommandDoneTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace Mail2Pst.Integration.Tests;
 
+[Collection("ConsoleCapture")]
 public class ConvertCommandDoneTests
 {
     [Fact]

--- a/tests/Mail2Pst.Integration.Tests/ImportColoursInputTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/ImportColoursInputTests.cs
@@ -51,4 +51,27 @@ public class ImportColoursInputTests
         var input = ImportColoursInput.Parse(new[] { "--profile" });
         Assert.NotNull(input.Error);
     }
+
+    [Fact]
+    public void Parse_PlanFile_IsAccepted()
+    {
+        var input = ImportColoursInput.Parse(new[] { "--plan-file", "C:\\tmp\\plan.json" });
+        Assert.Null(input.Error);
+        Assert.Equal("C:\\tmp\\plan.json", input.PlanFile);
+        Assert.Null(input.ProfilePath);
+    }
+
+    [Fact]
+    public void Parse_PlanFileAndProfile_IsRejected()
+    {
+        var input = ImportColoursInput.Parse(new[] { "--plan-file", "p.json", "--profile", "d" });
+        Assert.NotNull(input.Error);
+    }
+
+    [Fact]
+    public void Parse_PlanFileWithoutValue_IsRejected()
+    {
+        var input = ImportColoursInput.Parse(new[] { "--plan-file" });
+        Assert.NotNull(input.Error);
+    }
 }

--- a/tests/Mail2Pst.Integration.Tests/ImportColoursLoadPlanTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/ImportColoursLoadPlanTests.cs
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.IO;
+using Mail2Pst.Cli;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests;
+
+public class ImportColoursLoadPlanTests
+{
+    private static string WriteTempPlan(string json)
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"mail2pst-loadplan-{Guid.NewGuid()}.json");
+        File.WriteAllText(path, json);
+        return path;
+    }
+
+    [Fact]
+    public void WouldAdd_WithNullColour_IsDowngradedToSkippedNoColour()
+    {
+        string path = WriteTempPlan("""
+            [{"name":"Alpha","hex":null,"action":"would-add"}]
+            """);
+        try
+        {
+            var plan = ImportColoursCommand.LoadPlanFromFile(path);
+            Assert.Single(plan);
+            Assert.Equal("skipped-no-colour", plan[0].Action);
+            Assert.Null(plan[0].OutlookColor);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ActionAbsent_WithColour_IsWouldAdd()
+    {
+        string path = WriteTempPlan("""
+            [{"name":"Beta","hex":"#FF0000","outlookColor":6}]
+            """);
+        try
+        {
+            var plan = ImportColoursCommand.LoadPlanFromFile(path);
+            Assert.Single(plan);
+            Assert.Equal("would-add", plan[0].Action);
+            Assert.Equal(6, plan[0].OutlookColor);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ActionAbsent_WithNullColour_IsSkippedNoColour()
+    {
+        string path = WriteTempPlan("""
+            [{"name":"Gamma","hex":null}]
+            """);
+        try
+        {
+            var plan = ImportColoursCommand.LoadPlanFromFile(path);
+            Assert.Single(plan);
+            Assert.Equal("skipped-no-colour", plan[0].Action);
+            Assert.Null(plan[0].OutlookColor);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ActionPresent_NonWouldAdd_IsPreservedAsIs()
+    {
+        string path = WriteTempPlan("""
+            [{"name":"Delta","hex":"#00FF00","outlookColor":3,"action":"skipped-existing"}]
+            """);
+        try
+        {
+            var plan = ImportColoursCommand.LoadPlanFromFile(path);
+            Assert.Single(plan);
+            Assert.Equal("skipped-existing", plan[0].Action);
+            Assert.Equal(3, plan[0].OutlookColor);
+        }
+        finally { File.Delete(path); }
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/Mail2Pst.Integration.Tests.csproj
+++ b/tests/Mail2Pst.Integration.Tests/Mail2Pst.Integration.Tests.csproj
@@ -18,5 +18,6 @@
   <ItemGroup>
     <None Include="../../fixtures/**/*" CopyToOutputDirectory="PreserveNewest" LinkBase="fixtures" />
     <None Include="../../assets/template.pst" CopyToOutputDirectory="PreserveNewest" LinkBase="assets" />
+    <None Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/tests/Mail2Pst.Integration.Tests/xunit.runner.json
+++ b/tests/Mail2Pst.Integration.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false
+}


### PR DESCRIPTION
## What

The "polish + onboarding" half of the v0.2.0 desktop release. The multi-account half (one PST per account) lands in a follow-up PR; both ship together as v0.2.0. No engine/PST-writer change; all CLI additions are additive.

## Changes

- **Profile onboarding.** The "Choose profile" picker defaults to `%APPDATA%\Thunderbird\Profiles`, and a new **Scan for Thunderbird profiles** button auto-detects installed profiles (parsed from `profiles.ini`): each profile is labelled by its account email, profiles with no convertible mail are hidden (with a note), and manual **Browse** remains the fallback. Scanning is button-triggered (no auto-scan).
- **`.msf` "data present" badge** now uses a sage-teal `--data-present` colour instead of the error-looking terracotta; terracotta is kept for the degraded/warning case.
- **Instant Outlook Master-List apply** on the Done screen: `convert` emits the colour plan on its `done` event when the config carries a profile path, the Done card renders it with no second scan, and Apply writes it via a new `import-colours --plan-file`.

## Notes

- Additive CLI contract only (`done.colourPlan`, `import-colours --plan-file`); no `schemaVersion` bump. `import-colours --apply` still requires Outlook closed.
- All new scan/colour paths degrade silently (missing `profiles.ini`, no Outlook, unreadable `prefs.js`).
- No new Rust crate. Tests: 609 Core + 69 Integration (.NET), 164 Vitest, 8 cargo — all green.