### PR TITLE
feat(scan): counting-decode measure-only attachment path (parallel-scan foundation)

### DIFF
--- a/src/Mail2Pst.Core/Models/AttachmentContent.cs
+++ b/src/Mail2Pst.Core/Models/AttachmentContent.cs
@@ -11,6 +11,7 @@ public sealed class AttachmentContent : IDisposable
 {
     private readonly byte[]? _bytes;
     private readonly string? _tempPath;
+    private readonly bool _lengthOnly;
     private bool _disposed;
 
     public long Length { get; }
@@ -18,10 +19,11 @@ public sealed class AttachmentContent : IDisposable
     internal bool IsTempFileBacked => _tempPath is not null;
     internal string? TempPath => _tempPath;
 
-    private AttachmentContent(byte[]? bytes, string? tempPath, long length)
+    private AttachmentContent(byte[]? bytes, string? tempPath, long length, bool lengthOnly = false)
     {
         _bytes = bytes;
         _tempPath = tempPath;
+        _lengthOnly = lengthOnly;
         Length = length;
     }
 
@@ -31,11 +33,22 @@ public sealed class AttachmentContent : IDisposable
     public static AttachmentContent FromTempFile(string path, long length) =>
         new(null, path, length);
 
+    /// <summary>A scan measure-only attachment: carries the exact decoded <see cref="Length"/> but NO
+    /// content. <see cref="OpenRead"/>/<see cref="ReadAllBytes"/> throw — it must never reach the writer.</summary>
+    public static AttachmentContent FromLengthOnly(long length)
+    {
+        if (length < 0) throw new ArgumentOutOfRangeException(nameof(length)); // model invariant
+        return new(null, null, length, lengthOnly: true);
+    }
+
     // Materializes the whole attachment in memory (in-memory bytes, or the entire temp
     // file). The temp-file path bounds the parse/write queue's sustained memory, not peak —
     // see MimeMessageMapper.ToAttachmentContent.
     public byte[] ReadAllBytes()
     {
+        if (_lengthOnly)
+            throw new InvalidOperationException(
+                "This attachment was produced in scan measure-only mode and has no content (length only).");
         if (_disposed)
             throw new ObjectDisposedException(nameof(AttachmentContent));
         return _bytes ?? File.ReadAllBytes(_tempPath!);
@@ -49,6 +62,9 @@ public sealed class AttachmentContent : IDisposable
     /// </summary>
     public Stream OpenRead()
     {
+        if (_lengthOnly)
+            throw new InvalidOperationException(
+                "This attachment was produced in scan measure-only mode and has no content (length only).");
         if (_disposed) throw new ObjectDisposedException(nameof(AttachmentContent));
         if (_bytes is not null)
         {

--- a/src/Mail2Pst.Core/Parsing/MboxParser.cs
+++ b/src/Mail2Pst.Core/Parsing/MboxParser.cs
@@ -21,11 +21,11 @@ public class MboxParser : IMailSourceParser
 
     private readonly MimeMessageMapper _mapper;
 
-    public MboxParser(long tempFileThresholdBytes = 4L * 1024 * 1024)
+    public MboxParser(long tempFileThresholdBytes = 4L * 1024 * 1024, bool measureOnly = false)
     {
         if (tempFileThresholdBytes < 0)
             throw new ArgumentOutOfRangeException(nameof(tempFileThresholdBytes), tempFileThresholdBytes, "Temp-file threshold must be non-negative.");
-        _mapper = new MimeMessageMapper(tempFileThresholdBytes);
+        _mapper = new MimeMessageMapper(tempFileThresholdBytes, measureOnly);
     }
 
     public IEnumerable<ParseResult> Parse(string path, Action<long>? onBytesRead = null)

--- a/src/Mail2Pst.Core/Parsing/Mime/CountingStream.cs
+++ b/src/Mail2Pst.Core/Parsing/Mime/CountingStream.cs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+
+namespace Mail2Pst.Core.Parsing.Mime;
+
+/// <summary>Write-only <see cref="Stream"/> that counts bytes written and discards them. The scan
+/// measure-only path decodes each attachment into this sink to get its exact decoded length without
+/// retaining any bytes or spilling a temp file.</summary>
+internal sealed class CountingStream : Stream
+{
+    public long BytesWritten { get; private set; }
+
+    public override bool CanWrite => true;
+    public override bool CanRead => false;
+    public override bool CanSeek => false;
+    public override long Length => BytesWritten;
+    public override long Position { get => BytesWritten; set => throw new NotSupportedException(); }
+
+    public override void Write(byte[] buffer, int offset, int count) => Write(buffer.AsSpan(offset, count)); // validates args
+    public override void Write(ReadOnlySpan<byte> buffer) => BytesWritten += buffer.Length;
+    public override void WriteByte(byte value) => BytesWritten += 1;
+    public override void Flush() { }
+
+    public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+}

--- a/src/Mail2Pst.Core/Parsing/Mime/MimeMessageMapper.cs
+++ b/src/Mail2Pst.Core/Parsing/Mime/MimeMessageMapper.cs
@@ -22,17 +22,19 @@ namespace Mail2Pst.Core.Parsing.Mime;
 public class MimeMessageMapper
 {
     private readonly long _tempFileThresholdBytes;
+    private readonly bool _measureOnly;
 
     private const uint MozillaStatusRead = 0x0001;
     private const uint MozillaStatusReplied = 0x0002;
     private const uint MozillaStatusMarked = 0x0004;
     private const uint MozillaStatusForwarded = 0x1000;
 
-    public MimeMessageMapper(long tempFileThresholdBytes = 4L * 1024 * 1024)
+    public MimeMessageMapper(long tempFileThresholdBytes = 4L * 1024 * 1024, bool measureOnly = false)
     {
         if (tempFileThresholdBytes < 0)
             throw new ArgumentOutOfRangeException(nameof(tempFileThresholdBytes), tempFileThresholdBytes, "Temp-file threshold must be non-negative.");
         _tempFileThresholdBytes = tempFileThresholdBytes;
+        _measureOnly = measureOnly;
     }
 
     // A missing Date header yields null; a present-but-unparseable one makes
@@ -231,8 +233,7 @@ public class MimeMessageMapper
 
             try
             {
-                using var buffer = new MemoryStream();
-                part.Content.DecodeTo(buffer);
+                AttachmentContent content = DecodeContent(part);
 
                 string? contentId = string.IsNullOrEmpty(part.ContentId) ? null : NormalizeContentId(part.ContentId);
                 bool isInlineDisposition = part.ContentDisposition?.Disposition is { } partDisposition
@@ -245,7 +246,7 @@ public class MimeMessageMapper
                     ContentId = contentId,
                     ContentLocation = part.ContentLocation?.ToString(),
                     IsInline = isInlineDisposition || contentId is not null,
-                    Content = ToAttachmentContent(buffer),
+                    Content = content,
                 });
             }
             catch (Exception ex)
@@ -255,6 +256,22 @@ public class MimeMessageMapper
         }
 
         return attachments;
+    }
+
+    // Scan measure-only: decode the part to get its exact length, retaining nothing (no buffer, no temp
+    // file). Materialize mode keeps the existing memory/temp-spill behavior. Both run the decoder, so a
+    // decode failure still throws and is recorded as a dropped-attachment warning by the caller.
+    private AttachmentContent DecodeContent(MimeKit.MimePart part)
+    {
+        if (_measureOnly)
+        {
+            var counter = new CountingStream();
+            part.Content!.DecodeTo(counter);
+            return AttachmentContent.FromLengthOnly(counter.BytesWritten);
+        }
+        using var buffer = new MemoryStream();
+        part.Content!.DecodeTo(buffer);
+        return ToAttachmentContent(buffer);
     }
 
     // Routes attachment bytes to memory (small) or a temp file (large) to bound the

--- a/src/Mail2Pst.Core/Parsing/ParserRegistry.cs
+++ b/src/Mail2Pst.Core/Parsing/ParserRegistry.cs
@@ -15,6 +15,12 @@ public static class ParserRegistry
             ["mbox"] = new MboxParser(),
         };
 
