### PR TITLE
feat(msf): preserve Thunderbird-set message priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Thunderbird `.msf` enrichment now preserves **message priority** set inside Thunderbird. A
+  priority a user or filter applied in Thunderbird is stored only in the `.msf` (not in the mbox
+  headers), so it was previously lost; it is now read and written to Outlook's importance. Priority
+  that arrived on the message's own `X-Priority`/`Importance` header was already preserved.
+
 ### Fixed
 - Writer: a failed split (e.g. the next part can't be created mid-conversion) no longer
   deletes the already-completed previous part or leaves a stray blank part behind; the

--- a/src/Mail2Pst.Core/Msf/MsfEnricher.cs
+++ b/src/Mail2Pst.Core/Msf/MsfEnricher.cs
@@ -70,6 +70,10 @@ public static class MsfEnricher
         mail.IsForwarded = row.IsForwarded;
         mail.IsFlagged = row.IsFlagged;
         mail.IsJunk = row.IsJunk;
+        // .msf wins for priority too, but ONLY when it carries an explicit one (a user/filter can set
+        // priority in Thunderbird without touching the mbox headers). notSet/none leaves the
+        // header-derived importance intact — never clobber a header value with a .msf blank.
+        if (MapMsfPriority(row.Priority) is { } importance) mail.Importance = importance;
 
         var resolved = new List<string>(options.TagResolver.Resolve(row.Keywords));
         if (options.JunkHandling == JunkHandlingMode.Category && row.IsJunk) resolved.Add("Junk");
@@ -87,6 +91,16 @@ public static class MsfEnricher
         }
         return true;
     }
+
+    // Thunderbird nsMsgPriority -> our importance. Only an EXPLICITLY set priority (lowest..highest)
+    // maps; notSet(0)/none(1)/out-of-range -> null so the caller keeps the header-derived importance.
+    private static MailImportance? MapMsfPriority(int? priority) => priority switch
+    {
+        2 or 3 => MailImportance.Low,    // lowest, low
+        4      => MailImportance.Normal, // normal
+        5 or 6 => MailImportance.High,   // high, highest
+        _      => null,                  // notSet / none / unknown
+    };
 
     // Append new categories to existing, dedupe ordinal, preserve first occurrence; never remove.
     private static void MergeCategories(List<string> existing, IReadOnlyList<string> additions)

--- a/src/Mail2Pst.Core/Msf/MsfMessage.cs
+++ b/src/Mail2Pst.Core/Msf/MsfMessage.cs
@@ -17,6 +17,8 @@ public sealed class MsfMessage
     public IReadOnlyList<string> Keywords { get; }
     public int Label { get; }
     public long? MsgOffset { get; }
+    /// <summary>Raw Thunderbird nsMsgPriority (0=notSet,1=none,2=lowest,3=low,4=normal,5=high,6=highest); null if absent. Faithful mirror — mapping to importance is the enricher's job.</summary>
+    public int? Priority { get; }
     public string? MessageId { get; }
 
     public MsfMessage(
@@ -26,6 +28,7 @@ public sealed class MsfMessage
         IReadOnlyList<string> keywords,
         int label,
         long? msgOffset,
+        int? priority,
         string? messageId)
     {
         RowId = rowId ?? throw new ArgumentNullException(nameof(rowId));
@@ -35,6 +38,7 @@ public sealed class MsfMessage
         Keywords = new ReadOnlyCollection<string>(keywords.ToList()); // defensive copy
         Label = label;
         MsgOffset = msgOffset;
+        Priority = priority;
         MessageId = messageId;
     }
 

--- a/src/Mail2Pst.Core/Msf/MsfMessageReader.cs
+++ b/src/Mail2Pst.Core/Msf/MsfMessageReader.cs
@@ -43,7 +43,7 @@ public static class MsfMessageReader
         return new MsfReadResult(messages, diagnostics);
     }
 
-    // Diagnostic order is contractual: flags, junkscore, label, msgOffset.
+    // Diagnostic order is contractual: flags, junkscore, label, msgOffset, priority.
     private static MsfMessage ReadRow(MorkRow row, List<MsfDiagnostic> diagnostics)
     {
         MsfMessageFlags flags = ParseFlags(row, diagnostics);
@@ -51,9 +51,28 @@ public static class MsfMessageReader
         IReadOnlyList<string> keywords = ParseKeywords(row);
         int label = ParseLabel(row, diagnostics);
         long? msgOffset = ParseMsgOffset(row, diagnostics);
+        int? priority = ParsePriority(row, diagnostics);
         string? messageId = ParseMessageId(row);
 
-        return new MsfMessage(row.Id, flags, junkScore, keywords, label, msgOffset, messageId);
+        return new MsfMessage(row.Id, flags, junkScore, keywords, label, msgOffset, priority, messageId);
+    }
+
+    // Thunderbird nsMsgPriority (decimal, like junkscore/label — not the hex `flags`). Kept verbatim
+    // as a raw int; the enricher maps it to importance. Values 0-6 parse identically in hex/decimal.
+    private static int? ParsePriority(MorkRow row, List<MsfDiagnostic> diagnostics)
+    {
+        if (!row.TryGetCell("priority", out string raw) || raw.Length == 0)
+        {
+            return null;
+        }
+
+        if (int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out int value))
+        {
+            return value;
+        }
+
+        diagnostics.Add(new MsfDiagnostic(row.Id, "priority", raw, "not a number"));
+        return null;
     }
 
     private static string? ParseMessageId(MorkRow row)

