### PR TITLE
chore(desktop): gitignore local screenshot-capture tool

### DIFF
--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -27,3 +27,14 @@ dist-ssr
 src-tauri/binaries/
 src-tauri/resources/
 src-tauri/.sidecar-publish/
+
+# generated marketing/app screenshots (produced by the screenshot tool)
+screenshots/
+
+# local-only screenshot tool — dev capture harness + scripts, not part of the
+# public release. Decoupled from the app (standalone Vite entry shot.html), so
+# removing it never affects the shipped app or the build.
+shot.html
+src/dev/
+scripts/screenshot-web.ps1
+scripts/screenshot-mode.ps1


### PR DESCRIPTION
## What
Ignore the local-only, dev screenshot-capture tool so it's never committed to the public repo.

Added to `desktop/.gitignore`:
- `shot.html` + `src/dev/` — the standalone Vite screenshot harness (renders the real View components with mock data for marketing captures)
- `scripts/screenshot-web.ps1`, `scripts/screenshot-mode.ps1` — capture scripts
- `screenshots/` — generated PNG output

## Why
The harness is a dev/marketing tool, not part of the shipped converter. It's fully decoupled from the app (its own `shot.html` entry — no hook in `main.tsx` or `package.json`), so its absence on a clean checkout never affects `tsc`/`vite build`.

## Verification
- Only tracked change is `desktop/.gitignore` (+11 lines, ignore rules only).
- `git check-ignore` confirms all tool files are ignored.
- `node .githooks/leak-check.mjs --range origin/main..HEAD` → clean.
- `tsc --noEmit` passes with the tool present locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)