### PR TITLE
fix(colours): KB-004 — kill transient Outlook so colour import can't hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- The optional **"Import category colours"** step no longer hangs when the categories are already in
+  Outlook. Re-importing colours that already existed in Outlook's master list left the brief background
+  Outlook running and the import spinner stuck indefinitely. The importer now always shuts that temporary
+  Outlook down (and finishes in a few seconds when there's nothing new to add), and the desktop app caps
+  the step so it can't get stuck. No effect on the colours themselves.
 - Thunderbird `.msf` reading no longer fails on a **reparsed folder**. A folder that Thunderbird had
   reparsed left a table-rebuild fragment in its `.msf` that the reader mistook for a second message
   table, so it gave up on that folder's metadata ("found 2 msgs tables") and fell back to mbox flags.

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -702,6 +702,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-shell",
+ "tokio",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -24,4 +24,6 @@ tauri-plugin-opener = "2"
 tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Already in the tree via tauri; declared directly for tokio::time::timeout (KB-004 sidecar cap).
+tokio = { version = "1", features = ["time"] }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -39,14 +39,19 @@ fn drain_lines(buf: &mut String) -> Vec<String> {
 // something — import-colours' handled failures exit 1 while emitting a structured {type:"error"} JSON
 // object the frontend needs. Err only on a spawn failure or a nonzero exit with no stdout.
 async fn run_sidecar_capture(app: &tauri::AppHandle, args: Vec<String>) -> Result<String, String> {
-    let output = app
+    let cmd = app
         .shell()
         .sidecar("mail2pst-cli")
         .map_err(|e| format!("sidecar not found: {e}"))?
-        .args(args)
-        .output()
-        .await
-        .map_err(|e| format!("failed to run engine: {e}"))?;
+        .args(args);
+    // Defence-in-depth (KB-004): never let a stuck sidecar hang the UI forever. The CLI bounds its own
+    // Outlook work and kills its transient instance, but if a child ever keeps the stdout pipe open
+    // `.output()` would await EOF indefinitely. Cap it so the command always resolves; the colour-import
+    // card surfaces a retry on this error. ("timed out" maps to a friendly message in ColourImportCard.)
+    let output = match tokio::time::timeout(std::time::Duration::from_secs(120), cmd.output()).await {
+        Ok(r) => r.map_err(|e| format!("failed to run engine: {e}"))?,
+        Err(_) => return Err("timed out waiting for Outlook — close any Outlook window and retry.".to_string()),
+    };
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     if output.status.success() || !stdout.trim().is_empty() {
         Ok(stdout)

--- a/src/Mail2Pst.Cli/OutlookComCategoryStore.cs
+++ b/src/Mail2Pst.Cli/OutlookComCategoryStore.cs
@@ -34,7 +34,8 @@ internal sealed class OutlookComCategoryStore : IOutlookCategoryStore, IDisposab
 {
     private const string RoamingXmlStreamProp = "http://schemas.microsoft.com/mapi/proptag/0x7C080102";
     private const int OlFolderCalendar = 9;
-    private const int ShutdownWaitMs = 30_000;
+    private const int ShutdownWaitMs = 30_000;       // wait for a clean exit when we wrote a FAI Save (flush window)
+    private const int NoChangeShutdownWaitMs = 3_000; // nothing saved -> nothing to flush, so kill the linger fast
 
     private readonly object _app;
     private readonly object _session;
@@ -43,6 +44,7 @@ internal sealed class OutlookComCategoryStore : IOutlookCategoryStore, IDisposab
     private readonly IReadOnlySet<string> _existing;
     private readonly List<(string Name, int OutlookColor)> _pending = new();
     private readonly int[] _startedPids;   // OUTLOOK.EXE PIDs that appeared when we created the instance
+    private bool _savedChanges;            // true once Commit() actually wrote+saved the FAI (picks the wait budget)
 
     internal OutlookComCategoryStore()
     {
@@ -77,6 +79,7 @@ internal sealed class OutlookComCategoryStore : IOutlookCategoryStore, IDisposab
         dynamic pa = _storage.PropertyAccessor;
         pa.SetProperty(RoamingXmlStreamProp, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false).GetBytes(newXml));
         _storage.Save(); // single atomic commit of the FAI message
+        _savedChanges = true;
         _pending.Clear();
     }
 
@@ -121,9 +124,17 @@ internal sealed class OutlookComCategoryStore : IOutlookCategoryStore, IDisposab
             try { ((dynamic)_app).Quit(); } catch { /* best-effort */ }
 
             // Wait for the OUTLOOK.EXE we started to exit — that is the flush-complete signal — bounded so a
-            // hung instance can't block the CLI. (If Logon blocks earlier and the STA Join times out, the
-            // store is abandoned un-Disposed and the started instance can leak; that path emits a clear
-            // "dismiss any Outlook prompt" error and is rare given ShowDialog=false + Outlook-closed.)
+            // hung instance can't block the CLI. If Quit() does NOT terminate it within the budget (seen on a
+            // no-op run: nothing was Saved, so Outlook has no MAPI change to flush and lingers), force-kill it.
+            // CRITICAL (KB-004): the COM-launched OUTLOOK.EXE inherits THIS process's stdout pipe
+            // handle. A lingering instance keeps that pipe open after the CLI exits, so the GUI's
+            // `.output()` (which reads stdout to EOF) blocks until Outlook finally dies — effectively forever
+            // → the colour-import spinner hangs. Killing the instance we started releases the pipe at once.
+            // We only kill PIDs in _startedPids (our own transient instance), never the user's Outlook. By this
+            // point Commit()'s Save (if any) has had the full wait budget to flush a tiny FAI XML write.
+            // Full flush window only when we actually wrote a Save; otherwise there is nothing to flush, so a
+            // lingering instance gets killed after a short grace (the common re-import-existing case → fast).
+            int waitBudget = _savedChanges ? ShutdownWaitMs : NoChangeShutdownWaitMs;
             var sw = Stopwatch.StartNew();
             foreach (int pid in _startedPids)
             {
@@ -131,10 +142,11 @@ internal sealed class OutlookComCategoryStore : IOutlookCategoryStore, IDisposab
                 try
                 {
                     p = Process.GetProcessById(pid);
-                    int remaining = ShutdownWaitMs - (int)sw.ElapsedMilliseconds;
+                    int remaining = waitBudget - (int)sw.ElapsedMilliseconds;
                     if (remaining > 0) p.WaitForExit(remaining);
+                    if (!p.HasExited) p.Kill(entireProcessTree: true); // Quit() didn't take — don't leak/hold the pipe
                 }
-                catch { /* already exited / not found */ }
+                catch { /* already exited / not found / access denied */ }
                 finally { p?.Dispose(); }
             }
         }


### PR DESCRIPTION
## KB-004 — colour import no longer hangs when categories already exist

**Problem.** The optional Done-screen "Import category colours" step spun forever when the categories were already in Outlook's master list (re-importing the same profile's tags). Clearing the master list first made it work.

**Root cause (reproduced + confirmed via Task Manager).** `import-colours --apply` starts a **transient Outlook** via COM. The launched `OUTLOOK.EXE` **inherits the CLI's stdout pipe handle**. When the categories already exist nothing is added, so `Commit()` does no `Save()` — the instance has no MAPI change to flush and **lingers after `Quit()`**. `Dispose` waited 30 s but **never killed it**, so the leaked Outlook held the stdout pipe open after the CLI exited. The GUI's Rust `apply_colours` reads stdout to EOF (`.output().await`, no timeout) → blocked until Outlook eventually died → effectively forever. Live repro: launching the apply left an `OUTLOOK.EXE` resident with the CLI already exited and stdout empty; killing that PID released the pipe and the correct `added:0 / skipped-existing:8` result flushed instantly. The category logic was never at fault.

**Fix (two layers).**
1. **CLI root fix** (`OutlookComCategoryStore.Dispose`): force-kill the transient `OUTLOOK.EXE` PIDs we started (`_startedPids` only — never the user's Outlook) if `Quit()` didn't terminate them, releasing the inherited pipe. The full 30 s flush window applies only when a `Save` was written; with nothing to flush (the common re-import case) it kills after a 3 s grace.
2. **Rust defence** (`run_sidecar_capture`): a 120 s `tokio::time::timeout` so the colour commands can never hang the UI; on timeout the card shows a retry.

**Verification.** Reproduced and fix-verified directly against real Outlook: hang → **5.1 s, no leftover `OUTLOOK.EXE`**, result unchanged. Full solution Release build + `cargo check` green. (Remaining owner check: the GUI card end-to-end via `npm run tauri dev`.)
