### PR TITLE
feat(gui): v0.2.0 multi-account profiles — one PST per account

### DIFF
--- a/.githooks/leak-check-allowlist.txt
+++ b/.githooks/leak-check-allowlist.txt
@@ -6,7 +6,6 @@
 @example.net
 @example.org
 @example.test
-@contoso.test
 
 # Synthetic placeholder domains used throughout the unit-test suite (not real recipients).
 # (Migrating these tests to @example.* would let us drop these two — minor future cleanup.)

--- a/.githooks/leak-check-allowlist.txt
+++ b/.githooks/leak-check-allowlist.txt
@@ -6,6 +6,7 @@
 @example.net
 @example.org
 @example.test
+@contoso.test
 
 # Synthetic placeholder domains used throughout the unit-test suite (not real recipients).
 # (Migrating these tests to @example.* would let us drop these two — minor future cleanup.)

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -74,8 +74,7 @@ export default function App() {
       ? (step: number) => {
           if (step === 0) requestGoToSource();
           else if (isMultiAccount && step === 1 && f.stage !== "accounts") {
-            // jump back to accounts (not yet wired via useScan — fall back to backToReview for now)
-            flow.backToReview();
+            flow.backToAccounts();
           } else if (step === (isMultiAccount ? 2 : 1)) flow.backToReview();
         }
       : undefined;

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -83,12 +83,12 @@ export default function App() {
       {f.stage === "select" && (
         <SelectView
           files={f.inputFiles}
-          outputPath={f.outputPath}
+          outputTarget={f.outputTarget}
           inputMode={f.inputMode}
           profileRoot={f.profileRoot}
           sourceError={f.sourceError}
           onFilesChange={flow.setInputFiles}
-          onOutputPathChange={flow.setOutputPath}
+          onOutputTargetChange={flow.setOutputTarget}
           onInputModeChange={flow.setInputMode}
           onProfileRootChange={flow.setProfileRoot}
           onContinue={flow.continueToScan}
@@ -111,11 +111,12 @@ export default function App() {
           warnings={f.inputMode === "profile" ? f.discoverWarnings : undefined}
         />
       )}
-      {f.stage === "options" && f.outputPath && (
+      {f.stage === "options" && (
         f.inputMode === "profile" && f.profileRoot ? (
           <ProfileOptionsView
             rows={flow.sortedSources as ProfileSourceRow[]}
-            outputPath={f.outputPath}
+            outputTarget={f.outputTarget}
+            onOutputTargetChange={flow.setOutputTarget}
             profileRoot={f.profileRoot}
             checkedIds={f.checkedIds}
             skipEmpty={f.skipEmpty}
@@ -124,11 +125,11 @@ export default function App() {
             onStart={start}
             onBack={flow.backToReview}
           />
-        ) : f.scan ? (
+        ) : f.scan && f.outputTarget?.kind === "pstFile" ? (
           <OptionsView
             scan={f.scan}
             previewSources={flow.sortedSources}
-            outputPath={f.outputPath}
+            outputPath={f.outputTarget.path}
             checkedIds={f.checkedIds}
             skipEmpty={f.skipEmpty}
             options={f.options}

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -17,28 +17,18 @@ import { ErrorView } from "@/components/views/ErrorView";
 import { CancelledView } from "@/components/views/CancelledView";
 import { useConvert } from "@/lib/useConvert";
 import { useScan } from "@/lib/useScan";
-
-const STEP_FOR_PHASE: Record<string, number> = {
-  running: 3,
-  done: 4,
-  error: 4,
-  cancelled: 4,
-};
-
-// scanning/review/scanError live on stepper step 1 ("Review"); options on step 2.
-const STEP_FOR_STAGE: Record<string, number> = {
-  select: 0,
-  scanning: 1,
-  review: 1,
-  scanError: 1,
-  options: 2,
-};
+import { buildSteps, stepIndexForStage, stepIndexForPhase } from "@/lib/steps";
 
 export default function App() {
   const { state: conv, start, reset } = useConvert();
   const flow = useScan();
   const { state: f } = flow;
   const [confirmSource, setConfirmSource] = useState(false);
+
+  // Task 9c will wire the real discovered account count; for now pass 0 so
+  // behaviour is identical to the hard-coded 5-step list (files-mode + profile
+  // single-account both produce ["Source","Review","Options","Convert","Done"]).
+  const steps = buildSteps(f.inputMode, 0);
 
   // Memoized so ConfirmDialog's Esc-key effect (deps on onCancel) doesn't
   // re-register its keydown listener on every App render.
@@ -54,7 +44,7 @@ export default function App() {
       flow.resetFlow();
     };
     return (
-      <Shell currentStep={STEP_FOR_PHASE[conv.phase] ?? 0}>
+      <Shell steps={steps} currentStep={stepIndexForPhase(steps, conv.phase)}>
         {conv.phase === "running" && <ConvertView state={conv} />}
         {conv.phase === "done" && (
           <DoneView
@@ -89,7 +79,7 @@ export default function App() {
 
   return (
     <>
-    <Shell currentStep={STEP_FOR_STAGE[f.stage] ?? 0} onStepSelect={onStepSelect}>
+    <Shell steps={steps} currentStep={stepIndexForStage(steps, f.stage)} onStepSelect={onStepSelect}>
       {f.stage === "select" && (
         <SelectView
           files={f.inputFiles}

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -122,7 +122,7 @@ export default function App() {
           onToggle={flow.toggleChecked}
           onSkipEmptyChange={flow.setSkipEmpty}
           onContinue={flow.continueToOptions}
-          onBack={requestGoToSource}
+          onBack={isMultiAccount ? flow.backToAccounts : requestGoToSource}
           pairedIds={f.inputMode === "profile" ? flow.pairedIds : undefined}
           warnings={f.inputMode === "profile" ? f.discoverWarnings : undefined}
         />

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -9,6 +9,7 @@ import { ScanningView } from "@/components/views/ScanningView";
 import { ReviewView } from "@/components/views/ReviewView";
 import { OptionsView } from "@/components/views/OptionsView";
 import { ProfileOptionsView } from "@/components/views/ProfileOptionsView";
+import { AccountsView } from "@/components/views/AccountsView";
 import type { ProfileSourceRow } from "@/lib/types";
 import { ScanErrorView } from "@/components/views/ScanErrorView";
 import { ConvertView } from "@/components/views/ConvertView";
@@ -25,10 +26,7 @@ export default function App() {
   const { state: f } = flow;
   const [confirmSource, setConfirmSource] = useState(false);
 
-  // Task 9c will wire the real discovered account count; for now pass 0 so
-  // behaviour is identical to the hard-coded 5-step list (files-mode + profile
-  // single-account both produce ["Source","Review","Options","Convert","Done"]).
-  const steps = buildSteps(f.inputMode, 0);
+  const steps = buildSteps(f.inputMode, flow.discoveredAccountCount);
 
   // Memoized so ConfirmDialog's Esc-key effect (deps on onCancel) doesn't
   // re-register its keydown listener on every App render.
@@ -67,13 +65,18 @@ export default function App() {
   };
 
   // Clickable stepper (backward only, pre-convert stable stages). Step 0 → Source
-  // (guarded), step 1 → Review, reusing the existing transitions. Not offered during
-  // scanning/scanError (transient) so the stepper can't bail an in-flight scan.
+  // (guarded), step 1 → Accounts (multi) or Review (single), step 2 → Review
+  // (multi only). Not offered during scanning/scanError (transient) so the stepper
+  // can't bail an in-flight scan.
+  const isMultiAccount = flow.discoveredAccountCount >= 2 && f.inputMode === "profile";
   const onStepSelect =
-    f.stage === "review" || f.stage === "options"
+    f.stage === "accounts" || f.stage === "review" || f.stage === "options"
       ? (step: number) => {
           if (step === 0) requestGoToSource();
-          else if (step === 1) flow.backToReview();
+          else if (isMultiAccount && step === 1 && f.stage !== "accounts") {
+            // jump back to accounts (not yet wired via useScan — fall back to backToReview for now)
+            flow.backToReview();
+          } else if (step === (isMultiAccount ? 2 : 1)) flow.backToReview();
         }
       : undefined;
 
@@ -95,6 +98,20 @@ export default function App() {
         />
       )}
       {f.stage === "scanning" && <ScanningView fileCount={f.inputFiles.length} progress={f.scanProgress} />}
+      {f.stage === "accounts" && f.inputMode === "profile" && (
+        <AccountsView
+          rows={f.profileRows}
+          accounts={f.accounts}
+          selectedAccountKeys={f.selectedAccountKeys}
+          pstNames={f.pstNames}
+          outputTarget={f.outputTarget}
+          onOutputTargetChange={flow.setOutputTarget}
+          onToggleAccount={flow.toggleAccount}
+          onSetPstName={flow.setPstName}
+          onBack={requestGoToSource}
+          onContinue={flow.continueToReviewFromAccounts}
+        />
+      )}
       {f.stage === "review" && f.scan && (
         <ReviewView
           sources={flow.sortedSources}
@@ -124,6 +141,9 @@ export default function App() {
             onSetOptions={flow.setOptions}
             onStart={start}
             onBack={flow.backToReview}
+            accounts={f.accounts}
+            selectedAccountKeys={f.selectedAccountKeys}
+            pstNames={f.pstNames}
           />
         ) : f.scan && f.outputTarget?.kind === "pstFile" ? (
           <OptionsView

--- a/desktop/src/components/Shell.tsx
+++ b/desktop/src/components/Shell.tsx
@@ -5,14 +5,14 @@ import type { ReactNode } from "react";
 import { ArrowRightLeft, Clock, SlidersHorizontal } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-const STEPS = ["Source", "Review", "Options", "Convert", "Done"];
-
 export function Shell({
   children,
+  steps,
   currentStep = 0,
   onStepSelect,
 }: {
   children: ReactNode;
+  steps: string[];
   currentStep?: number;
   // When provided, already-completed steps (index < currentStep) become
   // clickable to navigate back. Forward/current steps are never clickable.
@@ -39,7 +39,7 @@ export function Shell({
       {/* main area */}
       <main className="flex flex-1 flex-col p-6">
         <ol className="mb-5 flex flex-wrap items-center gap-2 text-xs text-light-gray">
-          {STEPS.map((label, i) => {
+          {steps.map((label, i) => {
             const navigable = onStepSelect != null && i < currentStep;
             return (
               <li key={label} className="flex items-center gap-2">
@@ -62,7 +62,7 @@ export function Shell({
                     {i + 1} {label}
                   </span>
                 )}
-                {i < STEPS.length - 1 && <span aria-hidden>›</span>}
+                {i < steps.length - 1 && <span aria-hidden>›</span>}
               </li>
             );
           })}

--- a/desktop/src/components/views/AccountsView.tsx
+++ b/desktop/src/components/views/AccountsView.tsx
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { FolderOpen, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { groupByAccount } from "@/lib/accounts";
+import { formatBytes } from "@/lib/format";
+import { pickOutputFolder } from "@/lib/engine";
+import type { ProfileSourceRow, OutputTarget, Account } from "@/lib/types";
+
+interface AccountsViewProps {
+  rows: ProfileSourceRow[];
+  accounts: Account[];
+  selectedAccountKeys: Set<string>;
+  pstNames: Record<string, string>;
+  outputTarget: OutputTarget | null;
+  onOutputTargetChange: (target: OutputTarget | null) => void;
+  onToggleAccount: (key: string) => void;
+  onSetPstName: (key: string, name: string) => void;
+  onBack: () => void;
+  onContinue: () => void;
+}
+
+export function AccountsView({
+  rows,
+  accounts,
+  selectedAccountKeys,
+  pstNames,
+  outputTarget,
+  onOutputTargetChange,
+  onToggleAccount,
+  onSetPstName,
+  onBack,
+  onContinue,
+}: AccountsViewProps) {
+  const groups = groupByAccount(rows, accounts);
+  const selectedCount = selectedAccountKeys.size;
+  const folderDir = outputTarget?.kind === "folder" ? outputTarget.dir : null;
+  const canContinue = selectedCount >= 1 && folderDir !== null;
+
+  async function onPickFolder() {
+    const dir = await pickOutputFolder();
+    if (dir) onOutputTargetChange({ kind: "folder", dir });
+  }
+
+  function onClearFolder() {
+    onOutputTargetChange(null);
+  }
+
+  return (
+    <div className="flex flex-1 flex-col min-h-0">
+      <h1 className="text-xl font-semibold text-foreground">Accounts found</h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Select the accounts to convert. Each account produces one PST file.
+      </p>
+
+      <div className="mt-3 min-h-0 flex-1 overflow-auto flex flex-col gap-2">
+        {groups.map((group) => {
+          const checked = selectedAccountKeys.has(group.key);
+          const label = group.account?.email ?? group.account?.folderSegment ?? group.key;
+          const host = group.account?.host;
+          const notFound = group.account?.addressResolution === "not-found";
+          const currentName = pstNames[group.key] ?? group.defaultPstName;
+
+          return (
+            <div
+              key={group.key}
+              className="rounded-lg border border-border bg-card px-4 py-3"
+            >
+              <div className="flex items-start gap-3">
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={() => onToggleAccount(group.key)}
+                  aria-label={`Include account ${label}`}
+                  className="mt-0.5 accent-primary"
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="font-medium text-sm text-foreground truncate">{label}</div>
+                  <div className="mt-0.5 text-xs text-light-gray">
+                    {[
+                      host,
+                      `${group.folderCount} folder${group.folderCount === 1 ? "" : "s"}`,
+                      `${group.messageCount.toLocaleString()} messages`,
+                      formatBytes(group.estimatedBytes),
+                    ]
+                      .filter(Boolean)
+                      .join(" · ")}
+                  </div>
+                  {notFound && (
+                    <div className="mt-1 text-xs text-muted-foreground italic">
+                      address not found in profile
+                    </div>
+                  )}
+                  <div className="mt-2 flex items-center gap-2">
+                    <label className="text-xs text-light-gray shrink-0">PST name:</label>
+                    <input
+                      type="text"
+                      value={currentName}
+                      onChange={(e) => onSetPstName(group.key, e.target.value)}
+                      aria-label={`PST name for ${label}`}
+                      className="flex-1 min-w-0 rounded border border-border bg-background px-2 py-0.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+                    />
+                    <span className="text-xs text-light-gray">.pst</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="mt-3">
+        <div className="mb-1 text-sm font-medium text-foreground">Output folder</div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" onClick={onPickFolder}>
+            <FolderOpen /> {folderDir ? folderDir.split(/[\\/]/).pop() : "Choose output folder…"}
+          </Button>
+          {folderDir && (
+            <button
+              type="button"
+              onClick={onClearFolder}
+              aria-label="Clear output folder"
+              title="Clear"
+              className="shrink-0 rounded p-0.5 text-light-gray transition-colors hover:text-destructive"
+            >
+              <X className="size-4" />
+            </button>
+          )}
+        </div>
+        {folderDir && (
+          <div className="mt-1 text-xs text-light-gray">{folderDir}</div>
+        )}
+      </div>
+
+      <div className="mt-3 text-sm text-muted-foreground">
+        {selectedCount} account{selectedCount === 1 ? "" : "s"} selected &rarr; {selectedCount} PST file{selectedCount === 1 ? "" : "s"}
+      </div>
+
+      <div className="mt-4 flex items-center justify-end">
+        <div className="flex gap-3">
+          <Button variant="outline" onClick={onBack}>&#8249; Back</Button>
+          <Button disabled={!canContinue} onClick={onContinue}>Review folders &#8250;</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/components/views/ProfileOptionsView.tsx
+++ b/desktop/src/components/views/ProfileOptionsView.tsx
@@ -1,20 +1,23 @@
 // SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
 // SPDX-License-Identifier: GPL-3.0-or-later
 import { useMemo, useState } from "react";
+import { Save, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { HelpTip } from "@/components/ui/help-tip";
 import { SplitSizeControl } from "@/components/ui/split-size-control";
 import { buildProfileConfig } from "@/lib/profileConfig";
 import { effectiveRows } from "@/lib/review";
 import { ConvertConfigError, deriveOutputTarget } from "@/lib/convert";
+import { splitPath } from "@/lib/convert";
 import { formatBytes } from "@/lib/format";
-import { openJunkHelp } from "@/lib/engine";
+import { openJunkHelp, pickOutputPst } from "@/lib/engine";
 import type { OptionsState } from "@/lib/options";
-import type { ConversionConfig, ProfileSourceRow } from "@/lib/types";
+import type { ConversionConfig, ProfileSourceRow, OutputTarget } from "@/lib/types";
 
 interface ProfileOptionsViewProps {
   rows: ProfileSourceRow[];
-  outputPath: string;
+  outputTarget: OutputTarget | null;
+  onOutputTargetChange: (target: OutputTarget | null) => void;
   profileRoot: string;
   checkedIds: Set<string>;
   skipEmpty: boolean;
@@ -25,7 +28,7 @@ interface ProfileOptionsViewProps {
 }
 
 export function ProfileOptionsView({
-  rows, outputPath, profileRoot, checkedIds, skipEmpty, options, onSetOptions, onStart, onBack,
+  rows, outputTarget, onOutputTargetChange, profileRoot, checkedIds, skipEmpty, options, onSetOptions, onStart, onBack,
 }: ProfileOptionsViewProps) {
   const [startError, setStartError] = useState<string | null>(null);
   const [splitOk, setSplitOk] = useState(true);
@@ -34,13 +37,30 @@ export function ProfileOptionsView({
     () => effectiveRows(rows, checkedIds, skipEmpty) as ProfileSourceRow[],
     [rows, checkedIds, skipEmpty],
   );
+
+  const outputPath = outputTarget?.kind === "pstFile" ? outputTarget.path : null;
+
   const pstName = useMemo(() => {
+    if (!outputPath) return "Output";
     try { return deriveOutputTarget(outputPath).pstName; } catch { return "Output"; }
   }, [outputPath]);
   const totalBytes = eff.reduce((n, r) => n + r.bytes, 0);
-  const canStart = eff.length > 0 && splitOk;
+  const canStart = eff.length > 0 && splitOk && outputTarget !== null;
+
+  async function onChooseOutput() {
+    const path = await pickOutputPst();
+    if (path) onOutputTargetChange({ kind: "pstFile", path });
+  }
+
+  function onClearOutput() {
+    onOutputTargetChange(null);
+  }
 
   function onStartClick() {
+    if (!outputPath) {
+      setStartError("Choose an output .pst file first.");
+      return;
+    }
     try {
       const { config, outputDir } = buildProfileConfig(
         rows, checkedIds, skipEmpty, options, outputPath, profileRoot,
@@ -153,6 +173,27 @@ export function ProfileOptionsView({
             Carried over from Thunderbird automatically: <span className="text-foreground">read/unread, replied, forwarded, starred</span> flags and <span className="text-foreground">tags → Outlook categories</span> (folders with an <span className="text-primary">.msf</span> badge).
           </div>
         </div>
+      </div>
+
+      <div className="mt-4">
+        <div className="mb-1 text-sm font-medium text-foreground">Output PST file</div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" onClick={onChooseOutput}>
+            <Save /> {outputPath ? splitPath(outputPath).base : "Choose output…"}
+          </Button>
+          {outputPath && (
+            <button
+              type="button"
+              onClick={onClearOutput}
+              aria-label="Clear output location"
+              title="Clear"
+              className="shrink-0 rounded p-0.5 text-light-gray transition-colors hover:text-destructive"
+            >
+              <X className="size-4" />
+            </button>
+          )}
+        </div>
+        {outputPath && <div className="mt-1 text-xs text-light-gray">{splitPath(outputPath).dir}</div>}
       </div>
 
       {startError && <p className="mt-3 text-sm text-destructive">{startError}</p>}

--- a/desktop/src/components/views/ProfileOptionsView.tsx
+++ b/desktop/src/components/views/ProfileOptionsView.tsx
@@ -5,14 +5,15 @@ import { Save, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { HelpTip } from "@/components/ui/help-tip";
 import { SplitSizeControl } from "@/components/ui/split-size-control";
-import { buildProfileConfig } from "@/lib/profileConfig";
+import { buildProfileConfig, buildProfileConfigMulti } from "@/lib/profileConfig";
 import { effectiveRows } from "@/lib/review";
 import { ConvertConfigError, deriveOutputTarget } from "@/lib/convert";
 import { splitPath } from "@/lib/convert";
 import { formatBytes } from "@/lib/format";
 import { openJunkHelp, pickOutputPst } from "@/lib/engine";
+import { groupByAccount } from "@/lib/accounts";
 import type { OptionsState } from "@/lib/options";
-import type { ConversionConfig, ProfileSourceRow, OutputTarget } from "@/lib/types";
+import type { ConversionConfig, ProfileSourceRow, OutputTarget, Account } from "@/lib/types";
 
 interface ProfileOptionsViewProps {
   rows: ProfileSourceRow[];
@@ -25,10 +26,15 @@ interface ProfileOptionsViewProps {
   onSetOptions: (patch: Partial<OptionsState>) => void;
   onStart: (config: ConversionConfig, outputDir: string) => void;
   onBack: () => void;
+  // multi-account (optional — only present in profile mode with ≥2 accounts)
+  accounts?: Account[];
+  selectedAccountKeys?: Set<string>;
+  pstNames?: Record<string, string>;
 }
 
 export function ProfileOptionsView({
   rows, outputTarget, onOutputTargetChange, profileRoot, checkedIds, skipEmpty, options, onSetOptions, onStart, onBack,
+  accounts, selectedAccountKeys, pstNames,
 }: ProfileOptionsViewProps) {
   const [startError, setStartError] = useState<string | null>(null);
   const [splitOk, setSplitOk] = useState(true);
@@ -45,7 +51,8 @@ export function ProfileOptionsView({
     try { return deriveOutputTarget(outputPath).pstName; } catch { return "Output"; }
   }, [outputPath]);
   const totalBytes = eff.reduce((n, r) => n + r.bytes, 0);
-  const canStart = eff.length > 0 && splitOk && outputTarget !== null;
+  const isMultiAccount = outputTarget?.kind === "folder";
+  const canStart = eff.length > 0 && splitOk && outputTarget !== null && (isMultiAccount ? (selectedAccountKeys?.size ?? 0) > 0 : outputPath !== null);
 
   async function onChooseOutput() {
     const path = await pickOutputPst();
@@ -57,6 +64,31 @@ export function ProfileOptionsView({
   }
 
   function onStartClick() {
+    // Multi-account folder mode: build one output group per selected account.
+    if (outputTarget?.kind === "folder") {
+      const accs = accounts ?? [];
+      const keys = selectedAccountKeys ?? new Set<string>();
+      const names = pstNames ?? {};
+      try {
+        const allGroups = groupByAccount(rows, accs);
+        const selectedGroups = allGroups
+          .filter((g) => keys.has(g.key))
+          .map((g) => ({ key: g.key, pstName: names[g.key] ?? g.defaultPstName, rows: g.rows }));
+        const { config, outputDir } = buildProfileConfigMulti({
+          groups: selectedGroups,
+          checkedIds,
+          skipEmpty,
+          options,
+          target: outputTarget,
+          profileRoot,
+        });
+        onStart(config, outputDir);
+      } catch (e) {
+        setStartError(e instanceof ConvertConfigError ? e.message : "Could not start the conversion.");
+      }
+      return;
+    }
+    // Single-account / files mode: existing pstFile path.
     if (!outputPath) {
       setStartError("Choose an output .pst file first.");
       return;

--- a/desktop/src/components/views/SelectView.tsx
+++ b/desktop/src/components/views/SelectView.tsx
@@ -9,24 +9,25 @@ import { pickMboxFiles, pickFolder, listMboxInDir, statFiles, pickOutputPst, lis
 import { visibleProfiles, hiddenNote, profilePrimaryLabel, profileSubtext, pickDefaultProfile } from "@/lib/profiles";
 import { splitPath } from "@/lib/convert";
 import { formatBytes } from "@/lib/format";
-import type { FileStat, ProfileEntry } from "@/lib/types";
+import { canScan } from "@/lib/outputTarget";
+import type { FileStat, ProfileEntry, OutputTarget } from "@/lib/types";
 
 interface SelectViewProps {
   files: FileStat[];
-  outputPath: string | null;
+  outputTarget: OutputTarget | null;
   inputMode: "files" | "profile";
   profileRoot: string | null;
   sourceError?: string | null;
   onFilesChange: (files: FileStat[]) => void;
-  onOutputPathChange: (path: string | null) => void;
+  onOutputTargetChange: (target: OutputTarget | null) => void;
   onInputModeChange: (m: "files" | "profile") => void;
   onProfileRootChange: (path: string | null) => void;
   onContinue: () => void;
 }
 
 export function SelectView({
-  files, outputPath, inputMode, profileRoot, sourceError,
-  onFilesChange, onOutputPathChange, onInputModeChange, onProfileRootChange, onContinue,
+  files, outputTarget, inputMode, profileRoot, sourceError,
+  onFilesChange, onOutputTargetChange, onInputModeChange, onProfileRootChange, onContinue,
 }: SelectViewProps) {
   // Picker errors are transient and screen-local (e.g. "no .mbox in folder").
   // Parent owns the durable file/output state; this does NOT belong there.
@@ -86,7 +87,7 @@ export function SelectView({
   async function onChooseOutput() {
     setPickerError(null);
     const path = await pickOutputPst();
-    if (path) onOutputPathChange(path);
+    if (path) onOutputTargetChange({ kind: "pstFile", path });
   }
 
   function removeFile(path: string) {
@@ -96,13 +97,12 @@ export function SelectView({
 
   function clearOutput() {
     setPickerError(null);
-    onOutputPathChange(null);
+    onOutputTargetChange(null);
   }
 
   const totalBytes = files.reduce((sum, f) => sum + f.size, 0);
-  const canContinue =
-    outputPath !== null &&
-    (inputMode === "files" ? files.length > 0 : profileRoot !== null);
+  const outputPath = outputTarget?.kind === "pstFile" ? outputTarget.path : null;
+  const canContinue = canScan(inputMode, files.map((f) => f.path), profileRoot, outputTarget);
 
   // For the "manual path shown when not a scanned profile" check.
   const scannedEntries = scan.k === "done" ? scan.entries : [];
@@ -259,26 +259,28 @@ export function SelectView({
         </>
       )}
 
-      <div className="mt-5">
-        <div className="mb-1 text-sm font-medium text-foreground">Output location and PST name</div>
-        <div className="flex items-center gap-2">
-          <Button variant="outline" onClick={onChooseOutput}>
-            <Save /> {outputPath ? splitPath(outputPath).base : "Choose output…"}
-          </Button>
-          {outputPath && (
-            <button
-              type="button"
-              onClick={clearOutput}
-              aria-label="Clear output location"
-              title="Clear"
-              className="shrink-0 rounded p-0.5 text-light-gray transition-colors hover:text-destructive"
-            >
-              <X className="size-4" />
-            </button>
-          )}
+      {inputMode === "files" && (
+        <div className="mt-5">
+          <div className="mb-1 text-sm font-medium text-foreground">Output location and PST name</div>
+          <div className="flex items-center gap-2">
+            <Button variant="outline" onClick={onChooseOutput}>
+              <Save /> {outputPath ? splitPath(outputPath).base : "Choose output…"}
+            </Button>
+            {outputPath && (
+              <button
+                type="button"
+                onClick={clearOutput}
+                aria-label="Clear output location"
+                title="Clear"
+                className="shrink-0 rounded p-0.5 text-light-gray transition-colors hover:text-destructive"
+              >
+                <X className="size-4" />
+              </button>
+            )}
+          </div>
+          {outputPath && <div className="mt-1 text-xs text-light-gray">{splitPath(outputPath).dir}</div>}
         </div>
-        {outputPath && <div className="mt-1 text-xs text-light-gray">{splitPath(outputPath).dir}</div>}
-      </div>
+      )}
 
       {(pickerError || sourceError) && (
         <p className="mt-4 text-sm text-destructive">{pickerError ?? sourceError}</p>

--- a/desktop/src/lib/accounts.test.ts
+++ b/desktop/src/lib/accounts.test.ts
@@ -15,7 +15,7 @@ describe("groupByAccount", () => {
       [row("a", "A", ["imap.example.com", "Inbox"], 10, 100),
        row("b", "A", ["imap.example.com", "Sent"], 5, 50),
        row("c", "B", ["Office365", "Inbox"], 3, 30)],
-      [acct("A", "alice@example.com", "imap.example.com"), acct("B", "alice@contoso.test", "Office365")]);
+      [acct("A", "alice@example.com", "imap.example.com"), acct("B", "alice@example.test", "Office365")]);
     expect(groups).toHaveLength(2);
     const a = groups.find((g) => g.key === "A")!;
     expect(a.folderCount).toBe(2);

--- a/desktop/src/lib/accounts.test.ts
+++ b/desktop/src/lib/accounts.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { groupByAccount, sanitizePstName } from "./accounts";
+import type { Account, ProfileSourceRow } from "./types";
+
+const acct = (id: string, email: string | null, seg: string): Account =>
+  ({ id, folderSegment: seg, accountPath: id, store: "ImapMail",
+     email, host: seg, addressResolution: email ? "identity" : "not-found" });
+const row = (id: string, accountId: string | null, tfp: string[], msgs: number, bytes: number): ProfileSourceRow =>
+  ({ id, path: id, accountId, targetFolderPath: tfp, displayName: tfp.join(" / "),
+     messages: msgs, bytes, sourceBytes: bytes * 2, msfPath: null } as any);
+
+describe("groupByAccount", () => {
+  it("groups rows by accountId and aggregates estimated bytes", () => {
+    const groups = groupByAccount(
+      [row("a", "A", ["imap.example.com", "Inbox"], 10, 100),
+       row("b", "A", ["imap.example.com", "Sent"], 5, 50),
+       row("c", "B", ["Office365", "Inbox"], 3, 30)],
+      [acct("A", "alice@example.com", "imap.example.com"), acct("B", "alice@contoso.test", "Office365")]);
+    expect(groups).toHaveLength(2);
+    const a = groups.find((g) => g.key === "A")!;
+    expect(a.folderCount).toBe(2);
+    expect(a.messageCount).toBe(15);
+    expect(a.estimatedBytes).toBe(150);          // sum of `bytes`, NOT sourceBytes
+    expect(a.defaultPstName).toBe("alice@example.com");
+  });
+
+  it("defaults PST name to folderSegment when no email", () => {
+    const groups = groupByAccount([row("a", "A", ["Local Folders", "Notes"], 1, 1)],
+      [acct("A", null, "Local Folders")]);
+    expect(groups[0].defaultPstName).toBe("Local Folders");
+  });
+
+  it("falls back to targetFolderPath[0] when accountId is null", () => {
+    const groups = groupByAccount([row("a", null, ["imap.example.com", "Inbox"], 1, 1)], []);
+    expect(groups[0].key).toBe("imap.example.com");
+  });
+});
+
+describe("sanitizePstName", () => {
+  it("strips illegal filename + control chars, keeps @ and .", () => {
+    expect(sanitizePstName('a/b:c*?"<>|@x.com')).toBe("abc@x.com");
+  });
+  it("trims whitespace and leading/trailing periods", () => {
+    expect(sanitizePstName("  ...Mail...  ")).toBe("Mail");
+  });
+  it("falls back to 'Account' when empty after sanitizing", () => {
+    expect(sanitizePstName("...")).toBe("Account");
+  });
+  it("escapes reserved Windows device names", () => {
+    expect(sanitizePstName("CON")).toBe("CON-mail");
+    expect(sanitizePstName("LPT1.backup")).toBe("LPT1.backup-mail"); // stem LPT1 is reserved
+  });
+});

--- a/desktop/src/lib/accounts.ts
+++ b/desktop/src/lib/accounts.ts
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+import type { Account, ProfileSourceRow } from "./types";
+
+export interface AccountGroup {
+  account: Account | null;
+  key: string;
+  rows: ProfileSourceRow[];
+  folderCount: number;
+  messageCount: number;
+  estimatedBytes: number;            // sum of row.bytes (estimated PST size — matches Review)
+  defaultPstName: string;
+}
+
+// Windows reserved device names (stem only), mirroring Core OutputNameValidator.
+const RESERVED = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i;
+
+/** Match the engine's OutputNameValidator policy so a per-account PST name never fails validation. */
+export function sanitizePstName(raw: string): string {
+  let s = raw.replace(/[\\/:*?"<>|]/g, "");   // 1. invalid filename chars
+  s = s.replace(/[\x00-\x1f]/g, "");           //    + control chars
+  s = s.trim();                                // 2. whitespace
+  s = s.replace(/^\.+|\.+$/g, "").trim();       // 3. leading/trailing periods
+  if (s.length === 0) return "Account";         // 4. empty fallback
+  const stem = s.split(".")[0];                 // 5. reserved device-name stem -> suffix
+  if (RESERVED.test(stem)) s = `${s}-mail`;
+  return s;
+}
+
+/** Single source of truth for "which account does this row belong to". Reused by grouping, Review
+ * filtering, and config building so the key never drifts. */
+export function accountKeyForRow(row: ProfileSourceRow): string {
+  return row.accountId ?? row.targetFolderPath[0] ?? "(unknown)";
+}
+
+export function groupByAccount(rows: ProfileSourceRow[], accounts: Account[]): AccountGroup[] {
+  const byId = new Map(accounts.map((a) => [a.id, a]));
+  const order: string[] = [];
+  const buckets = new Map<string, ProfileSourceRow[]>();
+  for (const r of rows) {
+    const key = accountKeyForRow(r);
+    if (!buckets.has(key)) { buckets.set(key, []); order.push(key); }
+    buckets.get(key)!.push(r);
+  }
+  return order.map((key) => {
+    const groupRows = buckets.get(key)!;
+    const account = byId.get(key) ?? null;
+    const label = account?.email ?? account?.folderSegment ?? groupRows[0].targetFolderPath[0] ?? key;
+    return {
+      account, key, rows: groupRows,
+      folderCount: groupRows.length,
+      messageCount: groupRows.reduce((n, r) => n + (r.messages ?? 0), 0),
+      estimatedBytes: groupRows.reduce((n, r) => n + (r.bytes ?? 0), 0),
+      defaultPstName: sanitizePstName(label),
+    };
+  });
+}

--- a/desktop/src/lib/discover.test.ts
+++ b/desktop/src/lib/discover.test.ts
@@ -54,4 +54,39 @@ describe("parseDiscover", () => {
   it("throws when no discovery object is present", () => {
     expect(() => parseDiscover("not json at all")).toThrow(EngineParseError);
   });
+
+  it("parses accounts[] and accountId", () => {
+    const json = JSON.stringify({
+      type: "discovery", root: "P", layout: "profile",
+      sources: [{ path: "a", type: "mbox", targetFolderPath: ["imap.example.com", "Inbox"],
+        displayName: "Inbox", sourceBytes: 1, msfPath: null, accountId: "/p/ImapMail/imap.example.com" }],
+      warnings: [], skipped: [], pairing: { pairedMsfCount: 0, unpairedMboxCount: 1, orphanMsfCount: 0 },
+      accounts: [{ id: "/p/ImapMail/imap.example.com", folderSegment: "imap.example.com",
+        accountPath: "/p/ImapMail/imap.example.com", store: "ImapMail",
+        email: "alice@example.com", host: "imap.example.com", addressResolution: "identity" }],
+    });
+    const r = parseDiscover(json);
+    expect(r.accounts[0].email).toBe("alice@example.com");
+    expect(r.sources[0].accountId).toBe("/p/ImapMail/imap.example.com");
+  });
+
+  it("defaults accounts to [] and accountId to null when absent", () => {
+    const json = JSON.stringify({
+      type: "discovery", root: "P", layout: "single", sources: [
+        { path: "a", type: "mbox", targetFolderPath: ["Inbox"], displayName: "Inbox", sourceBytes: 1, msfPath: null }],
+      warnings: [], skipped: [], pairing: { pairedMsfCount: 0, unpairedMboxCount: 1, orphanMsfCount: 0 },
+    });
+    const r = parseDiscover(json);
+    expect(r.accounts).toEqual([]);
+    expect(r.sources[0].accountId).toBeNull();
+  });
+
+  it("clamps an invalid addressResolution to not-found", () => {
+    const json = JSON.stringify({
+      type: "discovery", root: "P", layout: "profile", sources: [],
+      warnings: [], skipped: [], pairing: { pairedMsfCount: 0, unpairedMboxCount: 0, orphanMsfCount: 0 },
+      accounts: [{ id: "x", folderSegment: "x", accountPath: "x", store: null, email: null, host: null, addressResolution: "bogus" }],
+    });
+    expect(parseDiscover(json).accounts[0].addressResolution).toBe("not-found");
+  });
 });

--- a/desktop/src/lib/discover.ts
+++ b/desktop/src/lib/discover.ts
@@ -4,6 +4,7 @@
 import { extractJsonObjects, isRecord, EngineParseError } from "./parse";
 import type {
   DiscoverResult, DiscoveredSource, DiscoverWarning, DiscoverSkipped, DiscoverPairing,
+  Account, AddressResolution,
 } from "./types";
 
 /** Parse the engine's single pretty-printed `discovery` object (tolerates dev-build
@@ -14,9 +15,14 @@ export function parseDiscover(stdout: string): DiscoverResult {
   ) as Record<string, unknown> | undefined;
   if (!obj) throw new EngineParseError("No discovery object in engine output");
 
-  const sources = (Array.isArray(obj.sources) ? obj.sources : []).map(
-    (s) => s as DiscoveredSource,
-  );
+  const VALID_RES = new Set<string>(["identity", "server", "local-folders", "not-found"]);
+
+  const sources: DiscoveredSource[] = (Array.isArray(obj.sources) ? obj.sources : []).map((s) => ({
+    ...(s as DiscoveredSource),
+    accountId: (s as Record<string, unknown>).accountId != null
+      ? String((s as Record<string, unknown>).accountId)
+      : null,
+  }));
   const warnings = (Array.isArray(obj.warnings) ? obj.warnings : []).map(
     (w) => w as DiscoverWarning,
   );
@@ -30,6 +36,21 @@ export function parseDiscover(stdout: string): DiscoverResult {
     orphanMsfCount: Number(p.orphanMsfCount ?? 0),
   };
 
+  const accounts: Account[] = (Array.isArray(obj.accounts) ? obj.accounts : []).map((a) => {
+    const ar = a as Record<string, unknown>;
+    const addressResolution: AddressResolution =
+      VALID_RES.has(String(ar.addressResolution)) ? (ar.addressResolution as AddressResolution) : "not-found";
+    return {
+      id: String(ar.id ?? ""),
+      folderSegment: String(ar.folderSegment ?? ""),
+      accountPath: String(ar.accountPath ?? ""),
+      store: ar.store != null ? String(ar.store) : null,
+      email: ar.email != null ? String(ar.email) : null,
+      host: ar.host != null ? String(ar.host) : null,
+      addressResolution,
+    };
+  });
+
   return {
     root: String(obj.root ?? ""),
     layout: String(obj.layout ?? ""),
@@ -37,6 +58,7 @@ export function parseDiscover(stdout: string): DiscoverResult {
     warnings,
     skipped,
     pairing,
+    accounts,
     schemaVersion: obj.schemaVersion as number | undefined,
   };
 }

--- a/desktop/src/lib/engine.ts
+++ b/desktop/src/lib/engine.ts
@@ -139,6 +139,12 @@ export async function pickOutputPst(): Promise<string | null> {
   return result ?? null;
 }
 
+/** Folder picker for a multi-account output directory, or null if cancelled. */
+export async function pickOutputFolder(): Promise<string | null> {
+  const result = await open({ multiple: false, directory: true });
+  return typeof result === "string" ? result : null;
+}
+
 export function startConvert(config: ConversionConfig, outputDir: string): Promise<void> {
   // Tauri v2 auto-converts camelCase JS arg keys to snake_case Rust params, so
   // `outputDir` here maps to the Rust `output_dir` parameter.

--- a/desktop/src/lib/outputTarget.test.ts
+++ b/desktop/src/lib/outputTarget.test.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, it, expect } from "vitest";
+import { canScan } from "./outputTarget";
+
+describe("canScan", () => {
+  it("files mode requires a pstFile target + files", () => {
+    expect(canScan("files", ["a.mbox"], null, { kind: "pstFile", path: "o.pst" })).toBe(true);
+    expect(canScan("files", ["a.mbox"], null, null)).toBe(false);
+    expect(canScan("files", [], null, { kind: "pstFile", path: "o.pst" })).toBe(false);
+  });
+  it("profile mode requires only a profile root (output chosen later)", () => {
+    expect(canScan("profile", [], "/p", null)).toBe(true);
+    expect(canScan("profile", [], null, null)).toBe(false);
+  });
+});

--- a/desktop/src/lib/outputTarget.ts
+++ b/desktop/src/lib/outputTarget.ts
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import type { OutputTarget } from "./types";
+
+export function canScan(
+  inputMode: "files" | "profile",
+  files: string[],
+  profileRoot: string | null,
+  outputTarget: OutputTarget | null,
+): boolean {
+  if (inputMode === "profile") return profileRoot !== null; // output chosen after discovery
+  return files.length > 0 && outputTarget?.kind === "pstFile";
+}

--- a/desktop/src/lib/profileConfig.test.ts
+++ b/desktop/src/lib/profileConfig.test.ts
@@ -9,7 +9,7 @@ import { ConvertConfigError } from "./convert";
 import { defaultOptions } from "./options";
 
 const disc = (path: string, tfp: string[], msf: string | null): DiscoveredSource => ({
-  path, type: "mbox", targetFolderPath: tfp, displayName: tfp[tfp.length - 1], sourceBytes: 1, msfPath: msf,
+  path, type: "mbox", targetFolderPath: tfp, displayName: tfp[tfp.length - 1], sourceBytes: 1, msfPath: msf, accountId: null,
 });
 
 const scan: ScanResult = {
@@ -24,6 +24,14 @@ const scan: ScanResult = {
 const opts = (over: Partial<import("./options").OptionsState> = {}) => ({ ...defaultOptions(), ...over });
 
 describe("mergeProfileSources", () => {
+  it("mergeProfileSources preserves accountId from discovery", () => {
+    const rows = mergeProfileSources(
+      [{ path: "a", type: "mbox", targetFolderPath: ["imap.example.com", "Inbox"],
+         displayName: "Inbox", sourceBytes: 1, msfPath: null, accountId: "/p/ImapMail/imap.example.com" }],
+      { sources: [{ path: "a", messages: 1, bytes: 2, sourceBytes: 1, dateFrom: null, dateTo: null, warnings: 0, skipped: 0 }] } as any);
+    expect(rows[0].accountId).toBe("/p/ImapMail/imap.example.com");
+  });
+
   it("joins by path, sets id=path and displayName=joined targetFolderPath, takes counts from scan", () => {
     const rows = mergeProfileSources(
       [disc("C:/p/A", ["Account", "Inbox"], "C:/p/A.msf"), disc("C:/p/B", ["Work", "Inbox"], null)],
@@ -51,8 +59,8 @@ describe("mergeProfileSources", () => {
 
 describe("buildProfileConfig", () => {
   const rows: ProfileSourceRow[] = [
-    { id: "C:/p/A", path: "C:/p/A", displayName: "Account / Inbox", messages: 5, bytes: 500, sourceBytes: 50, dateFrom: null, dateTo: null, warnings: 0, skipped: 0, targetFolderPath: ["Account", "Inbox"], msfPath: "C:/p/A.msf" },
-    { id: "C:/p/B", path: "C:/p/B", displayName: "Work / Inbox", messages: 3, bytes: 300, sourceBytes: 30, dateFrom: null, dateTo: null, warnings: 0, skipped: 0, targetFolderPath: ["Work", "Inbox"], msfPath: null },
+    { id: "C:/p/A", path: "C:/p/A", displayName: "Account / Inbox", messages: 5, bytes: 500, sourceBytes: 50, dateFrom: null, dateTo: null, warnings: 0, skipped: 0, targetFolderPath: ["Account", "Inbox"], msfPath: "C:/p/A.msf", accountId: null },
+    { id: "C:/p/B", path: "C:/p/B", displayName: "Work / Inbox", messages: 3, bytes: 300, sourceBytes: 30, dateFrom: null, dateTo: null, warnings: 0, skipped: 0, targetFolderPath: ["Work", "Inbox"], msfPath: null, accountId: null },
   ];
   const checked = new Set(["C:/p/A", "C:/p/B"]);
 

--- a/desktop/src/lib/profileConfig.test.ts
+++ b/desktop/src/lib/profileConfig.test.ts
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { describe, it, expect } from "vitest";
-import { mergeProfileSources, buildProfileConfig } from "./profileConfig";
+import { mergeProfileSources, buildProfileConfig, buildProfileConfigMulti } from "./profileConfig";
 import type { DiscoveredSource, ProfileSourceRow } from "./types";
+import type { OutputTarget } from "./types";
 import type { ScanResult } from "./parse";
 import { ConvertConfigError } from "./convert";
 import { defaultOptions } from "./options";
@@ -127,5 +128,138 @@ describe("buildProfileConfig", () => {
       expect(config.junkHandling).toBe("Folder");                   // junk/expunged ARE top-level
       expect(config.dropExpunged).toBe(true);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildProfileConfigMulti
+// ---------------------------------------------------------------------------
+
+const srcRow = (
+  id: string,
+  accountId: string,
+  tfp: string[],
+  msfPath: string | null,
+  messages = 1,
+): ProfileSourceRow => ({
+  id,
+  path: id,
+  displayName: tfp.join(" / "),
+  messages,
+  bytes: messages * 100,
+  sourceBytes: messages * 10,
+  dateFrom: null,
+  dateTo: null,
+  warnings: 0,
+  skipped: 0,
+  targetFolderPath: tfp,
+  msfPath,
+  accountId,
+});
+
+type MultiGroup = { key: string; pstName: string; rows: ProfileSourceRow[] };
+
+const buildProfileConfigMultiWrapper = ({
+  groups,
+  mapping,
+  target,
+  skipEmpty = false,
+  checkedIds,
+  profileRoot = "/profile",
+}: {
+  groups: MultiGroup[];
+  mapping: "mirror" | "flatten";
+  target: OutputTarget;
+  skipEmpty?: boolean;
+  checkedIds?: Set<string>;
+  profileRoot?: string;
+}) => {
+  const allIds = new Set(groups.flatMap((g) => g.rows.map((r) => r.id)));
+  return buildProfileConfigMulti({
+    groups,
+    checkedIds: checkedIds ?? allIds,
+    skipEmpty,
+    options: opts({ folderMapping: mapping }),
+    target,
+    profileRoot,
+  });
+};
+
+describe("buildProfileConfigMulti", () => {
+  it("emits one output group per kept account with stripped paths", () => {
+    const { config } = buildProfileConfigMultiWrapper({
+      groups: [
+        { key: "A", pstName: "alice@example.com", rows: [
+          srcRow("a", "A", ["imap.example.com", "Inbox"], "a.msf"),
+          srcRow("b", "A", ["imap.example.com", "Inbox", "Archive"], null)] },
+        { key: "B", pstName: "Office365", rows: [srcRow("c", "B", ["Office365", "Inbox"], null)] },
+      ],
+      mapping: "mirror", target: { kind: "folder", dir: "/out" },
+    });
+    expect(config.outputs).toHaveLength(2);
+    const a = config.outputs[0];
+    expect(a.name).toBe("alice@example.com");
+    expect(a.sources[0].targetFolderPath).toEqual(["Inbox"]);          // account prefix stripped
+    expect(a.sources[1].targetFolderPath).toEqual(["Inbox", "Archive"]);
+    expect(a.sources[0].msfPath).toBe("a.msf");                         // preserved
+  });
+
+  it("preserves profilePath and honours checkedIds (folder selection)", () => {
+    const { config } = buildProfileConfigMultiWrapper({
+      groups: [{ key: "A", pstName: "A", rows: [
+        srcRow("a", "A", ["imap.example.com", "Inbox"], null),
+        srcRow("b", "A", ["imap.example.com", "Spam"], null)] }],
+      mapping: "mirror", target: { kind: "folder", dir: "/out" },
+      checkedIds: new Set(["a"]),            // only Inbox selected in Review
+      profileRoot: "/p",
+    });
+    expect((config as any).profilePath).toBe("/p");
+    expect(config.outputs[0].sources).toHaveLength(1);
+    expect(config.outputs[0].sources[0].targetFolderPath).toEqual(["Inbox"]);
+  });
+
+  it("THROWS when stripping the account prefix leaves no folder (mirror)", () => {
+    expect(() => buildProfileConfigMultiWrapper({
+      groups: [{ key: "A", pstName: "A", rows: [srcRow("a", "A", ["imap.example.com"], null)] }],
+      mapping: "mirror", target: { kind: "folder", dir: "/out" },
+    })).toThrow(/no folder below its account/i);
+  });
+
+  it("excludes an account with no effective sources after skip-empty", () => {
+    const { config } = buildProfileConfigMultiWrapper({
+      groups: [
+        { key: "A", pstName: "A", rows: [srcRow("a", "A", ["imap.example.com", "Inbox"], null, 5)] },
+        { key: "B", pstName: "B", rows: [srcRow("c", "B", ["Office365", "Empty"], null, 0)] }],
+      mapping: "mirror", target: { kind: "folder", dir: "/out" }, skipEmpty: true,
+    });
+    expect(config.outputs.map((o) => o.name)).toEqual(["A"]);
+  });
+
+  it("suffixes colliding PST names deterministically", () => {
+    const { config } = buildProfileConfigMultiWrapper({
+      groups: [
+        { key: "A", pstName: "Mail", rows: [srcRow("a", "A", ["x", "Inbox"], null, 1)] },
+        { key: "B", pstName: "Mail", rows: [srcRow("c", "B", ["y", "Inbox"], null, 1)] }],
+      mapping: "mirror", target: { kind: "folder", dir: "/out" },
+    });
+    expect(config.outputs.map((o) => o.name)).toEqual(["Mail", "Mail-2"]);
+  });
+
+  it("skips an already-taken suffix (Mail-2 exists → next is Mail-3)", () => {
+    const { config } = buildProfileConfigMultiWrapper({
+      groups: [
+        { key: "A", pstName: "Mail", rows: [srcRow("a", "A", ["x", "Inbox"], null, 1)] },
+        { key: "B", pstName: "Mail-2", rows: [srcRow("c", "B", ["y", "Inbox"], null, 1)] },
+        { key: "C", pstName: "Mail", rows: [srcRow("d", "C", ["z", "Inbox"], null, 1)] }],
+      mapping: "mirror", target: { kind: "folder", dir: "/out" },
+    });
+    expect(config.outputs.map((o) => o.name)).toEqual(["Mail", "Mail-2", "Mail-3"]);
+  });
+
+  it("throws when all groups are empty after skip-empty", () => {
+    expect(() => buildProfileConfigMultiWrapper({
+      groups: [{ key: "A", pstName: "A", rows: [srcRow("a", "A", ["x", "Empty"], null, 0)] }],
+      mapping: "mirror", target: { kind: "folder", dir: "/out" }, skipEmpty: true,
+    })).toThrow(/at least one folder/i);
   });
 });

--- a/desktop/src/lib/profileConfig.ts
+++ b/desktop/src/lib/profileConfig.ts
@@ -28,6 +28,7 @@ export function mergeProfileSources(
       skipped: s?.skipped ?? 0,
       targetFolderPath: d.targetFolderPath,
       msfPath: d.msfPath,
+      accountId: d.accountId,
     };
   });
 }

--- a/desktop/src/lib/profileConfig.ts
+++ b/desktop/src/lib/profileConfig.ts
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import type { DiscoveredSource, ProfileSourceRow, ConversionConfig, SourceConfigEntry } from "./types";
+import type { DiscoveredSource, ProfileSourceRow, ConversionConfig, SourceConfigEntry, OutputTarget, OutputGroupConfig } from "./types";
 import type { ScanResult } from "./parse";
 import type { OptionsState } from "./options";
 import { effectiveRows } from "./review";
 import { deriveOutputTarget, ConvertConfigError } from "./convert";
+import { sanitizePstName } from "./accounts";
 
 /** Merge discovery sources with scan counts. Identity = discovered `path`; the
  * scan row's id is ignored (it is scan-local). displayName = joined nested path. */
@@ -75,6 +76,96 @@ export function buildProfileConfig(
         includeEmptyFolders: !skipEmpty,
         sources,
       }],
+    },
+  };
+}
+
+export interface MultiAccountGroup {
+  key: string;
+  pstName: string;
+  rows: ProfileSourceRow[];
+}
+
+/** Build a full profile-mode ConversionConfig with one OutputGroup per kept
+ * account. Mirror strips the first path segment (the account prefix) from each
+ * source's targetFolderPath and throws if stripping leaves an empty path.
+ * Flatten omits targetFolderPath entirely. Groups with no effective rows (after
+ * checkedIds + skipEmpty filtering) are silently dropped; a ConvertConfigError
+ * is thrown when none survive. PST names are de-duplicated by appending -2, -3,
+ * … in order, skipping suffixes already taken by other groups. */
+export function buildProfileConfigMulti({
+  groups,
+  checkedIds,
+  skipEmpty,
+  options,
+  target,
+  profileRoot,
+}: {
+  groups: MultiAccountGroup[];
+  checkedIds: Set<string>;
+  skipEmpty: boolean;
+  options: OptionsState;
+  target: OutputTarget;
+  profileRoot: string;
+}): { config: ConversionConfig; outputDir: string } {
+  const folderMapping = options.folderMapping;
+  const outputDir = target.kind === "folder" ? target.dir : deriveOutputTarget(target.path).outputDir;
+
+  // Build surviving output groups
+  const outputGroups: OutputGroupConfig[] = [];
+  for (const group of groups) {
+    const eff = effectiveRows(group.rows, checkedIds, skipEmpty) as ProfileSourceRow[];
+    if (eff.length === 0) continue; // drop group with no effective sources
+
+    const sources: SourceConfigEntry[] = eff.map((r) => {
+      const entry: SourceConfigEntry = { path: r.path, type: "mbox" };
+      if (folderMapping === "mirror") {
+        const stripped = r.targetFolderPath.slice(1);
+        if (stripped.length === 0) {
+          throw new ConvertConfigError(
+            `Discovered source ${r.path} has no folder below its account.`,
+          );
+        }
+        entry.targetFolderPath = stripped;
+      }
+      if (r.msfPath != null) entry.msfPath = r.msfPath;
+      return entry;
+    });
+
+    outputGroups.push({
+      name: sanitizePstName(group.pstName), // placeholder — de-duped below
+      maxSizeMB: options.maxSizeMB,
+      folderMapping,
+      includeEmptyFolders: !skipEmpty,
+      sources,
+    });
+  }
+
+  if (outputGroups.length === 0) {
+    throw new ConvertConfigError("Select at least one folder to convert.");
+  }
+
+  // De-duplicate names: case-insensitive, skip already-taken suffixes
+  const usedNames = new Set<string>();
+  for (const g of outputGroups) {
+    const base = g.name;
+    if (!usedNames.has(base.toLowerCase())) {
+      usedNames.add(base.toLowerCase());
+    } else {
+      let n = 2;
+      while (usedNames.has(`${base}-${n}`.toLowerCase())) n++;
+      g.name = `${base}-${n}`;
+      usedNames.add(g.name.toLowerCase());
+    }
+  }
+
+  return {
+    outputDir,
+    config: {
+      profilePath: profileRoot,
+      junkHandling: options.junkHandling,
+      dropExpunged: options.dropExpunged,
+      outputs: outputGroups,
     },
   };
 }

--- a/desktop/src/lib/steps.test.ts
+++ b/desktop/src/lib/steps.test.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, it, expect } from "vitest";
+import { buildSteps, stepIndexForStage } from "./steps";
+
+describe("buildSteps", () => {
+  it("files mode = 5 steps, no Accounts", () => {
+    expect(buildSteps("files", 0)).toEqual(["Source", "Review", "Options", "Convert", "Done"]);
+  });
+  it("profile single-account = 5 steps, no Accounts", () => {
+    expect(buildSteps("profile", 1)).toEqual(["Source", "Review", "Options", "Convert", "Done"]);
+  });
+  it("profile multi-account inserts Accounts after Source", () => {
+    expect(buildSteps("profile", 3)).toEqual(["Source", "Accounts", "Review", "Options", "Convert", "Done"]);
+  });
+});
+
+describe("stepIndexForStage", () => {
+  it("maps review to its index in each list", () => {
+    expect(stepIndexForStage(buildSteps("files", 0), "review")).toBe(1);
+    expect(stepIndexForStage(buildSteps("profile", 3), "review")).toBe(2);
+    expect(stepIndexForStage(buildSteps("profile", 3), "accounts")).toBe(1);
+  });
+});

--- a/desktop/src/lib/steps.ts
+++ b/desktop/src/lib/steps.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+export type StepList = string[];
+
+export function buildSteps(inputMode: "files" | "profile", accountCount: number): StepList {
+  const multi = inputMode === "profile" && accountCount >= 2;
+  return multi
+    ? ["Source", "Accounts", "Review", "Options", "Convert", "Done"]
+    : ["Source", "Review", "Options", "Convert", "Done"];
+}
+
+// stage names used by useScan; "accounts" only present in multi-account lists
+const STAGE_TO_LABEL: Record<string, string> = {
+  select: "Source",
+  scanning: "Review",
+  review: "Review",
+  scanError: "Review",
+  accounts: "Accounts",
+  options: "Options",
+};
+const PHASE_TO_LABEL: Record<string, string> = {
+  running: "Convert",
+  done: "Done",
+  error: "Done",
+  cancelled: "Done",
+};
+
+export function stepIndexForStage(steps: StepList, stage: string): number {
+  return Math.max(0, steps.indexOf(STAGE_TO_LABEL[stage] ?? "Source"));
+}
+
+export function stepIndexForPhase(steps: StepList, phase: string): number {
+  return Math.max(0, steps.indexOf(PHASE_TO_LABEL[phase] ?? "Convert"));
+}

--- a/desktop/src/lib/types.ts
+++ b/desktop/src/lib/types.ts
@@ -174,3 +174,5 @@ export interface ColourCategory {
 export type ColourPlanEntry = Pick<ColourCategory, "name" | "hex" | "outlookColor" | "action">;
 
 export interface ProfileEntry { name: string; path: string; isDefault: boolean; accounts: string[]; convertible: boolean }
+
+export type OutputTarget = { kind: "pstFile"; path: string } | { kind: "folder"; dir: string };

--- a/desktop/src/lib/types.ts
+++ b/desktop/src/lib/types.ts
@@ -101,6 +101,18 @@ export type ConvertEvent = (
     }
 ) & Versioned;
 
+export type AddressResolution = "identity" | "server" | "local-folders" | "not-found";
+
+export interface Account {
+  id: string;
+  folderSegment: string;
+  accountPath: string;
+  store: string | null;
+  email: string | null;
+  host: string | null;
+  addressResolution: AddressResolution;
+}
+
 export interface DiscoveredSource {
   path: string;
   type: string;
@@ -108,6 +120,7 @@ export interface DiscoveredSource {
   displayName: string;
   sourceBytes: number;
   msfPath: string | null;
+  accountId: string | null;
 }
 
 export interface DiscoverWarning {
@@ -139,6 +152,7 @@ export interface DiscoverResult {
   warnings: DiscoverWarning[];
   skipped: DiscoverSkipped[];
   pairing: DiscoverPairing;
+  accounts: Account[];
   schemaVersion?: number;
 }
 
@@ -147,6 +161,7 @@ export interface DiscoverResult {
 export interface ProfileSourceRow extends SourceRow {
   targetFolderPath: string[];
   msfPath: string | null;
+  accountId: string | null;
 }
 
 export interface ColourCategory {

--- a/desktop/src/lib/useScan.test.ts
+++ b/desktop/src/lib/useScan.test.ts
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * Tests for the pure helpers extracted from useScan:
+ *   - computeAccountRouting  (stage + seed selection/pstNames)
+ *   - filterSourcesBySelection (sortedSources filtering)
+ *
+ * useScan itself has no exported reducer — these helpers are the test seam.
+ */
+
+import { describe, it, expect } from "vitest";
+import { computeAccountRouting, filterSourcesBySelection } from "./useScan";
+import type { Account, ProfileSourceRow } from "./types";
+
+const acct = (id: string, email: string | null, seg: string): Account => ({
+  id,
+  folderSegment: seg,
+  accountPath: id,
+  store: "ImapMail",
+  email,
+  host: seg,
+  addressResolution: email ? "identity" : "not-found",
+});
+
+const row = (
+  id: string,
+  accountId: string | null,
+  tfp: string[],
+): ProfileSourceRow => ({
+  id,
+  path: id,
+  accountId,
+  targetFolderPath: tfp,
+  displayName: tfp.join(" / "),
+  messages: 1,
+  bytes: 100,
+  sourceBytes: 200,
+  msfPath: null,
+  warnings: 0,
+  skipped: 0,
+  dateFrom: null,
+  dateTo: null,
+});
+
+const accounts2 = [
+  acct("A", "alice@example.com", "imap.example.com"),
+  acct("B", "bob@example.com", "imap2.example.com"),
+];
+
+const rows2 = [
+  row("a1", "A", ["imap.example.com", "Inbox"]),
+  row("a2", "A", ["imap.example.com", "Sent"]),
+  row("b1", "B", ["imap2.example.com", "Inbox"]),
+];
+
+// ── computeAccountRouting ─────────────────────────────────────────────────────
+
+describe("computeAccountRouting", () => {
+  it("routes to 'accounts' stage when there are ≥2 discovered accounts", () => {
+    const result = computeAccountRouting(rows2, accounts2);
+    expect(result.stage).toBe("accounts");
+  });
+
+  it("seeds selectedAccountKeys with ALL account keys on multi-account", () => {
+    const { selectedAccountKeys } = computeAccountRouting(rows2, accounts2);
+    expect(selectedAccountKeys.has("A")).toBe(true);
+    expect(selectedAccountKeys.has("B")).toBe(true);
+    expect(selectedAccountKeys.size).toBe(2);
+  });
+
+  it("seeds pstNames from each group's defaultPstName", () => {
+    const { pstNames } = computeAccountRouting(rows2, accounts2);
+    // email label used → sanitizePstName("alice@example.com") = "alice@example.com"
+    expect(pstNames["A"]).toBe("alice@example.com");
+    expect(pstNames["B"]).toBe("bob@example.com");
+  });
+
+  it("routes to 'review' when there is exactly 1 account", () => {
+    const rows1 = [row("a1", "A", ["imap.example.com", "Inbox"])];
+    const accounts1 = [acct("A", "alice@example.com", "imap.example.com")];
+    const result = computeAccountRouting(rows1, accounts1);
+    expect(result.stage).toBe("review");
+  });
+
+  it("routes to 'review' when there are 0 accounts (files mode fallback)", () => {
+    const result = computeAccountRouting([], []);
+    expect(result.stage).toBe("review");
+  });
+
+  it("returns empty selectedAccountKeys and pstNames for single-account", () => {
+    const rows1 = [row("a1", "A", ["imap.example.com", "Inbox"])];
+    const accounts1 = [acct("A", null, "imap.example.com")];
+    const { selectedAccountKeys, pstNames } = computeAccountRouting(rows1, accounts1);
+    expect(selectedAccountKeys.size).toBe(0);
+    expect(Object.keys(pstNames)).toHaveLength(0);
+  });
+});
+
+// ── filterSourcesBySelection ──────────────────────────────────────────────────
+
+describe("filterSourcesBySelection", () => {
+  it("returns only rows for selected accounts in multi-account profile mode", () => {
+    const selected = new Set(["A"]);
+    const filtered = filterSourcesBySelection(rows2, selected, "profile", accounts2);
+    expect(filtered.map((r) => r.id).sort()).toEqual(["a1", "a2"]);
+  });
+
+  it("returns all rows when both accounts are selected", () => {
+    const selected = new Set(["A", "B"]);
+    const filtered = filterSourcesBySelection(rows2, selected, "profile", accounts2);
+    expect(filtered).toHaveLength(3);
+  });
+
+  it("does NOT filter in files mode (single-account path)", () => {
+    const selected = new Set(["A"]); // irrelevant for files mode
+    // In files mode rows have no accountId
+    const fileRows = [
+      row("f1", null, ["SomeFolder"]),
+      row("f2", null, ["OtherFolder"]),
+    ];
+    const filtered = filterSourcesBySelection(fileRows, selected, "files", []);
+    expect(filtered).toHaveLength(2);
+  });
+
+  it("does NOT filter when only 1 account exists (single-account profile)", () => {
+    const rows1 = [row("a1", "A", ["imap.example.com", "Inbox"])];
+    const accounts1 = [acct("A", "alice@example.com", "imap.example.com")];
+    const selected = new Set(["A"]);
+    const filtered = filterSourcesBySelection(rows1, selected, "profile", accounts1);
+    expect(filtered).toHaveLength(1);
+  });
+});

--- a/desktop/src/lib/useScan.ts
+++ b/desktop/src/lib/useScan.ts
@@ -7,14 +7,14 @@ import { mergeProfileSources } from "./profileConfig";
 import { checkSchemaVersion } from "./schema";
 import { defaultOptions, type OptionsState, FLATTEN_SOURCE_ID } from "./options";
 import { sortSources, type SortField, type SortDir } from "./review";
-import type { FileStat, SourceRow, ProfileSourceRow, DiscoverWarning, DiscoverResult } from "./types";
+import type { FileStat, SourceRow, ProfileSourceRow, DiscoverWarning, DiscoverResult, OutputTarget } from "./types";
 import type { ScanResult } from "./parse";
 
 export type FlowStage = "select" | "scanning" | "review" | "options" | "scanError";
 
 export interface PreConvertState {
   inputFiles: FileStat[];
-  outputPath: string | null;
+  outputTarget: OutputTarget | null;
   stage: FlowStage;
   scan: ScanResult | null;
   errorMessage: string | null;
@@ -34,7 +34,7 @@ export interface PreConvertState {
 function initialState(): PreConvertState {
   return {
     inputFiles: [],
-    outputPath: null,
+    outputTarget: null,
     stage: "select",
     scan: null,
     errorMessage: null,
@@ -59,8 +59,8 @@ export function useScan() {
     (inputFiles: FileStat[]) => setState((s) => ({ ...s, inputFiles })),
     [],
   );
-  const setOutputPath = useCallback(
-    (outputPath: string | null) => setState((s) => ({ ...s, outputPath })),
+  const setOutputTarget = useCallback(
+    (outputTarget: OutputTarget | null) => setState((s) => ({ ...s, outputTarget })),
     [],
   );
 
@@ -216,7 +216,7 @@ export function useScan() {
   return {
     state,
     setInputFiles,
-    setOutputPath,
+    setOutputTarget,
     setInputMode,
     setProfileRoot,
     continueToScan,

--- a/desktop/src/lib/useScan.ts
+++ b/desktop/src/lib/useScan.ts
@@ -248,6 +248,7 @@ export function useScan() {
   const continueToOptions = useCallback(() => setState((s) => ({ ...s, stage: "options" })), []);
   const backToReview = useCallback(() => setState((s) => ({ ...s, stage: "review" })), []);
   const continueToReviewFromAccounts = useCallback(() => setState((s) => ({ ...s, stage: "review" })), []);
+  const backToAccounts = useCallback(() => setState((s) => ({ ...s, stage: "accounts" })), []);
 
   const toggleAccount = useCallback((key: string) => {
     setState((s) => {
@@ -299,6 +300,7 @@ export function useScan() {
     setRename,
     continueToOptions,
     backToReview,
+    backToAccounts,
     continueToReviewFromAccounts,
     toggleAccount,
     setPstName,

--- a/desktop/src/lib/useScan.ts
+++ b/desktop/src/lib/useScan.ts
@@ -7,10 +7,50 @@ import { mergeProfileSources } from "./profileConfig";
 import { checkSchemaVersion } from "./schema";
 import { defaultOptions, type OptionsState, FLATTEN_SOURCE_ID } from "./options";
 import { sortSources, type SortField, type SortDir } from "./review";
-import type { FileStat, SourceRow, ProfileSourceRow, DiscoverWarning, DiscoverResult, OutputTarget } from "./types";
+import { groupByAccount, accountKeyForRow } from "./accounts";
+import type { FileStat, SourceRow, ProfileSourceRow, DiscoverWarning, DiscoverResult, OutputTarget, Account } from "./types";
 import type { ScanResult } from "./parse";
 
-export type FlowStage = "select" | "scanning" | "review" | "options" | "scanError";
+export type FlowStage = "select" | "scanning" | "review" | "options" | "scanError" | "accounts";
+
+// ── Pure helpers (exported for unit-testing) ─────────────────────────────────
+
+/**
+ * Given the rows + discovered accounts after a profile scan, compute:
+ *   - which stage to navigate to ("accounts" if ≥2 accounts, else "review")
+ *   - initial `selectedAccountKeys` (all keys when multi-account, empty otherwise)
+ *   - initial `pstNames` (keyed by account key, seeded from groupByAccount defaultPstName)
+ */
+export function computeAccountRouting(
+  rows: ProfileSourceRow[],
+  accounts: Account[],
+): { stage: "accounts" | "review"; selectedAccountKeys: Set<string>; pstNames: Record<string, string> } {
+  if (accounts.length >= 2) {
+    const groups = groupByAccount(rows, accounts);
+    const selectedAccountKeys = new Set(groups.map((g) => g.key));
+    const pstNames: Record<string, string> = {};
+    for (const g of groups) pstNames[g.key] = g.defaultPstName;
+    return { stage: "accounts", selectedAccountKeys, pstNames };
+  }
+  return { stage: "review", selectedAccountKeys: new Set(), pstNames: {} };
+}
+
+/**
+ * Filter profile rows to those belonging to selected accounts.
+ * Only active in multi-account profile mode (inputMode === "profile" AND accounts.length >= 2).
+ * Files mode and single-account mode pass through all rows unchanged.
+ */
+export function filterSourcesBySelection(
+  rows: ProfileSourceRow[],
+  selectedAccountKeys: Set<string>,
+  inputMode: "files" | "profile",
+  accounts: Account[],
+): ProfileSourceRow[] {
+  if (inputMode !== "profile" || accounts.length < 2) return rows;
+  return rows.filter((r) => selectedAccountKeys.has(accountKeyForRow(r)));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 
 export interface PreConvertState {
   inputFiles: FileStat[];
@@ -29,6 +69,10 @@ export interface PreConvertState {
   profileRows: ProfileSourceRow[];
   discoverWarnings: DiscoverWarning[];
   sourceError: string | null; // parent-owned discover-time error, shown on the Source screen
+  // Account selection (multi-account profile mode)
+  accounts: Account[];
+  selectedAccountKeys: Set<string>;
+  pstNames: Record<string, string>; // per-account edited PST name, keyed by account key
 }
 
 function initialState(): PreConvertState {
@@ -49,6 +93,9 @@ function initialState(): PreConvertState {
     profileRows: [],
     discoverWarnings: [],
     sourceError: null,
+    accounts: [],
+    selectedAccountKeys: new Set(),
+    pstNames: {},
   };
 }
 
@@ -104,9 +151,10 @@ export function useScan() {
         const schemaMsg = checkSchemaVersion(result.schemaVersion);
         if (schemaMsg) console.warn(`[mail2pst] ${schemaMsg}`);
         const profileRows = mergeProfileSources(disc.sources, result);
+        const { stage: nextStage, selectedAccountKeys, pstNames } = computeAccountRouting(profileRows, disc.accounts);
         setState((s) => ({
           ...s,
-          stage: "review",
+          stage: nextStage,
           scan: result,
           profileRows,
           discoverWarnings: disc.warnings,
@@ -116,6 +164,9 @@ export function useScan() {
           scanProgress: null,
           sortBy: "default",
           sortDir: "desc",
+          accounts: disc.accounts,
+          selectedAccountKeys,
+          pstNames,
         }));
       } catch (e) {
         const errorMessage = e instanceof Error ? e.message : String(e);
@@ -196,6 +247,20 @@ export function useScan() {
 
   const continueToOptions = useCallback(() => setState((s) => ({ ...s, stage: "options" })), []);
   const backToReview = useCallback(() => setState((s) => ({ ...s, stage: "review" })), []);
+  const continueToReviewFromAccounts = useCallback(() => setState((s) => ({ ...s, stage: "review" })), []);
+
+  const toggleAccount = useCallback((key: string) => {
+    setState((s) => {
+      const next = new Set(s.selectedAccountKeys);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return { ...s, selectedAccountKeys: next };
+    });
+  }, []);
+
+  const setPstName = useCallback((key: string, name: string) => {
+    setState((s) => ({ ...s, pstNames: { ...s.pstNames, [key]: name } }));
+  }, []);
 
   const back = useCallback(
     () => setState((s) => ({ ...s, stage: "select", scan: null, profileRows: [], discoverWarnings: [], errorMessage: null, sourceError: null, scanProgress: null })),
@@ -204,14 +269,19 @@ export function useScan() {
   const resetFlow = useCallback(() => setState(initialState()), []);
 
   const sortedSources: SourceRow[] = useMemo(() => {
-    if (state.inputMode === "profile") return sortSources(state.profileRows, state.sortBy, state.sortDir);
+    if (state.inputMode === "profile") {
+      const filtered = filterSourcesBySelection(state.profileRows, state.selectedAccountKeys, state.inputMode, state.accounts);
+      return sortSources(filtered, state.sortBy, state.sortDir);
+    }
     return state.scan ? sortSources(state.scan.sources, state.sortBy, state.sortDir) : [];
-  }, [state.inputMode, state.profileRows, state.scan, state.sortBy, state.sortDir]);
+  }, [state.inputMode, state.profileRows, state.selectedAccountKeys, state.accounts, state.scan, state.sortBy, state.sortDir]);
 
   const pairedIds: Set<string> = useMemo(
     () => new Set(state.profileRows.filter((r) => r.msfPath).map((r) => r.id)),
     [state.profileRows],
   );
+
+  const discoveredAccountCount = state.accounts.length;
 
   return {
     state,
@@ -229,6 +299,10 @@ export function useScan() {
     setRename,
     continueToOptions,
     backToReview,
+    continueToReviewFromAccounts,
+    toggleAccount,
+    setPstName,
+    discoveredAccountCount,
     back,
     resetFlow,
   };

--- a/src/Mail2Pst.Cli/DiscoverCommand.cs
+++ b/src/Mail2Pst.Cli/DiscoverCommand.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using Mail2Pst.Core.Cli;
 using Mail2Pst.Core.Discovery;
+using Mail2Pst.Core.Msf;
 
 namespace Mail2Pst.Cli;
 
@@ -40,6 +41,12 @@ internal static class DiscoverCommand
                 {
                     path = s.Path, type = s.Type, targetFolderPath = s.TargetFolderPath,
                     displayName = s.DisplayName, sourceBytes = s.SourceBytes, msfPath = s.MsfPath,
+                    accountId = s.AccountId,
+                }),
+                accounts = r.Accounts.Select(a => new
+                {
+                    id = a.Id, folderSegment = a.FolderSegment, accountPath = a.AccountPath, store = a.Store,
+                    email = a.Email, host = a.Host, addressResolution = ResolutionString(a.AddressResolution),
                 }),
                 warnings = r.Warnings.Select(w => new
                 {
@@ -64,4 +71,12 @@ internal static class DiscoverCommand
             return 1;
         }
     }
+
+    private static string ResolutionString(AddressResolution r) => r switch
+    {
+        AddressResolution.Identity => "identity",
+        AddressResolution.Server => "server",
+        AddressResolution.LocalFolders => "local-folders",
+        _ => "not-found",
+    };
 }

--- a/src/Mail2Pst.Core/Discovery/DiscoveryResult.cs
+++ b/src/Mail2Pst.Core/Discovery/DiscoveryResult.cs
@@ -8,7 +8,7 @@ namespace Mail2Pst.Core.Discovery;
 
 public sealed record DiscoveredSource(
     string Path, string Type, IReadOnlyList<string> TargetFolderPath, string DisplayName, long SourceBytes,
-    string? MsfPath);
+    string? MsfPath, string? AccountId = null);
 
 public sealed record DiscoveryWarning(
     string Code, string Path, IReadOnlyList<string>? TargetFolderPath,

--- a/src/Mail2Pst.Core/Discovery/DiscoveryResult.cs
+++ b/src/Mail2Pst.Core/Discovery/DiscoveryResult.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 using System.Collections.Generic;
+using Mail2Pst.Core.Msf;
 
 namespace Mail2Pst.Core.Discovery;
 
@@ -18,9 +19,16 @@ public sealed record DiscoverySkipped(string Code, string Path, string Reason);
 
 public sealed record DiscoveryPairingSummary(int PairedMsfCount, int UnpairedMboxCount, int OrphanMsfCount);
 
+public sealed record Account(
+    string Id, string FolderSegment, string AccountPath, string? Store,
+    string? Email, string? Host, AddressResolution AddressResolution);
+
 public sealed record DiscoveryResult(
     string Root, string Layout,
     IReadOnlyList<DiscoveredSource> Sources,
     IReadOnlyList<DiscoveryWarning> Warnings,
     IReadOnlyList<DiscoverySkipped> Skipped,
-    DiscoveryPairingSummary Pairing);
+    DiscoveryPairingSummary Pairing)
+{
+    public IReadOnlyList<Account> Accounts { get; init; } = System.Array.Empty<Account>();
+}

--- a/src/Mail2Pst.Core/Discovery/MailProfileDiscovery.cs
+++ b/src/Mail2Pst.Core/Discovery/MailProfileDiscovery.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Mail2Pst.Core.Msf;
 
 namespace Mail2Pst.Core.Discovery;
 
@@ -24,7 +25,10 @@ public static class MailProfileDiscovery
 
         // 1) Store-root: the input directory itself is named Mail/ImapMail.
         if (StoreNames.Contains(ownName, StringComparer.OrdinalIgnoreCase))
-            return DiscoverStores(path, new[] { path }, "thunderbird-store-root");
+        {
+            string? storeRootPrefs = Directory.GetParent(path)?.FullName;
+            return DiscoverStores(path, new[] { path }, "thunderbird-store-root", storeRootPrefs);
+        }
 
         // 2) Profile: contains Mail and/or ImapMail child directories.
         var stores = StoreNames
@@ -32,13 +36,13 @@ public static class MailProfileDiscovery
             .Where(Directory.Exists)
             .ToList();
         if (stores.Count > 0)
-            return DiscoverStores(path, stores, "thunderbird-profile");
+            return DiscoverStores(path, stores, "thunderbird-profile", path);
 
         // 3) Single tree: today's behaviour, no prefix.
         return MailTreeDiscovery.Discover(path);
     }
 
-    private static DiscoveryResult DiscoverStores(string root, IReadOnlyList<string> stores, string layout)
+    private static DiscoveryResult DiscoverStores(string root, IReadOnlyList<string> stores, string layout, string? prefsRoot)
     {
         // Track each source's ORIGIN (the account directory it came from) so the cross-account dedupe
         // can require >1 distinct origin — two same-named account dirs collide on path AND first segment,
@@ -111,9 +115,37 @@ public static class MailProfileDiscovery
         AddCrossAccountDuplicateWarnings(indexed, warnings);
 
         var sources = indexed.Select(x => x.Source).ToList();
+
+        var prefs = string.IsNullOrEmpty(prefsRoot)
+            ? new Dictionary<string, PrefsAccount>()
+            : PrefsAccountReader.Read(Path.Combine(prefsRoot, "prefs.js"));
+
+        var accounts = indexed
+            .Select(x => x.OriginKey)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(dir =>
+            {
+                string seg = Path.GetFileName(dir);
+                string? store = Path.GetFileName(Path.GetDirectoryName(dir));
+                string key = ((store ?? "") + "/" + seg).ToLowerInvariant();
+                PrefsAccount? pa = prefs.TryGetValue(key, out var v) ? v : null;
+                AddressResolution fallback = IsLocalFolders(store, seg)
+                    ? AddressResolution.LocalFolders
+                    : AddressResolution.NotFound;
+                return new Account(dir, seg, dir, store, pa?.Email, pa?.Host, pa?.Resolution ?? fallback);
+            })
+            .ToList();
+
         return new DiscoveryResult(root, layout, sources, warnings, skipped,
-            new DiscoveryPairingSummary(paired, unpaired, orphan));
+            new DiscoveryPairingSummary(paired, unpaired, orphan))
+        {
+            Accounts = accounts
+        };
     }
+
+    private static bool IsLocalFolders(string? store, string segment) =>
+        string.Equals(store, "Mail", StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(segment, "Local Folders", StringComparison.OrdinalIgnoreCase);
 
     // Emit a duplicate-target-folder-path warning ONLY for groups whose sources come from >1 distinct
     // ORIGIN (account dir). Same-account duplicates were already warned by MailTreeDiscovery's per-tree

--- a/src/Mail2Pst.Core/Discovery/MailProfileDiscovery.cs
+++ b/src/Mail2Pst.Core/Discovery/MailProfileDiscovery.cs
@@ -98,7 +98,8 @@ public static class MailProfileDiscovery
                     continue;
                 }
 
-                foreach (DiscoveredSource s in acct.Sources) indexed.Add((s, entry)); // OriginKey = account dir path
+                foreach (DiscoveredSource s in acct.Sources)
+                    indexed.Add((s with { AccountId = entry }, entry)); // OriginKey = account dir path
                 warnings.AddRange(acct.Warnings);
                 skipped.AddRange(acct.Skipped);
                 paired += acct.Pairing.PairedMsfCount;

--- a/src/Mail2Pst.Core/Msf/PrefsAccountReader.cs
+++ b/src/Mail2Pst.Core/Msf/PrefsAccountReader.cs
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace Mail2Pst.Core.Msf;
+
+public enum AddressResolution { Identity, Server, LocalFolders, NotFound }
+
+public sealed record PrefsAccount(string? Email, string? Host, AddressResolution Resolution);
+
+/// <summary>
+/// Reads Thunderbird account identity from prefs.js: maps each mail-server storage directory
+/// (normalized "&lt;store&gt;/&lt;name&gt;") to its resolved email + host. Line-oriented, does NOT run JS.
+/// </summary>
+public static class PrefsAccountReader
+{
+    private static readonly Regex Pref = new(
+        "^\\s*user_pref\\s*\\(\\s*\"(?<key>[^\"]+)\"\\s*,\\s*\"(?<val>(?:\\\\.|[^\"\\\\])*)\"\\s*\\)\\s*;?\\s*$",
+        RegexOptions.CultureInvariant);
+
+    public static IReadOnlyDictionary<string, PrefsAccount> Read(string prefsJsPath)
+    {
+        try { return ParseText(File.ReadAllText(prefsJsPath)); }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        { return new Dictionary<string, PrefsAccount>(StringComparer.Ordinal); }
+    }
+
+    public static IReadOnlyDictionary<string, PrefsAccount> ParseText(string content)
+    {
+        var srvDir = new Dictionary<string, string>();   // serverId -> normalized store/name
+        var srvHost = new Dictionary<string, string>();
+        var srvUser = new Dictionary<string, string>();
+        var srvType = new Dictionary<string, string>();
+        var acctServer = new Dictionary<string, string>(); // accountId -> serverId
+        var acctIdents = new Dictionary<string, string>(); // accountId -> "id1,id2"
+        var identMail = new Dictionary<string, string>();  // identId -> email
+
+        foreach (string line in content.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None))
+        {
+            Match m = Pref.Match(line);
+            if (!m.Success) continue;
+            string key = m.Groups["key"].Value;
+            if (!PrefsJsEscape.TryUnescape(m.Groups["val"].Value, out string val)) continue; // bad escape -> skip line
+            string[] p = key.Split('.');
+            if (p.Length == 4 && p[0] == "mail" && p[1] == "server")
+            {
+                string id = p[2];
+                switch (p[3])
+                {
+                    case "directory-rel": srvDir[id] = NormalizeRel(val); break;
+                    case "directory": if (!srvDir.ContainsKey(id)) srvDir[id] = NormalizeAbs(val); break;
+                    case "hostname": srvHost[id] = val; break;
+                    case "userName": srvUser[id] = val; break;
+                    case "type": srvType[id] = val; break;
+                }
+            }
+            else if (p.Length == 4 && p[0] == "mail" && p[1] == "account")
+            {
+                if (p[3] == "server") acctServer[p[2]] = val;
+                else if (p[3] == "identities") acctIdents[p[2]] = val;
+            }
+            else if (p.Length == 4 && p[0] == "mail" && p[1] == "identity" && p[3] == "useremail")
+            {
+                identMail[p[2]] = val;
+            }
+        }
+
+        // server -> first identity email (via the account that references it)
+        var srvEmail = new Dictionary<string, string>();
+        foreach (var (acct, srv) in acctServer)
+        {
+            if (!acctIdents.TryGetValue(acct, out string? ids)) continue;
+            foreach (string idRaw in ids.Split(','))
+            {
+                string id = idRaw.Trim();
+                if (id.Length > 0 && identMail.TryGetValue(id, out string? email) && email.Length > 0)
+                { srvEmail[srv] = email; break; }
+            }
+        }
+
+        var result = new Dictionary<string, PrefsAccount>(StringComparer.Ordinal);
+        foreach (var (srv, dirKey) in srvDir)
+        {
+            srvHost.TryGetValue(srv, out string? host);
+            srvType.TryGetValue(srv, out string? type);
+            string? email = null;
+            AddressResolution res;
+            if (string.Equals(type, "none", StringComparison.Ordinal))
+            {
+                res = AddressResolution.LocalFolders;
+            }
+            else if (srvEmail.TryGetValue(srv, out string? idEmail))
+            {
+                email = idEmail; res = AddressResolution.Identity;
+            }
+            else if (srvUser.TryGetValue(srv, out string? user) && user.Contains('@'))
+            {
+                email = user; res = AddressResolution.Server;
+            }
+            else { res = AddressResolution.NotFound; }
+            result[dirKey] = new PrefsAccount(email, host, res);
+        }
+        return result;
+    }
+
+    // "[ProfD]ImapMail/imap.example.com" -> "imapmail/imap.example.com"
+    private static string NormalizeRel(string v)
+    {
+        int b = v.IndexOf(']');
+        string rel = b >= 0 ? v[(b + 1)..] : v;
+        return rel.Replace('\\', '/').Trim('/').ToLowerInvariant();
+    }
+
+    // "C:\...\ImapMail\imap.example.com" -> last two segments "imapmail/imap.example.com"
+    private static string NormalizeAbs(string v)
+    {
+        string[] seg = v.Replace('\\', '/').TrimEnd('/').Split('/');
+        return seg.Length >= 2
+            ? (seg[^2] + "/" + seg[^1]).ToLowerInvariant()
+            : v.Replace('\\', '/').ToLowerInvariant();
+    }
+}

--- a/src/Mail2Pst.Core/Msf/PrefsJsEscape.cs
+++ b/src/Mail2Pst.Core/Msf/PrefsJsEscape.cs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Globalization;
+using System.Text;
+
+namespace Mail2Pst.Core.Msf;
+
+internal static class PrefsJsEscape
+{
+    public static bool TryUnescape(string raw, out string result)
+    {
+        var sb = new StringBuilder(raw.Length);
+        for (int i = 0; i < raw.Length; i++)
+        {
+            char c = raw[i];
+            if (c != '\\') { sb.Append(c); continue; }
+            i++;
+            if (i >= raw.Length) { result = ""; return false; } // dangling backslash
+            switch (raw[i])
+            {
+                case '\\': sb.Append('\\'); break;
+                case '"': sb.Append('"'); break;
+                case 'n': sb.Append('\n'); break;
+                case 'r': sb.Append('\r'); break;
+                case 't': sb.Append('\t'); break;
+                case 'u':
+                    if (i + 4 >= raw.Length) { result = ""; return false; }
+                    if (!ushort.TryParse(raw.Substring(i + 1, 4), NumberStyles.HexNumber,
+                            CultureInfo.InvariantCulture, out ushort code)) { result = ""; return false; }
+                    sb.Append((char)code);
+                    i += 4;
+                    break;
+                default: result = ""; return false; // unknown escape -> skip line
+            }
+        }
+        result = sb.ToString();
+        return true;
+    }
+}

--- a/src/Mail2Pst.Core/Msf/PrefsTagReader.cs
+++ b/src/Mail2Pst.Core/Msf/PrefsTagReader.cs
@@ -3,9 +3,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
-using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Mail2Pst.Core.Msf;
@@ -48,7 +46,7 @@ public static class PrefsTagReader
         {
             Match m = TagPrefRegex.Match(line);
             if (!m.Success) continue;
-            if (!TryUnescape(m.Groups["val"].Value, out string name)) continue; // bad escape -> skip line
+            if (!PrefsJsEscape.TryUnescape(m.Groups["val"].Value, out string name)) continue; // bad escape -> skip line
             if (name.Length == 0) continue;                                       // empty name -> skip line
             map[m.Groups["key"].Value] = name;                                    // later duplicate wins
         }
@@ -69,33 +67,4 @@ public static class PrefsTagReader
         return map;
     }
 
-    private static bool TryUnescape(string raw, out string result)
-    {
-        var sb = new StringBuilder(raw.Length);
-        for (int i = 0; i < raw.Length; i++)
-        {
-            char c = raw[i];
-            if (c != '\\') { sb.Append(c); continue; }
-            i++;
-            if (i >= raw.Length) { result = ""; return false; } // dangling backslash
-            switch (raw[i])
-            {
-                case '\\': sb.Append('\\'); break;
-                case '"': sb.Append('"'); break;
-                case 'n': sb.Append('\n'); break;
-                case 'r': sb.Append('\r'); break;
-                case 't': sb.Append('\t'); break;
-                case 'u':
-                    if (i + 4 >= raw.Length) { result = ""; return false; }
-                    if (!ushort.TryParse(raw.Substring(i + 1, 4), NumberStyles.HexNumber,
-                            CultureInfo.InvariantCulture, out ushort code)) { result = ""; return false; }
-                    sb.Append((char)code);
-                    i += 4;
-                    break;
-                default: result = ""; return false; // unknown escape -> skip line
-            }
-        }
-        result = sb.ToString();
-        return true;
-    }
 }

--- a/tests/Mail2Pst.Core.Tests/Discovery/MailProfileDiscoveryAccountIdTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Discovery/MailProfileDiscoveryAccountIdTests.cs
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Discovery;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Discovery;
+
+public class MailProfileDiscoveryAccountIdTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "m2p-acctid-" + Guid.NewGuid());
+    public MailProfileDiscoveryAccountIdTests() => Directory.CreateDirectory(_root);
+    public void Dispose() { try { Directory.Delete(_root, true); } catch { } }
+
+    private void Touch(string rel)
+    {
+        string p = Path.Combine(_root, rel);
+        Directory.CreateDirectory(Path.GetDirectoryName(p)!);
+        File.WriteAllBytes(p, Array.Empty<byte>());
+    }
+
+    [Fact]
+    public void Discover_StoreRoot_SetsAccountIdToAccountDir()
+    {
+        // ImapMail/<account>/INBOX — store-root layout
+        Touch("ImapMail/imap.example.com/INBOX");
+        string acctDir = Path.Combine(_root, "ImapMail", "imap.example.com");
+
+        DiscoveryResult result = MailProfileDiscovery.Discover(Path.Combine(_root, "ImapMail"));
+
+        Assert.NotEmpty(result.Sources);
+        Assert.All(result.Sources, s => Assert.Equal(acctDir, s.AccountId));
+    }
+
+    [Fact]
+    public void Discover_ProfileRoot_SetsAccountIdPerAccountDir()
+    {
+        // Profile layout: Mail/<acct1>/Inbox, ImapMail/<acct2>/INBOX
+        Touch("Mail/Local Folders/Inbox");
+        Touch("ImapMail/imap.example.com/INBOX");
+        string acct1Dir = Path.Combine(_root, "Mail", "Local Folders");
+        string acct2Dir = Path.Combine(_root, "ImapMail", "imap.example.com");
+
+        DiscoveryResult result = MailProfileDiscovery.Discover(_root);
+
+        var acct1Sources = result.Sources.Where(s => s.AccountId == acct1Dir).ToList();
+        var acct2Sources = result.Sources.Where(s => s.AccountId == acct2Dir).ToList();
+        Assert.NotEmpty(acct1Sources);
+        Assert.NotEmpty(acct2Sources);
+    }
+
+    [Fact]
+    public void Discover_SingleTree_AccountIdIsNull()
+    {
+        // Single-tree input (no Mail/ImapMail child) — AccountId must remain null
+        Touch("Inbox");
+
+        DiscoveryResult result = MailProfileDiscovery.Discover(_root);
+
+        Assert.All(result.Sources, s => Assert.Null(s.AccountId));
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Discovery/MailProfileDiscoveryAccountsTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Discovery/MailProfileDiscoveryAccountsTests.cs
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.IO;
+using Mail2Pst.Core.Discovery;
+using Mail2Pst.Core.Msf;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Discovery;
+
+public class MailProfileDiscoveryAccountsTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "m2p-accounts-" + Guid.NewGuid());
+    public MailProfileDiscoveryAccountsTests() => Directory.CreateDirectory(_root);
+    public void Dispose() { try { Directory.Delete(_root, true); } catch { } }
+
+    private void Touch(string rel)
+    {
+        string p = Path.Combine(_root, rel);
+        Directory.CreateDirectory(Path.GetDirectoryName(p)!);
+        File.WriteAllBytes(p, Array.Empty<byte>());
+    }
+
+    [Fact]
+    public void Discover_Profile_BuildsAccountsWithEmail()
+    {
+        // ImapMail/imap.example.com/INBOX — one message so it is discovered
+        Touch("ImapMail/imap.example.com/INBOX");
+
+        // prefs.js at the profile root wires up server1 -> identity email alice@example.com
+        File.WriteAllText(Path.Combine(_root, "prefs.js"), string.Join("\n", new[]
+        {
+            "user_pref(\"mail.server.server1.directory-rel\", \"[ProfD]ImapMail/imap.example.com\");",
+            "user_pref(\"mail.server.server1.hostname\", \"imap.example.com\");",
+            "user_pref(\"mail.server.server1.type\", \"imap\");",
+            "user_pref(\"mail.account.account1.server\", \"server1\");",
+            "user_pref(\"mail.account.account1.identities\", \"id1\");",
+            "user_pref(\"mail.identity.id1.useremail\", \"alice@example.com\");",
+        }));
+
+        DiscoveryResult r = MailProfileDiscovery.Discover(_root);
+
+        Account a = Assert.Single(r.Accounts);
+        Assert.Equal("alice@example.com", a.Email);
+        Assert.Equal("imap.example.com", a.FolderSegment);
+        Assert.Equal(AddressResolution.Identity, a.AddressResolution);
+    }
+
+    [Fact]
+    public void Discover_Profile_LocalFoldersWithoutPrefs_ResolvesToLocalFolders()
+    {
+        // Mail/Local Folders/Inbox — no prefs.js present
+        Touch("Mail/Local Folders/Inbox");
+
+        DiscoveryResult r = MailProfileDiscovery.Discover(_root);
+
+        Account a = Assert.Single(r.Accounts);
+        Assert.Equal("Local Folders", a.FolderSegment);
+        Assert.Equal(AddressResolution.LocalFolders, a.AddressResolution);
+        Assert.Null(a.Email);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Msf/PrefsAccountReaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/PrefsAccountReaderTests.cs
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using Mail2Pst.Core.Msf;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Msf;
+
+public class PrefsAccountReaderTests
+{
+    private const string Prefs = @"
+user_pref(""mail.server.server1.directory-rel"", ""[ProfD]ImapMail/imap.example.com"");
+user_pref(""mail.server.server1.hostname"", ""imap.example.com"");
+user_pref(""mail.server.server1.type"", ""imap"");
+user_pref(""mail.server.server1.userName"", ""alice@example.com"");
+user_pref(""mail.account.account1.server"", ""server1"");
+user_pref(""mail.account.account1.identities"", ""id1"");
+user_pref(""mail.identity.id1.useremail"", ""alice@example.com"");
+user_pref(""mail.server.server2.directory-rel"", ""[ProfD]Mail/Local Folders"");
+user_pref(""mail.server.server2.type"", ""none"");
+";
+
+    [Fact]
+    public void ParseText_ResolvesIdentityEmail()
+    {
+        var map = PrefsAccountReader.ParseText(Prefs);
+        var a = map["imapmail/imap.example.com"];
+        Assert.Equal("alice@example.com", a.Email);
+        Assert.Equal("imap.example.com", a.Host);
+        Assert.Equal(AddressResolution.Identity, a.Resolution);
+    }
+
+    [Fact]
+    public void ParseText_LocalFolders_IsLocalNotFailure()
+    {
+        var map = PrefsAccountReader.ParseText(Prefs);
+        var a = map["mail/local folders"];
+        Assert.Null(a.Email);
+        Assert.Equal(AddressResolution.LocalFolders, a.Resolution);
+    }
+
+    [Fact]
+    public void ParseText_AbsoluteDirectory_AndImapNoIdentity_IsNotFound()
+    {
+        var map = PrefsAccountReader.ParseText(
+            "user_pref(\"mail.server.server1.directory\", \"C:\\\\x\\\\ImapMail\\\\imap.other.test\");\n" +
+            "user_pref(\"mail.server.server1.type\", \"imap\");\n" +
+            "user_pref(\"mail.server.server1.hostname\", \"imap.other.test\");\n");
+        Assert.True(map.ContainsKey("imapmail/imap.other.test"));
+        Assert.Equal(AddressResolution.NotFound, map["imapmail/imap.other.test"].Resolution); // imap, no identity
+    }
+
+    [Fact]
+    public void ParseText_UnescapesIdentityEmail()
+    {
+        var map = PrefsAccountReader.ParseText(
+            "user_pref(\"mail.server.server1.directory-rel\", \"[ProfD]ImapMail/x\");\n" +
+            "user_pref(\"mail.server.server1.type\", \"imap\");\n" +
+            "user_pref(\"mail.account.account1.server\", \"server1\");\n" +
+            "user_pref(\"mail.account.account1.identities\", \"id1\");\n" +
+            "user_pref(\"mail.identity.id1.useremail\", \"al\\u00e6ce@example.com\");\n");
+        Assert.Equal("alæce@example.com", map["imapmail/x"].Email);
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/DiscoverCommandAccountsTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/DiscoverCommandAccountsTests.cs
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.IO;
+using System.Text.Json;
+using Mail2Pst.Cli;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests;
+
+[Collection("ConsoleCapture")]
+public class DiscoverCommandAccountsTests
+{
+    [Fact]
+    public void Discover_Profile_EmitsAccountsAndAccountId()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "m2p-disc-acct-" + Guid.NewGuid());
+        try
+        {
+            // ImapMail/imap.example.com/INBOX — must be non-empty to be discovered
+            string inboxPath = Path.Combine(root, "ImapMail", "imap.example.com", "INBOX");
+            Directory.CreateDirectory(Path.GetDirectoryName(inboxPath)!);
+            File.WriteAllText(inboxPath,
+                "From sender@example.com Mon Jan 01 00:00:00 2024\r\n" +
+                "Message-ID: <test-acct-1@example.com>\r\n" +
+                "Subject: Test\r\n" +
+                "\r\n" +
+                "Body.\r\n");
+
+            // prefs.js: wire server1 -> account1 -> identity id1 -> alice@example.com
+            File.WriteAllText(Path.Combine(root, "prefs.js"), string.Join("\n", new[]
+            {
+                "user_pref(\"mail.server.server1.directory-rel\", \"[ProfD]ImapMail/imap.example.com\");",
+                "user_pref(\"mail.server.server1.hostname\", \"imap.example.com\");",
+                "user_pref(\"mail.server.server1.type\", \"imap\");",
+                "user_pref(\"mail.account.account1.server\", \"server1\");",
+                "user_pref(\"mail.account.account1.identities\", \"id1\");",
+                "user_pref(\"mail.identity.id1.useremail\", \"alice@example.com\");",
+            }));
+
+            var sw = new StringWriter();
+            TextWriter original = Console.Out;
+            Console.SetOut(sw);
+            try
+            {
+                int exit = DiscoverCommand.Run(new[] { "--input", root });
+                Assert.Equal(0, exit);
+            }
+            finally
+            {
+                Console.SetOut(original);
+            }
+
+            string stdout = sw.ToString();
+            using JsonDocument doc = JsonDocument.Parse(stdout);
+            JsonElement rootEl = doc.RootElement;
+
+            // accounts[] must be non-empty and carry email + addressResolution
+            Assert.NotEqual(0, rootEl.GetProperty("accounts").GetArrayLength());
+            JsonElement acct = rootEl.GetProperty("accounts")[0];
+            Assert.Equal("alice@example.com", acct.GetProperty("email").GetString());
+            Assert.Equal("identity", acct.GetProperty("addressResolution").GetString());
+
+            // each source must carry a non-null accountId
+            Assert.NotEqual(0, rootEl.GetProperty("sources").GetArrayLength());
+            JsonElement src = rootEl.GetProperty("sources")[0];
+            Assert.False(string.IsNullOrEmpty(src.GetProperty("accountId").GetString()));
+        }
+        finally
+        {
+            try { Directory.Delete(root, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Discover_NonProfile_EmitsEmptyAccountsAndNullAccountId()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "m2p-disc-noprofile-" + Guid.NewGuid());
+        try
+        {
+            // A plain mbox file (non-profile layout) — no prefs.js, no ImapMail structure
+            Directory.CreateDirectory(root);
+            string mboxPath = Path.Combine(root, "Inbox");
+            File.WriteAllText(mboxPath,
+                "From sender@example.com Mon Jan 01 00:00:00 2024\r\n" +
+                "Message-ID: <test-np-1@example.com>\r\n" +
+                "Subject: Test\r\n" +
+                "\r\n" +
+                "Body.\r\n");
+
+            var sw = new StringWriter();
+            TextWriter original = Console.Out;
+            Console.SetOut(sw);
+            try
+            {
+                int exit = DiscoverCommand.Run(new[] { "--input", root });
+                Assert.Equal(0, exit);
+            }
+            finally
+            {
+                Console.SetOut(original);
+            }
+
+            string stdout = sw.ToString();
+            using JsonDocument doc = JsonDocument.Parse(stdout);
+            JsonElement rootEl = doc.RootElement;
+
+            // non-profile: accounts[] must be empty
+            Assert.Equal(0, rootEl.GetProperty("accounts").GetArrayLength());
+
+            // non-profile: accountId on each source must be null
+            foreach (JsonElement src in rootEl.GetProperty("sources").EnumerateArray())
+            {
+                JsonElement accountIdEl = src.GetProperty("accountId");
+                Assert.True(accountIdEl.ValueKind == JsonValueKind.Null,
+                    $"Expected accountId null but got: {accountIdEl}");
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(root, true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## What

The multi-account half of the v0.2.0 desktop release (the "polish + onboarding" half merged in #22). When a Thunderbird profile has 2+ accounts, the app now produces **one PST per account** via a new Accounts step. The engine/PST writer is unchanged — multi-PST rides the existing `outputs[]` config support; all CLI additions are additive.

## Changes

- **Discovery (Core):** each discovered source carries its `AccountId` (account directory); a new `PrefsAccountReader` resolves each account directory to its email + resolution outcome from `prefs.js` (shared `PrefsJsEscape` extracted from the tag reader); `MailProfileDiscovery` returns a per-account `Accounts` summary. Local Folders is a first-class account and never mislabelled "not found".
- **`discover` CLI:** additively emits `accountId` per source + a top-level `accounts[]` (`schemaVersion` unchanged; non-profile inputs emit `accounts:[]` / `accountId:null`).
- **GUI:** parses the new fields; groups sources by account; a dynamic stepper inserts an **Accounts** step (review/remove accounts, each labelled by email, edit its PST name) only for profiles with 2+ accounts; an explicit `OutputTarget` model (single `.pst` for files/single-account, output **folder** for multi-account); a multi-output `buildProfileConfig` emitting one `OutputGroupConfig` per kept account (account-prefix stripped, names sanitised + de-duplicated).

## Notes

- Files mode and single-account profiles are unchanged (no Accounts step, single PST).
- Additive contract only; no engine/PST-writer/Core-conversion change.
- Owner-validated end to end in Outlook (one PST per account, correct per-account folder structure, no cross-contamination).
- Tests: 618 Core + 71 Integration (.NET), 198 Vitest — all green. No new Rust crate.