### PR TITLE
fix(desktop): clean up temp config when the sidecar fails to launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Writer: a message carrying an attachment larger than a PST attachment can store
   (PidTagAttachSize is a 32-bit value) is now skipped and reported instead of writing a
   wrapped size or risking an out-of-memory load of the whole attachment.
+- Desktop: the per-run temp config file is now removed if the conversion engine fails to
+  launch (sidecar missing or spawn error), instead of being left behind in the temp directory.
 
 ## [0.2.0] — 2026-06-23
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -288,13 +288,21 @@ async fn start_convert(
     std::fs::write(&config_path, config_text).map_err(|e| format!("cannot write config: {e}"))?;
     let config_path_str = config_path.to_string_lossy().to_string();
 
+    // On any failure to launch the sidecar, remove the temp config we just wrote — the
+    // async reader task (which owns cleanup on normal exit) never starts in that case.
     let (mut rx, child) = app
         .shell()
         .sidecar("mail2pst-cli")
-        .map_err(|e| format!("sidecar not found: {e}"))?
+        .map_err(|e| {
+            let _ = std::fs::remove_file(&config_path);
+            format!("sidecar not found: {e}")
+        })?
         .args(["convert", "--config", &config_path_str, "--output", &output_dir])
         .spawn()
-        .map_err(|e| format!("failed to start engine: {e}"))?;
+        .map_err(|e| {
+            let _ = std::fs::remove_file(&config_path);
+            format!("failed to start engine: {e}")
+        })?;
 
     // Store the child BEFORE the reader task starts.
     *state.0.lock().unwrap() = Some(child);


### PR DESCRIPTION
`start_convert` writes a per-run temp config file before spawning the CLI sidecar, but the only cleanup runs inside the async reader task. If `.sidecar()` lookup or `.spawn()` returns `Err`, that task never starts, so the temp config is left behind in the temp directory. This removes it on both launch-failure paths.

## Notes
- The spawn-failure path is not unit-testable without the Tauri runtime; verified by `cargo check` and inspection.
- Independent of the writer fixes in #25; this branch is off `main`.