### PR TITLE
feat: PST Engine Phase 2 — attachment streaming + durable-memory measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keeps every message, so unique mail is never dropped.
 
 ### Changed
+- Writer: large attachments (≥ 16 MB) are now written by streaming. A single large attachment
+  previously caused writer-side peak memory to spike to a multiple of its size — the vendored
+  layer materialised the full payload in memory while building the data blocks. The attachment
+  data is now fed through a batched, bounded-residency pipeline, so an arbitrarily large
+  attachment no longer drives the process toward the OOM cliff. Small and medium attachments
+  (< 16 MB) keep the existing `byte[]` path; output is byte-identical and is structure-validated
+  by the independent MS-PST reader (`tools/pst-validate`).
 - Writer: PST files are now built from scratch via `PSTFile.CreateEmptyStore()` instead of
   copying a pre-seeded blank seed file. The blank-seed asset, the seed-extraction helper,
   and the dev-only seed-regeneration tool have been retired; `PstWriter`, `PstPartManager`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Writer: large attachments (≥ 16 MB) are now written by streaming. A single large attachment
   previously caused writer-side peak memory to spike to a multiple of its size — the vendored
   layer materialised the full payload in memory while building the data blocks. The attachment
-  data is now fed through a batched, bounded-residency pipeline, so an arbitrarily large
-  attachment no longer drives the process toward the OOM cliff. Small and medium attachments
-  (< 16 MB) keep the existing `byte[]` path; output is byte-identical and is structure-validated
-  by the independent MS-PST reader (`tools/pst-validate`).
+  data is now fed through a batched, bounded-residency pipeline, so the **writer-side** contribution
+  to peak memory stays bounded regardless of attachment size (verified end-to-end: resident block
+  count stays flat from 9 MB to 512 MB attachments). Small and medium attachments (< 16 MB) keep the
+  existing `byte[]` path; output is byte-identical and is structure-validated by the independent
+  MS-PST reader (`tools/pst-validate`). Note: the mbox parser still materialises one message at a
+  time, so total process memory for a single multi-GB attachment remains parser-bound — removing
+  that end-to-end ceiling is separate, future work.
 - Writer: PST files are now built from scratch via `PSTFile.CreateEmptyStore()` instead of
   copying a pre-seeded blank seed file. The blank-seed asset, the seed-extraction helper,
   and the dev-only seed-regeneration tool have been retired; `PstWriter`, `PstPartManager`,

--- a/src/Mail2Pst.Core/ConversionRunner.cs
+++ b/src/Mail2Pst.Core/ConversionRunner.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Diagnostics;
 using Mail2Pst.Core.Mapping;
 using Mail2Pst.Core.Models;
 using Mail2Pst.Core.Msf;
@@ -30,7 +31,7 @@ public class ConversionRunner
         _writer = new PstWriter(checkIntervalMessages, progressIntervalMessages);
     }
 
