### PR TITLE
Release v0.2.0 — Thunderbird profile conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,77 @@ All notable changes to ContinuMail Converter are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] — 2026-06-23
 
-### Added
-- **More Thunderbird/mbox status flags preserved.** When a source mbox carries `X-Mozilla-Status`
-  flags (typical of POP accounts and older Local Folders stores), the converter now also preserves
-  **replied** (→ Outlook reply arrow), **forwarded** (→ forward arrow), and **starred/marked**
-  (→ follow-up flag), in addition to read/unread. Modern IMAP/EWS exports carry no flags in the
-  mbox, so this has no effect there; tags (`X-Mozilla-Keys`) remain unsupported.
+**Major feature enrichments — and a hard-won grudge against Mozilla Mork — ship with 0.2.0. The
+headline is Thunderbird profile conversion.**
+
+ContinuMail Converter now reads Thunderbird's `.msf` / **Mork** metadata. Point it at a profile and
+your full folder and subfolder tree comes across — and the per-message state the mbox alone throws
+away (**read/unread, stars, replied/forwarded flags, junk, and tags**) is translated into native
+**MAPI properties (PID tags)** and shows up natively in Outlook. Tags become Outlook **categories**
+under your real Thunderbird tag names. It's paired with a **scan-for-profiles** step that
+automatically matches every mail account and local archive with its `.msf` sidecar — no hunting for
+files. This resolves the v0.1.2 "Thunderbird flags/starred not preserved" and "tags unsupported"
+limitations for live-profile conversions.
+
+*(Mork is an undocumented, dictionary-compressed text format from ~2000 that nobody should have to
+parse in 2026. We wrote a from-scratch reader for it so you never have to think about it.)*
+
+### New in 0.2.0 (CLI + GUI)
+- **Thunderbird `.msf` / Mork enrichment** — read/unread, replied, forwarded, starred (→ follow-up
+  flag), junk, and tags, recovered from a live profile and written as native MAPI properties.
+  Degrades gracefully: an unreadable or mismatched `.msf` is skipped per-source and reported, never
+  fatal.
+- **Tags → Outlook categories** using your real tag display-names from `prefs.js` (non-ASCII included).
+- **Scan for profiles** — auto-discovers Thunderbird profiles and pairs every mail account and local
+  archive with its `.msf` sidecar; per-account detection (email / host) included.
+- **Multi-account → one PST per account** by default (each account a top-level folder), with a
+  "Combine into a single PST" toggle.
+- **Junk handling** — leave / tag as a "Junk" category / move to a Junk Email folder.
+- **Drop expunged messages** — optionally skip mail Thunderbird marked deleted but hasn't compacted
+  out yet.
+- **Outlook category colours** — `import-colours` (CLI) and a one-click card on the Done screen (GUI)
+  push your Thunderbird tag colours into Outlook so the categories match.
+
+**On category colours and COM:** category *assignments* live in the PST as MAPI properties (PID tags)
+and need no Outlook. The **Master Category List** — the names-and-colours registry Outlook draws from
+— does **not** live in the PST and can't be written from PID tags, so colour import drives Outlook
+over COM to edit the CategoryList FAI message atomically (Windows only; Outlook installed and
+**closed**). A `--plan-file` mode applies a previewed plan without re-scanning.
+
+### Hardening, security & other changes
+- **Mork reader — nested folders no longer read as empty.** Real `.msf` files reuse a small numeric
+  table id across scopes; tables are now keyed by the composite (scope, id), so enrichment no longer
+  silently finds zero messages on real profiles.
+- **Mork reader — wider charset support** (windows-1252, Shift-JIS, Big5, EUC-JP, via the runtime
+  code-page provider) and more robust column-dictionary detection.
+- **`import-colours` fixes** — correct bytes for non-ASCII categories (e.g. "ÆØÅ"); only shuts down an
+  Outlook instance it actually started; excludes the `NonJunk` pseudo-tag from candidates.
+- **More mbox `X-Mozilla-Status` flags even without a profile** — replied / forwarded / starred added
+  to read/unread (POP / older Local Folders stores; no effect on flag-less IMAP/EWS exports) (#7).
+- **Faster large-folder writes** — per-folder `SaveChanges` is batched at checkpoints instead of after
+  every message. No behaviour change.
+- **GUI polish** — real source count on the Scanning screen (was "0 files"); one box per account on
+  the Source step (was "first@x +N more"); full-height rail with no sideways scroll; multi-account
+  defaults to split; stepper Back-navigation reaches the Accounts step.
+- **Security** — the vendored multi-string deserializer validates its item count with unsigned
+  arithmetic against the buffer length before casting, turning a malformed/oversized count into a
+  clean `InvalidDataException` instead of `OverflowException`/`OutOfMemoryException`.
+
+### Known limitations
+- **`.msf` enrichment needs a live profile** (the mbox plus its sibling `.msf`). A bare exported
+  `.mbox` still imports as before — only inline `X-Mozilla-Status` flags are recoverable, not
+  tags / junk / expunged state.
+- **`import-colours` is Windows-only and needs Outlook installed and closed.** Conversion itself still
+  requires no Outlook — only tag *colours* do.
+
+### Internal
+- New from-scratch, read-only **Mork (`.msf`) reader** (`src/Mail2Pst.Core/Mork/`) with enrichment
+  built on top (`src/Mail2Pst.Core/Msf/`); extensive unit + env-gated real-corpus tests.
+- Pure, COM-free, unit-tested category-colour XML/stream helpers extracted from the colour-import path.
+- Desktop helper extractions (account grouping, PST-name sanitization/de-dup, output-path join,
+  discovery parsing) and the single public-primary repo migration with a `leak-check` safety net.
 
 ## [0.1.2] — 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,6 @@ automatically matches every mail account and local archive with its `.msf` sidec
 files. This resolves the v0.1.2 "Thunderbird flags/starred not preserved" and "tags unsupported"
 limitations for live-profile conversions.
 
-*(Mork is an undocumented, dictionary-compressed text format from ~2000 that nobody should have to
-parse in 2026. We wrote a from-scratch reader for it so you never have to think about it.)*
-
 ### New in 0.2.0 (CLI + GUI)
 - **Thunderbird `.msf` / Mork enrichment** — read/unread, replied, forwarded, starred (→ follow-up
   flag), junk, and tags, recovered from a live profile and written as native MAPI properties.

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ The **ContinuMail** name, logos, icons, and brand assets are **not** covered by 
 
 - **[ROM-Knowledgeware/PSTFileFormat](https://github.com/ROM-Knowledgeware/PSTFileFormat)** by **Tal Aloni** — the rare, from-scratch MS-PST reader/writer that makes ContinuMail's Outlook-independence possible. **ContinuMail would not exist without it.** (Vendored, with local modifications, per the LGPL.)
 - **[MimeKit](https://github.com/jstedfast/MimeKit)** by **Jeffrey Stedfast** — the MIME parsing that reads every message.
+- **[knk106/MorkReader](https://github.com/knk106/MorkReader)** — a clear, public-domain reference implementation that helped us understand Thunderbird's undocumented Mork `.msf` format. ContinuMail's Mork reader is project-native code (not forked or vendored), but knk106's work was a valuable map of the territory — thank you.
 
 ## 🧑‍💻 How it works (for contributors)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ContinuMail Converter
 
-**Convert Gmail Takeout and other mbox mail archives into Outlook PST files — locally, with no upload and no Outlook installation required.**
+**Convert Thunderbird profiles and mbox mail archives — Gmail Takeout, exported Local Folders, old POP stores — into Outlook PST files, locally, with no upload and no Outlook installation required.**
 
 [![License: GPL-3.0-or-later](https://img.shields.io/badge/License-GPL--3.0--or--later-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/ContinuMail/continumail-converter?label=release)](../../releases/latest)
@@ -16,11 +16,11 @@
 
 - **No Outlook, no COM automation.** Writes `.pst` directly with a from-scratch PST engine — nothing to install, nothing hijacked.
 - **Private & local-first.** Reads your archive on disk, makes **no network connections**, uploads nothing. Originals are only ever read.
-- **Gmail-Takeout–aware.** Built and validated against real Google Takeout exports — including the quirks and a MimeKit mbox bug that truncates some archives (worked around here).
-- **Faithful.** Preserves folder structure (including Thunderbird subfolders via the CLI), attachments (inline images + embedded `.eml`), HTML bodies, dates, To/Cc/Bcc, importance, and threading headers.
+- **Thunderbird-first, mbox-everywhere.** Converts a whole **Thunderbird profile** — folder tree plus `.msf` flag/tag fidelity — or any **mbox** archive: Gmail Takeout, exported Local Folders, old POP stores. Built and validated against real exports, including a MimeKit mbox bug that truncates some archives (worked around here).
+- **Faithful.** Preserves folder structure (including nested Thunderbird folders), attachments (inline images + embedded `.eml`), HTML bodies, dates, To/Cc/Bcc, importance, and threading headers — and, from a live **Thunderbird profile**, recovers read/unread, replied/forwarded/starred flags, junk, and tags (→ Outlook categories, with their colours on Windows).
 - **Free, open, and it stays free** — GPL-3.0-or-later, part of the [ContinuMail](#-license) family of honest mail tools.
 
-> **Early release (0.x).** Covered by a comprehensive automated test suite and validated on real Gmail Takeout and Thunderbird/Exchange exports — but please keep backups and validate output before relying on it. See [`TESTING.md`](TESTING.md) for how releases are validated.
+> **Early release (0.x).** Covered by a comprehensive automated test suite and validated on real Thunderbird profiles and Gmail Takeout / Exchange exports — but please keep backups and validate output before relying on it. See [`TESTING.md`](TESTING.md) for how releases are validated.
 
 ## Overview
 
@@ -41,21 +41,27 @@ Prefer the command line? See [Command-line interface](#-command-line-interface).
 
 The desktop app walks you through the whole conversion; your originals are never modified.
 
-1. **Source** — pick `.mbox` files or a folder of them.
-2. **Scanning** — a fast dry-run counts messages and estimates output size before anything is written.
-3. **Review** — see per-folder counts; choose whether to include empty folders.
-4. **Options** — pick folder mapping (mirror or flatten), set a split size, preview the resulting PST folder tree, and rename folders if you like.
-5. **Convert** — watch live progress (count, MB/s, ETA); cancel any time.
-6. **Done** — open the output folder, or review any warnings.
+1. **Source** — point it at a **Thunderbird profile** (auto-discovered, or browse to one) or pick individual `.mbox` files / a folder of them.
+2. **Accounts** *(multi-account profiles)* — when a profile holds more than one mail account, review them and keep or drop each; by default each account becomes its **own PST**, or combine them into one.
+3. **Scanning** — a fast dry-run counts messages and estimates output size before anything is written.
+4. **Review** — see per-folder counts (with an `.msf` badge where Thunderbird flag/tag data is available); choose whether to include empty folders.
+5. **Options** — pick folder mapping (mirror or flatten), set a split size, preview the resulting PST tree, and (for profiles) choose junk handling and whether to skip deleted messages.
+6. **Convert** — watch live progress (count, MB/s, ETA); cancel any time.
+7. **Done** — open the output folder, review any warnings, see what Thunderbird state was applied, and (Windows + Outlook) optionally **import your Thunderbird tag colours** into Outlook so the new categories match.
 
 ## 🎯 Features
 
 - **mbox input** via a custom mbox splitter plus MimeKit entity parsing (robust to the Gmail Takeout / MimeKit EOF quirk).
+- **Thunderbird profile mode:** point the app (or `convert --profile`) at a Thunderbird profile and it auto-discovers the nested folder tree and pairs each mbox with its `.msf` for full flag/tag fidelity.
+- **Multi-account:** a profile with several mail accounts produces **one PST per account** by default (each account a top-level folder), or combine them into a single PST.
+- **Category colours (Windows + Outlook):** optionally import your Thunderbird tag colours into Outlook's category master list so the new categories match — one click on the Done screen, or the `import-colours` CLI command.
+- **Junk & expunged handling:** route Thunderbird-scored junk (leave / tag as a "Junk" category / move to a Junk Email folder), and optionally drop messages Thunderbird marked deleted.
 - **Folder mapping:** mirror (one PST folder per source file), flatten, or per-source custom target folder. Empty source folders can be kept as empty PST folders.
 - **Size-based splitting:** one PST per output group, auto-split into `Name-1.pst`, `Name-2.pst`, … when a size cap is exceeded (a single un-split output is just `Name.pst`).
 - **HTML bodies** (`PidTagHtml` + `PidTagNativeBody`) with an always-present plain-text fallback.
 - **Full attachments:** regular files, inline CID images (correctly hidden, so no phantom paperclip), and embedded `.eml` messages.
-- **Metadata fidelity:** To/Cc/Bcc recipient types, importance/priority, Message-ID / In-Reply-To / References, conversation topic. (Read/unread, replied, forwarded, and starred state are preserved when the source mbox carries `X-Mozilla-Status` flags — typical of POP accounts and older Local Folders stores; see [Limitations](#-limitations) for when flags are absent.) Bcc recipients are preserved with their MAPI Bcc type and appear in Outlook's Bcc field (this is a faithful archive of mail you already sent — nothing to hide in a local store).
+- **Metadata fidelity:** To/Cc/Bcc recipient types, importance/priority, Message-ID / In-Reply-To / References, conversation topic. Bcc recipients are preserved with their MAPI Bcc type and appear in Outlook's Bcc field (this is a faithful archive of mail you already sent — nothing to hide in a local store).
+- **Thunderbird flag & tag fidelity:** from a **live Thunderbird profile**, the converter reads each folder's `.msf` index to recover **read/unread, replied, forwarded, starred** (→ Outlook follow-up flag), **junk**, and **tags** — and turns tags into Outlook **categories** using your real tag names. (Without a profile, these are recovered only from inline `X-Mozilla-Status` flags where present — see [Limitations](#-limitations).)
 - **Memory-friendly:** large attachments (≥ 4 MB) spill to a temp file so many don't pile up in memory at once.
 - **Conversion reports** (human-readable + JSON) listing skipped messages and warnings.
 
@@ -63,7 +69,8 @@ The desktop app walks you through the whole conversion; your originals are never
 
 - **Non-UTF-8 / UTF-16 mbox envelopes.** The mbox envelope and headers are read as UTF-8/ASCII; archives whose *envelope framing* uses other encodings may not parse cleanly. (Message **bodies** honour their own MIME charset — this caveat is about the mbox framing, not body text.)
 - **Plain-text body is a best-effort fallback.** Real HTML is preserved faithfully (`PidTagHtml`) and is what Outlook displays; the generated plain-text alternative is a lightweight stripper, not a full renderer.
-- **Read/unread & starred state from Thunderbird is not preserved for IMAP/EWS accounts.** Thunderbird stores per-message flag state in its own index (`.msf`), not in the mbox, so an mbox-based conversion cannot recover it for modern server-backed stores — messages import as read and unflagged. When the mbox *does* carry `X-Mozilla-Status` (POP accounts, older Local Folders stores), the converter honors read/unread, replied (→ reply arrow), forwarded (→ forward arrow), and starred (→ follow-up flag). Tags (`X-Mozilla-Keys`) remain unsupported.
+- **Thunderbird flag/tag recovery needs a live profile.** Thunderbird stores per-message flag state in its `.msf` index, not the mbox. Point the converter at a **live profile** (the app's profile mode, or `convert --profile`) and it reads the `.msf` to recover read/unread, replied, forwarded, starred (→ follow-up flag), junk, and tags (→ Outlook categories) — including for IMAP/EWS accounts. A **standalone exported `.mbox`** with no adjacent `.msf` can't carry that: there, only inline `X-Mozilla-Status` flags (read/replied/forwarded/starred, typical of POP / older Local Folders stores) are recoverable, and tags/junk are not.
+- **Category *colours* need Outlook (Windows).** The conversion needs no Outlook, but matching Outlook's category colours to your Thunderbird tags is done by `import-colours` (one click on Done, or the CLI), which edits Outlook's master category list via COM and so requires Outlook installed and **closed**.
 
 ## ⌨️ Command-line interface
 
@@ -78,6 +85,14 @@ dotnet run --project src/Mail2Pst.Cli -- discover --input <mail-dir>
 
 # Convert: JSON Lines progress to stdout, PST + reports to the output directory.
 dotnet run --project src/Mail2Pst.Cli -- convert --config <config.json> --output <output-dir>
+
+# Convert a whole Thunderbird profile: discovers folders, pairs each mbox with its .msf,
+# and applies flag/tag/junk enrichment (optional --config tunes mapping/junk/split).
+dotnet run --project src/Mail2Pst.Cli -- convert --profile <thunderbird-profile-dir> --output <output-dir>
+
+# Import Thunderbird tag colours into Outlook's category list (Windows; Outlook must be closed).
+# Preview with --profile; write with --apply (or apply a saved plan with --plan-file).
+dotnet run --project src/Mail2Pst.Cli -- import-colours --profile <thunderbird-profile-dir> [--apply]
 ```
 
 A minimal working example lives in `fixtures/sample-config.json` + `fixtures/sample.mbox`. Send `cancel` on the process's **stdin** (or `SIGTERM` / `Ctrl+C`) to stop a running `convert` cleanly. Exit codes: **0** success, **1** fatal error, **2** cancelled.
@@ -86,7 +101,7 @@ A minimal working example lives in `fixtures/sample-config.json` + `fixtures/sam
 
 Point `discover` at a Thunderbird mail directory — a file `Inbox` sitting beside a sibling `Inbox.sbd/` that holds its subfolders — and it reconstructs the nested tree, emitting one source per folder with a nested `targetFolderPath` (parse-free and fast). Feed those into a `convert` config and the resulting PST preserves the folder hierarchy, including parent folders that have both their own mail and subfolders. A plain directory of `.mbox` files is handled too (each becomes a top-level folder).
 
-> **CLI-only for now.** This nested-folder/Thunderbird support is available through the `discover` command; the desktop app does not yet expose it (planned). The desktop app handles flat `.mbox` archives.
+> The **desktop app exposes this directly** via its Thunderbird **profile mode** (Source → *Thunderbird profile*), which runs `discover` under the hood and adds `.msf` flag/tag enrichment and multi-account handling. `discover` remains available on its own for scripting and for pointing at a bare mail directory (a plain folder of `.mbox` files also works in both the app and the CLI).
 
 <details>
 <summary><b>Configuration, scan output, and JSON Lines reference</b></summary>

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,8 +6,9 @@ real-world validation method used on actual mail (which, being private, is **not
 
 ## Automated tests
 
-The engine and the desktop app each have a unit-test suite (~575 engine, ~214 desktop tests
-as of v0.2.0; the suites, not the exact counts, are the contract):
+The engine and the desktop app each have a unit-test suite (~615 engine, ~214 desktop tests
+as of v0.2.0, plus a separate engine round-trip integration harness; the suites, not the exact
+counts, are the contract):
 
 ```bash
 # Engine + CLI (xUnit)

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,8 +6,8 @@ real-world validation method used on actual mail (which, being private, is **not
 
 ## Automated tests
 
-The engine and the desktop app each have a unit-test suite (274+ engine, 113+ desktop tests
-as of the v0.1.1 follow-up; the suites, not the exact counts, are the contract):
+The engine and the desktop app each have a unit-test suite (~575 engine, ~214 desktop tests
+as of v0.2.0; the suites, not the exact counts, are the contract):
 
 ```bash
 # Engine + CLI (xUnit)
@@ -19,7 +19,10 @@ cd desktop && npm test
 
 These cover mbox boundary/parse behaviour (including a worked-around MimeKit mbox EOF bug),
 PST writing and metadata fidelity, size-based splitting, output-name validation, the
-CLI JSON-Lines contract, and the template-provenance guard.
+CLI JSON-Lines contract, and the template-provenance guard — plus the v0.2.0 surface:
+Thunderbird `.msf`/Mork parsing and flag/junk/tag enrichment, tag → Outlook-category mapping
+and colour-plan building, profile discovery and multi-account routing, and junk/expunged
+handling.
 
 The repository contains only **synthetic fixtures** (`fixtures/`) — no real mail.
 
@@ -34,7 +37,8 @@ gitignored; it contains private mail). For each corpus the following is checked:
 - **Attachments:** regular files, inline CID images (no phantom paperclip), embedded
   `.eml` messages.
 - **Folder structure:** both `mirror` and `flatten` mappings.
-- **Metadata:** To/Cc/Bcc recipient types, read/unread, dates, threading headers.
+- **Metadata:** To/Cc/Bcc recipient types, dates, threading headers, and (from a live
+  Thunderbird profile) read/unread, replied/forwarded/starred flags, junk, and tags → categories.
 - **Splitting:** size-capped output produces complete, non-overlapping parts.
 - **End-to-end:** the output PST is opened in Outlook and imported into a test
   Microsoft 365 profile.

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,7 +1,36 @@
-# Tauri + React + Typescript
+# ContinuMail Converter — desktop app
 
-This template should help get you started developing with Tauri, React and Typescript in Vite.
+The Windows desktop GUI for [ContinuMail Converter](../README.md). A **Tauri v2 + React (Vite) +
+TypeScript** app that bundles the `mail2pst` CLI engine as a **sidecar** and drives it over the
+CLI's JSON-Lines contract — so the app never reimplements conversion logic, it orchestrates the
+same engine the CLI uses.
 
-## Recommended IDE Setup
+## Develop
 
-- [VS Code](https://code.visualstudio.com/) + [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) + [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
+Prerequisites: [Node.js](https://nodejs.org/) (LTS) + npm, the [Rust toolchain](https://rustup.rs/)
+with the MSVC target (`rustup target add x86_64-pc-windows-msvc`), and the
+[.NET 8 SDK](https://dotnet.microsoft.com/download) (to build the sidecar). Windows 10/11.
+
+```bash
+npm install
+npm run tauri dev     # run the app (the CLI sidecar auto-builds first, via the `pretauri` hook)
+npm test              # frontend unit tests (Vitest)
+npm run tauri build   # release build → NSIS installer under src-tauri/target/release/bundle/nsis/
+npm run sidecar       # rebuild just the CLI sidecar (win-x64) into src-tauri/binaries/
+```
+
+`npm run tauri dev` serves Vite on `:1420` for development only; the built app embeds its assets and
+uses no port.
+
+## How it fits together
+
+- **Sidecar:** `scripts/build-sidecar.ps1` publishes the CLI single-file self-contained (win-x64) to
+  `src-tauri/binaries/`; Rust runs it via `tauri-plugin-shell`. `src-tauri/binaries/` and
+  `src-tauri/resources/` are gitignored (rebuilt by the script).
+- **Frontend ↔ engine:** the React UI calls narrow Rust commands that invoke the sidecar; pure
+  parsing of the CLI's JSON-Lines events lives in `src/lib/` (unit-tested, no Tauri imports).
+- **Flows:** flat `.mbox` files, and full **Thunderbird profile mode** (discovery, `.msf` flag/tag
+  enrichment, multi-account → one PST per account, and an optional Outlook category-colour import).
+
+See the [root README](../README.md) for the product overview, the JSON-Lines contract, and
+build-from-source details for the engine.

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.2"
+version = "0.2.0"
 description = "ContinuMail Converter — convert mbox mail archives to Outlook PST"
 authors = ["Aksel Visby <aksel@visby.it>"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ContinuMail Converter",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "identifier": "com.continumail.converter",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -96,7 +96,7 @@ export default function App() {
           onContinue={flow.continueToScan}
         />
       )}
-      {f.stage === "scanning" && <ScanningView fileCount={f.inputFiles.length} progress={f.scanProgress} />}
+      {f.stage === "scanning" && <ScanningView fileCount={f.scanFileCount} progress={f.scanProgress} />}
       {f.stage === "accounts" && f.inputMode === "profile" && (
         <AccountsView
           rows={f.profileRows}

--- a/desktop/src/components/Shell.tsx
+++ b/desktop/src/components/Shell.tsx
@@ -19,7 +19,7 @@ export function Shell({
   onStepSelect?: (step: number) => void;
 }) {
   return (
-    <div className="flex h-screen bg-background text-foreground">
+    <div className="flex h-screen overflow-hidden bg-background text-foreground">
       {/* icon rail */}
       <nav className="flex w-16 flex-col items-center gap-5 bg-midnight pt-4 text-cream">
         <BrandMark />
@@ -36,8 +36,10 @@ export function Shell({
         </div>
       </nav>
 
-      {/* main area */}
-      <main className="flex flex-1 flex-col p-6">
+      {/* main area — the single scroll region: vertical scrolls, horizontal is
+          clipped so the app never scrolls sideways. Keeping scroll here (not on
+          the document) leaves the icon rail pinned full-height. */}
+      <main className="flex min-w-0 flex-1 flex-col overflow-y-auto overflow-x-hidden p-6">
         <ol className="mb-5 flex flex-wrap items-center gap-2 text-xs text-light-gray">
           {steps.map((label, i) => {
             const navigable = onStepSelect != null && i < currentStep;

--- a/desktop/src/components/views/ProfileOptionsView.tsx
+++ b/desktop/src/components/views/ProfileOptionsView.tsx
@@ -7,11 +7,11 @@ import { HelpTip } from "@/components/ui/help-tip";
 import { SplitSizeControl } from "@/components/ui/split-size-control";
 import { buildProfileConfig, buildProfileConfigMulti } from "@/lib/profileConfig";
 import { effectiveRows } from "@/lib/review";
-import { ConvertConfigError, deriveOutputTarget } from "@/lib/convert";
-import { splitPath } from "@/lib/convert";
+import { ConvertConfigError, deriveOutputTarget, splitPath, joinOutputPstPath } from "@/lib/convert";
 import { formatBytes } from "@/lib/format";
 import { openJunkHelp, pickOutputPst } from "@/lib/engine";
-import { groupByAccount } from "@/lib/accounts";
+import { groupByAccount, sanitizePstName, accountKeyForRow } from "@/lib/accounts";
+import { buildAccountPreview } from "@/lib/profilePreview";
 import type { OptionsState } from "@/lib/options";
 import type { ConversionConfig, ProfileSourceRow, OutputTarget, Account } from "@/lib/types";
 
@@ -38,6 +38,13 @@ export function ProfileOptionsView({
 }: ProfileOptionsViewProps) {
   const [startError, setStartError] = useState<string | null>(null);
   const [splitOk, setSplitOk] = useState(true);
+  // Combine is a local Options-only escape hatch (resets on Back→Review by design).
+  const [combine, setCombine] = useState(false);
+  const [combineName, setCombineName] = useState("Mail");
+
+  // Multi-account is determined ONLY by the discovered account count — never by
+  // outputTarget.kind. Both split and combine keep outputTarget as the folder.
+  const isMultiAccount = (accounts?.length ?? 0) >= 2;
 
   const eff = useMemo(
     () => effectiveRows(rows, checkedIds, skipEmpty) as ProfileSourceRow[],
@@ -45,14 +52,35 @@ export function ProfileOptionsView({
   );
 
   const outputPath = outputTarget?.kind === "pstFile" ? outputTarget.path : null;
+  const folderDir = outputTarget?.kind === "folder" ? outputTarget.dir : null;
 
-  const pstName = useMemo(() => {
+  const totalMessages = eff.reduce((n, r) => n + r.messages, 0);
+  const totalBytes = eff.reduce((n, r) => n + r.bytes, 0);
+
+  // Single-account / files mode: derive the header name from the chosen .pst path.
+  const singlePstName = useMemo(() => {
     if (!outputPath) return "Output";
     try { return deriveOutputTarget(outputPath).pstName; } catch { return "Output"; }
   }, [outputPath]);
-  const totalBytes = eff.reduce((n, r) => n + r.bytes, 0);
-  const isMultiAccount = outputTarget?.kind === "folder";
-  const canStart = eff.length > 0 && splitOk && outputTarget !== null && (isMultiAccount ? (selectedAccountKeys?.size ?? 0) > 0 : outputPath !== null);
+
+  const previewEntries = useMemo(
+    () =>
+      isMultiAccount
+        ? buildAccountPreview(eff, accounts ?? [], selectedAccountKeys ?? new Set<string>(), pstNames ?? {}, options.folderMapping)
+        : [],
+    [isMultiAccount, eff, accounts, selectedAccountKeys, pstNames, options.folderMapping],
+  );
+
+  const sanitizedCombineName = sanitizePstName(combineName);
+  const combineFilename = `${sanitizedCombineName}.pst`;
+
+  const canStart =
+    splitOk &&
+    (isMultiAccount
+      ? folderDir !== null && (combine
+          ? eff.length > 0 && sanitizedCombineName.length > 0
+          : previewEntries.length > 0)
+      : eff.length > 0 && outputPath !== null);
 
   async function onChooseOutput() {
     const path = await pickOutputPst();
@@ -64,25 +92,32 @@ export function ProfileOptionsView({
   }
 
   function onStartClick() {
-    // Multi-account folder mode: build one output group per selected account.
-    if (outputTarget?.kind === "folder") {
-      const accs = accounts ?? [];
+    setStartError(null);
+    if (isMultiAccount) {
+      if (!folderDir || outputTarget?.kind !== "folder") {
+        setStartError("Choose an output folder on the Accounts step.");
+        return;
+      }
       const keys = selectedAccountKeys ?? new Set<string>();
-      const names = pstNames ?? {};
       try {
-        const allGroups = groupByAccount(rows, accs);
-        const selectedGroups = allGroups
-          .filter((g) => keys.has(g.key))
-          .map((g) => ({ key: g.key, pstName: names[g.key] ?? g.defaultPstName, rows: g.rows }));
-        const { config, outputDir } = buildProfileConfigMulti({
-          groups: selectedGroups,
-          checkedIds,
-          skipEmpty,
-          options,
-          target: outputTarget,
-          profileRoot,
-        });
-        onStart(config, outputDir);
+        if (combine) {
+          // Defensive: only convert rows of still-selected accounts (rows is already
+          // selection-filtered upstream, but don't rely on that here).
+          const combineRows = rows.filter((r) => keys.has(accountKeyForRow(r)));
+          const path = joinOutputPstPath(folderDir, sanitizedCombineName);
+          const { config, outputDir } = buildProfileConfig(combineRows, checkedIds, skipEmpty, options, path, profileRoot);
+          onStart(config, outputDir);
+        } else {
+          const accs = accounts ?? [];
+          const names = pstNames ?? {};
+          const selectedGroups = groupByAccount(rows, accs)
+            .filter((g) => keys.has(g.key))
+            .map((g) => ({ key: g.key, pstName: names[g.key] ?? g.defaultPstName, rows: g.rows }));
+          const { config, outputDir } = buildProfileConfigMulti({
+            groups: selectedGroups, checkedIds, skipEmpty, options, target: outputTarget, profileRoot,
+          });
+          onStart(config, outputDir);
+        }
       } catch (e) {
         setStartError(e instanceof ConvertConfigError ? e.message : "Could not start the conversion.");
       }
@@ -94,9 +129,7 @@ export function ProfileOptionsView({
       return;
     }
     try {
-      const { config, outputDir } = buildProfileConfig(
-        rows, checkedIds, skipEmpty, options, outputPath, profileRoot,
-      );
+      const { config, outputDir } = buildProfileConfig(rows, checkedIds, skipEmpty, options, outputPath, profileRoot);
       onStart(config, outputDir);
     } catch (e) {
       setStartError(e instanceof ConvertConfigError ? e.message : "Could not start the conversion.");
@@ -186,20 +219,41 @@ export function ProfileOptionsView({
         <div className="flex flex-1 flex-col overflow-hidden">
           <div className="mb-1 text-sm font-medium text-foreground">Preview</div>
           <div className="flex-1 overflow-auto rounded-lg border border-border p-3 text-sm">
-            <div className="font-semibold text-foreground">{pstName}.pst</div>
-            <div className="mt-1 flex flex-col gap-1">
-              {options.folderMapping === "flatten" ? (
-                <div className="pl-3 text-foreground">└ Imported Mail
-                  <span className="ml-2 text-light-gray">{eff.reduce((n, r) => n + r.messages, 0).toLocaleString()} · {formatBytes(totalBytes)}</span>
+            {isMultiAccount && !combine ? (
+              <div className="flex flex-col gap-3">
+                {previewEntries.map((entry) => (
+                  <div key={entry.key}>
+                    <div className="font-semibold text-foreground">{entry.pstName}.pst</div>
+                    <div className="mt-1 flex flex-col gap-1">
+                      {entry.folders.map((f, i) => (
+                        <div key={i} className="pl-3 text-foreground">
+                          └ {f.displayName}
+                          <span className="ml-2 text-light-gray">{f.messages.toLocaleString()} · {formatBytes(f.bytes)}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+                {previewEntries.length === 0 && <div className="pl-3 text-xs text-light-gray">No folders selected.</div>}
+              </div>
+            ) : (
+              <>
+                <div className="font-semibold text-foreground">{isMultiAccount ? combineFilename : `${singlePstName}.pst`}</div>
+                <div className="mt-1 flex flex-col gap-1">
+                  {options.folderMapping === "flatten" ? (
+                    <div className="pl-3 text-foreground">└ Imported Mail
+                      <span className="ml-2 text-light-gray">{totalMessages.toLocaleString()} · {formatBytes(totalBytes)}</span>
+                    </div>
+                  ) : eff.map((r) => (
+                    <div key={r.id} className="pl-3 text-foreground">
+                      └ {r.displayName}
+                      <span className="ml-2 text-light-gray">{r.messages.toLocaleString()} · {formatBytes(r.bytes)}</span>
+                    </div>
+                  ))}
+                  {eff.length === 0 && <div className="pl-3 text-xs text-light-gray">No folders selected.</div>}
                 </div>
-              ) : eff.map((r) => (
-                <div key={r.id} className="pl-3 text-foreground">
-                  └ {r.displayName}
-                  <span className="ml-2 text-light-gray">{r.messages.toLocaleString()} · {formatBytes(r.bytes)}</span>
-                </div>
-              ))}
-              {eff.length === 0 && <div className="pl-3 text-xs text-light-gray">No folders selected.</div>}
-            </div>
+              </>
+            )}
           </div>
           <div className="mt-2 rounded-lg border border-border border-l-[3px] border-l-primary bg-card px-3 py-2 text-xs text-muted-foreground">
             Carried over from Thunderbird automatically: <span className="text-foreground">read/unread, replied, forwarded, starred</span> flags and <span className="text-foreground">tags → Outlook categories</span> (folders with an <span className="text-primary">.msf</span> badge).
@@ -207,26 +261,54 @@ export function ProfileOptionsView({
         </div>
       </div>
 
-      <div className="mt-4">
-        <div className="mb-1 text-sm font-medium text-foreground">Output PST file</div>
-        <div className="flex items-center gap-2">
-          <Button variant="outline" onClick={onChooseOutput}>
-            <Save /> {outputPath ? splitPath(outputPath).base : "Choose output…"}
-          </Button>
-          {outputPath && (
-            <button
-              type="button"
-              onClick={onClearOutput}
-              aria-label="Clear output location"
-              title="Clear"
-              className="shrink-0 rounded p-0.5 text-light-gray transition-colors hover:text-destructive"
-            >
-              <X className="size-4" />
-            </button>
+      {isMultiAccount ? (
+        <div className="mt-4">
+          <div className="mb-1 text-sm font-medium text-foreground">Output</div>
+          <label className="flex items-center gap-2 text-sm text-foreground">
+            <input type="checkbox" checked={combine} onChange={(e) => setCombine(e.target.checked)} />
+            Combine into a single PST
+          </label>
+          {combine && (
+            <div className="mt-2 flex items-center gap-2">
+              <label className="shrink-0 text-sm text-foreground">PST name:</label>
+              <input
+                type="text"
+                value={combineName}
+                onChange={(e) => setCombineName(e.target.value)}
+                aria-label="Combined PST name"
+                className="w-56 rounded border border-border bg-background px-2 py-1 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+              />
+              <span className="text-xs text-light-gray">{combineFilename}</span>
+            </div>
           )}
+          <div className="mt-1.5 text-xs text-light-gray">
+            {combine
+              ? `One PST → ${folderDir ?? "(choose an output folder on the Accounts step)"}`
+              : `${previewEntries.length} PST file${previewEntries.length === 1 ? "" : "s"} → ${folderDir ?? "(choose an output folder on the Accounts step)"}`}
+          </div>
         </div>
-        {outputPath && <div className="mt-1 text-xs text-light-gray">{splitPath(outputPath).dir}</div>}
-      </div>
+      ) : (
+        <div className="mt-4">
+          <div className="mb-1 text-sm font-medium text-foreground">Output PST file</div>
+          <div className="flex items-center gap-2">
+            <Button variant="outline" onClick={onChooseOutput}>
+              <Save /> {outputPath ? splitPath(outputPath).base : "Choose output…"}
+            </Button>
+            {outputPath && (
+              <button
+                type="button"
+                onClick={onClearOutput}
+                aria-label="Clear output location"
+                title="Clear"
+                className="shrink-0 rounded p-0.5 text-light-gray transition-colors hover:text-destructive"
+              >
+                <X className="size-4" />
+              </button>
+            )}
+          </div>
+          {outputPath && <div className="mt-1 text-xs text-light-gray">{splitPath(outputPath).dir}</div>}
+        </div>
+      )}
 
       {startError && <p className="mt-3 text-sm text-destructive">{startError}</p>}
 

--- a/desktop/src/components/views/ScanningView.tsx
+++ b/desktop/src/components/views/ScanningView.tsx
@@ -6,6 +6,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { ProgressBar } from "@/components/ui/progress-bar";
 import { easeToward } from "@/lib/progressStats";
 import { formatBytes } from "@/lib/format";
+import { scanningTitle } from "@/lib/scan";
 
 export interface ScanProgress {
   bytes: number;
@@ -53,7 +54,7 @@ export function ScanningView({
       <div className="flex flex-1 flex-col items-center justify-center text-center">
         <Spinner className="size-8 text-primary" />
         <h1 className="mt-4 text-lg font-semibold text-foreground">
-          Scanning {fileCount} file{fileCount === 1 ? "" : "s"}…
+          {scanningTitle(fileCount)}
         </h1>
         <p className="mt-1 text-sm text-muted-foreground">Large archives can take a while.</p>
       </div>
@@ -64,7 +65,7 @@ export function ScanningView({
   return (
     <div className="flex flex-1 flex-col items-center justify-center text-center">
       <h1 className="text-lg font-semibold text-foreground">
-        Scanning {fileCount} file{fileCount === 1 ? "" : "s"}…
+        {scanningTitle(fileCount)}
       </h1>
       <div className="mt-4 w-full max-w-md">
         <div className="flex justify-between text-sm text-foreground">

--- a/desktop/src/components/views/SelectView.tsx
+++ b/desktop/src/components/views/SelectView.tsx
@@ -6,7 +6,7 @@ import { FileText, FolderOpen, Save, Search, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { pickMboxFiles, pickFolder, listMboxInDir, statFiles, pickOutputPst, listThunderbirdProfiles } from "@/lib/engine";
-import { visibleProfiles, hiddenNote, profilePrimaryLabel, profileSubtext, pickDefaultProfile } from "@/lib/profiles";
+import { visibleProfiles, hiddenNote, profileAccountLabels, profileSubtext, pickDefaultProfile } from "@/lib/profiles";
 import { splitPath } from "@/lib/convert";
 import { formatBytes } from "@/lib/format";
 import { canScan } from "@/lib/outputTarget";
@@ -179,12 +179,25 @@ export function SelectView({
                         onChange={() => { setPickerError(null); onProfileRootChange(e.path); }}
                         className="mt-0.5 accent-primary shrink-0"
                       />
-                      <div className="min-w-0">
-                        <span className="font-medium">{profilePrimaryLabel(e)}</span>
-                        {e.isDefault && (
-                          <span className="ml-2 rounded bg-primary/15 px-1.5 py-0.5 text-xs text-primary">default</span>
-                        )}
-                        <div className="truncate text-xs text-light-gray">{profileSubtext(e)}</div>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-start justify-between gap-2">
+                          {/* One box per account found in the profile (each its own
+                              email) — the radio still selects the whole profile. */}
+                          <div className="flex min-w-0 flex-col gap-1">
+                            {profileAccountLabels(e).map((label) => (
+                              <span
+                                key={label}
+                                className="w-fit max-w-full truncate rounded-md border border-border bg-background px-2 py-0.5 text-sm font-medium"
+                              >
+                                {label}
+                              </span>
+                            ))}
+                          </div>
+                          {e.isDefault && (
+                            <span className="shrink-0 rounded bg-primary/15 px-1.5 py-0.5 text-xs text-primary">default</span>
+                          )}
+                        </div>
+                        <div className="mt-1.5 truncate text-xs text-light-gray">{profileSubtext(e)}</div>
                       </div>
                     </label>
                   ))}

--- a/desktop/src/lib/accounts.test.ts
+++ b/desktop/src/lib/accounts.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { groupByAccount, sanitizePstName } from "./accounts";
+import { groupByAccount, sanitizePstName, dedupePstNames } from "./accounts";
 import type { Account, ProfileSourceRow } from "./types";
 
 const acct = (id: string, email: string | null, seg: string): Account =>
@@ -49,5 +49,20 @@ describe("sanitizePstName", () => {
   it("escapes reserved Windows device names", () => {
     expect(sanitizePstName("CON")).toBe("CON-mail");
     expect(sanitizePstName("LPT1.backup")).toBe("LPT1.backup-mail"); // stem LPT1 is reserved
+  });
+});
+
+describe("dedupePstNames", () => {
+  it("leaves distinct names unchanged", () => {
+    expect(dedupePstNames(["A", "B"])).toEqual(["A", "B"]);
+  });
+  it("suffixes a collision with -2", () => {
+    expect(dedupePstNames(["Same", "Same"])).toEqual(["Same", "Same-2"]);
+  });
+  it("is case-insensitive", () => {
+    expect(dedupePstNames(["mail", "MAIL"])).toEqual(["mail", "MAIL-2"]);
+  });
+  it("skips an already-taken suffix", () => {
+    expect(dedupePstNames(["a", "a-2", "a"])).toEqual(["a", "a-2", "a-3"]);
   });
 });

--- a/desktop/src/lib/accounts.ts
+++ b/desktop/src/lib/accounts.ts
@@ -27,6 +27,24 @@ export function sanitizePstName(raw: string): string {
   return s;
 }
 
+/** De-duplicate PST names case-insensitively, appending -2, -3, … to collisions
+ * (skipping suffixes already taken) while preserving order. Shared by the
+ * multi-account config builder and the Options preview so names never drift. */
+export function dedupePstNames(names: string[]): string[] {
+  const used = new Set<string>();
+  return names.map((base) => {
+    if (!used.has(base.toLowerCase())) {
+      used.add(base.toLowerCase());
+      return base;
+    }
+    let n = 2;
+    while (used.has(`${base}-${n}`.toLowerCase())) n++;
+    const name = `${base}-${n}`;
+    used.add(name.toLowerCase());
+    return name;
+  });
+}
+
 /** Single source of truth for "which account does this row belong to". Reused by grouping, Review
  * filtering, and config building so the key never drifts. */
 export function accountKeyForRow(row: ProfileSourceRow): string {

--- a/desktop/src/lib/convert.test.ts
+++ b/desktop/src/lib/convert.test.ts
@@ -83,14 +83,14 @@ describe("convertExitError", () => {
 
 describe("joinOutputPstPath", () => {
   it("joins a Windows dir with backslash separator and appends .pst", () => {
-    expect(joinOutputPstPath("C:\\Users\\me\\out", "Mail")).toBe("C:\\Users\\me\\out\\Mail.pst");
+    expect(joinOutputPstPath("C:\\Mail\\out", "Mail")).toBe("C:\\Mail\\out\\Mail.pst");
   });
   it("joins a POSIX dir with forward slash", () => {
-    expect(joinOutputPstPath("/home/me/out", "Mail")).toBe("/home/me/out/Mail.pst");
+    expect(joinOutputPstPath("/srv/out", "Mail")).toBe("/srv/out/Mail.pst");
   });
   it("collapses a trailing separator on the dir", () => {
-    expect(joinOutputPstPath("C:\\Users\\me\\out\\", "Mail")).toBe("C:\\Users\\me\\out\\Mail.pst");
-    expect(joinOutputPstPath("/home/me/out/", "Mail")).toBe("/home/me/out/Mail.pst");
+    expect(joinOutputPstPath("C:\\Mail\\out\\", "Mail")).toBe("C:\\Mail\\out\\Mail.pst");
+    expect(joinOutputPstPath("/srv/out/", "Mail")).toBe("/srv/out/Mail.pst");
   });
   it("handles a drive-root dir", () => {
     expect(joinOutputPstPath("C:\\", "Mail")).toBe("C:\\Mail.pst");

--- a/desktop/src/lib/convert.test.ts
+++ b/desktop/src/lib/convert.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { describe, it, expect } from "vitest";
-import { parseConvertLine, deriveOutputTarget, appendWarningCapped, convertExitError } from "./convert";
+import { parseConvertLine, deriveOutputTarget, appendWarningCapped, convertExitError, joinOutputPstPath } from "./convert";
 import type { WarningItem } from "./convert";
 
 describe("parseConvertLine", () => {
@@ -78,5 +78,21 @@ describe("convertExitError", () => {
   it("errors on a zero/null exit while still running (no terminal event)", () => {
     expect(convertExitError(0, true)).toMatch(/without a terminal event/);
     expect(convertExitError(null, true)).toMatch(/without a terminal event/);
+  });
+});
+
+describe("joinOutputPstPath", () => {
+  it("joins a Windows dir with backslash separator and appends .pst", () => {
+    expect(joinOutputPstPath("C:\\Users\\me\\out", "Mail")).toBe("C:\\Users\\me\\out\\Mail.pst");
+  });
+  it("joins a POSIX dir with forward slash", () => {
+    expect(joinOutputPstPath("/home/me/out", "Mail")).toBe("/home/me/out/Mail.pst");
+  });
+  it("collapses a trailing separator on the dir", () => {
+    expect(joinOutputPstPath("C:\\Users\\me\\out\\", "Mail")).toBe("C:\\Users\\me\\out\\Mail.pst");
+    expect(joinOutputPstPath("/home/me/out/", "Mail")).toBe("/home/me/out/Mail.pst");
+  });
+  it("handles a drive-root dir", () => {
+    expect(joinOutputPstPath("C:\\", "Mail")).toBe("C:\\Mail.pst");
   });
 });

--- a/desktop/src/lib/convert.ts
+++ b/desktop/src/lib/convert.ts
@@ -26,6 +26,17 @@ export function deriveOutputTarget(outputPstPath: string): { outputDir: string; 
   return { outputDir: dir, pstName: stem };
 }
 
+/** Join an output directory and an already-sanitized PST stem into a full
+ * `<dir><sep><pstName>.pst` path. Preserves the dir's separator style (the
+ * Windows folder picker returns `\`-style paths); collapses a trailing
+ * separator. `pstName` must already be sanitized (no separators survive
+ * sanitizePstName), so no path-injection re-guard is needed here. */
+export function joinOutputPstPath(dir: string, pstName: string): string {
+  const sep = dir.includes("\\") ? "\\" : "/";
+  const cleanDir = dir.replace(/[/\\]+$/, "");
+  return `${cleanDir}${sep}${pstName}.pst`;
+}
+
 const KNOWN_TYPES = new Set([
   "started",
   "scan",

--- a/desktop/src/lib/profileConfig.ts
+++ b/desktop/src/lib/profileConfig.ts
@@ -6,7 +6,7 @@ import type { ScanResult } from "./parse";
 import type { OptionsState } from "./options";
 import { effectiveRows } from "./review";
 import { deriveOutputTarget, ConvertConfigError } from "./convert";
-import { sanitizePstName } from "./accounts";
+import { sanitizePstName, dedupePstNames } from "./accounts";
 
 /** Merge discovery sources with scan counts. Identity = discovered `path`; the
  * scan row's id is ignored (it is scan-local). displayName = joined nested path. */
@@ -145,19 +145,9 @@ export function buildProfileConfigMulti({
     throw new ConvertConfigError("Select at least one folder to convert.");
   }
 
-  // De-duplicate names: case-insensitive, skip already-taken suffixes
-  const usedNames = new Set<string>();
-  for (const g of outputGroups) {
-    const base = g.name;
-    if (!usedNames.has(base.toLowerCase())) {
-      usedNames.add(base.toLowerCase());
-    } else {
-      let n = 2;
-      while (usedNames.has(`${base}-${n}`.toLowerCase())) n++;
-      g.name = `${base}-${n}`;
-      usedNames.add(g.name.toLowerCase());
-    }
-  }
+  // De-duplicate names (shared helper — keeps parity with the Options preview).
+  const dedup = dedupePstNames(outputGroups.map((g) => g.name));
+  outputGroups.forEach((g, i) => { g.name = dedup[i]; });
 
   return {
     outputDir,

--- a/desktop/src/lib/profilePreview.test.ts
+++ b/desktop/src/lib/profilePreview.test.ts
@@ -14,7 +14,7 @@ const row = (id: string, accountId: string, tfp: string[], messages = 1, bytes =
   messages, bytes, sourceBytes: bytes * 2, dateFrom: null, dateTo: null, warnings: 0, skipped: 0, msfPath: null,
 });
 
-const accounts = [acct("a", "alice@x.com", "a"), acct("b", "bob@y.com", "b")];
+const accounts = [acct("a", "alice@example.com", "a"), acct("b", "bob@example.test", "b")];
 const rows = [
   row("a/Inbox", "a", ["a", "Inbox"], 10, 1000),
   row("a/Sent", "a", ["a", "Sent"], 5, 500),
@@ -25,7 +25,7 @@ const all = new Set(["a", "b"]);
 describe("buildAccountPreview", () => {
   it("one entry per selected account; mirror shows the account-stripped folder path", () => {
     const out = buildAccountPreview(rows, accounts, all, {}, "mirror");
-    expect(out.map((e) => e.pstName)).toEqual(["alice@x.com", "bob@y.com"]);
+    expect(out.map((e) => e.pstName)).toEqual(["alice@example.com", "bob@example.test"]);
     // account segment "a" is stripped (it becomes the PST), matching buildProfileConfigMulti
     expect(out[0].folders.map((f) => f.displayName)).toEqual(["Inbox", "Sent"]);
     expect(out[0].folders[0]).toEqual({ displayName: "Inbox", messages: 10, bytes: 1000 });
@@ -40,7 +40,7 @@ describe("buildAccountPreview", () => {
   it("uses edited pstNames (sanitized) and falls back to the account default", () => {
     const out = buildAccountPreview(rows, accounts, all, { a: "My Mail" }, "mirror");
     expect(out[0].pstName).toBe("My Mail");
-    expect(out[1].pstName).toBe("bob@y.com");
+    expect(out[1].pstName).toBe("bob@example.test");
   });
 
   it("de-duplicates colliding pst names with -2, matching the builder", () => {

--- a/desktop/src/lib/profilePreview.test.ts
+++ b/desktop/src/lib/profilePreview.test.ts
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, it, expect } from "vitest";
+import { buildAccountPreview } from "./profilePreview";
+import type { Account, ProfileSourceRow } from "./types";
+
+const acct = (id: string, email: string | null, seg: string): Account => ({
+  id, folderSegment: seg, accountPath: id, store: "ImapMail", email, host: seg,
+  addressResolution: email ? "identity" : "not-found",
+});
+const row = (id: string, accountId: string, tfp: string[], messages = 1, bytes = 100): ProfileSourceRow => ({
+  id, path: id, accountId, targetFolderPath: tfp, displayName: tfp.join(" / "),
+  messages, bytes, sourceBytes: bytes * 2, dateFrom: null, dateTo: null, warnings: 0, skipped: 0, msfPath: null,
+});
+
+const accounts = [acct("a", "alice@x.com", "a"), acct("b", "bob@y.com", "b")];
+const rows = [
+  row("a/Inbox", "a", ["a", "Inbox"], 10, 1000),
+  row("a/Sent", "a", ["a", "Sent"], 5, 500),
+  row("b/Inbox", "b", ["b", "Inbox"], 3, 300),
+];
+const all = new Set(["a", "b"]);
+
+describe("buildAccountPreview", () => {
+  it("one entry per selected account; mirror shows the account-stripped folder path", () => {
+    const out = buildAccountPreview(rows, accounts, all, {}, "mirror");
+    expect(out.map((e) => e.pstName)).toEqual(["alice@x.com", "bob@y.com"]);
+    // account segment "a" is stripped (it becomes the PST), matching buildProfileConfigMulti
+    expect(out[0].folders.map((f) => f.displayName)).toEqual(["Inbox", "Sent"]);
+    expect(out[0].folders[0]).toEqual({ displayName: "Inbox", messages: 10, bytes: 1000 });
+  });
+
+  it("flatten aggregates each account into one Imported Mail row", () => {
+    const out = buildAccountPreview(rows, accounts, all, {}, "flatten");
+    expect(out[0].folders).toEqual([{ displayName: "Imported Mail", messages: 15, bytes: 1500 }]);
+    expect(out[1].folders).toEqual([{ displayName: "Imported Mail", messages: 3, bytes: 300 }]);
+  });
+
+  it("uses edited pstNames (sanitized) and falls back to the account default", () => {
+    const out = buildAccountPreview(rows, accounts, all, { a: "My Mail" }, "mirror");
+    expect(out[0].pstName).toBe("My Mail");
+    expect(out[1].pstName).toBe("bob@y.com");
+  });
+
+  it("de-duplicates colliding pst names with -2, matching the builder", () => {
+    const out = buildAccountPreview(rows, accounts, all, { a: "Same", b: "Same" }, "mirror");
+    expect(out.map((e) => e.pstName)).toEqual(["Same", "Same-2"]);
+  });
+
+  it("omits accounts with no effective rows and respects selection", () => {
+    const out = buildAccountPreview(rows, accounts, new Set(["a"]), {}, "mirror");
+    expect(out.map((e) => e.key)).toEqual(["a"]);
+  });
+});

--- a/desktop/src/lib/profilePreview.ts
+++ b/desktop/src/lib/profilePreview.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { groupByAccount, sanitizePstName, dedupePstNames } from "./accounts";
+import type { Account, ProfileSourceRow } from "./types";
+
+export interface AccountPreviewFolder { displayName: string; messages: number; bytes: number }
+export interface AccountPreviewEntry { key: string; pstName: string; folders: AccountPreviewFolder[] }
+
+/** One preview entry per selected, non-empty account. `effRows` must already be
+ * effectiveRows(...)-filtered so the preview matches what Start converts. Mirror
+ * strips the account segment from each folder path (matching buildProfileConfigMulti);
+ * flatten aggregates to one "Imported Mail" row per account. PST names are sanitized
+ * and de-duplicated exactly like the builder via the shared dedupePstNames. */
+export function buildAccountPreview(
+  effRows: ProfileSourceRow[],
+  accounts: Account[],
+  selectedKeys: Set<string>,
+  pstNames: Record<string, string>,
+  folderMapping: "mirror" | "flatten",
+): AccountPreviewEntry[] {
+  const groups = groupByAccount(effRows, accounts).filter(
+    (g) => selectedKeys.has(g.key) && g.rows.length > 0,
+  );
+
+  const entries: AccountPreviewEntry[] = groups.map((g) => {
+    const pstName = sanitizePstName(pstNames[g.key] ?? g.defaultPstName);
+    const folders: AccountPreviewFolder[] =
+      folderMapping === "flatten"
+        ? [{
+            displayName: "Imported Mail",
+            messages: g.rows.reduce((n, r) => n + (r.messages ?? 0), 0),
+            bytes: g.rows.reduce((n, r) => n + (r.bytes ?? 0), 0),
+          }]
+        : g.rows.map((r) => {
+            const stripped = r.targetFolderPath.slice(1);
+            const displayName = stripped.length > 0 ? stripped.join(" / ") : r.displayName;
+            return { displayName, messages: r.messages, bytes: r.bytes };
+          });
+    return { key: g.key, pstName, folders };
+  });
+
+  const deduped = dedupePstNames(entries.map((e) => e.pstName));
+  entries.forEach((e, i) => { e.pstName = deduped[i]; });
+  return entries;
+}

--- a/desktop/src/lib/profiles.test.ts
+++ b/desktop/src/lib/profiles.test.ts
@@ -1,14 +1,17 @@
 import { describe, it, expect } from "vitest";
-import { visibleProfiles, hiddenProfiles, hiddenNote, profilePrimaryLabel, profileSubtext, pickDefaultProfile } from "./profiles";
+import { visibleProfiles, hiddenProfiles, hiddenNote, profileAccountLabels, profileSubtext, pickDefaultProfile } from "./profiles";
 import type { ProfileEntry } from "./types";
 
 const p = (o: Partial<ProfileEntry>): ProfileEntry =>
   ({ name: "default", path: "/p/default", isDefault: false, accounts: [], convertible: true, ...o });
 
 describe("labels", () => {
-  it("one email", () => expect(profilePrimaryLabel(p({ accounts: ["a@x.com"] }))).toBe("a@x.com"));
-  it("+N more", () => expect(profilePrimaryLabel(p({ accounts: ["a@x.com", "b@example.com"] }))).toBe("a@x.com +1 more"));
-  it("falls back to raw name", () => expect(profilePrimaryLabel(p({ name: "work", accounts: [] }))).toBe("work"));
+  it("one account -> single label", () =>
+    expect(profileAccountLabels(p({ accounts: ["a@x.com"] }))).toEqual(["a@x.com"]));
+  it("multiple accounts -> one label each, no collapsing", () =>
+    expect(profileAccountLabels(p({ accounts: ["a@x.com", "b@example.com"] }))).toEqual(["a@x.com", "b@example.com"]));
+  it("falls back to raw name when no accounts resolved", () =>
+    expect(profileAccountLabels(p({ name: "work", accounts: [] }))).toEqual(["work"]));
   it("subtext is name · path", () => expect(profileSubtext(p({ name: "work", path: "/p/w" }))).toBe("work · /p/w"));
 });
 

--- a/desktop/src/lib/profiles.ts
+++ b/desktop/src/lib/profiles.ts
@@ -12,10 +12,11 @@ export function hiddenNote(entries: ProfileEntry[]): string | null {
   return `${hidden.length} profiles were hidden — no convertible mail found.`;
 }
 
-export function profilePrimaryLabel(e: ProfileEntry): string {
-  if (e.accounts.length === 0) return e.name;
-  const extra = e.accounts.length - 1;
-  return extra > 0 ? `${e.accounts[0]} +${extra} more` : e.accounts[0];
+/** Account emails to show for a profile on the Source step — one chip each,
+ * rather than collapsing to "first +N more". Falls back to the raw profile
+ * name when no accounts resolved. */
+export function profileAccountLabels(e: ProfileEntry): string[] {
+  return e.accounts.length > 0 ? e.accounts : [e.name];
 }
 
 export const profileSubtext = (e: ProfileEntry): string => `${e.name} · ${e.path}`;

--- a/desktop/src/lib/scan.test.ts
+++ b/desktop/src/lib/scan.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { describe, it, expect } from "vitest";
-import { parseScanLine } from "./scan";
+import { parseScanLine, scanningTitle } from "./scan";
 
 const SCAN_LINE =
   '{"type":"scan","totals":{"messages":2,"bytes":167,"sourceBytes":735,"sources":1},"sources":[{"id":"sample","path":"C:/x/sample.mbox","displayName":"sample","messages":2,"bytes":167,"sourceBytes":735,"dateFrom":"2024-01-01T10:00:00Z","dateTo":"2024-01-02T11:30:00Z","warnings":0,"skipped":0}],"skipped":[],"warnings":[]}';
@@ -36,5 +36,22 @@ describe("parseScanLine", () => {
 
   it("returns null for scanProgress with non-numeric fields", () => {
     expect(parseScanLine('{"type":"scanProgress","bytes":"x","totalBytes":1}')).toBeNull();
+  });
+});
+
+describe("scanningTitle", () => {
+  it("omits the count when it is not yet known (0 or negative)", () => {
+    // Profile mode shows the Scanning view during discovery, before the
+    // discovered-source count exists — don't claim "0 files".
+    expect(scanningTitle(0)).toBe("Scanning…");
+    expect(scanningTitle(-1)).toBe("Scanning…");
+  });
+
+  it("uses the singular for one source", () => {
+    expect(scanningTitle(1)).toBe("Scanning 1 file…");
+  });
+
+  it("uses the plural for multiple sources", () => {
+    expect(scanningTitle(3)).toBe("Scanning 3 files…");
   });
 });

--- a/desktop/src/lib/scan.ts
+++ b/desktop/src/lib/scan.ts
@@ -28,3 +28,12 @@ export function parseScanLine(line: string): ScanLineEvent | null {
   if (o.type === "scan") return { type: "scan", result: toScanResult(o) };
   return null;
 }
+
+/** Heading for the Scanning view. The count is the number of sources being
+ * scanned (files in .mbox mode, discovered folders in profile mode). During
+ * profile discovery the count isn't known yet — render a bare "Scanning…"
+ * rather than the misleading "Scanning 0 files…". */
+export function scanningTitle(fileCount: number): string {
+  if (fileCount <= 0) return "Scanning…";
+  return `Scanning ${fileCount} file${fileCount === 1 ? "" : "s"}…`;
+}

--- a/desktop/src/lib/useScan.ts
+++ b/desktop/src/lib/useScan.ts
@@ -62,6 +62,7 @@ export interface PreConvertState {
   skipEmpty: boolean;
   options: OptionsState;
   scanProgress: { bytes: number; totalBytes: number } | null;
+  scanFileCount: number; // sources being scanned: files (.mbox mode) or discovered folders (profile mode); 0 until known
   sortBy: SortField;
   sortDir: SortDir;
   inputMode: "files" | "profile";
@@ -86,6 +87,7 @@ function initialState(): PreConvertState {
     skipEmpty: true,
     options: defaultOptions(),
     scanProgress: null,
+    scanFileCount: 0,
     sortBy: "default",
     sortDir: "desc",
     inputMode: "files",
@@ -126,7 +128,7 @@ export function useScan() {
         setState((s) => ({ ...s, sourceError: "Choose a Thunderbird profile or mail folder." }));
         return;
       }
-      setState((s) => ({ ...s, stage: "scanning", sourceError: null, errorMessage: null, scanProgress: null }));
+      setState((s) => ({ ...s, stage: "scanning", sourceError: null, errorMessage: null, scanProgress: null, scanFileCount: 0 }));
 
       // Discovery failure / empty discovery is a SOURCE-selection problem → return to Source with
       // sourceError. Only a scan failure AFTER successful discovery goes to the ScanError view.
@@ -142,6 +144,9 @@ export function useScan() {
         setState((s) => ({ ...s, stage: "select", sourceError: "No mail folders found in that location.", scanProgress: null }));
         return;
       }
+
+      // Discovery done: the source count is now known — surface it on the Scanning view.
+      setState((s) => (s.stage === "scanning" ? { ...s, scanFileCount: disc.sources.length } : s));
 
       try {
         const paths = disc.sources.map((d) => d.path);
@@ -181,7 +186,7 @@ export function useScan() {
       setState((s) => ({ ...s, errorMessage: "Select at least one .mbox file." }));
       return;
     }
-    setState((s) => ({ ...s, stage: "scanning", sourceError: null, errorMessage: null, scanProgress: null }));
+    setState((s) => ({ ...s, stage: "scanning", sourceError: null, errorMessage: null, scanProgress: null, scanFileCount: paths.length }));
     try {
       // Guard the progress update on stage so a late/queued event after the scan
       // resolves can't leak a bar into Review or ScanError.

--- a/desktop/src/styles/globals.css
+++ b/desktop/src/styles/globals.css
@@ -111,3 +111,11 @@
 html {
   scroll-behavior: smooth;
 }
+
+/* Vertical-only scrolling app-wide: the shell's <main> owns vertical scroll;
+   nothing should ever scroll horizontally. Backstop so no view can introduce
+   a horizontal scrollbar (long folder paths/emails truncate or wrap instead). */
+html,
+body {
+  overflow-x: hidden;
+}

--- a/src/Mail2Pst.Cli/Mail2Pst.Cli.csproj
+++ b/src/Mail2Pst.Cli/Mail2Pst.Cli.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Mail2Pst.Cli</RootNamespace>
-    <Version>0.1.2</Version>
+    <Version>0.2.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../Mail2Pst.Core/Mail2Pst.Core.csproj" />


### PR DESCRIPTION
Bundles the v0.2.0 pre-release work (merged on local `main`) into one PR so CI + leak-check gate it before it lands on public `main`. Rebase-merge to keep all commits linear.

## GUI fixes (owner-validated)
- **Multi-account profiles default to one PST per account**, with a "Combine into a single PST" toggle — fixes the single-PST picker silently collapsing the split (multi-account is now detected from the discovered account count, never from `outputTarget.kind`).
- **Scanning screen shows the real source count** in profile mode (was always "0 files").
- **Source step shows one box per account** instead of collapsing to "first@x +N more".
- **App shell owns scroll** — the icon rail stays full-height and the app never scrolls horizontally.

## Docs
- **CHANGELOG:** full `[0.2.0]` section (the Thunderbird live-profile release).
- **README:** leads with Thunderbird profiles + mbox archives; corrected the now-false read/unread/tags Limitations; added profile mode / multi-account / colours / junk+expunged to Features; added `convert --profile` and `import-colours` to the CLI section; credits knk106/MorkReader as a knowledge reference.
- **TESTING:** current suite sizes + new coverage; **desktop/README** replaced its Tauri scaffold stub with a real dev readme.

## Release
- Version bumped to **0.2.0** across `tauri.conf.json`, `desktop/package.json`, `Cargo.toml` (+lock), and `Mail2Pst.Cli.csproj`.

## Verification
- ~688 engine + 214 desktop (Vitest) tests pass; `tsc` clean.
- NSIS installer builds clean (`ContinuMail Converter_0.2.0_x64-setup.exe`).