--- a/tests/Mail2Pst.Core.Tests/Msf/MsfEnricherTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/MsfEnricherTests.cs
@@ -61,6 +61,42 @@ public class MsfEnricherTests
         Assert.Equal(0, result.ExpungedDropped);
     }
 
+    [Theory]
+    [InlineData("6", MailImportance.High)]    // highest
+    [InlineData("5", MailImportance.High)]    // high
+    [InlineData("4", MailImportance.Normal)]  // normal
+    [InlineData("3", MailImportance.Low)]     // low
+    [InlineData("2", MailImportance.Low)]     // lowest
+    public void Priority_ExplicitlySet_OverridesHeaderImportance(string raw, MailImportance expected)
+    {
+        // Header said Normal; the .msf priority is authoritative (.msf-wins, like the flags).
+        var mail = new MailMessage { MessageId = "<x@h>", Importance = MailImportance.Normal };
+        MsfReadResult msf = Msf(Row("1", ("message-id", "x@h"), ("priority", raw)));
+        ApplyOne(mail, msf, Opts());
+        Assert.Equal(expected, mail.Importance);
+    }
+
+    [Theory]
+    [InlineData("0")] // notSet
+    [InlineData("1")] // none
+    public void Priority_NotSetOrNone_KeepsHeaderImportance(string raw)
+    {
+        // .msf carries no real priority → never clobber the header-derived value with a blank.
+        var mail = new MailMessage { MessageId = "<x@h>", Importance = MailImportance.High };
+        MsfReadResult msf = Msf(Row("1", ("message-id", "x@h"), ("priority", raw)));
+        ApplyOne(mail, msf, Opts());
+        Assert.Equal(MailImportance.High, mail.Importance);
+    }
+
+    [Fact]
+    public void Priority_AbsentColumn_KeepsHeaderImportance()
+    {
+        var mail = new MailMessage { MessageId = "<x@h>", Importance = MailImportance.Low };
+        MsfReadResult msf = Msf(Row("1", ("message-id", "x@h"), ("flags", "1"))); // no priority cell
+        ApplyOne(mail, msf, Opts());
+        Assert.Equal(MailImportance.Low, mail.Importance);
+    }
+
     [Fact]
     public void DropExpunged_True_NonExpungedMatch_Kept()
     {

--- a/tests/Mail2Pst.Core.Tests/Msf/MsfMessageReaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/MsfMessageReaderTests.cs
@@ -67,6 +67,7 @@ public class MsfMessageReaderTests
         Assert.Empty(m.Keywords);
         Assert.Equal(0, m.Label);
         Assert.Null(m.MsgOffset);
+        Assert.Null(m.Priority);
         Assert.Null(m.MessageId);
         Assert.Empty(result.Diagnostics);
     }
@@ -250,6 +251,36 @@ public class MsfMessageReaderTests
         var r = MsfMessageReader.Read(MsgsDoc(Row("1", ("msgOffset", ""))));
         Assert.Null(Assert.Single(r.Messages).MsgOffset);
         Assert.Empty(r.Diagnostics);
+    }
+
+    [Theory]
+    [InlineData("0", 0)]   // notSet
+    [InlineData("4", 4)]   // normal
+    [InlineData("6", 6)]   // highest
+    public void Read_Priority_Parsed(string raw, int expected)
+    {
+        MsfMessage m = Assert.Single(MsfMessageReader.Read(MsgsDoc(Row("1", ("priority", raw)))).Messages);
+        Assert.Equal(expected, m.Priority);
+    }
+
+    [Fact]
+    public void Read_Priority_EmptyOrAbsent_Null_NoDiagnostic()
+    {
+        var r = MsfMessageReader.Read(MsgsDoc(Row("1", ("priority", ""))));
+        Assert.Null(Assert.Single(r.Messages).Priority);
+        Assert.Empty(r.Diagnostics);
+    }
+
+    [Theory]
+    [InlineData("high")]          // non-numeric
+    [InlineData("99999999999")]   // overflow int
+    public void Read_Priority_Invalid_NullPlusDiagnostic(string raw)
+    {
+        MsfReadResult r = MsfMessageReader.Read(MsgsDoc(Row("R1", ("priority", raw))));
+        Assert.Null(Assert.Single(r.Messages).Priority);
+        MsfDiagnostic d = Assert.Single(r.Diagnostics);
+        Assert.Equal("priority", d.Column);
+        Assert.Equal(raw, d.RawValue);
     }
 
     [Fact]


### PR DESCRIPTION
Thunderbird stores a message's priority in the `.msf` `priority` column, not in the mbox headers. When a user (or a filter) sets priority inside Thunderbird, it never touches the stored RFC822, so our enrichment — which derived importance solely from the `X-Priority`/`Importance` headers — dropped it. This brings priority in line with the other `.msf`-authoritative fields (read/replied/forwarded/starred/junk/tags).

## Change
- `MsfMessageReader` reads the `priority` column (nsMsgPriority; decimal like junkscore/label) as a raw `int?` on `MsfMessage`.
- `MsfEnricher.TryApply` maps an explicitly-set priority (lowest..highest) to `MailMessage.Importance` as authoritative; `notSet`/`none` leaves the header-derived importance untouched, so a `.msf` blank never clobbers a header priority. Applies on both the batch and streaming enrichment paths (single `TryApply` site).

Priority that arrived on the message's own header was already preserved — unchanged.

## Tests
New reader tests (parse/empty/invalid+diagnostic) and enricher tests (explicit override lowest..highest; notSet/none and absent-column keep the header value). Full suite: 638 Core + 78 Integration, 0 failures.