-    public ConversionReport Run(ConversionConfig config, string outputDirectory, Action<ConversionProgressEvent>? onProgress = null, CancellationToken cancellationToken = default)
+    public ConversionReport Run(ConversionConfig config, string outputDirectory, Action<ConversionProgressEvent>? onProgress = null, CancellationToken cancellationToken = default, DurableMemoryObserver? memoryObserver = null)
     {
         // Validate the config up front (output names, duplicates, sizes, sources)
         // so problems fail loudly before any output file is created.
@@ -81,7 +82,7 @@ public class ConversionRunner
             foreach (PstOutputPlan plan in plans)
             {
                 IEnumerable<PlannedMessage> plannedMessages = EnumeratePlannedMessages(plan, report, enrichmentOptions, onProgress);
-                List<string> outputFiles = _writer.WritePlan(plan, plannedMessages, outputDirectory, report, total, onProgress, cancellationToken);
+                List<string> outputFiles = _writer.WritePlan(plan, plannedMessages, outputDirectory, report, total, onProgress, cancellationToken, memoryObserver);
                 report.AddOutputFiles(outputFiles);
             }
 

--- a/src/Mail2Pst.Core/Diagnostics/DurableMemoryCollector.cs
+++ b/src/Mail2Pst.Core/Diagnostics/DurableMemoryCollector.cs
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System.Collections.Generic;
+using PSTFileFormat;
+
+namespace Mail2Pst.Core.Diagnostics;
+
+/// <summary>
+/// Walks the live PST writer structures and aggregates the five durable accumulator families (spec §7)
+/// into a DurableMemoryReport. Read-only: it only reads the …ForTest residency snapshots. The folder
+/// traversal (folders -> GetContentsTable() -> Heap -> DataTree) is REQUIRED [R2:M2]: keying only on
+/// PSTFile's public BlockBTree/NodeBTree would miss family #1 (the evictable folder-TC leaves) -> false 0% ratio.
+/// </summary>
+public static class DurableMemoryCollector
+{
+    public static DurableMemoryReport Collect(PSTFile file, IEnumerable<PSTFolder> openFolders, int messagesWritten)
+    {
+        // Family #1: folder contents-table DataTree block buffers (the evictable leaf term).
+        int bbCount = 0; long bbPayload = 0, bbPending = 0, bbEvictable = 0;
+
+        // Family #3 + partial #4: heap decoded-cache + free-space/row-index counts.
+        int heapCount = 0; long heapBytes = 0; int freeIdx = 0, blockAvail = 0, rowIndex = 0;
+
+        foreach (PSTFolder folder in openFolders)
+        {
+            NamedTableContext tc = folder.GetContentsTable();
+            rowIndex += tc.RowCount;
+
+            HeapOnNode heap = tc.Heap;
+            var hr = heap.HeapResidencyForTest();
+            heapCount += hr.bufferCount;
+            heapBytes += hr.decodedBytes;
+            freeIdx   += hr.freeIndexEntries;
+            blockAvail += hr.blockAvailEntries;
+
+            // Family #1: the TC's backing DataTree block buffer (the evictable leaf measure).
+            DataTree dt = tc.DataTree;
+            ulong? rootBid = dt.RootBlock?.BlockID.Value;
+            var dr = dt.BlockBufferResidencyForTest(rootBid);
+            bbCount    += dr.count;
+            bbPayload  += dr.payload;
+            bbPending  += dr.pending;
+            bbEvictable += dr.evictable;
+        }
+
+        // pinned = payload that is neither pending nor evictable; clamp at 0 (pending+evictable
+        // are disjoint subsets of payload by construction, so this never goes negative in practice).
+        long bbPinned = bbPayload - bbPending - bbEvictable;
+        if (bbPinned < 0) bbPinned = 0;
+
+        // Family #2: the two file-level page B-trees (BBT + NBT), always pinned.
+        var bbt = file.BlockBTree.PageBufferResidencyForTest();
+        var nbt = file.NodeBTree.PageBufferResidencyForTest();
+        long pagePinned = bbt.bytes + nbt.bytes;
+        int pageCount = bbt.count + nbt.count;
+        long pagePending = bbt.pending + nbt.pending;
+
+        // Family #5: AMap cache pages + free index, pinned.
+        var amap = file.AMapResidencyForTest();
+
+        var families = new List<FamilyResidency>
+        {
+            new("blockBuffer",               bbCount,                    bbPayload,  bbPending,  bbEvictable,  bbPinned),
+            new("pageBuffer",                pageCount,                  pagePinned, pagePending, 0,           pagePinned),
+            new("heapDecodedCache",          heapCount,                  heapBytes,  0,          0,            heapBytes),
+            new("freeSpaceIndex+rowIndex",   freeIdx + blockAvail + rowIndex, 0,    0,          0,            0),
+            new("amapCache",                 amap.pageCount,             amap.bytes, 0,          0,            amap.bytes),
+        };
+
+        return new DurableMemoryReport(families, file.BaseStream.Length, messagesWritten);
+    }
+}

--- a/src/Mail2Pst.Core/Diagnostics/DurableMemoryCollector.cs
+++ b/src/Mail2Pst.Core/Diagnostics/DurableMemoryCollector.cs
@@ -11,6 +11,8 @@ namespace Mail2Pst.Core.Diagnostics;
 /// into a DurableMemoryReport. Read-only: it only reads the …ForTest residency snapshots. The folder
 /// traversal (folders -> GetContentsTable() -> Heap -> DataTree) is REQUIRED [R2:M2]: keying only on
 /// PSTFile's public BlockBTree/NodeBTree would miss family #1 (the evictable folder-TC leaves) -> false 0% ratio.
+/// Assumes already-materialized folders: GetContentsTable() lazy-loads and caches the contents table, so
+/// call this only on folders the writer has already populated (true at the PstPartManager checkpoint hook).
 /// </summary>
 public static class DurableMemoryCollector
 {
@@ -35,6 +37,8 @@ public static class DurableMemoryCollector
             blockAvail += hr.blockAvailEntries;
 
             // Family #1: the TC's backing DataTree block buffer (the evictable leaf measure).
+            // Deferred: the TC's SubnodeBTree block buffer is not summed here (empty/minimal for
+            // small-to-medium TCs); only the contents-table DataTree is traversed.
             DataTree dt = tc.DataTree;
             ulong? rootBid = dt.RootBlock?.BlockID.Value;
             var dr = dt.BlockBufferResidencyForTest(rootBid);

--- a/src/Mail2Pst.Core/Diagnostics/DurableMemoryCollector.cs
+++ b/src/Mail2Pst.Core/Diagnostics/DurableMemoryCollector.cs
@@ -66,7 +66,7 @@ public static class DurableMemoryCollector
         var families = new List<FamilyResidency>
         {
             new("blockBuffer",               bbCount,                    bbPayload,  bbPending,  bbEvictable,  bbPinned),
-            new("pageBuffer",                pageCount,                  pagePinned, pagePending, 0,           pagePinned),
+            new("pageBuffer",                pageCount,                  pagePinned, pagePending, 0,           pagePinned - pagePending),
             new("heapDecodedCache",          heapCount,                  heapBytes,  0,          0,            heapBytes),
             new("freeSpaceIndex+rowIndex",   freeIdx + blockAvail + rowIndex, 0,    0,          0,            0),
             new("amapCache",                 amap.pageCount,             amap.bytes, 0,          0,            amap.bytes),

--- a/src/Mail2Pst.Core/Diagnostics/DurableMemoryObserver.cs
+++ b/src/Mail2Pst.Core/Diagnostics/DurableMemoryObserver.cs
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+namespace Mail2Pst.Core.Diagnostics;
+
+/// <summary>Opt-in peak-over-time accumulator for durable-memory snapshots taken at write checkpoints.</summary>
+public sealed class DurableMemoryObserver
+{
+    public DurableMemoryReport? Peak { get; private set; }
+
+    public void Observe(DurableMemoryReport report)
+    {
+        if (Peak is null || report.TotalDurableBytes > Peak.TotalDurableBytes)
+            Peak = report;
+    }
+}

--- a/src/Mail2Pst.Core/Diagnostics/DurableMemoryReport.cs
+++ b/src/Mail2Pst.Core/Diagnostics/DurableMemoryReport.cs
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Mail2Pst.Core.Diagnostics;
+
+/// <summary>Per-accumulator-family residency at one snapshot. Bytes are payload (content) bytes;
+/// Evictable = bytes in buffered full leaf DataBlocks that pass the §4 safe-eviction predicate.</summary>
+public readonly record struct FamilyResidency(
+    string Family, int InstanceCount, long PayloadBytes, long PendingBytes, long EvictableBytes, long PinnedBytes);
+
+/// <summary>Aggregate durable-memory snapshot for one PST part at one checkpoint (spec §7).
+/// Measurement-only: classifies the residual; it does not bound memory.</summary>
+public sealed record DurableMemoryReport(
+    IReadOnlyList<FamilyResidency> Families, long FileLengthBytes, int MessagesWritten)
+{
+    /// <summary>Acceptance ratio threshold [A5]: below this, the soft budget cannot be sold as a bound.</summary>
+    public const double EvictableDominantThreshold = 0.50;
+
+    public long TotalDurableBytes => Families.Sum(f => f.PayloadBytes);
+    public long EvictableBytes => Families.Sum(f => f.EvictableBytes);
+
+    public double EvictableRatio =>
+        TotalDurableBytes == 0 ? 0.0 : (double)EvictableBytes / TotalDurableBytes;
+
+    /// <summary>Decision-rule classification (§7): only "evictable-leaf-dominant" warrants a follow-up prune spec.</summary>
+    public string Classification =>
+        EvictableRatio >= EvictableDominantThreshold ? "evictable-leaf-dominant" : "pinned-dominant";
+}

--- a/src/Mail2Pst.Core/Diagnostics/DurableMemoryReportWriter.cs
+++ b/src/Mail2Pst.Core/Diagnostics/DurableMemoryReportWriter.cs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System.Text;
+using System.Text.Json;
+
+namespace Mail2Pst.Core.Diagnostics;
+
+/// <summary>Serializes a durable-memory report to JSON (machine) and a short text summary (human).</summary>
+public static class DurableMemoryReportWriter
+{
+    public static string ToJson(DurableMemoryReport r)
+    {
+        var doc = new
+        {
+            messagesWritten = r.MessagesWritten,
+            fileLengthBytes = r.FileLengthBytes,
+            totalDurableBytes = r.TotalDurableBytes,
+            evictableBytes = r.EvictableBytes,
+            evictableRatio = r.EvictableRatio,
+            classification = r.Classification,
+            families = r.Families,
+        };
+        return JsonSerializer.Serialize(doc, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    public static string ToSummary(DurableMemoryReport r)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Durable memory @ {r.MessagesWritten} msgs / file {r.FileLengthBytes:N0} B");
+        sb.AppendLine($"  totalDurable={r.TotalDurableBytes:N0} B  evictable={r.EvictableBytes:N0} B  evictableRatio={r.EvictableRatio:P1}");
+        sb.AppendLine($"  classification={r.Classification}");
+        foreach (var f in r.Families)
+            sb.AppendLine($"    {f.Family}: n={f.InstanceCount} payload={f.PayloadBytes:N0} pending={f.PendingBytes:N0} evictable={f.EvictableBytes:N0} pinned={f.PinnedBytes:N0}");
+        return sb.ToString();
+    }
+}

--- a/src/Mail2Pst.Core/Models/AttachmentContent.cs
+++ b/src/Mail2Pst.Core/Models/AttachmentContent.cs
@@ -41,6 +41,22 @@ public sealed class AttachmentContent : IDisposable
         return _bytes ?? File.ReadAllBytes(_tempPath!);
     }
 
+    /// <summary>
+    /// Opens a readable, seekable stream over the content WITHOUT materializing it: a MemoryStream
+    /// wrapping the existing byte[] (no copy) for in-memory content, or a FileStream over the temp file
+    /// (no read). The caller owns + disposes the returned stream. Enables streaming attachment writes
+    /// so a large attachment is never copied into a writer-side byte[].
+    /// </summary>
+    public Stream OpenRead()
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(AttachmentContent));
+        if (_bytes is not null)
+        {
+            return new MemoryStream(_bytes, writable: false);
+        }
+        return new FileStream(_tempPath!, FileMode.Open, FileAccess.Read, FileShare.Read);
+    }
+
     public void Dispose()
     {
         if (_disposed) return;

--- a/src/Mail2Pst.Core/Writing/PstPartManager.cs
+++ b/src/Mail2Pst.Core/Writing/PstPartManager.cs
@@ -152,6 +152,14 @@ internal sealed class PstPartManager
 
     public void DeleteCurrentPart() => TryDeletePart(_currentPath);
 
+    /// <summary>Measurement-only [§7]: aggregate this part's durable-memory residency from live state.</summary>
+    internal Mail2Pst.Core.Diagnostics.DurableMemoryReport SnapshotDurableMemory(int messagesWritten)
+    {
+        if (_file is null) return new Mail2Pst.Core.Diagnostics.DurableMemoryReport(
+            System.Array.Empty<Mail2Pst.Core.Diagnostics.FamilyResidency>(), 0, messagesWritten);
+        return Mail2Pst.Core.Diagnostics.DurableMemoryCollector.Collect(_file, _folders.Values, messagesWritten);
+    }
+
     // Closes the current (already-flushed) part and opens the next. PRECONDITION: the
     // caller has just flushed (EndSavingChanges). Once the old part is closed it is COMPLETE,
     // so _currentPath is cleared until the next part opens: if creating the next part throws,

--- a/src/Mail2Pst.Core/Writing/PstWriter.cs
+++ b/src/Mail2Pst.Core/Writing/PstWriter.cs
@@ -31,6 +31,18 @@ namespace Mail2Pst.Core.Writing;
 /// </summary>
 public class PstWriter
 {
+    // [M1] attachments below this never stream — the OOM is a hundreds-of-MB phenomenon (spec §1).
+    // internal (not const) so tests can lower it; production default is 16 MB.
+    internal long StreamingThresholdBytes = 16L * 1024 * 1024;
+
+    // [L4] kill-switch: env var (read once on first use) forces the byte[] path for ALL attachments.
+    private readonly bool _attachmentStreamingDisabled =
+        Environment.GetEnvironmentVariable("MAIL2PST_NO_ATTACH_STREAM") is { Length: > 0 };
+
+    // Set at the top of WritePlan so instance methods WriteMessage/WriteAttachment can pass it
+    // to SetExternalProperty without threading it through every call signature.
+    private CancellationToken _activeCancellationToken;
+
     // Number of successfully-written messages between on-disk size checks.
     private readonly int _checkIntervalMessages;
 
@@ -64,6 +76,7 @@ public class PstWriter
     {
         // Pre-flight: if already cancelled, create nothing so DeletedFiles stays empty.
         cancellationToken.ThrowIfCancellationRequested();
+        _activeCancellationToken = cancellationToken;
 
         var partManager = new PstPartManager(
             plan.Name, outputDirectory, plan.MaxSizeBytes, _checkIntervalMessages, WriteMessageCore);
@@ -378,7 +391,7 @@ public class PstWriter
 
     internal static bool AttachmentTooLarge(long contentLength) => contentLength > MaxAttachmentBytes;
 
-    private static void WriteMessage(PSTFile file, PSTFolder folder, MailMessage message)
+    private void WriteMessage(PSTFile file, PSTFolder folder, MailMessage message)
     {
         // Pre-flight: reject a message carrying an unrepresentable attachment BEFORE creating
         // any node, so an oversized attachment becomes a clean per-message skip rather than a
@@ -504,7 +517,7 @@ public class PstWriter
         // a folder's whole contents table per message is ~O(n^2); batching is the E3 perf win.
     }
 
-    private static void WriteAttachment(PSTFile file, Note note, MailAttachment a)
+    private void WriteAttachment(PSTFile file, Note note, MailAttachment a)
     {
         note.CreateSubnodeBTreeIfNotExist();
         AttachmentObject attachment = AttachmentObject.CreateNewAttachmentObject(file, note.SubnodeBTree);
@@ -515,7 +528,21 @@ public class PstWriter
         attachment.PC.SetStringProperty(PropertyID.PidTagAttachExtension, Path.GetExtension(a.FileName));
         attachment.PC.SetStringProperty(PropertyID.PidTagAttachMimeTag, a.MimeType);
         attachment.PC.SetInt32Property(PropertyID.PidTagAttachMethod, (int)AttachMethod.ByValue);
-        attachment.PC.SetBytesProperty(PropertyID.PidTagAttachData, a.Content.ReadAllBytes());
+        // [M1] Only large attachments stream; small/medium keep the proven byte[] path (zero memory
+        // benefit below tens of MB). [A9] streaming requires NDB_CRYPT_PERMUTE. [L4] kill-switch.
+        bool canStream = a.Content.Length >= StreamingThresholdBytes
+            && file.Header.bCryptMethod == bCryptMethodName.NDB_CRYPT_PERMUTE
+            && !_attachmentStreamingDisabled;
+        if (canStream)
+        {
+            using Stream attachStream = a.Content.OpenRead();   // [R2:H2] closed before finally deletes the temp file
+            attachment.PC.SetExternalProperty(PropertyID.PidTagAttachData, PropertyTypeName.PtypBinary,
+                attachStream, a.Content.Length, _activeCancellationToken);
+        }
+        else
+        {
+            attachment.PC.SetBytesProperty(PropertyID.PidTagAttachData, a.Content.ReadAllBytes());   // small/medium or non-PERMUTE
+        }
         attachment.PC.SetInt32Property(PropertyID.PidTagAttachSize, (int)a.Content.Length);
 
         if (!string.IsNullOrEmpty(a.ContentId))

--- a/src/Mail2Pst.Core/Writing/PstWriter.cs
+++ b/src/Mail2Pst.Core/Writing/PstWriter.cs
@@ -15,6 +15,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Mail2Pst.Core;
 using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Diagnostics;
 using Mail2Pst.Core.Mapping;
 using Mail2Pst.Core.Models;
 using Mail2Pst.Core.Progress;
@@ -59,7 +60,7 @@ public class PstWriter
         _progressIntervalMessages = progressIntervalMessages;
     }
 
-    public List<string> WritePlan(PstOutputPlan plan, IEnumerable<PlannedMessage> messages, string outputDirectory, ConversionReport report, int totalMessages = -1, Action<ConversionProgressEvent>? onProgress = null, CancellationToken cancellationToken = default)
+    public List<string> WritePlan(PstOutputPlan plan, IEnumerable<PlannedMessage> messages, string outputDirectory, ConversionReport report, int totalMessages = -1, Action<ConversionProgressEvent>? onProgress = null, CancellationToken cancellationToken = default, DurableMemoryObserver? memoryObserver = null)
     {
         // Pre-flight: if already cancelled, create nothing so DeletedFiles stays empty.
         cancellationToken.ThrowIfCancellationRequested();
@@ -154,6 +155,7 @@ public class PstWriter
                 if (partManager.CheckpointDue)
                 {
                     partManager.Flush();
+                    memoryObserver?.Observe(partManager.SnapshotDurableMemory(report.ConvertedCount));
                     throttler.Emit(report, currentSource, currentFolder, estimatedOutputBytes);
                     partManager.TrySplitOrResumeAfterFlush();   // both branches leave the part write-ready
                 }

--- a/src/Mail2Pst.Core/Writing/PstWriter.cs
+++ b/src/Mail2Pst.Core/Writing/PstWriter.cs
@@ -39,8 +39,11 @@ public class PstWriter
     private readonly bool _attachmentStreamingDisabled =
         Environment.GetEnvironmentVariable("MAIL2PST_NO_ATTACH_STREAM") is { Length: > 0 };
 
-    // Set at the top of WritePlan so instance methods WriteMessage/WriteAttachment can pass it
-    // to SetExternalProperty without threading it through every call signature.
+    // Holds the active WritePlan's cancellation token so the streaming attachment write (WriteAttachment ->
+    // SetExternalProperty(Stream)) can honor it without threading a token through the token-less write delegate.
+    // INVARIANT: set at the top of WritePlan and read only on that same WritePlan's (sequential) consumer thread.
+    // ConversionRunner runs WritePlan calls sequentially, so this is single-active. REVISIT before any
+    // multi-output / parallel WritePlan work — concurrent WritePlan calls on one PstWriter would race this field.
     private CancellationToken _activeCancellationToken;
 
     // Number of successfully-written messages between on-disk size checks.

--- a/tests/Mail2Pst.Core.Tests/Diagnostics/DurableMemoryCollectorTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Diagnostics/DurableMemoryCollectorTests.cs
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Diagnostics;
+using PSTFileFormat;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Mail2Pst.Core.Tests.Diagnostics;
+
+public class DurableMemoryCollectorTests : IDisposable
+{
+    private readonly string _path = Path.Combine(Path.GetTempPath(), $"m2p-collect-{Guid.NewGuid():N}.pst");
+    private global::PSTFileFormat.PSTFile? _file;
+    private readonly ITestOutputHelper _out;
+
+    public DurableMemoryCollectorTests(ITestOutputHelper output) { _out = output; }
+
+    public void Dispose()
+    {
+        try { _file?.CloseFile(); } catch { }
+        try { File.Delete(_path); } catch { }
+    }
+
+    [Fact]
+    public void Collect_OnStoreWithMessages_ReportsAllFiveFamilies_RatioInRange()
+    {
+        // Build a live store with 50 messages in a folder — mirrors exactly how PstWriter operates.
+        global::PSTFileFormat.PSTFile.CreateEmptyStore(_path);
+        _file = new global::PSTFileFormat.PSTFile(_path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+        _file.BeginSavingChanges();
+
+        // API: use TopOfPersonalFolders (not GetRootFolder — that's the internal root node).
+        // CreateChildFolder(name, FolderItemTypeName) is the correct overload (per CLAUDE.md gotcha).
+        PSTFolder folder = _file.TopOfPersonalFolders.CreateChildFolder("M", FolderItemTypeName.Note);
+
+        for (int i = 0; i < 50; i++)
+        {
+            // Note.CreateNewNote requires (file, parentNodeID) — the brief's single-arg form does not exist.
+            Note note = Note.CreateNewNote(_file, folder.NodeID);
+            note.Subject = "msg " + i;
+            folder.AddMessage(note);
+        }
+        folder.SaveChanges();
+
+        DurableMemoryReport r = DurableMemoryCollector.Collect(_file, new[] { folder }, messagesWritten: 50);
+
+        // All five families must be present.
+        Assert.Equal(5, r.Families.Select(f => f.Family).Distinct().Count());
+        Assert.True(r.TotalDurableBytes > 0);
+        Assert.InRange(r.EvictableRatio, 0.0, 1.0);
+        Assert.Contains(r.Classification, new[] { "evictable-leaf-dominant", "pinned-dominant" });
+
+        // [R2:M2] proof: the folder-TC traversal must reach the contents-table block buffer.
+        // If blockBuffer PayloadBytes == 0 the traversal is broken (family #1 would be missing
+        // or empty) and the evictable ratio would be falsely 0%.
+        FamilyResidency bb = r.Families.Single(f => f.Family == "blockBuffer");
+        Assert.True(bb.PayloadBytes > 0,
+            $"blockBuffer PayloadBytes is 0 — folder-TC traversal did not reach the DataTree block buffer. " +
+            $"Full report: [{string.Join(", ", r.Families.Select(f => $"{f.Family}:{f.PayloadBytes}B"))}]");
+
+        // Family #5 (amapCache): assert present. Do NOT require non-zero here — the unit test
+        // is mid-BeginSavingChanges and AMapCache may only populate at EndSavingChanges.
+        // The observed values are recorded in task-5-report.md for comparison with the Task 7
+        // real run (post-checkpoint Flush/EndSavingChanges).
+        FamilyResidency amap = r.Families.Single(f => f.Family == "amapCache");
+        Assert.NotNull(amap.Family); // present (the Single above would throw if missing)
+        // Emit observed values to test output for report recording.
+        _out.WriteLine("=== DurableMemoryCollector observed values ===");
+        foreach (var f in r.Families)
+            _out.WriteLine($"  {f.Family}: instances={f.InstanceCount} payload={f.PayloadBytes}B pending={f.PendingBytes}B evictable={f.EvictableBytes}B pinned={f.PinnedBytes}B");
+        _out.WriteLine($"  TotalDurableBytes={r.TotalDurableBytes} EvictableRatio={r.EvictableRatio:F4} Classification={r.Classification}");
+        _out.WriteLine($"  [report] blockBuffer.PayloadBytes={bb.PayloadBytes}  amapCache.InstanceCount={amap.InstanceCount}  amapCache.PayloadBytes={amap.PayloadBytes}");
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Diagnostics/DurableMemoryObserverTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Diagnostics/DurableMemoryObserverTests.cs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System.Collections.Generic;
+using Mail2Pst.Core.Diagnostics;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Diagnostics;
+
+public class DurableMemoryObserverTests
+{
+    private static DurableMemoryReport R(long payload) => new DurableMemoryReport(
+        new[] { new FamilyResidency("blockBuffer", 1, payload, 0, payload / 2, payload / 2) }, 0, 0);
+
+    [Fact]
+    public void Observer_KeepsThePeakReport()
+    {
+        var obs = new DurableMemoryObserver();
+        obs.Observe(R(100));
+        obs.Observe(R(900));        // peak
+        obs.Observe(R(300));
+        Assert.NotNull(obs.Peak);
+        Assert.Equal(900, obs.Peak!.TotalDurableBytes);
+    }
+
+    [Fact]
+    public void ReportWriter_EmitsRatioAndClassification()
+    {
+        string summary = DurableMemoryReportWriter.ToSummary(R(1000));
+        Assert.Contains("evictableRatio", summary, System.StringComparison.OrdinalIgnoreCase);
+        string json = DurableMemoryReportWriter.ToJson(R(1000));
+        Assert.Contains("\"classification\"", json);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Diagnostics/DurableMemoryReportTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Diagnostics/DurableMemoryReportTests.cs
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Collections.Generic;
+using Mail2Pst.Core.Diagnostics;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Diagnostics;
+
+public class DurableMemoryReportTests
+{
+    private static DurableMemoryReport Report(params FamilyResidency[] f) =>
+        new DurableMemoryReport(f, FileLengthBytes: 1_000_000, MessagesWritten: 500);
+
+    [Fact]
+    public void TotalsAndRatio_SumAcrossFamilies()
+    {
+        var r = Report(
+            new FamilyResidency("blockBuffer", 3, PayloadBytes: 800, PendingBytes: 100, EvictableBytes: 600, PinnedBytes: 100),
+            new FamilyResidency("pageBuffer", 2, PayloadBytes: 200, PendingBytes: 0, EvictableBytes: 0, PinnedBytes: 200));
+        Assert.Equal(1000, r.TotalDurableBytes);           // 800 + 200 payload
+        Assert.Equal(600, r.EvictableBytes);
+        Assert.Equal(0.60, r.EvictableRatio, 3);
+    }
+
+    [Fact]
+    public void Classification_EvictableLeafDominant_WhenRatioAtOrAboveHalf()
+    {
+        var r = Report(new FamilyResidency("blockBuffer", 1, 1000, 0, 600, 400));
+        Assert.Equal("evictable-leaf-dominant", r.Classification);   // >= 0.50 -> warrants follow-up prune spec
+    }
+
+    [Fact]
+    public void Classification_PinnedDominant_WhenRatioBelowHalf()
+    {
+        var r = Report(new FamilyResidency("pageBuffer", 1, 1000, 0, 100, 900));
+        Assert.Equal("pinned-dominant", r.Classification);           // < 0.50 -> ship as measured residual, no prune
+    }
+
+    [Fact]
+    public void EvictableRatio_ZeroDurableBytes_IsZeroNotNaN()
+    {
+        var r = Report(new FamilyResidency("blockBuffer", 0, 0, 0, 0, 0));
+        Assert.Equal(0.0, r.EvictableRatio, 3);
+        Assert.Equal("pinned-dominant", r.Classification);           // no evictable term -> not prune-warranted
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Models/AttachmentContentTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Models/AttachmentContentTests.cs
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+#nullable enable
 using System;
 using System.IO;
 using Mail2Pst.Core.Models;
@@ -107,5 +107,34 @@ public class AttachmentContentTests
         {
             if (File.Exists(path)) File.Delete(path);
         }
+    }
+
+    [Fact]
+    public void OpenRead_BytesBacked_StreamsExactContent_LengthMatches()
+    {
+        byte[] data = { 1, 2, 3, 4, 5 };
+        using var c = AttachmentContent.FromBytes(data);
+        using Stream s = c.OpenRead();
+        Assert.Equal(data.Length, c.Length);
+        var ms = new MemoryStream();
+        s.CopyTo(ms);
+        Assert.Equal(data, ms.ToArray());
+    }
+
+    [Fact]
+    public void OpenRead_TempFileBacked_StreamsFileContent_WithoutPreReading()
+    {
+        string path = Path.Combine(Path.GetTempPath(), "m2p-att-" + System.Guid.NewGuid().ToString("N"));
+        byte[] data = { 9, 8, 7, 6 };
+        File.WriteAllBytes(path, data);
+        try
+        {
+            using var c = AttachmentContent.FromTempFile(path, data.Length);
+            using Stream s = c.OpenRead();
+            var ms = new MemoryStream();
+            s.CopyTo(ms);
+            Assert.Equal(data, ms.ToArray());
+        }
+        finally { File.Delete(path); }
     }
 }

--- a/tests/Mail2Pst.Core.Tests/PSTFileFormat/BufferedBTreePageStoreResidencyTests.cs
+++ b/tests/Mail2Pst.Core.Tests/PSTFileFormat/BufferedBTreePageStoreResidencyTests.cs
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using PSTFileFormat;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.PSTFileFormat;
+
+public class BufferedBTreePageStoreResidencyTests : IDisposable
+{
+    private readonly string _path = Path.Combine(Path.GetTempPath(), $"m2p-page-{Guid.NewGuid():N}.pst");
+    private global::PSTFileFormat.PSTFile? _file;
+    public void Dispose() { try { _file?.CloseFile(); } catch { } try { File.Delete(_path); } catch { } }
+
+    [Fact]
+    public void PageResidency_OnFreshStore_BlockBtreeHasPages_Bytes512Each()
+    {
+        global::PSTFileFormat.PSTFile.CreateEmptyStore(_path);
+        _file = new global::PSTFileFormat.PSTFile(_path, FileAccess.Read, WriterCompatibilityMode.Outlook2007RTM);
+        // Touch the BBT so at least its root page is buffered.
+        Assert.NotNull(_file.BlockBTree);
+        var (count, bytes, _) = _file.BlockBTree.PageBufferResidencyForTest();
+        Assert.True(count >= 0);
+        Assert.Equal(count * 512L, bytes);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/PSTFileFormat/BufferedBlockStoreResidencyTests.cs
+++ b/tests/Mail2Pst.Core.Tests/PSTFileFormat/BufferedBlockStoreResidencyTests.cs
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using PSTFileFormat;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.PSTFileFormat;
+
+public class BufferedBlockStoreResidencyTests : IDisposable
+{
+    private readonly string _path = Path.Combine(Path.GetTempPath(), $"m2p-resid-{Guid.NewGuid():N}.pst");
+    private global::PSTFileFormat.PSTFile? _file;
+
+    private global::PSTFileFormat.PSTFile NewStore()
+    {
+        global::PSTFileFormat.PSTFile.CreateEmptyStore(_path);
+        _file = new global::PSTFileFormat.PSTFile(_path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+        _file.BeginSavingChanges();
+        return _file;
+    }
+
+    public void Dispose() { try { _file?.CloseFile(); } catch { } try { File.Delete(_path); } catch { } }
+
+    [Fact]
+    public void Residency_AfterPersist_CountsFullLeavesAsEvictable_TailAndRootExcluded()
+    {
+        var file = NewStore();
+        var tree = new DataTree(file);
+        byte[] payload = new byte[40_000];                       // ~5 leaves + XBlock spine
+        for (int i = 0; i < payload.Length; i++) payload[i] = (byte)(i * 31 & 0xFF);
+        tree.AppendData(payload);
+        int count = tree.DataBlockCount;
+        var fullLeaves = new System.Collections.Generic.List<ulong>();
+        for (int i = 0; i < count - 1; i++) fullLeaves.Add(tree.GetDataBlock(i).BlockID.Value);
+        tree.PersistLeafBlocks(fullLeaves);                       // full leaves -> BBT-indexed, not pending
+
+        ulong rootBid = tree.RootBlock.BlockID.Value;
+        var (bufCount, payloadBytes, pending, evictable) = tree.BlockBufferResidencyForTest(rootBid);
+
+        Assert.True(bufCount >= count);                           // leaves + spine resident
+        Assert.True(payloadBytes >= 40_000);                     // at least the content bytes
+        Assert.True(evictable > 0);                              // the persisted full leaves
+        Assert.True(pending > 0);                                // the partial tail + spine still pending
+        // The spine (XBlock root) is never evictable even though it may be BBT-indexed later.
+        Assert.True(evictable <= payloadBytes);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/PSTFileFormat/BufferedBlockStoreResidencyTests.cs
+++ b/tests/Mail2Pst.Core.Tests/PSTFileFormat/BufferedBlockStoreResidencyTests.cs
@@ -46,4 +46,50 @@ public class BufferedBlockStoreResidencyTests : IDisposable
         // The spine (XBlock root) is never evictable even though it may be BBT-indexed later.
         Assert.True(evictable <= payloadBytes);
     }
+
+    // Scenario A — falsifies the `!isPending` guard (and that a full leaf can be pending).
+    // 16,352 B = 2 x 8176 -> two FULL data leaves under an XBlock spine. Nothing persisted,
+    // so the full leaves are still pending: they must count as pending, NEVER evictable.
+    [Fact]
+    public void Residency_FullButPendingLeaves_CountedAsPending_NotEvictable()
+    {
+        var file = NewStore();
+        var tree = new DataTree(file);
+        byte[] payload = new byte[16_352];                       // exactly 2 full leaves
+        for (int i = 0; i < payload.Length; i++) payload[i] = (byte)(i * 31 & 0xFF);
+        tree.AppendData(payload);                                 // no PersistLeafBlocks / SaveChanges
+
+        Assert.Equal(2, tree.DataBlockCount);                     // two leaves
+        var (_, payloadBytes, pending, evictable) = tree.BlockBufferResidencyForTest(tree.RootBlock.BlockID.Value);
+
+        Assert.True(payloadBytes >= 16_352);                     // both leaves resident
+        Assert.True(pending > 0);                                // the full leaves are pending
+        Assert.Equal(0, evictable);                              // pending => excluded from evictable
+    }
+
+    // Scenario B — falsifies the `!isRoot` guard. 8176 B -> a single FULL DataBlock that is
+    // itself the root (no XBlock). After SaveChanges it is BBT-indexed and not pending, so it
+    // satisfies isFullLeaf && bbtIndexed && !isPending — it is excluded SOLELY because it is the root.
+    [Fact]
+    public void Residency_FullBbtIndexedRoot_ExcludedByRootGuardOnly()
+    {
+        var file = NewStore();
+        var tree = new DataTree(file);
+        byte[] payload = new byte[8_176];                        // exactly one full leaf == the root
+        for (int i = 0; i < payload.Length; i++) payload[i] = (byte)(i * 31 & 0xFF);
+        tree.AppendData(payload);
+        Assert.Equal(1, tree.DataBlockCount);                    // single-DataBlock root, no XBlock
+        tree.SaveChanges();                                      // root -> BBT-indexed, not pending
+
+        ulong rootBid = tree.RootBlock.BlockID.Value;
+
+        var withRoot = tree.BlockBufferResidencyForTest(rootBid);
+        Assert.Equal(0, withRoot.pending);                       // persisted -> nothing pending
+        Assert.Equal(0, withRoot.evictable);                     // excluded solely by !isRoot
+
+        // Sanity: with no root context the SAME block IS counted evictable, proving the only
+        // disqualifier above was the root guard (it is a full, BBT-indexed, non-pending DataBlock).
+        var noRoot = tree.BlockBufferResidencyForTest(null);
+        Assert.True(noRoot.evictable > 0);
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/PSTFileFormat/DataTreeStreamingSpikeTests.cs
+++ b/tests/Mail2Pst.Core.Tests/PSTFileFormat/DataTreeStreamingSpikeTests.cs
@@ -174,20 +174,27 @@ public class DataTreeStreamingSpikeTests : IDisposable
         }
     }
 
-    [Fact]
-    public void StreamAppend_KeepsBufferBounded_IndependentOfAttachmentSize()  // peak-memory intent
+    // Extended in Task 6 to three sizes (9 / 18 / 36 MB) to prove the post-drain residency is
+    // constant across sizes — not just a single-point check. The existing 9 MB case is kept
+    // so the Theory is a strict superset of the former Fact.
+    [Theory]
+    [InlineData(9_000_000)]    // ~1100 leaves — XXBlock territory (original single-Fact coverage)
+    [InlineData(18_000_000)]   // ~2200 leaves — 2× size: buffer must stay constant, not scale with size
+    [InlineData(36_000_000)]   // ~4400 leaves — 4× size: confirms O(1) post-drain residency at scale
+    public void StreamAppend_KeepsBufferBounded_IndependentOfAttachmentSize(int length)  // peak-memory intent
     {
         var file = NewStore();
         var tree = new DataTree(file);
-        using (var src = new MemoryStream(MakeBytes(9_000_000, 1), writable: false))
+        using (var src = new MemoryStream(MakeBytes(length, 1), writable: false))
         {
-            tree.AppendData(src, 9_000_000);
+            tree.AppendData(src, length);
         }
-        // ~1100 leaves written; after AppendData's final drain only tail + preceding + spine (~5) remain
-        // resident, independent of attachment size. (Mid-stream PEAK is ~one 8 MB batch of leaves — the
-        // bounded "+ batch" term in spec §1; this end-state check proves the drain reclaims it.) [R3:F1]
+        // After AppendData's final drain only tail + preceding + spine (~5) remain resident,
+        // independent of attachment size. (Mid-stream PEAK is ~one 8 MB batch of leaves — the
+        // bounded "+ batch" term in spec §1; this end-state check proves the drain reclaims it
+        // across all three sizes.) [R3:F1]
         Assert.True(tree.BufferedBlockCountForTest < 16,
-            $"buffer not bounded after drain: {tree.BufferedBlockCountForTest} resident blocks");
+            $"buffer not bounded after drain: {tree.BufferedBlockCountForTest} resident blocks (length={length})");
     }
 
     [Fact]

--- a/tests/Mail2Pst.Core.Tests/PSTFileFormat/DataTreeStreamingSpikeTests.cs
+++ b/tests/Mail2Pst.Core.Tests/PSTFileFormat/DataTreeStreamingSpikeTests.cs
@@ -191,6 +191,24 @@ public class DataTreeStreamingSpikeTests : IDisposable
     }
 
     [Fact]
+    public void Streaming_DoesNotReallocateSpine_AcrossManyBatches()  // [A2]
+    {
+        var file = NewStore();
+        var tree = new DataTree(file);
+        long before = tree.BlockReallocationsForTest;
+
+        using (var src = new MemoryStream(MakeBytes(9_000_000, 13), writable: false))
+        {
+            tree.AppendData(src, 9_000_000);            // many 8 MB-batch boundaries
+        }
+        long spineReallocs = tree.BlockReallocationsForTest - before;
+
+        // In-place spine updates only. A small constant (initial DataBlock->XBlock->XXBlock promotions)
+        // is fine; growth proportional to batch count is the failure mode.
+        Assert.True(spineReallocs < 16, $"spine reallocated {spineReallocs} times — superlinear churn");
+    }
+
+    [Fact]
     public void EveryPersistedInteriorLeaf_IsFull8176_NoPartialInteriorBlock()  // [R2:M4] — round-trip alone is vacuous
     {
         var file = NewStore();

--- a/tests/Mail2Pst.Core.Tests/PSTFileFormat/DataTreeStreamingSpikeTests.cs
+++ b/tests/Mail2Pst.Core.Tests/PSTFileFormat/DataTreeStreamingSpikeTests.cs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+using System;
+using System.IO;
+using System.Linq;
+using PSTFileFormat;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.PSTFileFormat;
+
+// Gating spike for Phase-2 attachment streaming (spec §8). Fail-closed: any tripped assertion
+// means Target A needs a different design. Operates at the DataTree level inside one
+// BeginSavingChanges() window; the round-trip test (Task 4) closes the loop via reopen.
+public class DataTreeStreamingSpikeTests : IDisposable
+{
+    private readonly string _path = Path.Combine(Path.GetTempPath(), $"m2p-spike-{Guid.NewGuid():N}.pst");
+    private global::PSTFileFormat.PSTFile? _file;
+
+    private global::PSTFileFormat.PSTFile NewStore()
+    {
+        global::PSTFileFormat.PSTFile.CreateEmptyStore(_path);
+        _file = new global::PSTFileFormat.PSTFile(_path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+        _file.BeginSavingChanges();
+        return _file;
+    }
+
+    // Deterministic, position-dependent bytes so a misplaced block fails the round-trip.
+    internal static byte[] MakeBytes(int length, int seed)
+    {
+        byte[] b = new byte[length];
+        for (int i = 0; i < length; i++) b[i] = (byte)((i * 31 + seed) & 0xFF);
+        return b;
+    }
+
+    public void Dispose() { try { _file?.CloseFile(); } catch { } try { File.Delete(_path); } catch { } }
+
+    [Fact]
+    public void IncrementalPersist_LeafIsBbtIndexedAndReadable_BeforeTransactionCommit()
+    {
+        var file = NewStore();
+        var tree = new DataTree(file);
+        // >8176 B forces DataBlock -> XBlock (at least two leaves + a spine).
+        byte[] payload = MakeBytes(20_000, 1);
+        tree.AppendData(payload);
+
+        ulong leaf0 = tree.GetDataBlock(0).BlockID.Value;
+
+        // Persist within the window (existing primitive); BBT entry is inserted in-memory.
+        tree.SaveChanges();
+
+        Assert.NotNull(file.FindBlockEntryByBlockID(leaf0));     // BBT-indexed in-memory
+        Assert.Equal(payload, tree.GetData());                  // re-readable, no EndSavingChanges yet
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/PSTFileFormat/DataTreeStreamingSpikeTests.cs
+++ b/tests/Mail2Pst.Core.Tests/PSTFileFormat/DataTreeStreamingSpikeTests.cs
@@ -52,4 +52,42 @@ public class DataTreeStreamingSpikeTests : IDisposable
         Assert.NotNull(file.FindBlockEntryByBlockID(leaf0));     // BBT-indexed in-memory
         Assert.Equal(payload, tree.GetData());                  // re-readable, no EndSavingChanges yet
     }
+
+    [Fact]
+    public void StreamingFlush_KeepsSpinePending_NoReallocationAcrossBatches()
+    {
+        var file = NewStore();
+        var tree = new DataTree(file);
+
+        // Batch 1: append > 8176 B so an XBlock spine exists with several leaves.
+        tree.AppendData(MakeBytes(40_000, 7));        // ~5 leaves + XBlock root
+        int count = tree.DataBlockCount;
+        ulong spineBidBefore = tree.RootBlock.BlockID.Value;
+
+        // Flush the full leaves (0 .. count-2); the partial tail (count-1) stays pending.
+        var fullLeaves = Enumerable.Range(0, count - 1)
+                                   .Select(i => tree.GetDataBlock(i).BlockID.Value)
+                                   .ToList();
+        tree.PersistLeafBlocks(fullLeaves);
+
+        Assert.True(tree.IsRootPendingWriteForTest(), "spine must remain pending after a leaf flush");
+
+        // Batch 2: more appends update the spine IN PLACE (pending) -> BID unchanged.
+        tree.AppendData(MakeBytes(40_000, 9));
+        Assert.Equal(spineBidBefore, tree.RootBlock.BlockID.Value);
+    }
+
+    [Fact]
+    public void NaiveSaveChanges_ReallocatesSpine_DemonstratingWhyFlushIsMandatory()  // [A2] fail-closed contrast
+    {
+        var file = NewStore();
+        var tree = new DataTree(file);
+        tree.AppendData(MakeBytes(40_000, 7));
+        ulong spineBidBefore = tree.RootBlock.BlockID.Value;
+
+        tree.SaveChanges();                            // clears m_blocksToWrite -> spine no longer pending
+        tree.AppendData(MakeBytes(40_000, 9));         // spine update now allocates a NEW BID
+
+        Assert.NotEqual(spineBidBefore, tree.RootBlock.BlockID.Value);
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/PSTFileFormat/DataTreeStreamingSpikeTests.cs
+++ b/tests/Mail2Pst.Core.Tests/PSTFileFormat/DataTreeStreamingSpikeTests.cs
@@ -229,6 +229,17 @@ public class DataTreeStreamingSpikeTests : IDisposable
         }
     }
 
+    [Fact]
+    public void StreamAppend_CancelledAtBatchBoundary_ThrowsOperationCanceled()
+    {
+        var file = NewStore();
+        var tree = new DataTree(file);
+        using var cts = new System.Threading.CancellationTokenSource();
+        cts.Cancel();   // already cancelled -> must throw at/just before the first batch boundary
+        using var src = new System.IO.MemoryStream(MakeBytes(9_000_000, 5), writable: false);
+        Assert.Throws<System.OperationCanceledException>(() => tree.AppendData(src, 9_000_000, cts.Token));
+    }
+
     // Every leaf BID except the final (tail) leaf, read from the live spine without re-caching. [R3:F3]
     private static System.Collections.Generic.List<ulong> InteriorLeafBids(global::PSTFileFormat.PSTFile file, DataTree tree)
     {

--- a/tests/Mail2Pst.Core.Tests/PSTFileFormat/DataTreeStreamingSpikeTests.cs
+++ b/tests/Mail2Pst.Core.Tests/PSTFileFormat/DataTreeStreamingSpikeTests.cs
@@ -90,4 +90,47 @@ public class DataTreeStreamingSpikeTests : IDisposable
 
         Assert.NotEqual(spineBidBefore, tree.RootBlock.BlockID.Value);
     }
+
+    [Fact]
+    public void TryEvictLeaf_RemovesPersistedLeafFromBuffer_PendingAndSpineSurvive()
+    {
+        var file = NewStore();
+        var tree = new DataTree(file);
+        tree.AppendData(MakeBytes(40_000, 3));
+        int count = tree.DataBlockCount;
+
+        ulong leaf0 = tree.GetDataBlock(0).BlockID.Value;
+        ulong tailLeaf = tree.GetDataBlock(count - 1).BlockID.Value;
+        ulong spine = tree.RootBlock.BlockID.Value;
+
+        tree.PersistLeafBlocks(Enumerable.Range(0, count - 1).Select(i => tree.GetDataBlock(i).BlockID.Value).ToList());
+        int bufBefore = tree.BufferedBlockCountForTest;
+
+        bool evicted = tree.TryEvictLeaf(leaf0, _ => true);   // full + persisted + leaf
+        Assert.True(evicted);
+        Assert.Equal(bufBefore - 1, tree.BufferedBlockCountForTest);
+
+        Assert.False(tree.TryEvictLeaf(tailLeaf, _ => true), "partial pending tail must not be evictable");
+        Assert.False(tree.TryEvictLeaf(spine, _ => true), "spine (XBlock) is not a leaf DataBlock");
+    }
+
+    [Fact]
+    public void ReadDataLeafWithoutCaching_ReturnsBytes_WithoutRepopulatingBuffer()  // [A12]
+    {
+        var file = NewStore();
+        var tree = new DataTree(file);
+        byte[] payload = MakeBytes(40_000, 5);
+        tree.AppendData(payload);
+        int count = tree.DataBlockCount;
+
+        ulong leaf0 = tree.GetDataBlock(0).BlockID.Value;
+        byte[] leaf0Bytes = tree.GetDataBlock(0).Data;       // capture expected leaf bytes
+        tree.PersistLeafBlocks(Enumerable.Range(0, count - 1).Select(i => tree.GetDataBlock(i).BlockID.Value).ToList());
+        tree.TryEvictLeaf(leaf0, _ => true);
+        int bufAfterEvict = tree.BufferedBlockCountForTest;
+
+        byte[] readBack = tree.ReadDataLeafWithoutCaching(leaf0);
+        Assert.Equal(leaf0Bytes, readBack);
+        Assert.Equal(bufAfterEvict, tree.BufferedBlockCountForTest);   // NOT re-cached
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/PSTFileFormat/DataTreeStreamingSpikeTests.cs
+++ b/tests/Mail2Pst.Core.Tests/PSTFileFormat/DataTreeStreamingSpikeTests.cs
@@ -135,4 +135,100 @@ public class DataTreeStreamingSpikeTests : IDisposable
         Assert.Equal(leaf0Bytes, readBack);
         Assert.Equal(bufAfterEvict, tree.BufferedBlockCountForTest);   // NOT re-cached
     }
+
+    [Theory]
+    [InlineData(20_000)]        // DataBlock -> XBlock
+    [InlineData(8_347_696)]     // exactly 1021 * 8176 — boundary at the XBlock -> XXBlock transition [R3:NEW-02]
+    [InlineData(9_000_000)]     // XXBlock, non-8176-aligned tail
+    public void StreamAppend_RoundTrips_AcrossSpineTransitions(int length)
+    {
+        byte[] payload = MakeBytes(length, 42);
+        ulong rootBid;
+
+        // --- write phase (streaming) ---
+        {
+            var file = NewStore();
+            var tree = new DataTree(file);
+            using (var src = new MemoryStream(payload, writable: false))
+            {
+                tree.AppendData(src, payload.Length);
+            }
+            Assert.Equal(0, tree.PendingWriteCountForTest);    // [C1] spine + all leaves flushed, nothing pending [R3]
+            rootBid = tree.RootBlock.BlockID.Value;
+            file.EndSavingChanges();
+            file.CloseFile();
+            _file = null;
+        }
+
+        // --- read phase (reopen) --- PSTFile has no IDisposable; close via try/finally [R3:F2]
+        var file2 = new global::PSTFileFormat.PSTFile(_path, FileAccess.Read, WriterCompatibilityMode.Outlook2007RTM);
+        try
+        {
+            Block root = file2.FindBlockByBlockID(rootBid);
+            var tree2 = new DataTree(file2, root);
+            Assert.Equal(payload, tree2.GetData());
+        }
+        finally
+        {
+            file2.CloseFile();
+        }
+    }
+
+    [Fact]
+    public void StreamAppend_KeepsBufferBounded_IndependentOfAttachmentSize()  // peak-memory intent
+    {
+        var file = NewStore();
+        var tree = new DataTree(file);
+        using (var src = new MemoryStream(MakeBytes(9_000_000, 1), writable: false))
+        {
+            tree.AppendData(src, 9_000_000);
+        }
+        // ~1100 leaves written; after AppendData's final drain only tail + preceding + spine (~5) remain
+        // resident, independent of attachment size. (Mid-stream PEAK is ~one 8 MB batch of leaves — the
+        // bounded "+ batch" term in spec §1; this end-state check proves the drain reclaims it.) [R3:F1]
+        Assert.True(tree.BufferedBlockCountForTest < 16,
+            $"buffer not bounded after drain: {tree.BufferedBlockCountForTest} resident blocks");
+    }
+
+    [Fact]
+    public void EveryPersistedInteriorLeaf_IsFull8176_NoPartialInteriorBlock()  // [R2:M4] — round-trip alone is vacuous
+    {
+        var file = NewStore();
+        var tree = new DataTree(file);
+        using (var src = new MemoryStream(MakeBytes(9_000_000, 11), writable: false))
+        {
+            tree.AppendData(src, 9_000_000);
+        }
+        // Read interior leaf BIDs from the in-memory spine WITHOUT GetDataBlock (which re-caches evicted
+        // leaves via GetBlock, violating [A12]); assert each BBT-recorded length == 8176. [R3:F3]
+        var interiorBids = InteriorLeafBids(file, tree);
+        Assert.NotEmpty(interiorBids);
+        foreach (ulong bid in interiorBids)
+        {
+            var entry = file.FindBlockEntryByBlockID(bid);
+            Assert.NotNull(entry);
+            Assert.Equal(DataBlock.MaximumDataLength, (int)entry.cb);   // cb is ushort (BlockBTreeEntry.cs:19) [R3]
+        }
+    }
+
+    // Every leaf BID except the final (tail) leaf, read from the live spine without re-caching. [R3:F3]
+    private static System.Collections.Generic.List<ulong> InteriorLeafBids(global::PSTFileFormat.PSTFile file, DataTree tree)
+    {
+        var bids = new System.Collections.Generic.List<ulong>();
+        Block root = tree.RootBlock;
+        if (root is XBlock xb)
+        {
+            foreach (BlockID b in xb.rgbid) bids.Add(b.Value);
+        }
+        else if (root is XXBlock xxb)
+        {
+            foreach (BlockID xbid in xxb.rgbid)
+            {
+                var child = (XBlock)file.FindBlockByBlockID(xbid.Value);   // non-caching (PSTFile level)
+                foreach (BlockID b in child.rgbid) bids.Add(b.Value);
+            }
+        }
+        if (bids.Count > 0) bids.RemoveAt(bids.Count - 1);   // drop the tail (allowed to be partial)
+        return bids;
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/PSTFileFormat/DataTreeStreamingSpikeTests.cs
+++ b/tests/Mail2Pst.Core.Tests/PSTFileFormat/DataTreeStreamingSpikeTests.cs
@@ -111,7 +111,9 @@ public class DataTreeStreamingSpikeTests : IDisposable
         Assert.Equal(bufBefore - 1, tree.BufferedBlockCountForTest);
 
         Assert.False(tree.TryEvictLeaf(tailLeaf, _ => true), "partial pending tail must not be evictable");
-        Assert.False(tree.TryEvictLeaf(spine, _ => true), "spine (XBlock) is not a leaf DataBlock");
+
+        tree.SaveChanges();   // persist the spine to the BBT + clear it from m_blocksToWrite so the next check reaches cond 4/6
+        Assert.False(tree.TryEvictLeaf(spine, _ => true), "spine is an XBlock, not a leaf DataBlock — fails cond 4/6");
     }
 
     [Fact]

--- a/tests/Mail2Pst.Core.Tests/PSTFileFormat/HeapOnNodeResidencyTests.cs
+++ b/tests/Mail2Pst.Core.Tests/PSTFileFormat/HeapOnNodeResidencyTests.cs
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using PSTFileFormat;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.PSTFileFormat;
+
+public class HeapOnNodeResidencyTests : IDisposable
+{
+    private readonly string _path = Path.Combine(Path.GetTempPath(), $"m2p-hon-{Guid.NewGuid():N}.pst");
+    private global::PSTFileFormat.PSTFile? _file;
+    public void Dispose() { try { _file?.CloseFile(); } catch { } try { File.Delete(_path); } catch { } }
+
+    [Fact]
+    public void HeapResidency_AfterAllocations_ReportsDecodedCacheAndIndexCounts()
+    {
+        global::PSTFileFormat.PSTFile.CreateEmptyStore(_path);
+        _file = new global::PSTFileFormat.PSTFile(_path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+        _file.BeginSavingChanges();
+        var heap = HeapOnNode.CreateNewHeap(_file);
+        heap.AddItemToHeap(new byte[100]);
+        heap.AddItemToHeap(new byte[200]);
+
+        var (bufferCount, decodedBytes, freeIdx, blockAvail) = heap.HeapResidencyForTest();
+        Assert.True(bufferCount >= 1);
+        Assert.True(decodedBytes >= 300);
+        Assert.True(freeIdx >= 0);
+        Assert.True(blockAvail >= 0);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/PSTFileFormat/PSTFileAMapResidencyTests.cs
+++ b/tests/Mail2Pst.Core.Tests/PSTFileFormat/PSTFileAMapResidencyTests.cs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using PSTFileFormat;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.PSTFileFormat;
+
+public class PSTFileAMapResidencyTests : IDisposable
+{
+    private readonly string _path = Path.Combine(Path.GetTempPath(), $"m2p-amap-{Guid.NewGuid():N}.pst");
+    private global::PSTFileFormat.PSTFile? _file;
+    public void Dispose() { try { _file?.CloseFile(); } catch { } try { File.Delete(_path); } catch { } }
+
+    [Fact]
+    public void AMapResidency_OnFreshStore_NonNegativeAndConsistent()
+    {
+        global::PSTFileFormat.PSTFile.CreateEmptyStore(_path);
+        _file = new global::PSTFileFormat.PSTFile(_path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+        _file.BeginSavingChanges();
+        var tree = new DataTree(_file);
+        tree.AppendData(new byte[20_000]);                       // force at least one allocation -> AMap touched
+        tree.SaveChanges();
+
+        var (pageCount, bytes, g, a) = _file.AMapResidencyForTest();
+        Assert.True(pageCount >= 0);
+        Assert.Equal(pageCount * 512L, bytes);
+        Assert.True(g >= 0 && a >= 0);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/PSTFileFormat/StoreExternalPropertyStreamTests.cs
+++ b/tests/Mail2Pst.Core.Tests/PSTFileFormat/StoreExternalPropertyStreamTests.cs
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using System.Threading;
+using PSTFileFormat;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.PSTFileFormat;
+
+// Fail-closed round-trip gate for the streaming INSERT-only StoreExternalProperty overload (Task 3).
+// Exercises all four routing zones: heap (≤3580), subnode DataBlock (>3580,≤8176), XBlock, XXBlock.
+// [L1] No hedging on the ≤3580 case — GetExternalPropertyBytes routes both heap and subnode through
+// the same read API, so byte-equality at ≤3580 proves ReadExactly correctness.
+public class StoreExternalPropertyStreamTests : IDisposable
+{
+    private readonly string _path = Path.Combine(Path.GetTempPath(), $"m2p-sxp-{Guid.NewGuid():N}.pst");
+    private global::PSTFileFormat.PSTFile? _file;
+
+    public void Dispose()
+    {
+        try { _file?.CloseFile(); } catch { }
+        try { File.Delete(_path); } catch { }
+    }
+
+    // Deterministic position-dependent bytes so a byte-displaced or zero-filled block fails the assertion.
+    private static byte[] Make(int n)
+    {
+        var b = new byte[n];
+        for (int i = 0; i < n; i++) b[i] = (byte)((i * 31 + 7) & 0xFF);
+        return b;
+    }
+
+    [Theory]
+    [InlineData(2000)]       // heap path (≤3580)
+    [InlineData(5000)]       // subnode DataBlock (>3580, ≤8176)
+    [InlineData(20000)]      // XBlock (>8176)
+    [InlineData(9_000_000)]  // XXBlock (>~7.96 MB)
+    public void StoreViaStream_RoundTrips_AcrossRoutingBoundaries(int size)
+    {
+        byte[] payload = Make(size);
+
+        // --- write phase ---
+        global::PSTFileFormat.PSTFile.CreateEmptyStore(_path);
+        _file = new global::PSTFileFormat.PSTFile(_path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+        _file.BeginSavingChanges();
+
+        HeapOnNode heap = HeapOnNode.CreateNewHeap(_file);
+        SubnodeBTree subnodeBTree = null!;   // INSERT path: may be created by the overload for >3580 B
+
+        using var ms = new MemoryStream(payload, writable: false);
+        HeapOrNodeID id = NodeStorageHelper.StoreExternalProperty(
+            _file, heap, ref subnodeBTree, ms, (long)payload.Length, CancellationToken.None);
+
+        // --- read-back in-window via GetExternalPropertyBytes ---
+        // Routes both heap (IsHeapID → heap.GetHeapItem) and subnode (DataTree.GetData()) uniformly.
+        // AppendData(Stream,...) ends with its own SaveChanges [R2:C1], so subnode data is BBT-indexed
+        // and readable in-window before EndSavingChanges.
+        byte[] readBack = NodeStorageHelper.GetExternalPropertyBytes(heap, subnodeBTree!, id);
+
+        // [L1] Exact byte-equality at ALL FOUR sizes — no hedge. A failure here is a §8 corruption signal.
+        Assert.Equal(payload, readBack);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Writing/PstWriterStreamingAttachmentTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/PstWriterStreamingAttachmentTests.cs
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Mail2Pst.Core.Mapping;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Reporting;
+using Mail2Pst.Core.Writing;
+using PSTFileFormat;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Writing;
+
+public class PstWriterStreamingAttachmentTests
+{
+    // Builds deterministic bytes of the given length via a repeating ramp pattern.
+    private static byte[] Ramp(int length)
+    {
+        var buf = new byte[length];
+        for (int i = 0; i < length; i++) buf[i] = (byte)(i & 0xFF);
+        return buf;
+    }
+
+    // Writes a single-attachment message, reopens the PST, and returns the attachment bytes.
+    // Does NOT dispose the PST temp dir — callers are responsible for cleanup.
+    private static (byte[] attachData, string pstPath) WriteReopenAndReadBack(
+        AttachmentContent attachment, long thresholdBytes, out string tempDir)
+    {
+        tempDir = Path.Combine(Path.GetTempPath(), "mail2pst-stream-" + Guid.NewGuid());
+        Directory.CreateDirectory(tempDir);
+
+        var plan = new PstOutputPlan { Name = "Test", MaxSizeBytes = 100L * 1024 * 1024 };
+        var message = new MailMessage
+        {
+            Subject = "Streaming test",
+            Source = new SourceReference { SourcePath = "test.mbox", Identifier = "msg#1" },
+            Attachments = new List<MailAttachment>
+            {
+                new() { FileName = "data.bin", MimeType = "application/octet-stream", Content = attachment },
+            },
+        };
+        var planned = new List<PlannedMessage>
+        {
+            new() { TargetFolderPath = new[] { "Inbox" }, Message = message },
+        };
+
+        var writer = new PstWriter();
+        writer.StreamingThresholdBytes = thresholdBytes;
+
+        List<string> outputFiles = writer.WritePlan(plan, planned, tempDir, new ConversionReport());
+        Assert.Single(outputFiles);
+        Assert.True(File.Exists(outputFiles[0]));
+
+        var pst = new PSTFile(outputFiles[0], FileAccess.Read);
+        byte[] data;
+        try
+        {
+            PSTFolder root = pst.TopOfPersonalFolders;
+            var inbox = (MailFolder)root.FindChildFolder("Inbox")!;
+            Assert.NotNull(inbox);
+            Note note = inbox.GetNote(0);
+            Assert.Equal(1, note.AttachmentCount);
+            AttachmentObject att = note.GetAttachmentObject(0);
+            byte[]? readBack = att.PC.GetBytesProperty(PropertyID.PidTagAttachData);
+            Assert.NotNull(readBack);
+            data = readBack!;
+        }
+        finally
+        {
+            pst.CloseFile();
+        }
+
+        return (data, outputFiles[0]);
+    }
+
+    // Test A: streaming path (threshold = 1 → even small attachments stream).
+    // Uses a >8176-byte body so the write crosses the DataBlock → XBlock spine transition,
+    // exercising the multi-block path of SetExternalProperty/AppendData.
+    [Fact]
+    public void StreamingPath_LargerThanSpine_BytesRoundTripExactly()
+    {
+        // 9 000 bytes > one DataBlock (8 176 bytes), so this exercises the XBlock path.
+        byte[] input = Ramp(9_000);
+        string tempAttach = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllBytes(tempAttach, input);
+
+            var content = AttachmentContent.FromTempFile(tempAttach, input.Length);
+            // threshold = 1 → streaming path for ALL attachments
+            (byte[] readBack, _) = WriteReopenAndReadBack(content, thresholdBytes: 1, out string tempDir);
+            try
+            {
+                Assert.Equal(input.Length, readBack.Length);
+                Assert.True(readBack.SequenceEqual(input),
+                    "PidTagAttachData must round-trip exactly via the streaming write path");
+            }
+            finally { Directory.Delete(tempDir, true); }
+        }
+        finally { if (File.Exists(tempAttach)) File.Delete(tempAttach); }
+    }
+
+    // Test A2: byte[] path (default threshold → small attachment stays in-memory).
+    // Guards that the non-streaming path is unaffected by the production change.
+    [Fact]
+    public void ByteArrayPath_SmallAttachment_BytesRoundTripExactly()
+    {
+        byte[] input = Ramp(256); // well below the 16 MB default threshold
+        var content = AttachmentContent.FromBytes(input);
+        // default threshold: 16 MB — small attachment takes the byte[] path
+        (byte[] readBack, _) = WriteReopenAndReadBack(content, thresholdBytes: 16L * 1024 * 1024,
+            out string tempDir);
+        try
+        {
+            Assert.Equal(input.Length, readBack.Length);
+            Assert.True(readBack.SequenceEqual(input),
+                "PidTagAttachData must round-trip exactly via the byte[] write path");
+        }
+        finally { Directory.Delete(tempDir, true); }
+    }
+
+    // Test B: cancel mid-streamed-attachment → OCE thrown, in-progress PST deleted, temp file disposed.
+    // The subclass cancels the CancellationTokenSource just before WriteMessage calls WriteAttachment,
+    // so SetExternalProperty receives an already-cancelled token and throws OperationCanceledException.
+    // Attachment must be > HeapOnNode.MaximumAllocationLength (3580 B) so StoreExternalProperty takes
+    // the DataTree/AppendData path, which checks the cancellation token on each DataBlock iteration.
+    [Fact]
+    public void StreamingPath_CancelDuringWrite_ThrowsOce_DeletesPartAndDisposesTempFile()
+    {
+        // 4000 bytes > HeapOnNode.MaximumAllocationLength (3580) → DataTree.AppendData path checks token
+        byte[] input = Ramp(4_000);
+        string tempAttach = Path.GetTempFileName();
+        File.WriteAllBytes(tempAttach, input);
+
+        string outputDir = Path.Combine(Path.GetTempPath(), "mail2pst-stream-cancel-" + Guid.NewGuid());
+        Directory.CreateDirectory(outputDir);
+        try
+        {
+            var plan = new PstOutputPlan { Name = "Streaming", MaxSizeBytes = 100L * 1024 * 1024 };
+            var message = new MailMessage
+            {
+                Subject = "Cancel test",
+                Source = new SourceReference { SourcePath = "test.mbox", Identifier = "msg#1" },
+                Attachments = new List<MailAttachment>
+                {
+                    new() { FileName = "data.bin", MimeType = "application/octet-stream",
+                            Content = AttachmentContent.FromTempFile(tempAttach, input.Length) },
+                },
+            };
+            var planned = new List<PlannedMessage>
+            {
+                new() { TargetFolderPath = new[] { "Inbox" }, Message = message },
+            };
+
+            using var cts = new CancellationTokenSource();
+            var report = new ConversionReport();
+            // CancelOnWriteWriter cancels the token inside WriteMessageCore, before the attachment
+            // write, so SetExternalProperty(... _activeCancellationToken) sees a cancelled token.
+            var writer = new CancelOnWriteWriter(cts);
+            writer.StreamingThresholdBytes = 1; // force streaming path
+
+            Assert.Throws<OperationCanceledException>(() =>
+                writer.WritePlan(plan, planned, outputDir, report, cancellationToken: cts.Token));
+
+            // In-progress PST part must be deleted
+            Assert.Empty(Directory.GetFiles(outputDir, "*.pst"));
+            Assert.Equal(new[] { Path.Combine(outputDir, "Streaming.pst") }, report.DeletedFiles.ToArray());
+
+            // Temp attachment file must be disposed (deleted by AttachmentContent.Dispose)
+            Assert.False(File.Exists(tempAttach), "temp attachment file must be deleted after cancel");
+        }
+        finally
+        {
+            if (File.Exists(tempAttach)) File.Delete(tempAttach);
+            Directory.Delete(outputDir, true);
+        }
+    }
+
+    /// <summary>
+    /// Cancels the CancellationTokenSource at the start of the first WriteMessageCore call so
+    /// that the streaming SetExternalProperty call receives an already-cancelled token and throws
+    /// OperationCanceledException — simulating a mid-attachment-write cancellation.
+    /// </summary>
+    private sealed class CancelOnWriteWriter : PstWriter
+    {
+        private readonly CancellationTokenSource _cts;
+        private int _callCount;
+
+        public CancelOnWriteWriter(CancellationTokenSource cts) => _cts = cts;
+
+        internal override void WriteMessageCore(PSTFile file, PSTFolder folder, MailMessage message)
+        {
+            if (Interlocked.Increment(ref _callCount) == 1)
+                _cts.Cancel(); // cancelled before WriteAttachment → SetExternalProperty sees it
+            base.WriteMessageCore(file, folder, message);
+        }
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/DurableMemoryMeasurementTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/DurableMemoryMeasurementTests.cs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using Mail2Pst.Core;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Diagnostics;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests;
+
+public class DurableMemoryMeasurementTests
+{
+    private static string? CorpusConfig => Environment.GetEnvironmentVariable("MAIL2PST_MEMORY_CORPUS_CONFIG");
+
+    [SkippableFact]
+    public void Measure_LargeCorpus_EmitsWellFormedDurableMemoryReport()
+    {
+        Skip.If(string.IsNullOrWhiteSpace(CorpusConfig),
+            "Set MAIL2PST_MEMORY_CORPUS_CONFIG to a corpus config.json to run.");
+
+        ConversionConfig config = ConfigLoader.Load(CorpusConfig!);
+        string outDir = Path.Combine(Path.GetTempPath(), "m2p-memrun-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outDir);
+
+        var observer = new DurableMemoryObserver();
+        var runner = new ConversionRunner();
+        runner.Run(config, outDir, onProgress: null, memoryObserver: observer);
+
+        DurableMemoryReport? peak = observer.Peak;
+        Assert.NotNull(peak);
+        string reportPath = Path.Combine(outDir, "durable-memory-report.txt");
+        File.WriteAllText(reportPath, DurableMemoryReportWriter.ToSummary(peak!));
+        File.WriteAllText(Path.ChangeExtension(reportPath, ".json"), DurableMemoryReportWriter.ToJson(peak!));
+
+        Assert.InRange(peak!.EvictableRatio, 0.0, 1.0);
+        Assert.True(peak.TotalDurableBytes > 0);
+        // The classification + which family dominates is read manually from the emitted report (spec §7).
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/StreamingAttachmentAcceptanceTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/StreamingAttachmentAcceptanceTests.cs
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Mapping;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Reporting;
+using Mail2Pst.Core.Writing;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests;
+
+public class StreamingAttachmentAcceptanceTests
+{
+    private static readonly TimeSpan ValidatorTimeout = TimeSpan.FromSeconds(60);
+
+    // [L5] residual: pst-validate reads structural metadata (opened, folder paths, message counts)
+    // but NOT PidTagAttachData — it cannot independently verify attachment payload bytes. The
+    // closed-loop byte-equality check (Task 5, StreamingAttachmentRoundTripTests) is the only
+    // payload verification; both the round-trip test and this structural gate use the same vendored
+    // DataTree/block machinery, so a write/read-symmetric encoding bug could pass both. Accepted
+    // residual, justified: the on-disk *encoding* is the same shared DataTree/block machinery as the
+    // existing byte[] large-attachment path; only the build/eviction *sequencing* is new in
+    // Target-A. Extending tools/pst-validate to byte-compare PidTagAttachData via the MIT
+    // outlook-pst crate is out of proportion for this Low finding. Formal sign-off recorded in
+    // Task 7's acceptance memo.
+    [SkippableFact]
+    public void StreamedLargeAttachment_PstValidatesClean_WithIndependentReader()
+    {
+        Skip.If(PstValidatorRunner.ValidatorPath is null,
+            "Set MAIL2PST_PST_VALIDATOR to the built pst-validate exe to run the independent-reader gate.");
+
+        // 9 MB > 8,347,696 B XXBlock boundary — exercises the full XXBlock streaming machinery.
+        // StreamingThresholdBytes is lowered to 1 B so streaming triggers without needing a 16+ MB
+        // fixture (avoids slow test; the threshold is internal and accessible via InternalsVisibleTo).
+        const int attachmentSize = 9_000_000;
+        byte[] payload = new byte[attachmentSize];
+        for (int i = 0; i < attachmentSize; i++) payload[i] = (byte)((i * 31 + 7) & 0xFF);
+
+        using var content = AttachmentContent.FromBytes(payload);
+        var msg = new MailMessage
+        {
+            MessageId = "<stream-accept-gate@test>",
+            Subject = "Streaming acceptance gate — XXBlock attachment",
+            Attachments = new List<MailAttachment>
+            {
+                new()
+                {
+                    FileName = "large.bin",
+                    MimeType = "application/octet-stream",
+                    Content = content,
+                },
+            },
+        };
+
+        string outDir = Path.Combine(Path.GetTempPath(), "m2p-stream-accept-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outDir);
+        try
+        {
+            var plan = new PstOutputPlan
+            {
+                Name = "StreamAccept",
+                MaxSizeBytes = 100L * 1024 * 1024,
+                IncludeEmptyFolders = false,
+            };
+            PlannedMessage[] planned =
+            [
+                new() { Message = msg, TargetFolderPath = new[] { "Inbox" } },
+            ];
+            var report = new ConversionReport();
+            var writer = new PstWriter();
+            writer.StreamingThresholdBytes = 1;   // force streaming path for this <16 MB fixture
+
+            List<string> outputs = writer.WritePlan(plan, planned, outDir, report);
+            Assert.NotEmpty(outputs);
+
+            // --- independent structural validation ---
+            ValidatorResult r = PstValidatorRunner.Run(outputs[0], ValidatorTimeout);
+            Assert.True(r.Opened,
+                $"pst-validate could not open output PST: " +
+                string.Join("; ", r.Errors.Select(e => $"{e.Stage}:{e.Message}")));
+            Assert.Empty(r.Errors);
+
+            // The single message must appear somewhere in the store.
+            long total = r.Folders.Sum(f => f.MessageCount);
+            Assert.Equal(1L, total);
+
+            // [L5] residual (see class-level comment): PidTagAttachData payload bytes are NOT
+            // independently verified here — pst-validate does not expose attachment body bytes.
+            // Structural integrity (AMap, NDB open, folder/message counts) is confirmed above.
+        }
+        finally
+        {
+            Directory.Delete(outDir, recursive: true);
+        }
+    }
+}

--- a/vendor/PSTFileFormat-MODIFICATIONS.md
+++ b/vendor/PSTFileFormat-MODIFICATIONS.md
@@ -87,15 +87,17 @@ authoritative description of the local PSTFileFormat modifications.
   measurement (measurement-only; no production behaviour change; each accessor is a property or
   method returning current in-memory counts/sizes and is never called on the hot write path)
   (ContinuMail, 2026):
-  - `BufferedBlockStore.BlockBufferResidencyForTest`: returns `(int count, long payloadBytes,
-    long pendingBytes, long evictableBytes, long pinnedBytes)` summarising the resident block
-    buffer (count of buffered blocks, payload bytes, pending-write bytes, evictable-leaf bytes,
-    and pinned bytes). Read-only snapshot; does not mutate buffer state.
-  - `BufferedBTreePageStore.PageBufferResidencyForTest`: returns `(int count, long payloadBytes)`
-    for the resident BTree-page buffer. Read-only snapshot.
-  - `HeapOnNode.HeapResidencyForTest`: returns `(int blockCount, long payloadBytes)` for all
-    in-memory HID heap blocks. Read-only snapshot; does not mutate heap state.
-  - `PSTFile.AMapResidencyForTest`: returns `(int pageCount, long payloadBytes)` for in-memory
-    AMap pages cached on the file object. Read-only snapshot.
+  - `BufferedBlockStore.BlockBufferResidencyForTest(ulong? liveRootBid)`: returns
+    `(int count, long payload, long pending, long evictable)` summarising the resident block
+    buffer (count of buffered blocks, payload bytes, pending-write bytes, and evictable-leaf
+    bytes). Read-only snapshot; does not mutate buffer state.
+  - `BufferedBTreePageStore.PageBufferResidencyForTest()`: returns `(int count, long bytes,
+    long pending)` for the resident BTree-page buffer. Read-only snapshot.
+  - `HeapOnNode.HeapResidencyForTest()`: returns `(int bufferCount, long decodedBytes,
+    int freeIndexEntries, int blockAvailEntries)` for the decoded-heap-block cache and
+    free-space index entry counts. Read-only snapshot; does not mutate heap state.
+  - `PSTFile.AMapResidencyForTest()`: returns `(int pageCount, long bytes,
+    int maxFreeGeneral, int maxFreeAligned)` for in-memory AMap pages and free-index list
+    lengths cached on the file object. Read-only snapshot.
 
 See the project git history (`git log -- vendor/PSTFileFormat`) for the full diffs.

--- a/vendor/PSTFileFormat-MODIFICATIONS.md
+++ b/vendor/PSTFileFormat-MODIFICATIONS.md
@@ -64,4 +64,23 @@ authoritative description of the local PSTFileFormat modifications.
   `PSTFolder`). The write path (search-update queue included) is untouched; output PSTs are byte-for-byte
   unchanged and pass the round-trip + independent-reader gates (ContinuMail, 2026).
 
+- Phase-2 streaming spike — new public APIs added to `BufferedBlockStore` and `DataTree` for streaming
+  large-attachment writes with bounded resident memory (ContinuMail, 2026):
+  - `BufferedBlockStore.PersistLeafBlocks(IEnumerable<ulong>)`: flush named leaf blocks to the BBT
+    without clearing the pending-write set wholesale, leaving the spine pending for in-place updates.
+  - `BufferedBlockStore.TryEvictLeaf(ulong, Func<ulong,bool>)`: residency-only eviction of a
+    persisted, full leaf DataBlock from the in-memory buffer so block count stays bounded.
+  - `BufferedBlockStore.ReadDataLeafWithoutCaching(ulong)`: read a persisted data leaf by BID without
+    re-adding it to the resident buffer.
+  - `BufferedBlockStore.PendingWriteCountForTest`: spike instrumentation — current pending (unwritten)
+    block count.
+  - `BufferedBlockStore.BufferedBlockCountForTest`: spike instrumentation — current resident block count.
+  - `BufferedBlockStore.BlockReallocationsForTest`: spike instrumentation — BID reallocation counter
+    (incremented in the non-pending `UpdateBlock` branch); used by the scaling gate to assert the spine
+    is updated in-place across many batch boundaries.
+  - `DataTree.AppendData(Stream, long)`: streaming append of `length` bytes from a `Stream` across
+    leaf blocks with batched persist+evict, so resident memory is independent of attachment size.
+  - `DataTree.IsRootPendingWriteForTest()`: spike instrumentation — whether the current root/spine
+    block is still in the pending-write set.
+
 See the project git history (`git log -- vendor/PSTFileFormat`) for the full diffs.

--- a/vendor/PSTFileFormat-MODIFICATIONS.md
+++ b/vendor/PSTFileFormat-MODIFICATIONS.md
@@ -83,4 +83,19 @@ authoritative description of the local PSTFileFormat modifications.
   - `DataTree.IsRootPendingWriteForTest()`: spike instrumentation — whether the current root/spine
     block is still in the pending-write set.
 
+- Phase-2 Target-C measurement — read-only residency snapshot APIs added for durable-memory
+  measurement (measurement-only; no production behaviour change; each accessor is a property or
+  method returning current in-memory counts/sizes and is never called on the hot write path)
+  (ContinuMail, 2026):
+  - `BufferedBlockStore.BlockBufferResidencyForTest`: returns `(int count, long payloadBytes,
+    long pendingBytes, long evictableBytes, long pinnedBytes)` summarising the resident block
+    buffer (count of buffered blocks, payload bytes, pending-write bytes, evictable-leaf bytes,
+    and pinned bytes). Read-only snapshot; does not mutate buffer state.
+  - `BufferedBTreePageStore.PageBufferResidencyForTest`: returns `(int count, long payloadBytes)`
+    for the resident BTree-page buffer. Read-only snapshot.
+  - `HeapOnNode.HeapResidencyForTest`: returns `(int blockCount, long payloadBytes)` for all
+    in-memory HID heap blocks. Read-only snapshot; does not mutate heap state.
+  - `PSTFile.AMapResidencyForTest`: returns `(int pageCount, long payloadBytes)` for in-memory
+    AMap pages cached on the file object. Read-only snapshot.
+
 See the project git history (`git log -- vendor/PSTFileFormat`) for the full diffs.

--- a/vendor/PSTFileFormat-MODIFICATIONS.md
+++ b/vendor/PSTFileFormat-MODIFICATIONS.md
@@ -83,6 +83,31 @@ authoritative description of the local PSTFileFormat modifications.
   - `DataTree.IsRootPendingWriteForTest()`: spike instrumentation — whether the current root/spine
     block is still in the pending-write set.
 
+- Phase-2 Target-A production wiring — streaming-write APIs wired into the production write path,
+  removing the writer-side OOM cliff on large attachments (ContinuMail, 2026):
+  - `DataTree.SaveChanges()`: hoisted `DataBlockCount - 1` out of the zero-fill loop (the
+    `DataBlockCount` getter clones the last XBlock/XXBlock for multi-level trees, so evaluating it
+    on every iteration was wasteful). Behaviour-preserving performance fix; a modification to an
+    existing method, not a new API. (`[R2:L2]`)
+  - `DataTree.AppendData(Stream, long, CancellationToken)`: cancellation-aware streaming append
+    overload. Checks the token at the top of each leaf iteration (~8 KB); an
+    `OperationCanceledException` propagates before the final spine `SaveChanges()`, leaving the
+    tree partial+pending for the caller to discard with the in-progress PST part. The two-argument
+    `AppendData(Stream, long)` overload (shipping since the Phase-2 spike) delegates to this with
+    `CancellationToken.None`.
+  - `NodeStorageHelper.StoreExternalProperty(PSTFile, HeapOnNode, ref SubnodeBTree, Stream, long,
+    CancellationToken)` (`internal`): INSERT-only streaming store path. Routes small payloads
+    (≤ `HeapOnNode.MaximumAllocationLength`) through the existing heap path after buffering them
+    from the stream; routes large payloads into a fresh `DataTree` via
+    `AppendData(stream, length, cancellationToken)` followed by a new subnode entry. No streaming
+    UPDATE overload is provided — the converter writes `PidTagAttachData` exactly once per
+    attachment, so an UPDATE path is never reached.
+  - `PropertyContext.SetExternalProperty(PropertyID, PropertyTypeName, Stream, long,
+    CancellationToken)`: INSERT-only streaming seam on the property context. Delegates to
+    `NodeStorageHelper.StoreExternalProperty(…, Stream, long, CancellationToken)`. Throws
+    `NotSupportedException` if a record for `propertyID` already exists (UPDATE not supported);
+    the production write path never triggers this because `PidTagAttachData` is written once.
+
 - Phase-2 Target-C measurement — read-only residency snapshot APIs added for durable-memory
   measurement (measurement-only; no production behaviour change; each accessor is a property or
   method returning current in-memory counts/sizes and is never called on the hot write path)

--- a/vendor/PSTFileFormat/ListsTablesAndProperties/HeapOnNode/HeapOnNode.cs
+++ b/vendor/PSTFileFormat/ListsTablesAndProperties/HeapOnNode/HeapOnNode.cs
@@ -391,6 +391,16 @@ namespace PSTFileFormat
             }
         }
 
+        /// <summary>Measurement-only [§7]. Decoded-heap-block cache residency (m_buffer — pinned, above
+        /// BufferedBlockStore, not reachable by §4 eviction) + #34 free-space index entry counts (O(1) at
+        /// write-heavy steady state). Read-only.</summary>
+        internal (int bufferCount, long decodedBytes, int freeIndexEntries, int blockAvailEntries) HeapResidencyForTest()
+        {
+            long decoded = 0;
+            foreach (var kv in m_buffer) decoded += kv.Value.DataLength;
+            return (m_buffer.Count, decoded, m_freeSpaceIndex.Count, m_blockAvail.Count);
+        }
+
         public DataTree DataTree
         {
             get

--- a/vendor/PSTFileFormat/ListsTablesAndProperties/NodeStorageHelper.cs
+++ b/vendor/PSTFileFormat/ListsTablesAndProperties/NodeStorageHelper.cs
@@ -8,6 +8,7 @@
  */
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using Utilities;
 
@@ -68,6 +69,48 @@ namespace PSTFileFormat
         public static HeapOrNodeID StoreExternalProperty(PSTFile file, HeapOnNode heap, ref SubnodeBTree subnodeBTree, byte[] propertyBytes)
         {
             return StoreExternalProperty(file, heap, ref subnodeBTree, new HeapOrNodeID(HeapID.EmptyHeapID), propertyBytes);
+        }
+
+        /// <summary>
+        /// [A11] INSERT-only streaming overload: heap-vs-subnode routing by length.
+        /// ≤3580 B: reads from stream into a buffer and delegates to the existing heap (byte[]) INSERT path.
+        /// &gt;3580 B: builds a new subnode DataTree via streaming AppendData (which ends with its own
+        /// SaveChanges [R2:C1]), then inserts the subnode entry AFTER that flush [A4].
+        /// [I2] No UPDATE-path stream overload — INSERT-only is enforced at the PropertyContext seam (Task 4).
+        /// </summary>
+        internal static HeapOrNodeID StoreExternalProperty(PSTFile file, HeapOnNode heap,
+            ref SubnodeBTree subnodeBTree, Stream stream, long length,
+            System.Threading.CancellationToken cancellationToken)
+        {
+            if (length <= HeapOnNode.MaximumAllocationLength)
+            {
+                byte[] small = new byte[(int)length];
+                ReadExactly(stream, small, (int)length);
+                return StoreExternalProperty(file, heap, ref subnodeBTree, small);
+            }
+
+            if (subnodeBTree == null)
+            {
+                subnodeBTree = new SubnodeBTree(file);
+            }
+            DataTree dataTree = new DataTree(file);
+            dataTree.AppendData(stream, length, cancellationToken); // streams + persists/evicts + final local SaveChanges [R2:C1]
+
+            NodeID subnodeID = file.Header.AllocateNextNodeID(NodeTypeName.NID_TYPE_LTP);
+            subnodeBTree.InsertSubnodeEntry(subnodeID, dataTree, null); // [A4] reads RootBlock.BlockID AFTER AppendData's flush
+
+            return new HeapOrNodeID(subnodeID);
+        }
+
+        private static void ReadExactly(Stream stream, byte[] buffer, int count)
+        {
+            int read = 0;
+            while (read < count)
+            {
+                int n = stream.Read(buffer, read, count - read);
+                if (n <= 0) throw new EndOfStreamException("Stream ended before the declared property length.");
+                read += n;
+            }
         }
 
         /// <param name="subnodeBTree">Note: We use ref, this way we are able to create a new subnode BTree and update the subnodeBTree the caller provided</param>

--- a/vendor/PSTFileFormat/ListsTablesAndProperties/PropertyContext/PropertyContext.cs
+++ b/vendor/PSTFileFormat/ListsTablesAndProperties/PropertyContext/PropertyContext.cs
@@ -426,6 +426,32 @@ namespace PSTFileFormat
             }
         }
 
+        /// <summary>
+        /// INSERT-only stream overload. Allocates a new external storage entry for
+        /// <paramref name="propertyID"/> by routing to
+        /// <see cref="NodeStorageHelper.StoreExternalProperty(PSTFile,HeapOnNode,ref SubnodeBTree,System.IO.Stream,long,System.Threading.CancellationToken)"/>.
+        /// The stream is consumed and closed synchronously before this method returns [A10].
+        /// If a property record for <paramref name="propertyID"/> already exists,
+        /// <see cref="System.NotSupportedException"/> is thrown — UPDATE is not supported via this
+        /// overload [R2:H1].
+        /// </summary>
+        public void SetExternalProperty(PropertyID propertyID, PropertyTypeName propertyType, System.IO.Stream stream, long length, System.Threading.CancellationToken cancellationToken)
+        {
+            PropertyContextRecord record = GetRecordByPropertyID(propertyID);
+            if (record != null)
+            {
+                throw new System.NotSupportedException("streaming external property write is INSERT-only");
+            }
+            else // old record does not exist
+            {
+                record = new PropertyContextRecord();
+                record.HeapOrNodeID = NodeStorageHelper.StoreExternalProperty(this.File, this.Heap, ref m_subnodeBTree, stream, length, cancellationToken);
+                record.wPropId = propertyID;
+                record.wPropType = propertyType;
+                AddRecord(record);
+            }
+        }
+
         public void SetBooleanProperty(PropertyID propertyID, bool value)
         {
             SetInternalProperty(propertyID, PropertyTypeName.PtypBoolean, Convert.ToByte(value));

--- a/vendor/PSTFileFormat/NodeDatabse/BTree/BufferedBTreePageStore.cs
+++ b/vendor/PSTFileFormat/NodeDatabse/BTree/BufferedBTreePageStore.cs
@@ -25,7 +25,7 @@ namespace PSTFileFormat
 
         // The NDB is immutable, we allocate pages for both new pages and modified pages,
         // for modified pages, we unallocate the original pages (using m_pagesToFree).
-        private List<ulong> m_pagesToWrite = new List<ulong>();
+        private HashSet<ulong> m_pagesToWrite = new HashSet<ulong>();
         private List<ulong> m_offsetsToFree = new List<ulong>();
 
         public BufferedBTreePageStore(PSTFile file)

--- a/vendor/PSTFileFormat/NodeDatabse/BTree/BufferedBTreePageStore.cs
+++ b/vendor/PSTFileFormat/NodeDatabse/BTree/BufferedBTreePageStore.cs
@@ -185,6 +185,16 @@ namespace PSTFileFormat
             }
         }
 
+        /// <summary>Measurement-only [§7]. Page-buffer residency: every BTree page is a fixed Page.Length (512 B).
+        /// Read-only: never evicts. All of this is "pinned" in the durable-memory report.</summary>
+        internal (int count, long bytes, long pending) PageBufferResidencyForTest()
+        {
+            int count = m_pageBuffer.Count;
+            long bytes = (long)count * Page.Length;
+            long pending = (long)m_pagesToWrite.Count * Page.Length;
+            return (count, bytes, pending);
+        }
+
         private static int CompareByCLevel(BTreePage x, BTreePage y)
         {
             if (x.cLevel > y.cLevel)

--- a/vendor/PSTFileFormat/NodeDatabse/Block/BufferedBlockStore.cs
+++ b/vendor/PSTFileFormat/NodeDatabse/Block/BufferedBlockStore.cs
@@ -180,6 +180,9 @@ namespace PSTFileFormat
                     continue; // already persisted in a prior batch
                 }
                 Block block = m_blockBuffer[blockID];
+                System.Diagnostics.Debug.Assert(
+                    block is DataBlock dbl && dbl.DataLength == DataBlock.MaximumDataLength,
+                    "PersistLeafBlocks requires full (8176 B) leaf DataBlocks — partial/interior block would violate the zero-fill invariant [A1]");
                 long offset = AllocationHelper.AllocateSpaceForBlock(m_file, block.TotalLength);
                 block.WriteToStream(m_file.BaseStream, offset);
                 m_file.BlockBTree.InsertBlockEntry(block.BlockID, offset, block.DataLength);

--- a/vendor/PSTFileFormat/NodeDatabse/Block/BufferedBlockStore.cs
+++ b/vendor/PSTFileFormat/NodeDatabse/Block/BufferedBlockStore.cs
@@ -161,6 +161,28 @@ namespace PSTFileFormat
             m_blocksToFree.Clear();
         }
 
+        /// <summary>
+        /// Streaming-flush primitive [R2:M1]: persist the given leaf blocks (write bytes + insert the
+        /// in-memory BBT entry) and remove ONLY their BIDs from the pending set, leaving the spine and
+        /// every other pending block untouched. Unlike SaveChanges() this does NO rescan/zero-fill and
+        /// does NOT clear m_blocksToWrite wholesale. Caller guarantees each BID is a full leaf DataBlock.
+        /// </summary>
+        public void PersistLeafBlocks(IEnumerable<ulong> leafBlockIDs)
+        {
+            foreach (ulong blockID in leafBlockIDs)
+            {
+                if (!m_blocksToWrite.Contains(blockID))
+                {
+                    continue; // already persisted in a prior batch
+                }
+                Block block = m_blockBuffer[blockID];
+                long offset = AllocationHelper.AllocateSpaceForBlock(m_file, block.TotalLength);
+                block.WriteToStream(m_file.BaseStream, offset);
+                m_file.BlockBTree.InsertBlockEntry(block.BlockID, offset, block.DataLength);
+                m_blocksToWrite.Remove(blockID);
+            }
+        }
+
         public PSTFile File
         {
             get

--- a/vendor/PSTFileFormat/NodeDatabse/Block/BufferedBlockStore.cs
+++ b/vendor/PSTFileFormat/NodeDatabse/Block/BufferedBlockStore.cs
@@ -183,6 +183,45 @@ namespace PSTFileFormat
             }
         }
 
+        /// <summary>
+        /// Residency-only eviction [§4]. Evicts blockID from m_blockBuffer iff ALL hold:
+        /// (1) present in the buffer; (2) not pending; (4/6) a leaf DataBlock; (3) BBT-indexed;
+        /// (5/7) the owner's live-spine policy approves (caller passes the CURRENT live BID + fullness).
+        /// The GetBlock clone contract makes this logically safe (callers never alias the cached block).
+        /// </summary>
+        public bool TryEvictLeaf(ulong blockID, Func<ulong, bool> isFullAndEvictable)
+        {
+            if (!m_blockBuffer.ContainsKey(blockID)) return false;          // cond 1
+            if (m_blocksToWrite.Contains(blockID)) return false;            // cond 2 (pending)
+            if (!(m_blockBuffer[blockID] is DataBlock)) return false;       // cond 4/6 (leaf only)
+            if (m_file.FindBlockEntryByBlockID(blockID) == null) return false; // cond 3 (BBT-indexed)
+            // cond 7b: leaf is full. cond 7a (live-spine identity) is the CALLER's job — it must pass the
+            // current rgbid[index] BID, re-read each batch, never a remembered/cached BID. [R3]
+            if (!isFullAndEvictable(blockID)) return false;
+            m_blockBuffer.Remove(blockID);
+            return true;
+        }
+
+        /// <summary>Read a persisted data leaf by BID WITHOUT re-adding it to m_blockBuffer [A12].</summary>
+        public byte[] ReadDataLeafWithoutCaching(ulong blockID)
+        {
+            DataBlock block = (DataBlock)m_file.FindBlockByBlockID(blockID);
+            return block.Data;
+        }
+
+        // Spike instrumentation: current resident block count.
+        public int BufferedBlockCountForTest
+        {
+            get { return m_blockBuffer.Count; }
+        }
+
+        // Spike instrumentation: pending (unwritten) block count. A strictly stronger [C1] gate than a
+        // per-leaf walk — it also catches a pending spine block — and allocation-free. [R3]
+        public int PendingWriteCountForTest
+        {
+            get { return m_blocksToWrite.Count; }
+        }
+
         public PSTFile File
         {
             get

--- a/vendor/PSTFileFormat/NodeDatabse/Block/BufferedBlockStore.cs
+++ b/vendor/PSTFileFormat/NodeDatabse/Block/BufferedBlockStore.cs
@@ -24,7 +24,7 @@ namespace PSTFileFormat
 
         // The NDB is immutable, we allocate blocks for both new blocks and modified blocks,
         // for modified blocks, we unallocate the original blocks (using m_blocksToFree).
-        private List<ulong> m_blocksToWrite = new List<ulong>();
+        private HashSet<ulong> m_blocksToWrite = new HashSet<ulong>();
         private List<ulong> m_blocksToFree = new List<ulong>();
 
         protected BufferedBlockStore(PSTFile file)

--- a/vendor/PSTFileFormat/NodeDatabse/Block/BufferedBlockStore.cs
+++ b/vendor/PSTFileFormat/NodeDatabse/Block/BufferedBlockStore.cs
@@ -27,6 +27,9 @@ namespace PSTFileFormat
         private HashSet<ulong> m_blocksToWrite = new HashSet<ulong>();
         private List<ulong> m_blocksToFree = new List<ulong>();
 
+        // Spike instrumentation: counts BID reallocations (the non-pending UpdateBlock branch).
+        private long m_blockReallocationsForTest = 0;
+
         protected BufferedBlockStore(PSTFile file)
         {
             m_file = file;
@@ -83,6 +86,7 @@ namespace PSTFileFormat
             {
                 // we need to mark the old block for freeing, and add the new block to the buffer
                 DeleteBlock(block);
+                m_blockReallocationsForTest++;
                 bool isInternal = block.BlockID.Internal;
                 block.BlockID = m_file.Header.AllocateNextBlockID();
                 block.BlockID.Internal = isInternal;
@@ -228,6 +232,11 @@ namespace PSTFileFormat
             {
                 return m_file;
             }
+        }
+
+        public long BlockReallocationsForTest
+        {
+            get { return m_blockReallocationsForTest; }
         }
     }
 }

--- a/vendor/PSTFileFormat/NodeDatabse/Block/BufferedBlockStore.cs
+++ b/vendor/PSTFileFormat/NodeDatabse/Block/BufferedBlockStore.cs
@@ -241,5 +241,32 @@ namespace PSTFileFormat
         {
             get { return m_blockReallocationsForTest; }
         }
+
+        /// <summary>
+        /// Measurement-only [§7]. Sums residency of m_blockBuffer WITHOUT mutating it: total payload bytes,
+        /// pending bytes (BID still in m_blocksToWrite), and "evictable" bytes — buffered FULL leaf DataBlocks
+        /// that pass a non-mutating mirror of the §4 safe-eviction predicate (present, not pending, BBT-indexed,
+        /// a full 8176 B DataBlock, and not the live root BID). Read-only: never evicts.
+        /// </summary>
+        internal (int count, long payload, long pending, long evictable) BlockBufferResidencyForTest(ulong? liveRootBid)
+        {
+            int count = 0;
+            long payload = 0, pending = 0, evictable = 0;
+            foreach (var kv in m_blockBuffer)
+            {
+                ulong bid = kv.Key;
+                Block block = kv.Value;
+                count++;
+                long bytes = block.DataLength;
+                payload += bytes;
+                bool isPending = m_blocksToWrite.Contains(bid);
+                if (isPending) { pending += bytes; continue; }
+                bool isFullLeaf = block is DataBlock db && db.DataLength == DataBlock.MaximumDataLength;
+                bool isRoot = liveRootBid.HasValue && bid == liveRootBid.Value;
+                bool bbtIndexed = m_file.FindBlockEntryByBlockID(bid) != null;
+                if (isFullLeaf && bbtIndexed && !isRoot) evictable += bytes;
+            }
+            return (count, payload, pending, evictable);
+        }
     }
 }

--- a/vendor/PSTFileFormat/NodeDatabse/DataTree/DataTree.cs
+++ b/vendor/PSTFileFormat/NodeDatabse/DataTree/DataTree.cs
@@ -576,6 +576,7 @@ namespace PSTFileFormat
                 DataBlock leaf = GetDataBlock(i);                     // live spine identity, re-read each batch [A3]
                 ulong liveBid = leaf.BlockID.Value;
                 bool full = leaf.DataLength == DataBlock.MaximumDataLength;
+                // [A3] liveBid is re-read from the live spine each batch (never a remembered BID); the lambda only carries fullness.
                 if (TryEvictLeaf(liveBid, _ => full))
                 {
                     lowWaterIndex = i + 1;

--- a/vendor/PSTFileFormat/NodeDatabse/DataTree/DataTree.cs
+++ b/vendor/PSTFileFormat/NodeDatabse/DataTree/DataTree.cs
@@ -494,6 +494,110 @@ namespace PSTFileFormat
             }
         }
 
+        /// <summary>
+        /// Streaming append [Target A]: write `length` bytes from `stream` across leaf blocks, persisting
+        /// and evicting older full leaves in byte-batches so resident memory is independent of `length`.
+        /// Ends with one explicit spine SaveChanges() [R2:C1]. Never partial-persists an interior block [A1].
+        /// </summary>
+        public void AppendData(Stream stream, long length)
+        {
+            if (m_bCryptMethod != bCryptMethodName.NDB_CRYPT_PERMUTE)   // [A9/R2:M3]
+            {
+                throw new NotSupportedException("Streaming attachment write requires NDB_CRYPT_PERMUTE");
+            }
+            if (length == 0)
+            {
+                return;   // zero-length: leave the tree empty, caller must not write a subnode entry [R3:NEW-03]
+            }
+            // Precondition: a freshly created DataTree (single empty root DataBlock).
+            System.Diagnostics.Debug.Assert(DataBlockCount == 1, "AppendData(Stream,long) requires a fresh DataTree");
+
+            const int LeafSize = DataBlock.MaximumDataLength;          // 8176
+            const long BatchBytes = 8L * 1024 * 1024;                 // 8 MB starting batch
+
+            long remaining = length;
+            long bytesSinceFlush = 0;
+            int lowWaterIndex = 0;                                     // first not-yet-evicted leaf
+            bool first = true;
+
+            while (remaining > 0)
+            {
+                int toRead = (int)Math.Min((long)LeafSize, remaining);
+                byte[] leaf = new byte[toRead];                       // one fresh buffer per leaf [R3:F5]
+                ReadExactly(stream, leaf, toRead);
+
+                if (first)
+                {
+                    UpdateDataBlock(0, leaf);                          // fill the initial empty root DataBlock
+                    first = false;
+                }
+                else
+                {
+                    AddDataBlock(leaf);                               // zero-fills prior tail, grows the spine
+                }
+
+                remaining -= toRead;
+                bytesSinceFlush += toRead;
+
+                if (bytesSinceFlush >= BatchBytes)
+                {
+                    FlushAndEvictBatch(ref lowWaterIndex);
+                    bytesSinceFlush = 0;
+                }
+            }
+
+            // Drain: one final flush+evict so end-state residency is just tail + preceding + spine,
+            // making writer-side residency independent of attachment size [R3:F1].
+            FlushAndEvictBatch(ref lowWaterIndex);
+
+            // Final, explicit local spine flush [R2:C1] — persists the spine + the unflushed tail leaf.
+            // (Caller inserts the subnode entry AFTER this, reading RootBlock.BlockID at that instant [A4].)
+            SaveChanges();
+        }
+
+        // Persist the FULL leaves (0..count-2) not yet persisted; evict old full leaves up to count-3,
+        // keeping the preceding block (count-2) and the partial tail (count-1) resident [A1, R2:L3].
+        private void FlushAndEvictBatch(ref int lowWaterIndex)
+        {
+            int count = DataBlockCount;                               // hoisted (XXBlock getter clones) [R2:L2]
+            int highestFull = count - 2;                              // count-1 tail is partial
+            if (highestFull < lowWaterIndex) return;
+
+            var fullLeaves = new List<ulong>();
+            for (int i = lowWaterIndex; i <= highestFull; i++)
+            {
+                fullLeaves.Add(GetDataBlock(i).BlockID.Value);
+            }
+            PersistLeafBlocks(fullLeaves);
+
+            int highestEvictable = count - 3;                         // keep preceding + tail
+            for (int i = lowWaterIndex; i <= highestEvictable; i++)
+            {
+                DataBlock leaf = GetDataBlock(i);                     // live spine identity, re-read each batch [A3]
+                ulong liveBid = leaf.BlockID.Value;
+                bool full = leaf.DataLength == DataBlock.MaximumDataLength;
+                if (TryEvictLeaf(liveBid, _ => full))
+                {
+                    lowWaterIndex = i + 1;
+                }
+                else
+                {
+                    break;                                           // stop at first non-evictable; preserves order
+                }
+            }
+        }
+
+        private static void ReadExactly(Stream stream, byte[] buffer, int count)
+        {
+            int read = 0;
+            while (read < count)
+            {
+                int n = stream.Read(buffer, read, count - read);
+                if (n <= 0) throw new EndOfStreamException("Attachment stream ended before declared length");
+                read += n;
+            }
+        }
+
         public void Clear()
         {
             // delete extra blocks

--- a/vendor/PSTFileFormat/NodeDatabse/DataTree/DataTree.cs
+++ b/vendor/PSTFileFormat/NodeDatabse/DataTree/DataTree.cs
@@ -502,6 +502,16 @@ namespace PSTFileFormat
         /// </summary>
         public void AppendData(Stream stream, long length)
         {
+            AppendData(stream, length, System.Threading.CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Cancellation-aware streaming append. Checks the token at the top of each leaf iteration
+        /// (every ≤8176 B); an OCE propagates before the final spine SaveChanges(), leaving the tree
+        /// partial+pending for the caller to discard with the part.
+        /// </summary>
+        public void AppendData(Stream stream, long length, System.Threading.CancellationToken cancellationToken)
+        {
             if (m_bCryptMethod != bCryptMethodName.NDB_CRYPT_PERMUTE)   // [A9/R2:M3]
             {
                 throw new NotSupportedException("Streaming attachment write requires NDB_CRYPT_PERMUTE");
@@ -523,6 +533,8 @@ namespace PSTFileFormat
 
             while (remaining > 0)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 int toRead = (int)Math.Min((long)LeafSize, remaining);
                 byte[] leaf = new byte[toRead];                       // one fresh buffer per leaf [R3:F5]
                 ReadExactly(stream, leaf, toRead);

--- a/vendor/PSTFileFormat/NodeDatabse/DataTree/DataTree.cs
+++ b/vendor/PSTFileFormat/NodeDatabse/DataTree/DataTree.cs
@@ -511,6 +511,12 @@ namespace PSTFileFormat
             }
         }
 
+        // Spike instrumentation: is the current spine/root block still pending write?
+        public bool IsRootPendingWriteForTest()
+        {
+            return m_rootBlock != null && IsBlockPendingWrite(m_rootBlock);
+        }
+
         public int DataBlockCount
         {
             get

--- a/vendor/PSTFileFormat/NodeDatabse/DataTree/DataTree.cs
+++ b/vendor/PSTFileFormat/NodeDatabse/DataTree/DataTree.cs
@@ -405,7 +405,8 @@ namespace PSTFileFormat
             // A data block could have been modified (heap item was removed) and a block that was 
             // supposed to be zero-filled may have become non-zero filled.
             // We must make sure that all blocks that are pending write (except the last block) are zero filled
-            for(int blockIndex = 0; blockIndex < DataBlockCount - 1; blockIndex++)
+            int lastIndexExclusive = DataBlockCount - 1;   // [R2:L2] DataBlockCount clones the last XBlock for XXBlock trees — read once
+            for (int blockIndex = 0; blockIndex < lastIndexExclusive; blockIndex++)
             {
                 if (IsDataBlockPendingWrite(blockIndex))
                 {

--- a/vendor/PSTFileFormat/PSTFile.cs
+++ b/vendor/PSTFileFormat/PSTFile.cs
@@ -40,6 +40,16 @@ namespace PSTFileFormat
         internal List<int> AMapMaxFreeGeneral;
         internal List<int> AMapMaxFreeAligned;
 
+        /// <summary>Measurement-only [§7]. AMap cache residency (one AllocationMapPage per ~254 KB of file,
+        /// pinned by the #34/free-space design) + the AMapMaxFree* index list lengths. Read-only.</summary>
+        internal (int pageCount, long bytes, int maxFreeGeneral, int maxFreeAligned) AMapResidencyForTest()
+        {
+            int pages = AMapCache?.Count ?? 0;
+            int g = AMapMaxFreeGeneral?.Count ?? 0;
+            int a = AMapMaxFreeAligned?.Count ?? 0;
+            return (pages, (long)pages * 512, g, a);
+        }
+
         private WriterCompatibilityMode m_writerCompatibilityMode;
         
         FileStream m_stream;

--- a/vendor/PSTFileFormat/PSTFile.cs
+++ b/vendor/PSTFileFormat/PSTFile.cs
@@ -13,7 +13,6 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using Utilities;
 
-[assembly: InternalsVisibleTo("Mail2Pst.Core")]
 [assembly: InternalsVisibleTo("Mail2Pst.Core.Tests")]
 
 namespace PSTFileFormat

--- a/vendor/PSTFileFormat/PSTFile.cs
+++ b/vendor/PSTFileFormat/PSTFile.cs
@@ -13,6 +13,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using Utilities;
 
+[assembly: InternalsVisibleTo("Mail2Pst.Core")]
 [assembly: InternalsVisibleTo("Mail2Pst.Core.Tests")]
 
 namespace PSTFileFormat


### PR DESCRIPTION
## PST Engine Phase 2 — attachment streaming + durable-memory measurement

Makes the writer's peak memory independent of **attachment** size and quantifies durable PST-writer memory. Three sub-efforts, built spike-first so the risky part was gated before any product wiring:

### 1. Streaming spike (gate)
Proved — with fail-closed tests — that an attachment `DataTree` can be written in 8 MB batches that persist + evict leaf blocks mid-write within one `BeginSavingChanges()` window, without reallocating the XBlock/XXBlock spine or ever persisting a partial interior block. New vendored primitives: `BufferedBlockStore.{PersistLeafBlocks, TryEvictLeaf, ReadDataLeafWithoutCaching}`, `DataTree.AppendData(Stream,long)`. Round-trip across both spine transitions, zero-fill, bounded-residency, and no-spine-reallocation gates all green → **GO**.

### 2. Target-C durable-memory measurement (measure + document only)
Read-only residency instrumentation over the five durable accumulator families, aggregated via the folder-TC traversal into an opt-in checkpoint observer + report. Real Gmail-corpus run: **evictable ratio ≈ 22% → `pinned-dominant`** (BBT/NBT pages + decoded heap cache + AMap dominate, as designed). **No pruning mechanism built** — a leaf-prune would reclaim too little to sell as a bound. Opt-in (`DurableMemoryObserver` defaults null): zero production behavior change.

### 3. Target-A wiring (the production change)
Streams `PidTagAttachData` into the PST instead of materializing the whole attachment writer-side. **Size-gated: only attachments ≥ 16 MB stream; smaller keep the proven `byte[]` path** (the OOM was a hundreds-of-MB phenomenon, so this keeps the new path off ordinary conversions). Attachment data lives in the attachment's own PC, so the Outlook2007RTM property-size re-read never re-materializes evicted leaves; the message **body is never streamed**. Heap-vs-subnode routing preserved; INSERT-only; per-batch cancellation; PERMUTE precondition with `byte[]` fallback; `MAIL2PST_NO_ATTACH_STREAM` kill-switch.

### Validation
- **End-to-end on real attachments 5 MB → 512 MB** (mbox → convert → reopen): all convert, **byte-identical (SHA-256 match) for every size**, independently structure-validated (`pst-validate`, 0 errors).
- Writer-side resident-block count stays **flat from 9 MB to 512 MB** (bounded, independent of attachment size).
- Scope (honest): this removes the *writer-side* multiplier. The mbox parser still materializes one message, so total process memory for a single multi-GB attachment remains parser-bound — separate future work.
- Engine suite: **686 Core + 80 Integration green** / opt-in slow gates skipped. `#34` `AddMessage` characterization unregressed. No desktop changes.

### Process
Built subagent-driven, one reviewed conventional commit per task; opus whole-branch reviews per sub-effort; the Target-A plan was hardened by a multi-agent adversarial review (8 findings folded) before execution.

**Merge:** rebase-merge to preserve the per-task commits and keep `main` linear.
