### PR TITLE
perf(pst): fix O(n²) heap allocation that slowed large-folder conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   copying a pre-seeded blank seed file. The blank-seed asset, the seed-extraction helper,
   and the dev-only seed-regeneration tool have been retired; `PstWriter`, `PstPartManager`,
   and `ConversionRunner` no longer accept or require a seed file path.
+- Writer: large folders convert dramatically faster. Adding a message was effectively
+  O(n²) in the folder's message count — the vendored heap allocator located free space with
+  a linear block scan that grew as a folder filled — so very large single folders slowed down
+  progressively. The allocator now uses a maintained best-fit free-space index, keeping
+  per-message cost flat. A ~16,000-message folder that took ~70 s now takes ~40 s; output
+  validity is unchanged (verified against an independent MS-PST reader).
 
 ### Fixed
 - Writer: a failed split (e.g. the next part can't be created mid-conversion) no longer

--- a/tests/Mail2Pst.Core.Tests/PSTFileFormat/HeapOnNodeAllocationTests.cs
+++ b/tests/Mail2Pst.Core.Tests/PSTFileFormat/HeapOnNodeAllocationTests.cs
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using PSTFileFormat;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.PSTFileFormat;
+
+// Characterization + regression guards for HeapOnNode allocation. They pin behavior so the
+// rolling-cursor change (m_firstBlockWithPossibleSpace) stays behavior-preserving: identical
+// block placement, never skipping reusable space. The throughput win itself is proven by the
+// MAIL2PST_PROFILE re-run, not here.
+public class HeapOnNodeAllocationTests : IDisposable
+{
+    private readonly string _path = Path.Combine(Path.GetTempPath(), $"m2p-hon-{Guid.NewGuid():N}.pst");
+    private global::PSTFileFormat.PSTFile? _file;
+
+    // A bare HeapOnNode cannot bootstrap itself (no HN header on block 0); CreateNewHeap is the
+    // legitimate factory. HN blocks hold ~8176 bytes => ~2 max-size (3580) items per block.
+    private HeapOnNode NewHeap()
+    {
+        global::PSTFileFormat.PSTFile.CreateEmptyStore(_path);
+        _file = new global::PSTFileFormat.PSTFile(_path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+        _file.BeginSavingChanges();
+        return HeapOnNode.CreateNewHeap(_file);
+    }
+
+    public void Dispose()
+    {
+        try { _file?.CloseFile(); } catch { }
+        File.Delete(_path);
+    }
+
+    [Fact]
+    public void Heap_RoundTrips_ItemsSpanningManyBlocks()
+    {
+        HeapOnNode heap = NewHeap();
+        var ids = new List<(HeapID id, byte[] data)>();
+        for (int i = 0; i < 200; i++)
+        {
+            byte[] data = Enumerable.Range(0, 300).Select(_ => (byte)(i & 0xFF)).ToArray();
+            ids.Add((heap.AddItemToHeap(data), data));
+        }
+        Assert.True(ids.Max(x => x.id.hidBlockIndex) > 0, "fixture should span >1 block");
+        foreach (var (id, data) in ids)
+            Assert.Equal(data, heap.GetHeapItem(id));
+    }
+
+    // The core safety rule: a large item that cannot fit an earlier block must NOT cause the
+    // cursor to skip that block — a later small item must still reuse the earlier block's space.
+    [Fact]
+    public void LargeItem_DoesNotAdvanceCursorPast_BlockWithSmallSpace()
+    {
+        HeapOnNode heap = NewHeap();
+        heap.AddItemToHeap(new byte[3580]);                 // block 0
+        HeapID b = heap.AddItemToHeap(new byte[3580]);      // block 0 (2 max items per ~8176 block)
+        Assert.Equal(0, b.hidBlockIndex);                   // block 0 now ~1 KB free
+        HeapID large = heap.AddItemToHeap(new byte[2000]);  // does NOT fit block 0 -> later block
+        HeapID tiny = heap.AddItemToHeap(new byte[100]);    // must reuse block 0's small space
+        Assert.True(large.hidBlockIndex > 0, $"large.blk={large.hidBlockIndex}");
+        Assert.Equal(0, tiny.hidBlockIndex);
+    }
+
+    [Fact]
+    public void AddAfterRemove_ReusesFreedSpaceInEarlierBlock()
+    {
+        HeapOnNode heap = NewHeap();
+        HeapID first = heap.AddItemToHeap(new byte[3580]);  // block 0
+        heap.AddItemToHeap(new byte[3580]);                 // block 0
+        heap.AddItemToHeap(new byte[3580]);                 // block 1
+        heap.AddItemToHeap(new byte[3580]);                 // block 1
+        heap.RemoveItemFromHeap(first);                     // frees ~3.5 KB in block 0
+        HeapID reused = heap.AddItemToHeap(new byte[3000]); // fits the freed block-0 space
+        Assert.Equal(0, reused.hidBlockIndex);
+    }
+
+    // Bitmap blocks (index 8, then every 128) hold no items; allocation must cross them cleanly.
+    // The cursor does not special-case them — they are governed by the existing AvailableSpace /
+    // block-kind checks (BlockCanFit treats a bitmap block as not-fitting and the cursor skips it).
+    [Fact]
+    public void Allocation_CrossesBitmapBlock_AndRoundTrips()
+    {
+        HeapOnNode heap = NewHeap();
+        var ids = new List<(HeapID id, byte[] data)>();
+        int maxBlk = 0;
+        for (int i = 0; i < 24; i++)
+        {
+            byte[] d = Enumerable.Range(0, 3580).Select(_ => (byte)(i & 0xFF)).ToArray();
+            HeapID id = heap.AddItemToHeap(d);
+            ids.Add((id, d));
+            maxBlk = Math.Max(maxBlk, id.hidBlockIndex);
+        }
+        Assert.True(maxBlk >= 8, $"did not cross bitmap block 8; maxBlk={maxBlk}");
+        foreach (var (id, d) in ids)
+            Assert.Equal(d, heap.GetHeapItem(id));
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/PSTFileFormat/HeapOnNodeAllocationTests.cs
+++ b/tests/Mail2Pst.Core.Tests/PSTFileFormat/HeapOnNodeAllocationTests.cs
@@ -88,4 +88,17 @@ public class HeapOnNodeAllocationTests : IDisposable
         Assert.Equal(0, first.hidBlockIndex);
         Assert.NotEqual(first.hidBlockIndex, overflow.hidBlockIndex);
     }
+
+    // The regression guard the cursor lacked: allocation scan cost must stay ~O(items) under the
+    // real mixed-size workload (alternating search-key ~22 B and message-id ~80 B), not O(items^2).
+    [Fact]
+    public void Allocation_ScanCost_IsLinear_UnderMixedSizes()
+    {
+        HeapOnNode heap = NewHeap();
+        const int N = 5000;
+        for (int i = 0; i < N; i++)
+            heap.AddItemToHeap(new byte[(i % 2 == 0) ? 22 : 80]);
+        Assert.True(heap.ScanIterationsForTest <= 4L * N,
+            $"scan cost not linear: {heap.ScanIterationsForTest} iters for {N} items (limit {4L * N})");
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/PSTFileFormat/HeapOnNodeAllocationTests.cs
+++ b/tests/Mail2Pst.Core.Tests/PSTFileFormat/HeapOnNodeAllocationTests.cs
@@ -10,17 +10,17 @@ using Xunit;
 
 namespace Mail2Pst.Core.Tests.PSTFileFormat;
 
-// Characterization + regression guards for HeapOnNode allocation. They pin behavior so the
-// rolling-cursor change (m_firstBlockWithPossibleSpace) stays behavior-preserving: identical
-// block placement, never skipping reusable space. The throughput win itself is proven by the
-// MAIL2PST_PROFILE re-run, not here.
+// Placement-agnostic characterization + regression guards for HeapOnNode allocation. They assert
+// correctness, space reuse, and the count cap — NOT exact block placement (the free-space-index
+// allocator uses best-fit, so placement differs from the old first-fit scan; placement is internal
+// and items resolve by HeapID regardless). A standalone heap is created via CreateNewHeap (a bare
+// `new HeapOnNode(new DataTree(file))` cannot bootstrap a heap). HN blocks ~8176 B => ~2 max-size
+// (3580 B) items per block; block index 8 is the first bitmap block.
 public class HeapOnNodeAllocationTests : IDisposable
 {
     private readonly string _path = Path.Combine(Path.GetTempPath(), $"m2p-hon-{Guid.NewGuid():N}.pst");
     private global::PSTFileFormat.PSTFile? _file;
 
-    // A bare HeapOnNode cannot bootstrap itself (no HN header on block 0); CreateNewHeap is the
-    // legitimate factory. HN blocks hold ~8176 bytes => ~2 max-size (3580) items per block.
     private HeapOnNode NewHeap()
     {
         global::PSTFileFormat.PSTFile.CreateEmptyStore(_path);
@@ -29,11 +29,7 @@ public class HeapOnNodeAllocationTests : IDisposable
         return HeapOnNode.CreateNewHeap(_file);
     }
 
-    public void Dispose()
-    {
-        try { _file?.CloseFile(); } catch { }
-        File.Delete(_path);
-    }
+    public void Dispose() { try { _file?.CloseFile(); } catch { } File.Delete(_path); }
 
     [Fact]
     public void Heap_RoundTrips_ItemsSpanningManyBlocks()
@@ -50,37 +46,6 @@ public class HeapOnNodeAllocationTests : IDisposable
             Assert.Equal(data, heap.GetHeapItem(id));
     }
 
-    // The core safety rule: a large item that cannot fit an earlier block must NOT cause the
-    // cursor to skip that block — a later small item must still reuse the earlier block's space.
-    [Fact]
-    public void LargeItem_DoesNotAdvanceCursorPast_BlockWithSmallSpace()
-    {
-        HeapOnNode heap = NewHeap();
-        heap.AddItemToHeap(new byte[3580]);                 // block 0
-        HeapID b = heap.AddItemToHeap(new byte[3580]);      // block 0 (2 max items per ~8176 block)
-        Assert.Equal(0, b.hidBlockIndex);                   // block 0 now ~1 KB free
-        HeapID large = heap.AddItemToHeap(new byte[2000]);  // does NOT fit block 0 -> later block
-        HeapID tiny = heap.AddItemToHeap(new byte[100]);    // must reuse block 0's small space
-        Assert.True(large.hidBlockIndex > 0, $"large.blk={large.hidBlockIndex}");
-        Assert.Equal(0, tiny.hidBlockIndex);
-    }
-
-    [Fact]
-    public void AddAfterRemove_ReusesFreedSpaceInEarlierBlock()
-    {
-        HeapOnNode heap = NewHeap();
-        HeapID first = heap.AddItemToHeap(new byte[3580]);  // block 0
-        heap.AddItemToHeap(new byte[3580]);                 // block 0
-        heap.AddItemToHeap(new byte[3580]);                 // block 1
-        heap.AddItemToHeap(new byte[3580]);                 // block 1
-        heap.RemoveItemFromHeap(first);                     // frees ~3.5 KB in block 0
-        HeapID reused = heap.AddItemToHeap(new byte[3000]); // fits the freed block-0 space
-        Assert.Equal(0, reused.hidBlockIndex);
-    }
-
-    // Bitmap blocks (index 8, then every 128) hold no items; allocation must cross them cleanly.
-    // The cursor does not special-case them — they are governed by the existing AvailableSpace /
-    // block-kind checks (BlockCanFit treats a bitmap block as not-fitting and the cursor skips it).
     [Fact]
     public void Allocation_CrossesBitmapBlock_AndRoundTrips()
     {
@@ -97,5 +62,30 @@ public class HeapOnNodeAllocationTests : IDisposable
         Assert.True(maxBlk >= 8, $"did not cross bitmap block 8; maxBlk={maxBlk}");
         foreach (var (id, d) in ids)
             Assert.Equal(d, heap.GetHeapItem(id));
+    }
+
+    // Freed space in an existing block must be reused rather than always growing the heap.
+    [Fact]
+    public void Reuse_AfterRemove_DoesNotGrowHeap()
+    {
+        HeapOnNode heap = NewHeap();
+        HeapID a = heap.AddItemToHeap(new byte[3580]);   // block 0
+        heap.AddItemToHeap(new byte[3580]);              // block 0
+        heap.AddItemToHeap(new byte[3580]);              // block 1 (max existing index = 1)
+        heap.RemoveItemFromHeap(a);                      // frees ~3.5 KB in block 0
+        HeapID reused = heap.AddItemToHeap(new byte[3000]);
+        Assert.True(reused.hidBlockIndex <= 1, $"expected reuse of an existing block, got blk={reused.hidBlockIndex}");
+    }
+
+    // A block at the HID-index cap (MaximumHidIndex) must not be reused even though it has free space.
+    [Fact]
+    public void CountCap_FullBlock_NotReused_DespiteSpace()
+    {
+        HeapOnNode heap = NewHeap();
+        HeapID first = heap.AddItemToHeap(new byte[1]);
+        for (int i = 1; i < 2047; i++) heap.AddItemToHeap(new byte[1]);   // block 0 now at HID cap, space remains
+        HeapID overflow = heap.AddItemToHeap(new byte[1]);
+        Assert.Equal(0, first.hidBlockIndex);
+        Assert.NotEqual(first.hidBlockIndex, overflow.hidBlockIndex);
     }
 }

--- a/vendor/PSTFileFormat-MODIFICATIONS.md
+++ b/vendor/PSTFileFormat-MODIFICATIONS.md
@@ -44,11 +44,12 @@ authoritative description of the local PSTFileFormat modifications.
   each, producing a zeroed BTree leaf page with a valid page trailer (ContinuMail, 2026).
 - `Pages/DensityListPage.cs`: added `CreateEmpty` factory, producing the empty Density List page
   that Outlook expects at offset 0x4200 in every store (ContinuMail, 2026).
-- `HeapOnNode.cs`: added a rolling free-space cursor (`m_firstBlockWithPossibleSpace`) so
-  `AddItemToHeap` scans for free space starting from the lowest not-provably-full block instead of
-  block 0, turning per-allocation O(blocks) into O(1) amortized for append-heavy use (fixes the
-  O(n²) growth in `PSTFolder.AddMessage`'s contents-table row index). First-fit placement is
-  unchanged; the cursor advances only past blocks that can fit no item and resets on removal
-  (ContinuMail, 2026).
+- `HeapOnNode.cs`: replaced the linear free-space scan in `AddItemToHeap` with a maintained best-fit
+  free-space index — a `SortedSet<(availableSpace, blockIndex)>` over not-provably-full blocks plus a
+  per-block available-space map, queried in O(log n) and verified against the real block before use,
+  maintained on every heap-item mutation and populated lazily at first allocation. This makes
+  allocation cost independent of block count and item-size mix (fixes the O(n²) growth in
+  `PSTFolder.AddMessage`'s per-row external columns). Allocation placement changes from first-fit to
+  best-fit (valid PSTs; not byte-identical to prior output) (ContinuMail, 2026).
 
 See the project git history (`git log -- vendor/PSTFileFormat`) for the full diffs.

--- a/vendor/PSTFileFormat-MODIFICATIONS.md
+++ b/vendor/PSTFileFormat-MODIFICATIONS.md
@@ -44,5 +44,11 @@ authoritative description of the local PSTFileFormat modifications.
   each, producing a zeroed BTree leaf page with a valid page trailer (ContinuMail, 2026).
 - `Pages/DensityListPage.cs`: added `CreateEmpty` factory, producing the empty Density List page
   that Outlook expects at offset 0x4200 in every store (ContinuMail, 2026).
+- `HeapOnNode.cs`: added a rolling free-space cursor (`m_firstBlockWithPossibleSpace`) so
+  `AddItemToHeap` scans for free space starting from the lowest not-provably-full block instead of
+  block 0, turning per-allocation O(blocks) into O(1) amortized for append-heavy use (fixes the
+  O(n²) growth in `PSTFolder.AddMessage`'s contents-table row index). First-fit placement is
+  unchanged; the cursor advances only past blocks that can fit no item and resets on removal
+  (ContinuMail, 2026).
 
 See the project git history (`git log -- vendor/PSTFileFormat`) for the full diffs.

--- a/vendor/PSTFileFormat/ListsTablesAndProperties/HeapOnNode/HeapOnNode.cs
+++ b/vendor/PSTFileFormat/ListsTablesAndProperties/HeapOnNode/HeapOnNode.cs
@@ -8,7 +8,6 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Text;
 using Utilities;
 
@@ -23,22 +22,48 @@ namespace PSTFileFormat
         private Dictionary<int, HeapOnNodeBlockData> m_buffer = new Dictionary<int,HeapOnNodeBlockData>();
         private List<int> m_blocksToUpdate = new List<int>();
 
-        // Rolling free-space hint: the lowest block index not provably full. Allocation scans from here
-        // instead of 0, turning AddItemToHeap from O(blocks) into O(1) amortized. It only ever advances
-        // past blocks that can fit NO item, so first-fit placement is identical to a scan from 0.
-        private int m_firstBlockWithPossibleSpace = 0;
+        // Test-only: number of candidate-block evaluations during allocation (must stay ~O(items)).
+        internal long ScanIterationsForTest { get; private set; }
+
+        // Free-space index for O(log n) best-fit allocation regardless of item-size mix.
+        // m_freeSpaceIndex holds (availableSpace, blockIndex) for every NOT-provably-full block;
+        // m_blockAvail maps blockIndex -> its recorded availableSpace so the exact tuple can be removed;
+        // m_indexedBlockCount = number of data-tree blocks already passed through ReindexBlock.
+        private readonly SortedSet<(int availableSpace, int blockIndex)> m_freeSpaceIndex = new();
+        private readonly Dictionary<int, int> m_blockAvail = new();
+        private int m_indexedBlockCount = 0;
 
         // EXACT copy of the AddItemToHeap fit predicate (do not change > to >=, do not drop the count cap).
         private bool BlockCanFit(HeapOnNodeBlockData blockData, int itemLength) =>
             blockData.AvailableSpace > itemLength + 2 && blockData.HeapItems.Count < HeapID.MaximumHidIndex;
 
-        // "Provably full" = cannot fit even a 1-byte item. Advancing past such blocks is always safe.
-        private void AdvanceCursorPastProvablyFullBlocks()
+        // Maintain the free-space index for one block after any change to its heap items. A block is in
+        // the index iff it can fit >= a 1-byte item (BlockCanFit(_, 1)); count-full blocks fall out via
+        // the count cap. Bitmap blocks are treated uniformly (their AvailableSpace accounts for the
+        // bitmap header). MUST be called after every UpdateBuffer that changed heap items.
+        private void ReindexBlock(int blockIndex, HeapOnNodeBlockData blockData)
         {
-            while (m_firstBlockWithPossibleSpace < m_dataTree.DataBlockCount &&
-                   !BlockCanFit(GetBlockData(m_firstBlockWithPossibleSpace), 1))
+            if (m_blockAvail.TryGetValue(blockIndex, out int oldAvail))
             {
-                m_firstBlockWithPossibleSpace++;
+                m_freeSpaceIndex.Remove((oldAvail, blockIndex));
+                m_blockAvail.Remove(blockIndex);
+            }
+            if (BlockCanFit(blockData, 1))
+            {
+                int avail = blockData.AvailableSpace;
+                m_freeSpaceIndex.Add((avail, blockIndex));
+                m_blockAvail[blockIndex] = avail;
+            }
+        }
+
+        // Lazily index all existing data-tree blocks before an allocation query. Fresh heap: indexes
+        // block 0 on first allocation. Reopened heap: indexes existing blocks once. Read-only opens
+        // never call AddItemToHeap, so they never pay this and stay lazy.
+        private void EnsureBlocksIndexed()
+        {
+            for (; m_indexedBlockCount < m_dataTree.DataBlockCount; m_indexedBlockCount++)
+            {
+                ReindexBlock(m_indexedBlockCount, GetBlockData(m_indexedBlockCount));
             }
         }
 
@@ -124,33 +149,47 @@ namespace PSTFileFormat
             {
                 return HeapID.EmptyHeapID;
             }
-            
-            // We can use the Header / BitmapHeader to locate available space,
-            // but the final authority is HNPAGEMAP located at the end of each block
-            // Note: we are only required to maintain HNPAGEMAP
-            // Skip the provably-full prefix (amortized O(1) total), then first-fit from the cursor.
-            AdvanceCursorPastProvablyFullBlocks();
-            for (int blockIndex = m_firstBlockWithPossibleSpace; blockIndex < m_dataTree.DataBlockCount; blockIndex ++)
+
+            EnsureBlocksIndexed();
+
+            // Best-fit: smallest availableSpace satisfying BlockCanFit (> len+2  ==>  >= len+3).
+            // Take the view's first element via foreach+break (smallest in range) and only mutate
+            // (ReindexBlock) AFTER the enumerator is disposed — never mutate the set mid-enumeration,
+            // and never read view.Count (it can be O(n)). The loop repeats only on a stale entry.
+            int lowerAvail = itemBytes.Length + 3;
+            while (true)
             {
-                HeapOnNodeBlockData blockData = GetBlockData(blockIndex);
-                // We need space for the item itself and for a place for it in the page map (2 bytes)
-                // We also have to make sure we do not allocate more items then can be represented by hidIndex
+                (int availableSpace, int blockIndex) candidate = default;
+                bool found = false;
+                foreach (var entry in m_freeSpaceIndex.GetViewBetween((lowerAvail, int.MinValue), (int.MaxValue, int.MaxValue)))
+                {
+                    candidate = entry;
+                    found = true;
+                    break;
+                }
+                if (!found)
+                {
+                    break;
+                }
+
+                ScanIterationsForTest++;
+                HeapOnNodeBlockData blockData = GetBlockData(candidate.blockIndex);
                 if (BlockCanFit(blockData, itemBytes.Length))
                 {
                     blockData.HeapItems.Add(itemBytes);
-                    UpdateBuffer(blockIndex, blockData);
-
+                    UpdateBuffer(candidate.blockIndex, blockData);
+                    ReindexBlock(candidate.blockIndex, blockData);
                     // hidIndex is one-based
-                    ushort hidIndex = (ushort)(blockData.HeapItems.Count);
-                    return new HeapID((ushort)blockIndex, hidIndex);
+                    return new HeapID((ushort)candidate.blockIndex, (ushort)blockData.HeapItems.Count);
                 }
+                ReindexBlock(candidate.blockIndex, blockData); // stale entry: correct it, then re-query
             }
 
-            // no space found in existing blocks, we need to allocate new data block
+            // No existing block fits: allocate a new data block. PRESERVE the existing construction
+            // exactly (the % 128 == 8 branch creates a bitmap block; the item is added to whichever
+            // block is created — this implementation places items in bitmap blocks). Then index it.
+            ScanIterationsForTest++; // the "no indexed block fits" decision
             int newBlockIndex = m_dataTree.DataBlockCount;
-            // The leading AdvanceCursor... guarantees every block below the cursor is provably full,
-            // so a new block is only appended after a fully-full prefix.
-            Debug.Assert(m_firstBlockWithPossibleSpace <= newBlockIndex);
             HeapOnNodeBlockData newBlockData;
             if (newBlockIndex % 128 == 8)
             {
@@ -162,6 +201,8 @@ namespace PSTFileFormat
             }
             newBlockData.HeapItems.Add(itemBytes);
             this.DataTree.AddDataBlock(newBlockData.GetBytes());
+            ReindexBlock(newBlockIndex, newBlockData);
+            m_indexedBlockCount = m_dataTree.DataBlockCount; // account for the just-appended block
             // hidIndex is one-based
             return new HeapID((ushort)newBlockIndex, 1);
         }
@@ -169,13 +210,6 @@ namespace PSTFileFormat
         public void RemoveItemFromHeap(HeapID heapID)
         {
             int blockIndex = heapID.hidBlockIndex;
-            // Removal frees space in an earlier block; lower the cursor so it stays discoverable.
-            // Defensive bounds check so the cursor never becomes a second failure mode for a bad id
-            // (the GetBlockData below validates the index for real).
-            if (blockIndex >= 0 && blockIndex < m_dataTree.DataBlockCount)
-            {
-                m_firstBlockWithPossibleSpace = Math.Min(m_firstBlockWithPossibleSpace, blockIndex);
-            }
             HeapOnNodeBlockData blockData = GetBlockData(blockIndex);
             // We can't remove the HeapItem, because then the HeapID of the subsequent items will be incorrect
             // So instead we put an empty item instead of the item we wish to remove.
@@ -185,6 +219,7 @@ namespace PSTFileFormat
             blockData.HeapItems[heapID.hidIndex - 1] = new byte[0];
             CompactBlockData(blockData);
             UpdateBuffer(blockIndex, blockData);
+            ReindexBlock(blockIndex, blockData);
         }
 
         /// <summary>
@@ -202,6 +237,7 @@ namespace PSTFileFormat
             {
                 blockData.HeapItems[heapID.hidIndex - 1] = itemBytes;
                 UpdateBuffer(blockIndex, blockData);
+                ReindexBlock(blockIndex, blockData);
                 return true;
             }
             else

--- a/vendor/PSTFileFormat/ListsTablesAndProperties/HeapOnNode/HeapOnNode.cs
+++ b/vendor/PSTFileFormat/ListsTablesAndProperties/HeapOnNode/HeapOnNode.cs
@@ -8,6 +8,7 @@
  */
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 using Utilities;
 
@@ -21,6 +22,25 @@ namespace PSTFileFormat
 
         private Dictionary<int, HeapOnNodeBlockData> m_buffer = new Dictionary<int,HeapOnNodeBlockData>();
         private List<int> m_blocksToUpdate = new List<int>();
+
+        // Rolling free-space hint: the lowest block index not provably full. Allocation scans from here
+        // instead of 0, turning AddItemToHeap from O(blocks) into O(1) amortized. It only ever advances
+        // past blocks that can fit NO item, so first-fit placement is identical to a scan from 0.
+        private int m_firstBlockWithPossibleSpace = 0;
+
+        // EXACT copy of the AddItemToHeap fit predicate (do not change > to >=, do not drop the count cap).
+        private bool BlockCanFit(HeapOnNodeBlockData blockData, int itemLength) =>
+            blockData.AvailableSpace > itemLength + 2 && blockData.HeapItems.Count < HeapID.MaximumHidIndex;
+
+        // "Provably full" = cannot fit even a 1-byte item. Advancing past such blocks is always safe.
+        private void AdvanceCursorPastProvablyFullBlocks()
+        {
+            while (m_firstBlockWithPossibleSpace < m_dataTree.DataBlockCount &&
+                   !BlockCanFit(GetBlockData(m_firstBlockWithPossibleSpace), 1))
+            {
+                m_firstBlockWithPossibleSpace++;
+            }
+        }
 
         public HeapOnNode(DataTree dataTree)
         {
@@ -108,12 +128,14 @@ namespace PSTFileFormat
             // We can use the Header / BitmapHeader to locate available space,
             // but the final authority is HNPAGEMAP located at the end of each block
             // Note: we are only required to maintain HNPAGEMAP
-            for (int blockIndex = 0; blockIndex < m_dataTree.DataBlockCount; blockIndex ++)
+            // Skip the provably-full prefix (amortized O(1) total), then first-fit from the cursor.
+            AdvanceCursorPastProvablyFullBlocks();
+            for (int blockIndex = m_firstBlockWithPossibleSpace; blockIndex < m_dataTree.DataBlockCount; blockIndex ++)
             {
                 HeapOnNodeBlockData blockData = GetBlockData(blockIndex);
                 // We need space for the item itself and for a place for it in the page map (2 bytes)
                 // We also have to make sure we do not allocate more items then can be represented by hidIndex
-                if (blockData.AvailableSpace > itemBytes.Length + 2 && blockData.HeapItems.Count < HeapID.MaximumHidIndex)
+                if (BlockCanFit(blockData, itemBytes.Length))
                 {
                     blockData.HeapItems.Add(itemBytes);
                     UpdateBuffer(blockIndex, blockData);
@@ -126,6 +148,9 @@ namespace PSTFileFormat
 
             // no space found in existing blocks, we need to allocate new data block
             int newBlockIndex = m_dataTree.DataBlockCount;
+            // The leading AdvanceCursor... guarantees every block below the cursor is provably full,
+            // so a new block is only appended after a fully-full prefix.
+            Debug.Assert(m_firstBlockWithPossibleSpace <= newBlockIndex);
             HeapOnNodeBlockData newBlockData;
             if (newBlockIndex % 128 == 8)
             {
@@ -144,6 +169,13 @@ namespace PSTFileFormat
         public void RemoveItemFromHeap(HeapID heapID)
         {
             int blockIndex = heapID.hidBlockIndex;
+            // Removal frees space in an earlier block; lower the cursor so it stays discoverable.
+            // Defensive bounds check so the cursor never becomes a second failure mode for a bad id
+            // (the GetBlockData below validates the index for real).
+            if (blockIndex >= 0 && blockIndex < m_dataTree.DataBlockCount)
+            {
+                m_firstBlockWithPossibleSpace = Math.Min(m_firstBlockWithPossibleSpace, blockIndex);
+            }
             HeapOnNodeBlockData blockData = GetBlockData(blockIndex);
             // We can't remove the HeapItem, because then the HeapID of the subsequent items will be incorrect
             // So instead we put an empty item instead of the item we wish to remove.


### PR DESCRIPTION
## Problem

Converting a large single folder slowed down progressively: a ~16,000-message folder ran at roughly half the throughput of a small one. Instrumented attribution traced it to `PSTFolder.AddMessage` → `TableContextHelper.CopyProperties` → `NodeStorageHelper.StoreExternalProperty` → `HeapOnNode.AddItemToHeap`, whose **linear free-space scan** grew with the heap's block count. For the contents table's per-row external columns (`PidTagSearchKey`, `PidTagInternetMessageId`), that made adding a message effectively **O(n²)** in the folder's message count.

## Fix

`HeapOnNode.AddItemToHeap` now allocates via a maintained **best-fit free-space index**
(`SortedSet<(availableSpace, blockIndex)>` + a per-block available-space map), queried in O(log n)
and **verified against the real block before use** (the index is an advisory hint — it can never
cause incorrect output, only, in the worst case, a wasted block). The index is maintained on every
heap-item mutation and populated lazily at first allocation.

This supersedes an interim **rolling-cursor** attempt (kept in this branch's history as provenance):
the cursor only skips *provably-full* blocks, which is sufficient for uniform-append heaps but not
for this heap's interleaved small sizes (the gaps it leaves aren't provably full yet can't fit the
next item). The size-aware best-fit index handles the mix. Suggest **rebase-merge** to preserve that
cursor → index narrative for this vendored LGPL component.

## Results (real Gmail corpus)

| metric | before | after |
|---|---|---|
| Indbakke (16k-msg folder) convert | ~70–82 s, 17.7 MB/s | **~40 s, 36.8 MB/s** |
| per-message `AddMessage` cost (4.4k → 16k folder) | 0.79 → 2.38 ms (grows) | **0.42 → 0.44 ms (flat)** |
| large-folder throughput vs small-folder | ~½ | **parity** |

The degradation-with-folder-size is eliminated.

## Validation

- Full suite green (641 engine + 78 integration).
- New regression guard `Allocation_ScanCost_IsLinear_UnderMixedSizes` asserts the heap scan stays linear under the real mixed-size workload (it is RED on the old scan, GREEN on the index).
- Best-fit changes the PST's internal byte layout but **not its validity**: the independent MS-PST reader (`tools/pst-validate`, Microsoft's MIT `outlook-pst`) opens the 1.45 GB output cleanly with all 16,274 messages and zero errors.

## Scope

Confined to the vendored `HeapOnNode.cs` (+ its test, the LGPLv3 modifications ledger, and a CHANGELOG note). The CLI JSON-Lines event contract, `ConversionRunner`, the sidecar, and the desktop app are untouched — the change is entirely below the CLI boundary.