### PR TITLE
fix(writer): preserve completed parts on failed split; guard oversized attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to ContinuMail Converter are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Writer: a failed split (e.g. the next part can't be created mid-conversion) no longer
+  deletes the already-completed previous part or leaves a stray blank part behind; the
+  failure still surfaces as fatal, but completed output is preserved.
+- Writer: a message carrying an attachment larger than a PST attachment can store
+  (PidTagAttachSize is a 32-bit value) is now skipped and reported instead of writing a
+  wrapped size or risking an out-of-memory load of the whole attachment.
+
 ## [0.2.0] — 2026-06-23
 
 **Major feature enrichments — and a hard-won grudge against Mozilla Mork — ship with 0.2.0. The

--- a/desktop/src/lib/options.ts
+++ b/desktop/src/lib/options.ts
@@ -158,8 +158,9 @@ export function buildPstPreview(
 }
 
 /** Build the final ConversionConfig from the selection + options. Validates the
- * final folder names + uniqueness itself (the engine does not validate
- * TargetFolder), reusing buildPstPreview so it checks exactly what's shown. */
+ * final folder names + uniqueness up front (fast feedback before invoking the CLI;
+ * the engine's ConfigValidator re-validates as a backstop), reusing buildPstPreview
+ * so it checks exactly what's shown. */
 export function buildConfigFromOptions(
   sources: SourceRow[],
   checkedIds: Set<string>,

--- a/src/Mail2Pst.Core/Writing/AttachmentTooLargeException.cs
+++ b/src/Mail2Pst.Core/Writing/AttachmentTooLargeException.cs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#nullable enable
+using System;
+
+namespace Mail2Pst.Core.Writing;
+
+/// <summary>
+/// Thrown when a single attachment's decoded content exceeds what a PST attachment can
+/// represent (PidTagAttachSize is a PT_LONG, signed 32-bit). The message carrying it is
+/// recorded as a per-message skip rather than aborting the whole conversion — see
+/// <see cref="PstWriter.IsRecoverableWriteError"/>.
+/// </summary>
+public sealed class AttachmentTooLargeException : Exception
+{
+    public string FileName { get; }
+    public long ContentLength { get; }
+
+    public AttachmentTooLargeException(string fileName, long contentLength)
+        : base($"Attachment '{fileName}' is {contentLength} bytes, which exceeds the maximum " +
+               $"size a PST attachment can store ({PstWriter.MaxAttachmentBytes} bytes).")
+    {
+        FileName = fileName;
+        ContentLength = contentLength;
+    }
+}

--- a/src/Mail2Pst.Core/Writing/PstPartManager.cs
+++ b/src/Mail2Pst.Core/Writing/PstPartManager.cs
@@ -150,36 +150,49 @@ internal sealed class PstPartManager
     public void DeleteCurrentPart() => TryDeletePart(_currentPath);
 
     // Closes the current (already-flushed) part and opens the next. PRECONDITION: the
-    // caller has just flushed (EndSavingChanges). Builds the next part fully into LOCALS
-    // before mutating shared state, so a StartNewFile/PSTFile failure leaves the last-good
-    // part intact rather than half-initialised.
+    // caller has just flushed (EndSavingChanges). Once the old part is closed it is COMPLETE,
+    // so _currentPath is cleared until the next part opens: if creating the next part throws,
+    // the fatal-cleanup DeleteCurrentPart() must delete neither the completed part nor a
+    // half-made next part (the orphan template copy is removed here). Builds the next part
+    // fully into LOCALS before mutating shared state, so a StartNewFile/PSTFile failure leaves
+    // the last-good part intact rather than half-initialised.
     private void StartNextPartAfterFlush()
     {
         _file!.CloseFile();
+        _file = null;
+
+        // The just-closed part is complete. There is no in-progress part until the next one
+        // opens; clear _currentPath so an abort mid-split targets nothing (see DeleteCurrentPart).
+        string completedPath = _currentPath;
+        _currentPath = "";
+
         if (_partNumber == 1)
         {
             // First split: the initial "Name.pst" becomes part 1.
             string part1 = ResolveOutputPath(_groupName, 1, _outputDirectory);
             try
             {
-                TransientFileRetry.Run(() => File.Move(_currentPath, part1, overwrite: true));
+                TransientFileRetry.Run(() => File.Move(completedPath, part1, overwrite: true));
             }
             catch (IOException ex)
             {
                 // Any IOException that escapes the retry helper — a transient violation whose
                 // retries were exhausted, or a non-transient one surfaced immediately — gets a
-                // clear, attributable message instead of a bare File.Move failure.
+                // clear, attributable message instead of a bare File.Move failure. The initial
+                // part still exists under its original name (the move failed) and is kept.
                 throw new IOException(
-                    $"Failed to rename '{_currentPath}' to '{part1}' while starting split part 2.", ex);
+                    $"Failed to rename '{completedPath}' to '{part1}' while starting split part 2.", ex);
             }
             _outputFiles[0] = part1;
         }
 
         int nextPartNumber = _partNumber + 1;
-        string nextPath = StartNewFile(_groupName, nextPartNumber, _outputDirectory);
+        string nextPath = "";
         PSTFile? nextFile = null;
+        bool opened = false;
         try
         {
+            nextPath = StartNewFile(_groupName, nextPartNumber, _outputDirectory);
             nextFile = new PSTFile(nextPath, FileAccess.ReadWrite);
             nextFile.BeginSavingChanges();
 
@@ -188,19 +201,24 @@ internal sealed class PstPartManager
             _currentPath = nextPath;
             _outputFiles.Add(nextPath);
             _file = nextFile;
-            nextFile = null;   // ownership transferred to _file
             _folders.Clear();
             _dirtyFolders.Clear();
             _estimatedContentBytes = 0;
             _messagesSinceCheck = 0;
             _messagesInCurrentPart = 0;
+            opened = true;
         }
         finally
         {
-            // If open/BeginSavingChanges threw before ownership transfer, close the orphan
-            // handle so a failed split can't leak the newly opened file. (The pre-refactor
-            // code had this latent leak; tightened here per review 2026-06-17.)
-            nextFile?.CloseFile();
+            if (!opened)
+            {
+                // The split failed after the previous part was completed. Close the orphan
+                // handle and delete the orphan template copy (if StartNewFile got that far) so
+                // a failed split leaves no stray blank part. _currentPath stays "" so the
+                // completed parts already on disk are preserved by the caller's fatal cleanup.
+                nextFile?.CloseFile();
+                if (nextPath.Length > 0) TryDeletePart(nextPath);
+            }
         }
     }
 

--- a/src/Mail2Pst.Core/Writing/PstWriter.cs
+++ b/src/Mail2Pst.Core/Writing/PstWriter.cs
@@ -366,14 +366,31 @@ public class PstWriter
     // write, the message has parsed successfully, so a write failure is almost certainly
     // a bug, a vendored PST-library failure, invalid internal state, or a filesystem/temp
     // problem — all of which must surface as fatal (mirroring the parse-side taxonomy in
-    // MboxParser). This allowlist is intentionally EMPTY: add a specific exception type
+    // MboxParser). The allowlist is kept DELIBERATELY MINIMAL: add a specific exception type
     // ONLY after a real data-driven write failure is observed and proven safely skippable.
-    // Keeping the predicate + catch-filter makes that a one-line change. This is a
-    // deliberate, documented extension seam — NOT dead code to "clean up".
-    internal static bool IsRecoverableWriteError(Exception ex) => false;
+    // Its one member is AttachmentTooLargeException — a property of one bad message, detected
+    // up front before any node is written, so that message is recorded as a skip and the rest
+    // of the conversion proceeds. Everything else stays fatal.
+    internal static bool IsRecoverableWriteError(Exception ex) => ex is AttachmentTooLargeException;
+
+    // PidTagAttachSize is a PT_LONG (signed 32-bit), so an attachment can store at most
+    // int.MaxValue content bytes; larger content cannot be represented and would also force
+    // a >2 GB single allocation in AttachmentContent.ReadAllBytes.
+    internal const long MaxAttachmentBytes = int.MaxValue;
+
+    internal static bool AttachmentTooLarge(long contentLength) => contentLength > MaxAttachmentBytes;
 
     private static void WriteMessage(PSTFile file, PSTFolder folder, MailMessage message)
     {
+        // Pre-flight: reject a message carrying an unrepresentable attachment BEFORE creating
+        // any node, so an oversized attachment becomes a clean per-message skip rather than a
+        // wrapped PidTagAttachSize cast, a >2 GB ReadAllBytes allocation, or an orphan note.
+        foreach (MailAttachment preflight in message.Attachments)
+        {
+            if (AttachmentTooLarge(preflight.Content.Length))
+                throw new AttachmentTooLargeException(preflight.FileName, preflight.Content.Length);
+        }
+
         Note note = Note.CreateNewNote(file, folder.NodeID);
         note.Subject = message.Subject ?? string.Empty;
 

--- a/tests/Mail2Pst.Core.Tests/Writing/PstWriterAttachmentLimitTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/PstWriterAttachmentLimitTests.cs
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Mapping;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Reporting;
+using Mail2Pst.Core.Writing;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Writing;
+
+public class PstWriterAttachmentLimitTests
+{
+    private static string TemplatePath => Path.Combine(AppContext.BaseDirectory, "assets", "template.pst");
+
+    // PidTagAttachSize is a PT_LONG (signed 32-bit), so content up to int.MaxValue bytes
+    // is representable and anything above it is not (and would also force a >2 GB single
+    // allocation in ReadAllBytes).
+    [Theory]
+    [InlineData(0L, false)]
+    [InlineData((long)int.MaxValue, false)]
+    [InlineData((long)int.MaxValue + 1, true)]
+    public void AttachmentTooLarge_FlagsOnlyContentAboveInt32Max(long length, bool expected)
+    {
+        Assert.Equal(expected, PstWriter.AttachmentTooLarge(length));
+    }
+
+    [Fact]
+    public void IsRecoverableWriteError_True_ForAttachmentTooLarge()
+    {
+        var ex = new AttachmentTooLargeException("big.bin", (long)int.MaxValue + 1);
+        Assert.True(PstWriter.IsRecoverableWriteError(ex));
+    }
+
+    [Fact]
+    public void WritePlan_AttachmentExceedsPstLimit_SkipsThatMessageAndConvertsRest()
+    {
+        string outputDir = Path.Combine(Path.GetTempPath(), "mail2pst-attlimit-" + Guid.NewGuid());
+        Directory.CreateDirectory(outputDir);
+        string tiny = Path.GetTempFileName();
+        File.WriteAllBytes(tiny, new byte[] { 1, 2, 3 });
+        try
+        {
+            // Declare a >2 GB attachment WITHOUT allocating it: FromTempFile takes an explicit
+            // length. The message must be skipped (recorded), not abort the run or wrap the cast.
+            var oversized = new PlannedMessage
+            {
+                TargetFolderPath = new[] { "Imported Mail" },
+                Message = new MailMessage
+                {
+                    Subject = "huge",
+                    Source = new SourceReference { SourcePath = "Archive.mbox", Identifier = "#big" },
+                    Attachments = new List<MailAttachment>
+                    {
+                        new()
+                        {
+                            FileName = "big.bin",
+                            MimeType = "application/octet-stream",
+                            Content = AttachmentContent.FromTempFile(tiny, (long)int.MaxValue + 1),
+                        },
+                    },
+                },
+            };
+            var normal = new PlannedMessage
+            {
+                TargetFolderPath = new[] { "Imported Mail" },
+                Message = new MailMessage
+                {
+                    Subject = "ok",
+                    TextBody = "body",
+                    Source = new SourceReference { SourcePath = "Archive.mbox", Identifier = "#ok" },
+                    Attachments = new List<MailAttachment>(),
+                },
+            };
+
+            var plan = new PstOutputPlan { Name = "Archive", MaxSizeBytes = 100L * 1024 * 1024 };
+            var report = new ConversionReport();
+            var writer = new PstWriter(TemplatePath);
+            List<string> outputs = writer.WritePlan(plan, new[] { oversized, normal }, outputDir, report);
+
+            Assert.Equal(1, report.ConvertedCount);   // the normal message converted
+            Assert.Equal(1, report.SkippedCount);      // the oversized message skipped, run not fatal
+            Assert.Single(outputs);                    // single completed part, no split or abort
+        }
+        finally
+        {
+            if (File.Exists(tiny)) File.Delete(tiny);
+            Directory.Delete(outputDir, true);
+        }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Writing/PstWriterErrorTaxonomyTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/PstWriterErrorTaxonomyTests.cs
@@ -130,4 +130,46 @@ public class PstWriterErrorTaxonomyTests
         }
         finally { Directory.Delete(outputDir, true); }
     }
+
+    [Fact]
+    public void WritePlan_SplitCreationFails_KeepsCompletedPartsAndLeavesNoOrphan()
+    {
+        long templateSize = new FileInfo(TemplatePath).Length;
+        string outputDir = Path.Combine(Path.GetTempPath(), "mail2pst-tests-" + Guid.NewGuid());
+        Directory.CreateDirectory(outputDir);
+        try
+        {
+            // Plant a DIRECTORY where the THIRD part (Archive-3.pst) would be written, so the
+            // SECOND split fails while creating it — AFTER part 2 is already complete on disk.
+            // A failed split must surface as fatal but must NOT delete a completed part, and
+            // must not leave a stray part behind. (Regression: the pre-fix code left _currentPath
+            // pointing at the completed part 2, so the fatal cleanup deleted it.)
+            Directory.CreateDirectory(Path.Combine(outputDir, "Archive-3.pst"));
+
+            var plan = new PstOutputPlan { Name = "Archive", MaxSizeBytes = templateSize + 20_000 };
+            string bigBody = new string('x', 5000);
+            var messages = new List<PlannedMessage>();
+            for (int i = 0; i < 20; i++)
+            {
+                PlannedMessage m = SmallMessage(i);
+                m.Message.TextBody = bigBody;
+                messages.Add(m);
+            }
+
+            var writer = new PstWriter(TemplatePath);
+            Assert.ThrowsAny<Exception>(() => writer.WritePlan(plan, messages, outputDir, new ConversionReport()));
+
+            string part1 = Path.Combine(outputDir, "Archive-1.pst");
+            string part2 = Path.Combine(outputDir, "Archive-2.pst");
+            Assert.True(File.Exists(part1), "completed part 1 must remain on disk");
+            Assert.True(File.Exists(part2), "a failed split must NOT delete the completed part 2");
+
+            // The only surviving part FILES are the two completed parts — no stray/orphan part.
+            var pstFiles = Directory.GetFiles(outputDir, "*.pst").Select(Path.GetFileName).ToList();
+            Assert.Equal(2, pstFiles.Count);
+            Assert.Contains("Archive-1.pst", pstFiles);
+            Assert.Contains("Archive-2.pst", pstFiles);
+        }
+        finally { Directory.Delete(outputDir, true); }
+    }
 }


### PR DESCRIPTION
Two writer correctness fixes, verified against the code and covered by tests (TDD: red watched first, then green).

## Changes

**1. Failed split no longer destroys completed output (`PstPartManager`)**
When creating the next PST part failed mid-conversion, `_currentPath` still referenced the previous part, so the fatal-cleanup path deleted an already-completed split part (on a 2nd-or-later split) and could leave the orphan template copy behind. The closed part is now completed first, `_currentPath` is cleared until the next part opens, and on failure only the orphan next-part copy is removed. The failure still surfaces as fatal; completed parts are preserved.

**2. Oversized attachments are skipped, not mis-sized (`PstWriter`)**
`PidTagAttachSize` is a PT_LONG (signed 32-bit), so an attachment over `int.MaxValue` bytes cannot be represented and previously wrapped the size cast, while `ReadAllBytes` would also try to materialise the whole payload. Such a message is now detected up front (before any node is written) and recorded as a per-message skip via the recoverable-write allowlist, so the rest of the conversion proceeds.

**3. Docs** — `[Unreleased]` changelog entries and a corrected stale `options.ts` comment (the engine`s `ConfigValidator` does validate `TargetFolder`; GUI-side validation is for fast up-front feedback).

## Tests
- `WritePlan_SplitCreationFails_KeepsCompletedPartsAndLeavesNoOrphan`
- `PstWriterAttachmentLimitTests` (boundary, allowlist wiring, behavioral skip-and-continue)

Full suite: 624 Core + 71 Integration passing (3 env-gated skips).

## Not included
A 65,535-messages-per-folder split is intentionally left out: that limit is unverified against MS-PST for Unicode PSTs, and will be settled empirically by a follow-up scanpst validation gate rather than enforced on assumption.