+    private static readonly Dictionary<string, IMailSourceParser> ScanParsers =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["mbox"] = new MboxParser(measureOnly: true),
+        };
+
     public static IMailSourceParser Get(string sourceType)
     {
         if (Parsers.TryGetValue(sourceType, out IMailSourceParser? parser))
@@ -22,6 +28,15 @@ public static class ParserRegistry
             return parser;
         }
 
+        throw new NotSupportedException($"Unsupported source type: '{sourceType}'");
+    }
+
+    /// <summary>Resolves the measure-only parser for scan (length-only attachments, no retained bytes,
+    /// no temp files). Same unsupported-type contract as <see cref="Get"/>.</summary>
+    public static IMailSourceParser GetForScan(string sourceType)
+    {
+        if (ScanParsers.TryGetValue(sourceType, out IMailSourceParser? parser))
+            return parser;
         throw new NotSupportedException($"Unsupported source type: '{sourceType}'");
     }
 }

--- a/src/Mail2Pst.Core/Scanning/ScanRunner.cs
+++ b/src/Mail2Pst.Core/Scanning/ScanRunner.cs
@@ -34,7 +34,7 @@ public class ScanRunner
 
         // Resolve (and validate) the parser once, eagerly: an unsupported type must
         // fail before we touch any file, and the lookup is identical for every source.
