### PR TITLE
Release 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   progressively. The allocator now uses a maintained best-fit free-space index, keeping
   per-message cost flat. A ~16,000-message folder that took ~70 s now takes ~40 s; output
   validity is unchanged (verified against an independent MS-PST reader).
+- Thunderbird enrichment is far quieter on real profiles. Two harmless internal conditions no
+  longer raise per-folder warnings: (1) an **empty folder** (whose `.msf` has no message table) is
+  now treated as "no messages" instead of an unreadable-`.msf` warning; (2) the dead-copy
+  **live-offset filter declining to run** — the common, expected case for IMAP accounts, whose `.msf`
+  rows usually carry no usable byte offset — is now silent. In both cases behaviour is unchanged
+  (every message is still exported and flags/tags still applied); only the noise is gone. A genuinely
+  corrupt `.msf`, and an ambiguous multi-table `.msf`, still warn. The aggregate filter-disabled count
+  remains in the conversion report for diagnostics.
 
 ### Fixed
 - Writer: a failed split (e.g. the next part can't be created mid-conversion) no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] — 2026-06-27
+
 ### Added
 - Thunderbird `.msf` enrichment now preserves **message priority** set inside Thunderbird. A
   priority a user or filter applied in Thunderbird is stored only in the `.msf` (not in the mbox

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@radix-ui/react-slot": "^1.3.0",
         "@tauri-apps/api": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.2.0"
+version = "0.2.1"
 description = "ContinuMail Converter — convert mbox mail archives to Outlook PST"
 authors = ["Aksel Visby <aksel@visby.it>"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ContinuMail Converter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "com.continumail.converter",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/Mail2Pst.Cli/Mail2Pst.Cli.csproj
+++ b/src/Mail2Pst.Cli/Mail2Pst.Cli.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Mail2Pst.Cli</RootNamespace>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../Mail2Pst.Core/Mail2Pst.Core.csproj" />

--- a/src/Mail2Pst.Core/Msf/MsfMessageReader.cs
+++ b/src/Mail2Pst.Core/Msf/MsfMessageReader.cs
@@ -18,16 +18,23 @@ public static class MsfMessageReader
     internal const string MsgsKind  = "ns:msg:db:table:kind:msgs";
 
     /// <summary>
-    /// Interprets the single msgs table in <paramref name="doc"/>.
+    /// Interprets the msgs table in <paramref name="doc"/>. Zero msgs tables means an empty
+    /// Thunderbird folder (no messages stored) and yields an empty result. Two or more tables
+    /// is genuinely ambiguous (we cannot pick which holds the live messages) and throws.
     /// </summary>
     /// <exception cref="ArgumentNullException"><paramref name="doc"/> is null.</exception>
-    /// <exception cref="MorkFormatException">The document does not contain exactly one msgs table.</exception>
+    /// <exception cref="MorkFormatException">The document contains more than one msgs table.</exception>
     public static MsfReadResult Read(MorkDocument doc)
     {
         ArgumentNullException.ThrowIfNull(doc);
 
         IReadOnlyList<MorkTable> tables = doc.GetTables(MsgsScope, MsgsKind);
-        if (tables.Count != 1)
+        if (tables.Count == 0)
+        {
+            // Empty folder: a .msf with no msgs table is "zero messages", not a malformed file.
+            return new MsfReadResult(System.Array.Empty<MsfMessage>(), System.Array.Empty<MsfDiagnostic>());
+        }
+        if (tables.Count > 1)
         {
             throw new MorkFormatException(
                 $"Expected exactly one Thunderbird msgs table, found {tables.Count}.");

--- a/src/Mail2Pst.Core/Msf/SourceEnrichmentContext.cs
+++ b/src/Mail2Pst.Core/Msf/SourceEnrichmentContext.cs
@@ -102,16 +102,14 @@ internal sealed class SourceEnrichmentContext
         {
             context.Result.LiveOffsetFilterEnabledSources = 1;
         }
-        else if (filter.LiveRows > 0)   // HAD a live set but refused to filter -> report it (keep all)
+        else if (filter.LiveRows > 0)   // HAD a live set but refused to filter -> count it (keep all)
         {
+            // A disabled filter is an internal optimisation declining to run (the common, expected case
+            // for IMAP-derived .msf, which usually lacks usable per-row offsets), NOT a user-actionable
+            // problem. The .msf is NOT degraded and the source stays enriched:true. We keep the aggregate
+            // count on the enrichment summary for diagnostics but DO NOT surface a per-source warning or
+            // WarningEvent — doing so produced one alarming warning per IMAP folder for no user benefit.
             context.Result.LiveOffsetFilterDisabledSources = 1;
-            string detail = $"live-offset-filter-disabled: {filter.DisabledReason}; msf={msfPath}; " +
-                $"liveRows={filter.LiveRows} usableOffsets={filter.UsableOffsets} matchedOffsets={filter.MatchedOffsets}" +
-                (filter.UnmatchedSample.Count > 0 ? $" unmatchedSample=[{string.Join(",", filter.UnmatchedSample)}]" : "");
-            // RecordWarning + WarningEvent, NOT Degrade: a disabled filter is a warning, but the .msf itself is
-            // NOT degraded and the source stays enriched:true.
-            report.RecordWarning(sourceRef, detail);
-            onProgress?.Invoke(new WarningEvent(sourceRef.SourcePath, sourceRef.Identifier, detail));
         }
         // filter.LiveRows == 0 (empty live set): keep all, NO warning, NOT counted disabled — nothing to filter.
         return context;

--- a/tests/Mail2Pst.Core.Tests/Msf/MsfMessageReaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/MsfMessageReaderTests.cs
@@ -34,11 +34,14 @@ public class MsfMessageReaderTests
     }
 
     [Fact]
-    public void Read_NoMsgsTable_ThrowsMorkFormatException()
+    public void Read_NoMsgsTable_ReturnsEmptyResult()
     {
+        // An empty Thunderbird folder has a .msf with no msgs table. That is "zero messages",
+        // not a malformed file — return an empty result (no warning, no degradation) rather than throw.
         var doc = new MorkDocument(Array.Empty<MorkTable>());
-        var ex = Assert.Throws<MorkFormatException>(() => MsfMessageReader.Read(doc));
-        Assert.Contains("found 0", ex.Message);
+        MsfReadResult result = MsfMessageReader.Read(doc);
+        Assert.Empty(result.Messages);
+        Assert.Empty(result.Diagnostics);
     }
 
     [Fact]

--- a/tests/Mail2Pst.Core.Tests/Msf/SourceEnrichmentContextTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Msf/SourceEnrichmentContextTests.cs
@@ -58,8 +58,12 @@ public class SourceEnrichmentContextTests
     [Fact]
     public void TryCreate_MalformedMsf_Degrades_WithWarning()
     {
+        // Genuine Mork-level corruption (an unterminated row) — MorkReader fails loud, so the source
+        // degrades and warns. NOTE: this must be malformed Mork, not merely table-less: a valid .msf
+        // with no msgs table is an empty folder (see TryCreate_EmptyMsf_NoMsgsTable_Enriched_NoWarning),
+        // not a degradation.
         string mbox = Write(Mbox(), ".mbox");
-        string msf = Write("this is not mork", ".msf");
+        string msf = Write("[1(^88=1)", ".msf");
         var report = new ConversionReport();
         try
         {
@@ -68,6 +72,28 @@ public class SourceEnrichmentContextTests
             Assert.Null(ctx);
             Assert.Equal(1, report.EnrichmentSummary.SourcesDegraded);
             Assert.Equal(1, report.WarningCount);
+        }
+        finally { File.Delete(mbox); File.Delete(msf); }
+    }
+
+    [Fact]
+    public void TryCreate_EmptyMsf_NoMsgsTable_Enriched_NoWarning()
+    {
+        // A valid .msf with column dicts but no msgs table = an empty Thunderbird folder. It must be
+        // treated as "enriched, zero messages" — NOT a degradation and NOT a warning (Bucket B noise).
+        string mbox = Write(Mbox(), ".mbox");
+        string msf = Write(
+            "< <(a=c)> (80=ns:msg:db:row:scope:msgs:all)(96=ns:msg:db:table:kind:msgs)(88=flags)(89=message-id) >\n",
+            ".msf");
+        var report = new ConversionReport();
+        try
+        {
+            var ctx = SourceEnrichmentContext.TryCreate(
+                new SourceConfig { Path = mbox, Type = "mbox", MsfPath = msf }, Opts(), report);
+            Assert.NotNull(ctx);
+            Assert.Equal(1, report.EnrichmentSummary.SourcesEnriched);
+            Assert.Equal(0, report.EnrichmentSummary.SourcesDegraded);
+            Assert.Equal(0, report.WarningCount);
         }
         finally { File.Delete(mbox); File.Delete(msf); }
     }
@@ -152,7 +178,7 @@ public class SourceEnrichmentContextTests
     }
 
     [Fact]
-    public void TryCreate_MisalignedMsf_DisablesFilter_KeepsAll_Warns()
+    public void TryCreate_MisalignedMsf_DisablesFilter_KeepsAll_NoUserWarning()
     {
         string mbox = Write("From a@b\nMessage-ID: <a@h>\nSubject: t\n\nbody\n", ".mbox");
         string msf = Write(
@@ -165,17 +191,20 @@ public class SourceEnrichmentContextTests
                 new SourceConfig { Path = mbox, Type = "mbox", MsfPath = msf }, Opts(), report);
             Assert.NotNull(ctx);
             Assert.False(ctx!.ShouldDropOrphan(0));   // disabled -> never drops
+            // A disabled filter is an internal optimisation declining to run, not a user-actionable
+            // problem: the count is kept for diagnostics, but NO warning is surfaced.
             Assert.Equal(1, ctx.Result.LiveOffsetFilterDisabledSources);
-            Assert.Equal(1, report.WarningCount);     // disabled warning recorded immediately in TryCreate
+            Assert.Equal(1, report.EnrichmentSummary.SourcesEnriched); // still enriched, NOT degraded
+            Assert.Equal(0, report.WarningCount);
         }
         finally { File.Delete(mbox); File.Delete(msf); }
     }
 
     [Fact]
-    public void TryCreate_OneRowWithoutUsableOffset_DisablesFilter_KeepsAll_Warns()
+    public void TryCreate_OneRowWithoutUsableOffset_DisablesFilter_KeepsAll_NoUserWarning()
     {
         // Two physical messages; .msf has the first row's storeToken numeric but the second row has NO
-        // usable offset -> activation condition 3 fails -> keep all + warn (must-fix 2).
+        // usable offset -> activation condition 3 fails -> keep all, count it, but DON'T warn.
         string m1 = "From a@b\nMessage-ID: <a@h>\nSubject: t\n\nbody\n\n";
         string mbox = Write(m1 + "From c@d\nMessage-ID: <c@h>\nSubject: t\n\nbody\n", ".mbox");
         string msf = Write(
@@ -189,7 +218,29 @@ public class SourceEnrichmentContextTests
             Assert.NotNull(ctx);
             Assert.False(ctx!.ShouldDropOrphan(0));   // disabled -> nothing dropped, even index 0
             Assert.Equal(1, ctx.Result.LiveOffsetFilterDisabledSources);
-            Assert.Equal(1, report.WarningCount);
+            Assert.Equal(0, report.WarningCount);
+        }
+        finally { File.Delete(mbox); File.Delete(msf); }
+    }
+
+    [Fact]
+    public void TryCreate_DisabledFilter_EmitsNoWarningEvent()
+    {
+        // The disabled-filter case must not push a WarningEvent into the streaming progress channel
+        // (which the CLI/GUI surface to the user) — contrast TryCreate_MissingMsf_EmitsWarningEvent.
+        string mbox = Write("From a@b\nMessage-ID: <a@h>\nSubject: t\n\nbody\n", ".mbox");
+        string msf = Write(
+            "< <(a=c)> (80=ns:msg:db:row:scope:msgs:all)(96=ns:msg:db:table:kind:msgs)(88=flags)(CE=storeToken) >\n" +
+            "{1:^80 {(k^96:c)} [1(^88=1)(^CE=999999)] }", ".msf");
+        var report = new ConversionReport();
+        var events = new List<ConversionProgressEvent>();
+        try
+        {
+            var ctx = SourceEnrichmentContext.TryCreate(
+                new SourceConfig { Path = mbox, Type = "mbox", MsfPath = msf }, Opts(), report, events.Add);
+            Assert.NotNull(ctx);
+            Assert.Equal(1, ctx!.Result.LiveOffsetFilterDisabledSources);
+            Assert.Empty(events.OfType<WarningEvent>());
         }
         finally { File.Delete(mbox); File.Delete(msf); }
     }


### PR DESCRIPTION
## Release 0.2.1

Cuts the **0.2.1** release: the accumulated unreleased writer/`.msf` work plus one new fix found during owner validation on a real Thunderbird profile.

### Headline fix — quieter `.msf` enrichment on real profiles
A full profile conversion raised ~30 warnings that were all fail-safe (no mail lost). Two benign internal conditions were being surfaced as per-folder warnings; both are now silent, behaviour otherwise unchanged:

- **Empty folders.** A folder whose `.msf` has no message table threw "found 0 msgs table" → degrade + warning. Zero tables is now treated as an empty folder (empty result, source stays `enriched`). Two-or-more tables still throws (the ambiguous multi-table case, KB-003).
- **Live-offset filter declining to run.** The dead-copy filter cannot activate on IMAP `.msf` (rows lack usable per-row offsets) — the expected case. It no longer emits a per-folder warning/`WarningEvent`; the aggregate `LiveOffsetFilterDisabledSources` count stays in the report for diagnostics.

A genuinely corrupt `.msf` still warns + degrades. Net effect on a real profile: ~30 → ~3 warnings.

### Release mechanics
- Version bumped 0.2.0 → **0.2.1** across `Cli.csproj`, `tauri.conf.json`, `package.json` (+lock), `Cargo.toml` (+lock).
- `CHANGELOG.md` `[Unreleased]` promoted to `[0.2.1] — 2026-06-27` (streaming large attachments, from-scratch PST writer, HeapOnNode O(n²)→best-fit perf, `.msf` live-offset dead-copy filtering + priority, split/oversize-attachment fixes, desktop temp-config cleanup, and this warning-noise fix).

### Verification
Engine 689 · integration 80 · desktop Vitest 214 — all green. Release build clean. leak-check clean on the range.
