### PR TITLE
fix(msf): KB-003 — fold Mork table-cut fragment, don't fork a phantom table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Thunderbird `.msf` reading no longer fails on a **reparsed folder**. A folder that Thunderbird had
+  reparsed left a table-rebuild fragment in its `.msf` that the reader mistook for a second message
+  table, so it gave up on that folder's metadata ("found 2 msgs tables") and fell back to mbox flags.
+  The reader now recognises the rebuild marker and folds it into the real table, so tags, read/unread,
+  and flags come across for those folders too. Affected only metadata fidelity — message content and
+  folder structure were never at risk.
+
 ## [0.2.1] — 2026-06-27
 
 ### Added

--- a/src/Mail2Pst.Core/Mork/MorkReader.cs
+++ b/src/Mail2Pst.Core/Mork/MorkReader.cs
@@ -439,6 +439,16 @@ internal sealed class MorkAssembler
         // Table id
         string tableId = ExpectText();
 
+        // A leading '-' is the Mork transaction CUT/clear marker on the table (e.g. `{-1:^80 ...}`,
+        // emitted during a Thunderbird folder reparse) — it targets table `1`, it is NOT part of the id
+        // and NOT a distinct table. The tokenizer only recognises the ROW-level cut (`[-id]`, after '['),
+        // so without this the '-' stays attached to the id ("-1") and ReadTable forks a phantom second
+        // table with the same scope/kind — which made MsfMessageReader throw "found 2 msgs tables"
+        // (KB-003). Strip it so the fragment folds into the real table via the append-log merge below.
+        // Hex table ids never legitimately start with '-', so this cannot collide with a real table.
+        if (tableId.Length > 1 && tableId[0] == '-')
+            tableId = tableId.Substring(1);
+
         // Colon separator
         Expect(MorkTokenKind.Colon);
 

--- a/tests/Mail2Pst.Core.Tests/Mork/MorkMergeTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mork/MorkMergeTests.cs
@@ -40,6 +40,22 @@ public class MorkMergeTests
     }
 
     [Fact]
+    public void Merge_TableLevelCutMarker_FoldsIntoBaseTable_NotPhantomTable()
+    {
+        // KB-003: a transaction restating the table with a leading '-' (`{-1:^80 ...}`) is a Mork
+        // table-level cut/transaction marker that targets table 1 — NOT a declaration of a new table
+        // "-1". Real Thunderbird .msf emits this during a folder reparse. The assembler must fold it
+        // into table 1 (yielding ONE msgs table), not fork a phantom second msgs table — which made
+        // MsfMessageReader throw "found 2 msgs tables".
+        var doc = MorkReader.ParseString(
+            Dict + "{1:^80 {(k^96:c)} [1(^88=1)] } @$${1{@ {-1:^80 {(k^96:c)} [1(^88=5)] } @$$}1}@");
+        // Exactly one msgs-scoped table — TryGetSingleTable returns false if a phantom "-1" also exists.
+        Assert.True(doc.TryGetSingleTable(
+            "ns:msg:db:row:scope:msgs:all", "ns:msg:db:table:kind:msgs", out var t));
+        Assert.Equal("5", t.Rows["1"].Cells["flags"]); // transaction folded into table 1 (last-write-wins)
+    }
+
+    [Fact]
     public void Merge_RowUpdateToEmptyValue_CellPresentButEmpty()
     {
         // Task 0 RESOLVED: Thunderbird .msf has NO cell-cut. `(^81=)` is an EMPTY-STRING value applied


### PR DESCRIPTION
## KB-003 — `.msf` reader no longer fails on a reparsed folder

**Problem.** Some folders' `.msf` parse threw "found 2 msgs tables", so the converter dropped that folder's Thunderbird metadata (tags, read/unread, flags) and fell back to mbox flags. Seen on a real profile: `outlook.office365.com\Slettet post.msf` and a deeply-nested Gmail folder.

**Root cause (verified against both real files).** The Mork tokenizer recognises the cut marker `-` only when it directly follows `[` (a row cut, `[-id]`) — never after `{` (a table cut). During a Thunderbird **folder reparse**, the `.msf` append-log contains a table-cut fragment `{-1:^80 {(k^96:c)} …}` that targets the existing msgs table `1`. The table parser read the id verbatim, so the leading `-` stayed attached and `{-1:…}` was assembled as a **phantom** table keyed `(msgs, "-1")` alongside the real `(msgs, "1")` → two msgs tables → `MsfMessageReader.Read` threw.

**Fix.** `MorkAssembler.ReadTable` strips a leading `-` from the table id, so the cut/transaction fragment folds into the real table via the existing append-log merge. A hex table id never legitimately starts with `-`, so this cannot collide with a real table. Row-level cut handling (`[-id]`) is unchanged.

**Limitation (documented).** The fold merges the fragment's row *restatements* but does not replay the reparse's row *cuts*/re-adds, so a freshly-reparsed folder may enrich from slightly stale rows. Safe for read-only enrichment (no throw, usable flags/tags).

**Verification.** Synthetic PII-free regression (`MorkMergeTests.Merge_TableLevelCutMarker_FoldsIntoBaseTable_NotPhantomTable`); validated directly against the two real offending `.msf` files (both now parse to exactly one msgs table). Core 690 + integration 80 green.