-        IMailSourceParser parser = ParserRegistry.Get(sourceType);
+        IMailSourceParser parser = ParserRegistry.GetForScan(sourceType);
 
         // Stat each source once: reused below for per-source sourceBytes. FileInfo.Length still
         // throws FileNotFoundException here (before any parsing) for a missing path, preserving the

--- a/tests/Mail2Pst.Core.Tests/Models/AttachmentContentTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Models/AttachmentContentTests.cs
@@ -138,3 +138,22 @@ public class AttachmentContentTests
         finally { File.Delete(path); }
     }
 }
+
+public class AttachmentContentLengthOnlyTests
+{
+    [Fact]
+    public void FromLengthOnly_ExposesLength_ButByteAccessThrows()
+    {
+        var c = AttachmentContent.FromLengthOnly(4096);
+        Assert.Equal(4096, c.Length);
+        Assert.Throws<InvalidOperationException>(() => c.OpenRead());
+        Assert.Throws<InvalidOperationException>(() => c.ReadAllBytes());
+        c.Dispose(); // no temp file, no throw
+    }
+
+    [Fact]
+    public void FromLengthOnly_NegativeLength_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => AttachmentContent.FromLengthOnly(-1));
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Parsing/CountingStreamTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Parsing/CountingStreamTests.cs
@@ -1,0 +1,18 @@
+using System.IO;
+using Mail2Pst.Core.Parsing.Mime;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Parsing;
+
+public class CountingStreamTests
+{
+    [Fact]
+    public void CopyTo_CountsEveryByte_RetainsNothing()
+    {
+        var sink = new CountingStream();
+        using var src = new MemoryStream(new byte[12345]);
+        src.CopyTo(sink);                 // mirrors MimeKit's part.Content.DecodeTo(stream)
+        Assert.Equal(12345, sink.BytesWritten);
+        Assert.Equal(12345, sink.Length);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Parsing/CountingStreamTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Parsing/CountingStreamTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
 using System.IO;
 using Mail2Pst.Core.Parsing.Mime;
 using Xunit;

--- a/tests/Mail2Pst.Core.Tests/Parsing/MboxParserMeasureOnlyTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Parsing/MboxParserMeasureOnlyTests.cs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Parsing;
+using Mail2Pst.Core.Models;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Parsing;
+
+public class MboxParserMeasureOnlyTests
+{
+    // One message with a base64 attachment whose decoded length is 3 bytes ("abc").
+    private const string Mbox =
+        "From a@b Thu Jan 01 00:00:00 2026\r\n" +
+        "Subject: t\r\n" +
+        "Content-Type: multipart/mixed; boundary=X\r\n\r\n" +
+        "--X\r\nContent-Type: text/plain\r\n\r\nhi\r\n" +
+        "--X\r\nContent-Type: application/octet-stream\r\nContent-Disposition: attachment; filename=a.bin\r\n" +
+        "Content-Transfer-Encoding: base64\r\n\r\nYWJj\r\n--X--\r\n";
+
+    [Fact]
+    public void MeasureOnly_Parse_AttachmentLengthExact_ContentThrows()
+    {
+        string path = Path.Combine(Path.GetTempPath(), "m2p-measureonly-" + Guid.NewGuid() + ".mbox");
+        File.WriteAllText(path, Mbox);
+        try
+        {
+            ParseResult r = new MboxParser(measureOnly: true).Parse(path).Single();
+            Assert.True(r.Success);
+            MailAttachment a = Assert.Single(r.Message!.Attachments);
+            Assert.Equal(3, a.Content.Length);                       // decoded "abc"
+            Assert.Throws<InvalidOperationException>(() => a.Content.OpenRead());
+        }
+        finally { File.Delete(path); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Parsing/MimeMessageMapperMeasureOnlyTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Parsing/MimeMessageMapperMeasureOnlyTests.cs
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Parsing.Mime;
+using MimeKit;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Parsing;
+
+public class MimeMessageMapperMeasureOnlyTests
+{
+    // Literal MIME parsed by MimeKit — avoids MimeContent/transfer-encoding construction ambiguity.
+    // The attachment body "YWJj" is base64 for "abc", so its DECODED length is exactly 3.
+    private static MimeMessage MsgWithBase64Attachment()
+    {
+        const string raw =
+            "From: A <a@example.com>\r\nTo: B <b@example.com>\r\nSubject: t\r\n" +
+            "Content-Type: multipart/mixed; boundary=X\r\n\r\n" +
+            "--X\r\nContent-Type: text/plain\r\n\r\nhi\r\n" +
+            "--X\r\nContent-Type: application/octet-stream\r\n" +
+            "Content-Disposition: attachment; filename=a.bin\r\n" +
+            "Content-Transfer-Encoding: base64\r\n\r\nYWJj\r\n--X--\r\n";
+        using var ms = new MemoryStream(System.Text.Encoding.ASCII.GetBytes(raw));
+        return MimeMessage.Load(ms);
+    }
+
+    [Fact]
+    public void MeasureOnly_AttachmentLengthMatchesMaterialized_ButContentThrows()
+    {
+        var src = new SourceReference { SourcePath = "p", Identifier = "message #1" };
+
+        var materialized = new MimeMessageMapper(4L * 1024 * 1024)
+            .Map(MsgWithBase64Attachment(), src, new List<string>());
+        long materializedLen = Assert.Single(materialized.Attachments).Content.Length;
+
+        var measured = new MimeMessageMapper(4L * 1024 * 1024, measureOnly: true)
+            .Map(MsgWithBase64Attachment(), src, new List<string>());
+        AttachmentContent content = Assert.Single(measured.Attachments).Content;
+
+        Assert.Equal(3, materializedLen);                // decoded "abc"
+        Assert.Equal(materializedLen, content.Length);   // byte-identical estimate input
+        Assert.Throws<InvalidOperationException>(() => content.OpenRead());
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Parsing/MimeMessageMapperMeasureOnlyTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Parsing/MimeMessageMapperMeasureOnlyTests.cs
@@ -46,4 +46,19 @@ public class MimeMessageMapperMeasureOnlyTests
         Assert.Equal(materializedLen, content.Length);   // byte-identical estimate input
         Assert.Throws<InvalidOperationException>(() => content.OpenRead());
     }
+
+    [Fact]
+    public void MeasureOnly_WritesNoAttachmentTempFile_EvenAtTinyThreshold()
+    {
+        var src = new SourceReference { SourcePath = "p", Identifier = "message #1" };
+        // Materialize mode at threshold 1: the (decoded) attachment spills to a temp file.
+        var materialized = new MimeMessageMapper(tempFileThresholdBytes: 1)
+            .Map(MsgWithBase64Attachment(), src, new System.Collections.Generic.List<string>());
+        Assert.True(Assert.Single(materialized.Attachments).Content.IsTempFileBacked);
+        Assert.Single(materialized.Attachments).Content.Dispose();
+        // Measure-only mode at threshold 1: length-only content, NO temp file.
+        var measured = new MimeMessageMapper(tempFileThresholdBytes: 1, measureOnly: true)
+            .Map(MsgWithBase64Attachment(), src, new System.Collections.Generic.List<string>());
+        Assert.False(Assert.Single(measured.Attachments).Content.IsTempFileBacked);
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Scanning/ScanRunnerMeasureOnlyTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Scanning/ScanRunnerMeasureOnlyTests.cs
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Parsing;
+using Mail2Pst.Core.Scanning;
+using Mail2Pst.Core.Reporting;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Scanning;
+
+public class ScanRunnerMeasureOnlyTests
+{
+    private const string Mbox =
+        "From a@b Thu Jan 01 00:00:00 2026\r\n" +
+        "Subject: t\r\n" +
+        "Content-Type: multipart/mixed; boundary=X\r\n\r\n" +
+        "--X\r\nContent-Type: text/plain\r\n\r\nhi\r\n" +
+        "--X\r\nContent-Type: application/octet-stream\r\nContent-Disposition: attachment; filename=a.bin\r\n" +
+        "Content-Transfer-Encoding: base64\r\n\r\nYWJj\r\n--X--\r\n";
+
+    [Fact]
+    public void Scan_WithAttachment_EstimateAndCountUnchanged_NoCrash()
+    {
+        string path = Path.Combine(Path.GetTempPath(), "m2p-scan-" + Guid.NewGuid() + ".mbox");
+        File.WriteAllText(path, Mbox);
+        try
+        {
+            ScanReport report = new ScanRunner().Scan(path, "mbox");
+            Assert.Equal(1, report.Totals.Messages);
+            Assert.True(report.Totals.Bytes > 0);     // estimate computed from the length-only attachment
+        }
+        finally { File.Delete(path); }
+    }
+
+    // Proves the SCAN registry path actually returns a measure-only parser (length-only content),
+    // not just that scan happens to still work.
+    [Fact]
+    public void GetForScan_ReturnsMeasureOnlyParser_AttachmentIsLengthOnly()
+    {
+        string path = Path.Combine(Path.GetTempPath(), "m2p-getforscan-" + Guid.NewGuid() + ".mbox");
+        File.WriteAllText(path, Mbox);
+        try
+        {
+            var result = ParserRegistry.GetForScan("mbox").Parse(path).Single();
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                result.Message!.Attachments.Single().Content.OpenRead();
+            });
+        }
+        finally { File.Delete(path); }
+    }
+}


### PR DESCRIPTION
## Scan: counting-decode measure-only attachment path

Foundation for the parallel-scan work (spec §2.1). Gives the scan path a length-only attachment mode so it stops retaining attachment buffers and writing attachment temp files — with **byte-identical** scan output.

### What changed
- **`CountingStream`** — a write-only `Stream` that counts decoded bytes and retains nothing.
- **`AttachmentContent.FromLengthOnly(long)`** — carries the exact decoded `Length` but no content; `OpenRead()`/`ReadAllBytes()` **throw** so it can never reach the writer (negative length guarded).
- **`MimeMessageMapper`** measure-only branch — decodes each attachment into the counting sink (`DecodeContent`); the materialize/convert path is untouched.
- **`MboxParser(measureOnly)`** + **`ParserRegistry.GetForScan`** — scan resolves a separate measure-only parser singleton; `ScanRunner` switches its one parser-resolution line to it.

### Why it's byte-identical
`PstWriter.EstimateMessageSize` reads attachments **only** via `Content.Length`, and both decode branches run the same `DecodeTo`, so the length and any decode-failure warning are unchanged. The existing `ScanRunner`/parser suites are the standing regression proof.

### Convert path isolation
`ParserRegistry.Get` (convert) still returns the full-materialize parser; `GetForScan`'s only production caller is `ScanRunner`. A length-only attachment cannot reach the writer, and if it ever did, byte access throws (fails loud).

### Tests
6 commits, each TDD + reviewed (spec + quality) + an opus whole-branch review. New: `CountingStream`, length-only `AttachmentContent` (incl. negative-length), measure-only mapper (length identity vs materialize + no-temp-file at tiny threshold), `MboxParser` measure-only, `GetForScan` returns length-only content. Full suite green: **Core 698 / Integration 80, 0 failed** (8 new scan tests).

Note: this is the foundation — the actual scan **speedup** comes from the follow-up byte-range-partitioning + parallel-runner change that builds on these primitives.
