### PR TITLE
Release 0.2.2 — parallel scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] — 2026-06-28
+
+### Changed
+- Scanning is now **parallel and dramatically faster**. The dry-run that counts messages and estimates
+  output size — the CLI `scan` step and the desktop app's pre-conversion scan — now parses each mailbox
+  as several message-aligned byte ranges across CPU cores instead of one sequential pass. On a large
+  multi-GB archive this is roughly **3–4× faster** (a 4.5 GB Gmail export scans in ~13 s instead of
+  ~47 s), with no slowdown on a single very large folder. Peak memory during a scan is now **bounded and
+  independent of mailbox or message size** (large messages spill to a temp file rather than residing in
+  memory), so scanning a multi-GB archive no longer grows memory with the file. Scan results — counts,
+  size estimates, dates, and warnings — are byte-for-byte identical to the previous sequential scan, and
+  a scan-only parse never materialises attachment bytes or writes attachment temp files. (CLI scan JSON
+  output and the GUI scan contract are unchanged.)
+
 ### Fixed
 - The optional **"Import category colours"** step no longer hangs when the categories are already in
   Outlook. Re-importing colours that already existed in Outlook's master list left the brief background

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@radix-ui/react-slot": "^1.3.0",
         "@tauri-apps/api": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.2.1"
+version = "0.2.2"
 description = "ContinuMail Converter — convert mbox mail archives to Outlook PST"
 authors = ["Aksel Visby <aksel@visby.it>"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ContinuMail Converter",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "com.continumail.converter",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/Mail2Pst.Cli/Mail2Pst.Cli.csproj
+++ b/src/Mail2Pst.Cli/Mail2Pst.Cli.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Mail2Pst.Cli</RootNamespace>
-    <Version>0.2.1</Version>
+    <Version>0.2.2</Version>
     <!-- Server GC: measured win on the parallel byte-range scan (4.5 GB gmail corpus:
          ~19s -> ~13.5s wall-clock, ~30% faster). Peak working set rises 163 -> 314 MB,
          still size-independent and modest. See docs/pst-engine-benchmarks.md. -->

--- a/src/Mail2Pst.Cli/Mail2Pst.Cli.csproj
+++ b/src/Mail2Pst.Cli/Mail2Pst.Cli.csproj
@@ -6,6 +6,11 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Mail2Pst.Cli</RootNamespace>
     <Version>0.2.1</Version>
+    <!-- Server GC: measured win on the parallel byte-range scan (4.5 GB gmail corpus:
+         ~19s -> ~13.5s wall-clock, ~30% faster). Peak working set rises 163 -> 314 MB,
+         still size-independent and modest. See docs/pst-engine-benchmarks.md. -->
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../Mail2Pst.Core/Mail2Pst.Core.csproj" />

--- a/src/Mail2Pst.Core/Parsing/Mbox/SpillableMessageBuffer.cs
+++ b/src/Mail2Pst.Core/Parsing/Mbox/SpillableMessageBuffer.cs
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using Mail2Pst.Core.Parsing;
+
+namespace Mail2Pst.Core.Parsing.Mbox;
+
+/// <summary>Accumulates one raw message's bytes, keeping it in memory until it exceeds a threshold, then
+/// spilling to a temp file (so per-message peak RAM is bounded by the threshold). <see cref="OpenRead"/>
+/// returns a FRESH, caller-owned read stream; <see cref="Dispose"/> deletes the temp file. Temp create/write/read
+/// failures throw <see cref="RawMessageSpillException"/> (fatal, never a skip).</summary>
+internal sealed class SpillableMessageBuffer : IDisposable
+{
+    private readonly long _threshold;
+    private MemoryStream? _memory = new();
+    private FileStream? _writeFile;   // write handle while spilling; flushed+closed on OpenRead/Dispose
+    private string? _tempPath;
+    private bool _disposed;
+
+    public SpillableMessageBuffer(long thresholdBytes) => _threshold = thresholdBytes;
+
+    public bool SpilledToDisk => _tempPath is not null;
+    internal string? TempPathForTest => _tempPath;
+    public long Length => _writeFile?.Length ?? _memory!.Length;
+
+    public void Write(ReadOnlySpan<byte> bytes)
+    {
+        if (_tempPath is null && _memory!.Length + bytes.Length > _threshold)
+            SpillNow();
+        if (_writeFile is not null)
+        {
+            try { _writeFile.Write(bytes); }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            { throw new RawMessageSpillException("Failed to write the raw-message spill temp file.", ex); }
+        }
+        else _memory!.Write(bytes);
+    }
+
+    private void SpillNow()
+    {
+        try
+        {
+            _tempPath = Path.Combine(Path.GetTempPath(), $"mail2pst-raw-{Guid.NewGuid()}");
+            _writeFile = new FileStream(_tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+            _memory!.Position = 0;
+            _memory.CopyTo(_writeFile);
+            _memory.Dispose();
+            _memory = null;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        { throw new RawMessageSpillException("Failed to create the raw-message spill temp file.", ex); }
+    }
+
+    /// <summary>Returns a FRESH, read-only, seek-0 stream the caller OWNS and disposes. For a spilled message
+    /// this flushes+closes the write handle and opens a new read-only FileStream over the temp.</summary>
+    public Stream OpenRead()
+    {
+        if (_tempPath is not null)
+        {
+            if (_writeFile is not null) { _writeFile.Flush(); _writeFile.Dispose(); _writeFile = null; }
+            try { return new FileStream(_tempPath, FileMode.Open, FileAccess.Read, FileShare.Read); }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            { throw new RawMessageSpillException("Failed to read the raw-message spill temp file.", ex); }
+        }
+        return new MemoryStream(_memory!.GetBuffer(), 0, (int)_memory.Length, writable: false);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _memory?.Dispose();
+        _writeFile?.Dispose();
+        if (_tempPath is not null)
+            try { File.Delete(_tempPath); } catch { /* best-effort: delete failure is a warning, not fatal */ }
+    }
+}

--- a/src/Mail2Pst.Core/Parsing/MboxParser.cs
+++ b/src/Mail2Pst.Core/Parsing/MboxParser.cs
@@ -315,6 +315,99 @@ public class MboxParser : IMailSourceParser
         }
     }
 
+    /// <summary>Back-seek window for <see cref="FindBoundaryAtOrAfter"/>'s context bootstrap.</summary>
+    private const int BoundaryBackWindow = 64 * 1024;
+
+    /// <summary>
+    /// Discovery helper for the byte-range splitter (<see cref="Scanning.MboxMessageSplitter"/>): returns the
+    /// absolute offset of the first REAL message boundary at offset &gt;= <paramref name="target"/>, decided by
+    /// the SAME <see cref="IsMessageBoundary"/>/<see cref="IsBlankLine"/> rule the parse engine uses — so a
+    /// split offset can never disagree with where <see cref="Parse"/>/<see cref="ScanRange"/> would begin a
+    /// message (the byte-identity guarantee depends on the two notions of "boundary" being one and the same).
+    ///
+    /// Context bootstrap `[R3]`: seeks back up to <see cref="BoundaryBackWindow"/> before <paramref name="target"/>
+    /// to a clean line start, then refuses to accept any boundary until at least one full line has been observed
+    /// since that clean start, so <c>previousLineWasBlank</c> reflects a line actually read (not assumed). When the
+    /// back-window reaches BOF the scan starts with <c>previousLineWasBlank = true</c> (the engine's BOF rule).
+    ///
+    /// Returns <c>null</c> if no boundary is found before <c>target + <paramref name="scanCap"/></c>.
+    /// </summary>
+    internal static long? FindBoundaryAtOrAfter(Stream stream, long target, long scanCap)
+    {
+        long backStart = Math.Max(0, target - BoundaryBackWindow);
+        stream.Seek(backStart, SeekOrigin.Begin);
+
+        long scanLimit = target + scanCap;            // boundaries at >= this offset are out of budget
+        bool previousLineWasBlank = backStart == 0;   // BOF: previous "line" is treated as blank
+        bool contextEstablished = backStart == 0;     // at BOF the blank-state is real immediately
+        bool needCleanStart = backStart > 0;          // mid-stream: discard the first (partial) line
+
+        var buffer = new byte[BufferSize];
+        using var line = new MemoryStream(256);
+        long lineStart = backStart;                   // absolute offset of the current line's first byte
+
+        int bytesRead;
+        while ((bytesRead = stream.Read(buffer, 0, buffer.Length)) > 0)
+        {
+            int offset = 0;
+            while (offset < bytesRead)
+            {
+                int newlineIndex = Array.IndexOf(buffer, (byte)'\n', offset, bytesRead - offset);
+                if (newlineIndex == -1)
+                {
+                    // Partial line — carry it across to the next read.
+                    line.Write(buffer, offset, bytesRead - offset);
+                    break;
+                }
+
+                int lineLength = newlineIndex - offset + 1;
+                line.Write(buffer, offset, lineLength);
+                offset = newlineIndex + 1;
+
+                int lineLen = (int)line.Length;
+
+                if (needCleanStart)
+                {
+                    // We seeked into the middle of this line; discard it. The next line begins at a
+                    // clean line start, and only then does observed blank-state become trustworthy.
+                    needCleanStart = false;
+                    lineStart += lineLen;
+                    line.SetLength(0);
+                    continue;
+                }
+
+                ReadOnlySpan<byte> span = line.GetBuffer().AsSpan(0, lineLen);
+                if (contextEstablished && lineStart >= target
+                    && IsMessageBoundary(span, previousLineWasBlank))
+                {
+                    return lineStart;
+                }
+
+                previousLineWasBlank = IsBlankLine(span);
+                contextEstablished = true;            // one full line observed since the clean start
+                lineStart += lineLen;
+                line.SetLength(0);
+
+                if (lineStart >= scanLimit)
+                    return null;
+            }
+        }
+
+        // A boundary can be the final line even without a trailing '\n'.
+        if (line.Length > 0 && !needCleanStart)
+        {
+            int finalLen = (int)line.Length;
+            ReadOnlySpan<byte> span = line.GetBuffer().AsSpan(0, finalLen);
+            if (contextEstablished && lineStart >= target && lineStart < scanLimit
+                && IsMessageBoundary(span, previousLineWasBlank))
+            {
+                return lineStart;
+            }
+        }
+
+        return null;
+    }
+
     private static bool StartsWithMarkerAt(ReadOnlySpan<byte> line, int index, ReadOnlySpan<byte> marker)
     {
         if (line.Length - index < marker.Length)

--- a/src/Mail2Pst.Core/Parsing/MboxParser.cs
+++ b/src/Mail2Pst.Core/Parsing/MboxParser.cs
@@ -10,6 +10,8 @@ using System.Text;
 using Mail2Pst.Core.Models;
 using Mail2Pst.Core.Parsing.Mime;
 using Mail2Pst.Core.Parsing.Mbox;
+using Mail2Pst.Core.Scanning;
+using Mail2Pst.Core.Writing;
 using MimeKit;
 
 namespace Mail2Pst.Core.Parsing;
@@ -81,6 +83,76 @@ public class MboxParser : IMailSourceParser
     }
 
     /// <summary>
+    /// Parses only the messages whose start ("From ") boundary falls in <c>[startOffset, endOffset)</c>
+    /// and returns a structured per-message record for each. Used by the range-parallel scan: a file is
+    /// split into message-aligned windows, each parsed independently, then merged. No "message #N"
+    /// identifier is assigned here — that is rendered only at merge.
+    ///
+    /// <paramref name="startOffset"/> is always a real boundary offset (or 0); the stream seeks there
+    /// and the shared boundary engine runs over the window (stopping at the first boundary &gt;=
+    /// <paramref name="endOffset"/>). Measure-only + spill is used (this instance is the scan parser),
+    /// so per-message data is derived IDENTICALLY to <see cref="Parse"/> / ScanRunner:
+    /// <see cref="PstWriter.EstimateMessageSize"/>, <c>message.Date</c>, and the mapper warnings; a
+    /// per-message <see cref="FormatException"/>/<see cref="IOException"/> becomes a skip
+    /// (<see cref="RangeMessage.SkipReason"/>) and anything else (incl. spill) propagates.
+    /// </summary>
+    public RangeScanResult ScanRange(string path, long startOffset, long endOffset, Action<long>? onBytesRead)
+    {
+        using FileStream stream = File.OpenRead(path);
+        stream.Seek(startOffset, SeekOrigin.Begin);
+
+        var messages = new List<RangeMessage>();
+        foreach (SpillableMessageBuffer raw in EnumerateMessageChunks(
+                     stream, materialize: true, _rawSpillThreshold, onBytesRead,
+                     onMessageStart: null, startAbsolute: startOffset, endOffset: endOffset)
+                 .Select(b => b!))
+        {
+            // Same sourceRef shape as Parse, minus the rendered "message #N" identifier
+            // (assigned only at merge in the range-merge step).
+            var sourceRef = new SourceReference { SourcePath = path };
+
+            MimeMessage? mime = null;
+            string? error = null;
+            try
+            {
+                using var s = raw.OpenRead();
+                mime = ParseMimeMessage(s);
+            }
+            catch (Exception ex) when (ex is FormatException or IOException)
+            {
+                // Same per-message skip allowlist as Parse: malformed MIME / stream error.
+                // RawMessageSpillException is neither, so it propagates → fatal (handled at merge).
+                error = ex.Message;
+            }
+            finally
+            {
+                raw.Dispose();
+            }
+
+            if (error is not null)
+            {
+                messages.Add(new RangeMessage(0, null, error, Array.Empty<string>()));
+                continue;
+            }
+
+            var warnings = new List<string>();
+            MailMessage message = _mapper.Map(mime!, sourceRef, warnings);
+            long estimatedBytes = PstWriter.EstimateMessageSize(message);
+            DateTimeOffset? date = message.Date;
+
+            // Mirror ScanRunner: release measured attachment content immediately.
+            foreach (MailAttachment attachment in message.Attachments)
+                attachment.Content.Dispose();
+
+            messages.Add(new RangeMessage(
+                estimatedBytes, date, null,
+                warnings.Count > 0 ? warnings : Array.Empty<string>()));
+        }
+
+        return new RangeScanResult(startOffset, messages);
+    }
+
+    /// <summary>
     /// Parses one message's raw bytes (via stream) into a <see cref="MimeMessage"/>. Per
     /// MimeKit, throws <see cref="FormatException"/> for malformed MIME and
     /// <see cref="IOException"/> for stream errors; <see cref="Parse"/> treats
@@ -140,9 +212,21 @@ public class MboxParser : IMailSourceParser
     ///              the caller only counts and never dereferences. Keeps counting cheap.
     /// <paramref name="onBytesRead"/> is invoked with the stream position at each yield
     /// (scan progress); pass null when counting.
+    ///
+    /// Windowing (for range-parallel scan, see <see cref="ScanRange"/>):
+    /// <paramref name="startAbsolute"/> is the absolute file offset that the stream is already
+    /// positioned at (the engine's local <c>consumed</c> is relative to it), so a boundary's
+    /// absolute offset is <c>startAbsolute + lineStart</c>. When a boundary's absolute offset is
+    /// &gt;= <paramref name="endOffset"/>, that boundary begins the NEXT window's first message:
+    /// the engine yields the just-completed message (which is owned by this window) and stops —
+    /// it does not begin/parse the out-of-window message. The defaults
+    /// (<c>startAbsolute = 0</c>, <c>endOffset = long.MaxValue</c>) make whole-file callers
+    /// (<see cref="SplitMessages"/>, <see cref="CountMessages"/>, <see cref="ScanMessageStartOffsets"/>)
+    /// behave exactly as before.
     /// </summary>
     private static IEnumerable<SpillableMessageBuffer?> EnumerateMessageChunks(
-        Stream rawStream, bool materialize, long rawSpillThreshold, Action<long>? onBytesRead, Action<long>? onMessageStart = null)
+        Stream rawStream, bool materialize, long rawSpillThreshold, Action<long>? onBytesRead,
+        Action<long>? onMessageStart = null, long startAbsolute = 0, long endOffset = long.MaxValue)
     {
         var buffer = new byte[BufferSize];
         using var line = new MemoryStream(256);
@@ -194,6 +278,11 @@ public class MboxParser : IMailSourceParser
                         if (materialize) current = new SpillableMessageBuffer(rawSpillThreshold);
                         currentHasContent = false;
                     }
+                    // A boundary at or beyond endOffset begins the NEXT window's first message:
+                    // the message just yielded above is the last one this window owns, so stop
+                    // here without starting (or parsing) the out-of-window message.
+                    if (startAbsolute + lineStart >= endOffset)
+                        yield break;
                     currentStart = lineStart;  // this boundary begins the next message
                     // The marker line is not written into the message.
                 }

--- a/src/Mail2Pst.Core/Parsing/MboxParser.cs
+++ b/src/Mail2Pst.Core/Parsing/MboxParser.cs
@@ -20,11 +20,14 @@ public class MboxParser : IMailSourceParser
     private const int BufferSize = 81920;
 
     private readonly MimeMessageMapper _mapper;
+    private readonly long _rawSpillThreshold;
 
-    public MboxParser(long tempFileThresholdBytes = 4L * 1024 * 1024, bool measureOnly = false)
+    public MboxParser(long tempFileThresholdBytes = 4L * 1024 * 1024, bool measureOnly = false,
+                      long rawSpillThreshold = long.MaxValue)
     {
         if (tempFileThresholdBytes < 0)
             throw new ArgumentOutOfRangeException(nameof(tempFileThresholdBytes), tempFileThresholdBytes, "Temp-file threshold must be non-negative.");
+        _rawSpillThreshold = rawSpillThreshold;
         _mapper = new MimeMessageMapper(tempFileThresholdBytes, measureOnly);
     }
 
@@ -33,7 +36,7 @@ public class MboxParser : IMailSourceParser
         using FileStream stream = File.OpenRead(path);
 
         int index = 0;
-        foreach (byte[] messageBytes in SplitMessages(stream, onBytesRead))
+        foreach (SpillableMessageBuffer raw in SplitMessages(stream, onBytesRead))
         {
             index++;
             var sourceRef = new SourceReference
@@ -46,7 +49,8 @@ public class MboxParser : IMailSourceParser
             string? error = null;
             try
             {
-                mime = ParseMimeMessage(messageBytes);
+                using var s = raw.OpenRead();
+                mime = ParseMimeMessage(s);
             }
             catch (Exception ex) when (ex is FormatException or IOException)
             {
@@ -54,7 +58,14 @@ public class MboxParser : IMailSourceParser
                 // error): record as a skip and continue. Any other exception is
                 // an unexpected defect and is allowed to propagate so it surfaces
                 // loudly instead of silently dropping mail.
+                // RawMessageSpillException is NOT FormatException/IOException so it
+                // propagates through the finally → fatal path, never swallowed here.
                 error = ex.Message;
+            }
+            finally
+            {
+                // Delete temp file immediately after parse — before yielding the result.
+                raw.Dispose();
             }
 
             if (error is not null)
@@ -70,16 +81,15 @@ public class MboxParser : IMailSourceParser
     }
 
     /// <summary>
-    /// Parses one message's raw bytes into a <see cref="MimeMessage"/>. Per
+    /// Parses one message's raw bytes (via stream) into a <see cref="MimeMessage"/>. Per
     /// MimeKit, throws <see cref="FormatException"/> for malformed MIME and
     /// <see cref="IOException"/> for stream errors; <see cref="Parse"/> treats
     /// only those as a per-message skip and lets anything else propagate.
     /// Virtual so tests can substitute the parse step.
     /// </summary>
-    protected virtual MimeMessage ParseMimeMessage(byte[] messageBytes)
+    protected virtual MimeMessage ParseMimeMessage(Stream s)
     {
-        using var messageStream = new MemoryStream(messageBytes);
-        var entityParser = new MimeParser(messageStream, MimeFormat.Entity);
+        var entityParser = new MimeParser(s, MimeFormat.Entity);
         return entityParser.ParseMessage();
     }
 
@@ -90,7 +100,7 @@ public class MboxParser : IMailSourceParser
         // drifts from the messages Parse yields. (ConversionRunner reads the file twice:
         // count here, then Parse during conversion; external mutation of the file between
         // the two passes can still diverge — an accepted, out-of-scope limitation.)
-        return EnumerateMessageChunks(stream, materialize: false, onBytesRead: null, onMessageStart: null).Count();
+        return EnumerateMessageChunks(stream, materialize: false, rawSpillThreshold: 0, onBytesRead: null, onMessageStart: null).Count();
     }
 
     /// <summary>
@@ -102,19 +112,19 @@ public class MboxParser : IMailSourceParser
     {
         using FileStream stream = File.OpenRead(path);
         var offsets = new List<long>();
-        foreach (var _ in EnumerateMessageChunks(stream, materialize: false, onBytesRead: null, onMessageStart: offsets.Add))
+        foreach (var _ in EnumerateMessageChunks(stream, materialize: false, rawSpillThreshold: 0, onBytesRead: null, onMessageStart: offsets.Add))
         { /* enumerate to drive the callback */ }
         return offsets;
     }
 
     /// <summary>
-    /// Splits an mbox file into the raw bytes of each contained message. Thin adapter over
+    /// Splits an mbox file into a <see cref="SpillableMessageBuffer"/> per message. Thin adapter over
     /// the shared <see cref="EnumerateMessageChunks"/> engine (materialize mode). See that
     /// method for the boundary rule and why we avoid MimeKit's <see cref="MimeFormat.Mbox"/>
     /// parser. The `!` is sound: materialize mode never yields a null chunk.
     /// </summary>
-    private static IEnumerable<byte[]> SplitMessages(Stream rawStream, Action<long>? onBytesRead = null) =>
-        EnumerateMessageChunks(rawStream, materialize: true, onBytesRead, onMessageStart: null).Select(b => b!);
+    private IEnumerable<SpillableMessageBuffer> SplitMessages(Stream rawStream, Action<long>? onBytesRead = null) =>
+        EnumerateMessageChunks(rawStream, materialize: true, _rawSpillThreshold, onBytesRead, onMessageStart: null).Select(b => b!);
 
     /// <summary>
     /// THE single source of truth for "where do messages begin and end" in an mbox stream.
@@ -125,18 +135,18 @@ public class MboxParser : IMailSourceParser
     /// and un-escaped here. The marker line itself is not part of the returned message.
     ///
     /// Return-value invariant keyed off <paramref name="materialize"/>:
-    ///   - true  -> every yielded element is a NON-NULL message byte array.
+    ///   - true  -> every yielded element is a NON-NULL SpillableMessageBuffer (caller owns + disposes).
     ///   - false -> yields a null placeholder per message (no per-message buffer allocated);
     ///              the caller only counts and never dereferences. Keeps counting cheap.
     /// <paramref name="onBytesRead"/> is invoked with the stream position at each yield
     /// (scan progress); pass null when counting.
     /// </summary>
-    private static IEnumerable<byte[]?> EnumerateMessageChunks(
-        Stream rawStream, bool materialize, Action<long>? onBytesRead, Action<long>? onMessageStart = null)
+    private static IEnumerable<SpillableMessageBuffer?> EnumerateMessageChunks(
+        Stream rawStream, bool materialize, long rawSpillThreshold, Action<long>? onBytesRead, Action<long>? onMessageStart = null)
     {
         var buffer = new byte[BufferSize];
         using var line = new MemoryStream(256);
-        MemoryStream? current = materialize ? new MemoryStream() : null;
+        SpillableMessageBuffer? current = materialize ? new SpillableMessageBuffer(rawSpillThreshold) : null;
         bool previousLineWasBlank = true;
         bool currentHasContent = false;
         long consumed = 0;      // total bytes of completed lines (independent of rawStream.Position)
@@ -180,8 +190,8 @@ public class MboxParser : IMailSourceParser
                     {
                         onBytesRead?.Invoke(rawStream.Position);
                         onMessageStart?.Invoke(currentStart);
-                        yield return materialize ? current!.ToArray() : null;
-                        if (materialize) current = new MemoryStream();
+                        yield return materialize ? current : null;
+                        if (materialize) current = new SpillableMessageBuffer(rawSpillThreshold);
                         currentHasContent = false;
                     }
                     currentStart = lineStart;  // this boundary begins the next message
@@ -212,7 +222,7 @@ public class MboxParser : IMailSourceParser
         {
             onBytesRead?.Invoke(rawStream.Position);
             onMessageStart?.Invoke(currentStart);
-            yield return materialize ? current!.ToArray() : null;
+            yield return materialize ? current : null;
         }
     }
 
@@ -238,7 +248,7 @@ public class MboxParser : IMailSourceParser
     // extra leading '>' to distinguish it from a real envelope boundary. Strip exactly one
     // '>' from any line of the form ^>+From ; write every other line unchanged. Writes
     // straight into the message buffer — no per-line allocation.
-    private static void WriteUnescapedFromLine(ReadOnlySpan<byte> line, MemoryStream destination)
+    private static void WriteUnescapedFromLine(ReadOnlySpan<byte> line, SpillableMessageBuffer destination)
     {
         int gt = 0;
         while (gt < line.Length && line[gt] == (byte)'>')

--- a/src/Mail2Pst.Core/Parsing/MboxParser.cs
+++ b/src/Mail2Pst.Core/Parsing/MboxParser.cs
@@ -96,7 +96,7 @@ public class MboxParser : IMailSourceParser
     /// per-message <see cref="FormatException"/>/<see cref="IOException"/> becomes a skip
     /// (<see cref="RangeMessage.SkipReason"/>) and anything else (incl. spill) propagates.
     /// </summary>
-    public RangeScanResult ScanRange(string path, long startOffset, long endOffset, Action<long>? onBytesRead)
+    public virtual RangeScanResult ScanRange(string path, long startOffset, long endOffset, Action<long>? onBytesRead)
     {
         using FileStream stream = File.OpenRead(path);
         stream.Seek(startOffset, SeekOrigin.Begin);

--- a/src/Mail2Pst.Core/Parsing/ParserRegistry.cs
+++ b/src/Mail2Pst.Core/Parsing/ParserRegistry.cs
@@ -18,7 +18,7 @@ public static class ParserRegistry
     private static readonly Dictionary<string, IMailSourceParser> ScanParsers =
         new(StringComparer.OrdinalIgnoreCase)
         {
-            ["mbox"] = new MboxParser(measureOnly: true),
+            ["mbox"] = new MboxParser(measureOnly: true, rawSpillThreshold: 4L * 1024 * 1024),
         };
 
     public static IMailSourceParser Get(string sourceType)

--- a/src/Mail2Pst.Core/Parsing/RawMessageSpillException.cs
+++ b/src/Mail2Pst.Core/Parsing/RawMessageSpillException.cs
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+
+namespace Mail2Pst.Core.Parsing;
+
+/// <summary>An OPERATIONAL failure of the scan raw-message spill infrastructure (temp file create/write/read —
+/// disk full, permission, AV lock, missing temp path). It is deliberately NOT a FormatException/IOException so
+/// the per-message skip taxonomy never swallows it as "corrupt mail": it must surface through the fatal path.</summary>
+public sealed class RawMessageSpillException : Exception
+{
+    public RawMessageSpillException(string message, Exception inner) : base(message, inner) { }
+}

--- a/src/Mail2Pst.Core/Scanning/MboxMessageSplitter.cs
+++ b/src/Mail2Pst.Core/Scanning/MboxMessageSplitter.cs
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Parsing;
+
+namespace Mail2Pst.Core.Scanning;
+
+/// <summary>
+/// Fail-closed byte-range split discovery for the range-parallel scan `[spec §2.3.3, R3]`. Computes
+/// message-aligned <c>(Start, End)</c> ranges that tile <c>[0, length)</c> exactly. Each interior split
+/// is found by seeking near an even target offset and scanning forward to the first REAL message boundary
+/// (<see cref="MboxParser.FindBoundaryAtOrAfter"/> — the parser's own boundary engine, so a returned split
+/// can never disagree with where <see cref="MboxParser.ScanRange"/> begins a message). If a target finds no
+/// boundary within its scan cap that split is dropped (the range absorbs the oversized message). The final
+/// list is validated against the tiling invariant; on ANY violation it fails closed to the single whole-file
+/// range <c>[(0, length)]</c>, so a degenerate discovery can never corrupt the scan — only forgo parallelism.
+/// </summary>
+public static class MboxMessageSplitter
+{
+    public static IReadOnlyList<(long Start, long End)> ComputeRanges(string path, long length, long targetChunkBytes)
+    {
+        if (targetChunkBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(targetChunkBytes), targetChunkBytes,
+                "Target chunk size must be positive.");
+
+        if (length == 0)
+            return new[] { (0L, 0L) };
+
+        // A file no larger than one chunk needs no interior split — skip discovery entirely.
+        if (length <= targetChunkBytes)
+            return new[] { (0L, length) };
+
+        long n = Math.Max(1, (length + targetChunkBytes - 1) / targetChunkBytes);   // ceil(length / chunk)
+        long scanCap = targetChunkBytes;
+
+        var offsets = new List<long>();
+        using (FileStream stream = File.OpenRead(path))
+        {
+            for (long k = 1; k < n; k++)
+            {
+                long target = k * length / n;
+                long? boundary = MboxParser.FindBoundaryAtOrAfter(stream, target, scanCap);
+                if (boundary is long b)
+                    offsets.Add(b);
+            }
+        }
+
+        // Keep only strictly-interior offsets, deduped and sorted.
+        List<long> splits = offsets
+            .Where(o => o > 0 && o < length)
+            .Distinct()
+            .OrderBy(o => o)
+            .ToList();
+
+        var ranges = new List<(long Start, long End)>(splits.Count + 1);
+        long prev = 0;
+        foreach (long s in splits)
+        {
+            ranges.Add((prev, s));
+            prev = s;
+        }
+        ranges.Add((prev, length));
+
+        // Fail-closed: any breach of the tiling invariant collapses to the whole-file range.
+        return RangesTile(ranges, length) ? ranges : new[] { (0L, length) };
+    }
+
+    /// <summary>
+    /// True iff the ranges form a sorted, gap-free, overlap-free tiling of <c>[0, length)</c>: first starts
+    /// at 0, last ends at <paramref name="length"/>, each range is non-empty, and each starts exactly where
+    /// the previous one ended.
+    /// </summary>
+    private static bool RangesTile(IReadOnlyList<(long Start, long End)> ranges, long length)
+    {
+        if (ranges.Count == 0)
+            return false;
+        if (ranges[0].Start != 0 || ranges[^1].End != length)
+            return false;
+
+        for (int i = 0; i < ranges.Count; i++)
+        {
+            if (ranges[i].Start >= ranges[i].End)               // empty or inverted
+                return false;
+            if (i > 0 && ranges[i].Start != ranges[i - 1].End)  // gap or overlap
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Mail2Pst.Core/Scanning/RangeScanResult.cs
+++ b/src/Mail2Pst.Core/Scanning/RangeScanResult.cs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Mail2Pst.Core.Scanning;
+
+/// <summary>
+/// A single per-message record produced by <see cref="Mail2Pst.Core.Parsing.MboxParser.ScanRange"/>.
+/// Structured (no rendered "message #N" identifier — that is assigned only when ranges are merged).
+/// Mirrors the per-message data ScanRunner derives today: estimated PST size, the message date,
+/// and the mapper warnings. A failed (skipped) message carries a <see cref="SkipReason"/> and
+/// zero size / no date / no warnings.
+/// </summary>
+public sealed record RangeMessage(long EstimatedBytes, DateTimeOffset? Date, string? SkipReason, IReadOnlyList<string> Warnings)
+{
+    public bool IsSkipped => SkipReason is not null;
+}
+
+/// <summary>
+/// The result of parsing one message-aligned byte range. <see cref="StartOffset"/> is the range's
+/// start argument; <see cref="Messages"/> are exactly the messages whose start boundary fell in
+/// <c>[startOffset, endOffset)</c>, in file order.
+/// </summary>
+public sealed record RangeScanResult(long StartOffset, IReadOnlyList<RangeMessage> Messages);

--- a/src/Mail2Pst.Core/Scanning/ScanProgressAggregator.cs
+++ b/src/Mail2Pst.Core/Scanning/ScanProgressAggregator.cs
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Threading;
+
+namespace Mail2Pst.Core.Scanning;
+
+internal sealed class ScanProgressAggregator
+{
+    private readonly long _total;
+    private readonly Action<ScanProgress>? _onProgress;
+    private readonly long _threshold;
+    private readonly object _emitLock = new();
+    private long _bytes;        // Interlocked
+    private long _lastEmitted;  // guarded by _emitLock
+
+    public ScanProgressAggregator(long totalBytes, Action<ScanProgress>? onProgress, long thresholdBytes)
+    {
+        _total = totalBytes; _onProgress = onProgress; _threshold = thresholdBytes;
+    }
+
+    public void Add(long deltaBytes)
+    {
+        if (_onProgress is null || deltaBytes <= 0) return;
+        long now = Interlocked.Add(ref _bytes, deltaBytes);
+        lock (_emitLock)
+        {
+            if (now - _lastEmitted < _threshold) return;
+            _lastEmitted = now;
+            _onProgress(new ScanProgress(Math.Min(now, _total), _total)); // snapshot read in-lock; monotonic
+        }
+    }
+
+    public void EmitFinal()
+    {
+        if (_onProgress is null) return;
+        lock (_emitLock)
+        {
+            if (_lastEmitted >= _total) return;     // already at 100%
+            _lastEmitted = _total;
+            _onProgress(new ScanProgress(_total, _total));
+        }
+    }
+}

--- a/src/Mail2Pst.Core/Scanning/ScanRunner.cs
+++ b/src/Mail2Pst.Core/Scanning/ScanRunner.cs
@@ -5,21 +5,36 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Text.RegularExpressions;
-using Mail2Pst.Core.Models;
+using System.Threading.Tasks;
 using Mail2Pst.Core.Parsing;
 using Mail2Pst.Core.Reporting;
-using Mail2Pst.Core.Writing;
 
 namespace Mail2Pst.Core.Scanning;
+
+/// <summary>Tunables for <see cref="ScanRunner"/>'s range-parallel scan. The defaults are the production
+/// values; tests inject a tiny <see cref="TargetChunkBytes"/> to force the multi-range path.</summary>
+internal sealed class ScanRunnerOptions
+{
+    public long TargetChunkBytes { get; init; } = 64L * 1024 * 1024;
+    public int MaxDegreeOfParallelism { get; init; } = Math.Min(Environment.ProcessorCount, 8);
+}
 
 public class ScanRunner
 {
     // Byte-based throttle (deterministic/testable, no clock): emit a progress
-    // update once this many new bytes have been read. A guaranteed emit at each
-    // file's end ensures the bar always reaches the file/total boundary.
+    // update once this many new bytes have been read. A guaranteed final emit at
+    // scan end ensures the bar always reaches 100%.
     private const long ProgressEmitThresholdBytes = 64L * 1024 * 1024;
+
+    private readonly ScanRunnerOptions _options;
+
+    public ScanRunner() : this(new ScanRunnerOptions()) { }
+
+    internal ScanRunner(ScanRunnerOptions options) => _options = options;
 
     /// <summary>Convenience overload for a single source.</summary>
     public ScanReport Scan(string path, string sourceType) =>
@@ -32,13 +47,13 @@ public class ScanRunner
         if (paths.Count == 0)
             throw new ArgumentException("At least one input path is required.", nameof(paths));
 
-        // Resolve (and validate) the parser once, eagerly: an unsupported type must
-        // fail before we touch any file, and the lookup is identical for every source.
-        IMailSourceParser parser = ParserRegistry.GetForScan(sourceType);
+        // Resolve (and validate) the scan parser once, eagerly: an unsupported type must fail before we
+        // touch any file. Cast to MboxParser to call ScanRange (the range-parallel measure-only API).
+        MboxParser parser = ResolveScanParser(sourceType);
 
         // Stat each source once: reused below for per-source sourceBytes. FileInfo.Length still
         // throws FileNotFoundException here (before any parsing) for a missing path, preserving the
-        // existing missing-file behavior exactly.
+        // existing missing-file behavior exactly. SEQUENTIAL and first, as before.
         long[] sourceSizes = new long[paths.Count];
         long scanTotalBytes = 0;
         for (int i = 0; i < paths.Count; i++)
@@ -48,16 +63,71 @@ public class ScanRunner
             scanTotalBytes += length;
         }
 
-        // Progress accounting is kept in its OWN variable, decoupled from the
-        // report's `totalSourceBytes` total, so an agent can't accidentally break
-        // cumulative progress by moving the report accumulation around.
-        long lastEmittedBytes = 0;
-        long completedSourceBytes = 0;
+        // Ids precomputed in source order (sequential), exactly as before.
+        var usedIds = new HashSet<string>(StringComparer.Ordinal);
+        string[] ids = new string[paths.Count];
+        for (int i = 0; i < paths.Count; i++)
+            ids[i] = MakeUniqueId(paths[i], usedIds, i);
 
-        var sources = new List<SourceScanResult>();
+        // Build the flat list of range work items across ALL sources. Each item carries its source
+        // index (for the lowest-(source,offset) tie-break and per-source merge) and a stable global
+        // range index used to slot its result/error without contention.
+        var workItems = new List<(int sourceIndex, string path, long start, long end, int rangeIndex)>();
+        for (int i = 0; i < paths.Count; i++)
+        {
+            IReadOnlyList<(long Start, long End)> ranges =
+                MboxMessageSplitter.ComputeRanges(paths[i], sourceSizes[i], _options.TargetChunkBytes);
+            foreach ((long start, long end) in ranges)
+                workItems.Add((i, paths[i], start, end, workItems.Count));
+        }
+
+        var results = new RangeScanResult?[workItems.Count];
+        var errors = new (int sourceIndex, long offset, Exception ex)?[workItems.Count];
+        var agg = new ScanProgressAggregator(scanTotalBytes, onProgress, ProgressEmitThresholdBytes);
+
+        Parallel.ForEach(
+            workItems,
+            new ParallelOptions { MaxDegreeOfParallelism = _options.MaxDegreeOfParallelism },
+            work =>
+            {
+                try
+                {
+                    long prevPos = work.start;   // [R3] prevPos init = range start
+                    results[work.rangeIndex] = parser.ScanRange(work.path, work.start, work.end,
+                        pos => { agg.Add(pos - prevPos); prevPos = pos; });
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    // Spill (RawMessageSpillException) and any non-FormatException/IOException from
+                    // ScanRange land here → fatal. Recorded per-range; rethrown lowest-(source,offset).
+                    errors[work.rangeIndex] = (work.sourceIndex, work.start, ex);
+                }
+            });
+
+        // Fatal path FIRST (before EmitFinal): if any range failed, rethrow the lowest-(sourceIndex, offset)
+        // one preserving its original stack — no success progress is emitted on failure. [R1/R2.5/R3]
+        (int sourceIndex, long offset, Exception ex)? lowest = null;
+        foreach (var e in errors)
+        {
+            if (e is null) continue;
+            if (lowest is null
+                || e.Value.sourceIndex < lowest.Value.sourceIndex
+                || (e.Value.sourceIndex == lowest.Value.sourceIndex && e.Value.offset < lowest.Value.offset))
+                lowest = e;
+        }
+        if (lowest is not null)
+            ExceptionDispatchInfo.Throw(lowest.Value.ex);
+
+        // Success only: drive the bar to 100%. [R3]
+        agg.EmitFinal();
+
+        // Merge per source (in source order). Byte-identity with the old sequential ScanRunner:
+        //   - rawOrdinal increments for EVERY message (skip or not) and IS both the "message #N"
+        //     identifier AND the source's `messages` count (old `messages++` was unconditional).
+        //   - "message #N" is rendered ONLY here (structured RangeMessage carries no identifier). [R2 Blocker 3]
+        var sources = new List<SourceScanResult>(paths.Count);
         var allSkipped = new List<SkippedMessage>();
         var allWarnings = new List<SkippedMessage>();
-        var usedIds = new HashSet<string>(StringComparer.Ordinal);
 
         int totalMessages = 0;
         long totalBytes = 0;
@@ -67,96 +137,76 @@ public class ScanRunner
         {
             string path = paths[i];
 
-            string id = MakeUniqueId(path, usedIds, i);
-            string displayName = System.IO.Path.GetFileNameWithoutExtension(path);
-            long sourceBytes = sourceSizes[i];
+            // This source's range results, sorted by StartOffset (file order).
+            IEnumerable<RangeScanResult> sourceRanges = workItems
+                .Where(w => w.sourceIndex == i)
+                .Select(w => results[w.rangeIndex]!)
+                .OrderBy(r => r.StartOffset);
 
-            int messages = 0;
-            long estimatedBytes = 0;
+            int rawOrdinal = 0;
+            long estBytes = 0;
             int warningCount = 0;
             int skippedCount = 0;
             DateTimeOffset? dateFrom = null;
             DateTimeOffset? dateTo = null;
 
-            // Bytes from already-completed files (own progress accumulator,
-            // independent of the report's totalSourceBytes).
-            long fileBase = completedSourceBytes;
-            Action<long>? onBytesRead = onProgress is null ? null : pos =>
+            foreach (RangeScanResult range in sourceRanges)
             {
-                long cumulative = Math.Min(fileBase + pos, scanTotalBytes);
-                if (cumulative - lastEmittedBytes >= ProgressEmitThresholdBytes)
+                foreach (RangeMessage m in range.Messages)
                 {
-                    lastEmittedBytes = cumulative;
-                    onProgress(new ScanProgress(cumulative, scanTotalBytes));
-                }
-            };
-
-            foreach (ParseResult result in parser.Parse(path, onBytesRead))
-            {
-                messages++;
-                if (!result.Success)
-                {
-                    skippedCount++;
-                    allSkipped.Add(new SkippedMessage
+                    rawOrdinal++;
+                    if (m.IsSkipped)
                     {
-                        SourcePath = path,
-                        Identifier = result.Source.Identifier,
-                        Reason = result.Error!,
-                    });
-                    continue;
-                }
+                        skippedCount++;
+                        allSkipped.Add(new SkippedMessage
+                        {
+                            SourcePath = path,
+                            Identifier = $"message #{rawOrdinal}",
+                            Reason = m.SkipReason!,
+                        });
+                        continue;
+                    }
 
-                estimatedBytes += PstWriter.EstimateMessageSize(result.Message!);
-
-                DateTimeOffset? date = result.Message!.Date;
-                if (date.HasValue)
-                {
-                    if (dateFrom is null || date < dateFrom) dateFrom = date;
-                    if (dateTo is null || date > dateTo) dateTo = date;
-                }
-
-                foreach (string warning in result.Warnings)
-                {
-                    warningCount++;
-                    allWarnings.Add(new SkippedMessage
+                    estBytes += m.EstimatedBytes;
+                    if (m.Date.HasValue)
                     {
-                        SourcePath = path,
-                        Identifier = result.Source.Identifier,
-                        Reason = warning,
-                    });
-                }
+                        if (dateFrom is null || m.Date < dateFrom) dateFrom = m.Date;
+                        if (dateTo is null || m.Date > dateTo) dateTo = m.Date;
+                    }
 
-                foreach (MailAttachment attachment in result.Message!.Attachments)
-                    attachment.Content.Dispose();
+                    foreach (string warning in m.Warnings)
+                    {
+                        warningCount++;
+                        allWarnings.Add(new SkippedMessage
+                        {
+                            SourcePath = path,
+                            Identifier = $"message #{rawOrdinal}",
+                            Reason = warning,
+                        });
+                    }
+                }
             }
 
-            // Guaranteed emit at this file's end so the bar reaches the file
-            // boundary even if the last chunk was under the throttle. For the
-            // last file this equals scanTotalBytes (the scan-end / 100% emit).
-            // Skip if a throttled emit already landed exactly here (no duplicate).
-            if (onProgress is not null)
-            {
-                long fileEnd = Math.Min(fileBase + sourceBytes, scanTotalBytes);
-                if (fileEnd != lastEmittedBytes)
-                {
-                    lastEmittedBytes = fileEnd;
-                    onProgress(new ScanProgress(fileEnd, scanTotalBytes));
-                }
-            }
-            completedSourceBytes += sourceBytes;
-
+            long sourceBytes = sourceSizes[i];
             sources.Add(new SourceScanResult(
-                id, path, displayName, messages, estimatedBytes, sourceBytes,
+                ids[i], path, System.IO.Path.GetFileNameWithoutExtension(path),
+                rawOrdinal, estBytes, sourceBytes,
                 dateFrom, dateTo, warningCount, skippedCount));
 
-            totalMessages += messages;
-            totalBytes += estimatedBytes;
+            totalMessages += rawOrdinal;
+            totalBytes += estBytes;
             totalSourceBytes += sourceBytes;
         }
 
         var totals = new ScanTotals(totalMessages, totalBytes, totalSourceBytes, sources.Count);
         return new ScanReport(totals, sources, allSkipped, allWarnings);
     }
+
+    /// <summary>Resolves the measure-only scan parser. <c>internal virtual</c> so tests can inject a
+    /// parser whose <see cref="MboxParser.ScanRange"/> throws (fatal-path coverage); production behavior
+    /// is unchanged.</summary>
+    internal virtual MboxParser ResolveScanParser(string sourceType) =>
+        (MboxParser)ParserRegistry.GetForScan(sourceType);
 
     private static string MakeUniqueId(string path, HashSet<string> used, int index)
     {

--- a/tests/Mail2Pst.Core.Tests/Parsing/MboxParserErrorHandlingTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Parsing/MboxParserErrorHandlingTests.cs
@@ -54,7 +54,7 @@ public class MboxParserErrorHandlingTests
     // downgrade it to a per-message skip, which would hide real defects.
     private sealed class BugParser : MboxParser
     {
-        protected override MimeMessage ParseMimeMessage(byte[] messageBytes) =>
+        protected override MimeMessage ParseMimeMessage(Stream s) =>
             throw new InvalidOperationException("simulated bug");
     }
 

--- a/tests/Mail2Pst.Core.Tests/Parsing/MboxParserRangeTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Parsing/MboxParserRangeTests.cs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Mail2Pst.Core.Parsing;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Parsing;
+
+public class MboxParserRangeTests
+{
+    private static string Msg(string id, string body) =>
+        $"From {id}@b Thu Jan 01 00:00:00 2026\r\nMessage-ID: <{id}>\r\nSubject: {id}\r\n\r\n{body}\r\n";
+
+    [Fact]
+    public void ScanRange_SplitAtBoundary_OwnsCorrectMessages_NoOverlapNoDrop()
+    {
+        string m1 = Msg("a", "one"), m2 = Msg("b", "two"), m3 = Msg("c", "three");
+        string all = m1 + m2 + m3;
+        long o2 = Encoding.ASCII.GetByteCount(m1);              // start boundary of m2
+        long o3 = Encoding.ASCII.GetByteCount(m1 + m2);         // start boundary of m3
+        string path = Path.Combine(Path.GetTempPath(), "m2p-range-" + Guid.NewGuid() + ".mbox");
+        File.WriteAllText(path, all);
+        try
+        {
+            var p = new MboxParser(measureOnly: true, rawSpillThreshold: 4L * 1024 * 1024);
+            var left  = p.ScanRange(path, 0,  o3, null);  // owns m1, m2
+            var right = p.ScanRange(path, o3, Encoding.ASCII.GetByteCount(all), null); // owns m3
+            Assert.Equal(2, left.Messages.Count);
+            Assert.Equal(1, right.Messages.Count);
+            Assert.Equal(0, left.StartOffset);
+            Assert.Equal(o3, right.StartOffset);
+            // Whole-file count equals the sum of the two ranges (no overlap, no drop)
+            int whole = p.Parse(path).Count();
+            Assert.Equal(whole, left.Messages.Count + right.Messages.Count);
+        }
+        finally { File.Delete(path); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Parsing/MboxParserSpillTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Parsing/MboxParserSpillTests.cs
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Mail2Pst.Core.Parsing;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Parsing;
+
+public class MboxParserSpillTests
+{
+    [Fact]
+    public void SpillThreshold_LargeMessage_ParsesIdenticallyToNoSpill()
+    {
+        // A message whose body is larger than the tiny spill threshold but small enough to inline-compare.
+        string big = new string('x', 50_000);
+        string mbox = $"From a@b Thu Jan 01 00:00:00 2026\r\nSubject: t\r\n\r\n{big}\r\n";
+        string path = Path.Combine(Path.GetTempPath(), "m2p-spill-" + Guid.NewGuid() + ".mbox");
+        File.WriteAllText(path, mbox);
+        try
+        {
+            var noSpill = new MboxParser(measureOnly: true, rawSpillThreshold: long.MaxValue).Parse(path).Single();
+            var spilled = new MboxParser(measureOnly: true, rawSpillThreshold: 4096).Parse(path).Single();
+            Assert.True(noSpill.Success && spilled.Success);
+            Assert.Equal(noSpill.Message!.Subject, spilled.Message!.Subject);
+            Assert.Equal(noSpill.Message!.TextBody, spilled.Message!.TextBody); // body byte-identical via spill
+        }
+        finally { File.Delete(path); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Parsing/RawMessageSpillExceptionTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Parsing/RawMessageSpillExceptionTests.cs
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using Mail2Pst.Core.Parsing;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Parsing;
+
+public class RawMessageSpillExceptionTests
+{
+    [Fact]
+    public void IsNotASkippableParseException()
+    {
+        var ex = new RawMessageSpillException("temp write failed", new IOException("disk full"));
+        // The per-message skip allowlist is FormatException/IOException ONLY. Spill failures must be neither
+        // (else a disk-full would be swallowed as a "skipped message" = silent data loss).
+        Assert.IsNotType<IOException>(ex);
+        Assert.IsNotType<FormatException>(ex);
+        Assert.IsAssignableFrom<Exception>(ex);
+        Assert.Contains("temp write failed", ex.Message);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Parsing/SpillableMessageBufferTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Parsing/SpillableMessageBufferTests.cs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System.IO;
+using System.Text;
+using Mail2Pst.Core.Parsing.Mbox;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Parsing;
+
+public class SpillableMessageBufferTests
+{
+    [Fact]
+    public void BelowThreshold_StaysInMemory_RoundTrips()
+    {
+        using var buf = new SpillableMessageBuffer(thresholdBytes: 1024);
+        buf.Write(Encoding.ASCII.GetBytes("hello"));
+        Assert.False(buf.SpilledToDisk);
+        using var s = buf.OpenRead();
+        Assert.Equal("hello", new StreamReader(s).ReadToEnd());
+    }
+
+    [Fact]
+    public void AboveThreshold_SpillsToTemp_RoundTrips_AndDeletesOnDispose()
+    {
+        string tempPath;
+        using (var buf = new SpillableMessageBuffer(thresholdBytes: 4))
+        {
+            buf.Write(Encoding.ASCII.GetBytes("abcdefghij")); // 10 > 4 -> spill
+            Assert.True(buf.SpilledToDisk);
+            tempPath = buf.TempPathForTest!;
+            Assert.True(File.Exists(tempPath));
+            using var s = buf.OpenRead();
+            Assert.Equal("abcdefghij", new StreamReader(s).ReadToEnd());
+        }
+        Assert.False(File.Exists(tempPath)); // deleted on Dispose
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Scanning/MboxMessageSplitterTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Scanning/MboxMessageSplitterTests.cs
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Mail2Pst.Core.Parsing;
+using Mail2Pst.Core.Scanning;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Scanning;
+
+public class MboxMessageSplitterTests
+{
+    private static string Msg(string id, int bodyBytes) =>
+        $"From {id}@b Thu Jan 01 00:00:00 2026\r\nSubject: {id}\r\n\r\n{new string('x', bodyBytes)}\r\n";
+
+    private static string Write(string content)
+    {
+        string p = Path.Combine(Path.GetTempPath(), "m2p-split-" + Guid.NewGuid() + ".mbox");
+        File.WriteAllText(p, content); return p;
+    }
+
+    [Fact]
+    public void Ranges_TileFileExactly_AndAreBoundaryAligned()
+    {
+        // 4 equal-ish messages; target chunk ~ half the file -> expect 2 ranges split on a real boundary.
+        string all = Msg("a", 1000) + Msg("b", 1000) + Msg("c", 1000) + Msg("d", 1000);
+        string path = Write(all);
+        try
+        {
+            long len = Encoding.ASCII.GetByteCount(all);
+            var ranges = MboxMessageSplitter.ComputeRanges(path, len, targetChunkBytes: len / 2);
+            Assert.True(ranges.Count >= 2);
+            Assert.Equal(0, ranges.First().Start);
+            Assert.Equal(len, ranges.Last().End);
+            byte[] bytes = File.ReadAllBytes(path);
+            for (int i = 1; i < ranges.Count; i++)
+            {
+                Assert.Equal(ranges[i - 1].End, ranges[i].Start);   // contiguous, no gaps/overlap
+                // Each interior split lands on a REAL boundary ("From " line), not a guessed offset. [R4]
+                Assert.Equal("From ", Encoding.ASCII.GetString(bytes, (int)ranges[i].Start, 5));
+            }
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void OneGiantMessage_AbsorbsTargets_FallsBackTowardWholeFile()
+    {
+        string all = Msg("a", 500_000);                 // single huge message
+        string path = Write(all);
+        try
+        {
+            long len = Encoding.ASCII.GetByteCount(all);
+            var ranges = MboxMessageSplitter.ComputeRanges(path, len, targetChunkBytes: len / 8);
+            Assert.Single(ranges);                       // no interior boundary -> one whole-file range
+            Assert.Equal((0L, len), ranges[0]);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void SmallFile_BelowTargetChunk_ReturnsSingleRange()
+    {
+        string all = Msg("a", 100) + Msg("b", 100);
+        string path = Write(all);
+        try
+        {
+            long len = Encoding.ASCII.GetByteCount(all);
+            var ranges = MboxMessageSplitter.ComputeRanges(path, len, targetChunkBytes: len * 4);
+            Assert.Single(ranges);
+            Assert.Equal((0L, len), ranges[0]);
+        }
+        finally { File.Delete(path); }
+    }
+
+    // Step 4: context-bootstrap stress. A "From " boundary that is a boundary ONLY because the line
+    // immediately before it is blank (NOT an envelope postmark), placed > BackWindow into the file so
+    // discovery's back-seek must reach back to re-observe that blank line. The target lands immediately
+    // before the boundary; the preceding blank line begins before the target. With context bootstrap the
+    // boundary is found and equals the offset the sequential parse engine reports for that same message.
+    [Fact]
+    public void FindBoundaryAtOrAfter_TargetJustBeforeBoundary_MatchesSequentialOffset()
+    {
+        // msg1 envelope-postmark boundary at 0; a big body pushes the second (non-postmark) boundary
+        // well past the 64 KiB back-window so backStart > 0 and context must be re-bootstrapped.
+        string msg1 = "From a@b Thu Jan 01 00:00:00 2026\r\nSubject: a\r\n\r\n"
+                      + new string('x', 80_000) + "\r\n";
+        string blankThenBareFrom = "\r\nFrom notapostmark\r\nSubject: b\r\n\r\nbody\r\n";
+        string all = msg1 + blankThenBareFrom;
+        string path = Write(all);
+        try
+        {
+            long len = Encoding.ASCII.GetByteCount(all);
+
+            // Ground truth from the SAME boundary engine the parser uses end to end.
+            var sequential = new MboxParser().ScanMessageStartOffsets(path);
+            Assert.Equal(2, sequential.Count);
+            long bareFromOffset = sequential[1];            // the non-postmark boundary
+            Assert.True(bareFromOffset > 64 * 1024,
+                "fixture must place the second boundary past the back-window");
+
+            long target = bareFromOffset - 1;               // immediately before the boundary
+            using FileStream stream = File.OpenRead(path);
+            long? found = MboxParser.FindBoundaryAtOrAfter(stream, target, scanCap: len);
+
+            Assert.Equal(bareFromOffset, found);
+        }
+        finally { File.Delete(path); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Scanning/ScanProgressAggregatorTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Scanning/ScanProgressAggregatorTests.cs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Mail2Pst.Core.Scanning;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Scanning;
+
+public class ScanProgressAggregatorTests
+{
+    [Fact]
+    public async Task ConcurrentDeltas_Monotonic_Clamped_ReachesTotalOnFinal()
+    {
+        var emitted = new List<ScanProgress>();
+        var gate = new object();
+        long total = 8_000_000;
+        var agg = new ScanProgressAggregator(total,
+            p => { lock (gate) emitted.Add(p); }, thresholdBytes: 1_000_000);
+
+        // 8 "ranges" each contributing 1,000,000 bytes in 100 chunks, concurrently.
+        await Task.WhenAll(Enumerable.Range(0, 8).Select(_ => Task.Run(() =>
+        {
+            for (int i = 0; i < 100; i++) agg.Add(10_000);
+        })));
+        agg.EmitFinal();
+
+        Assert.All(emitted, p => Assert.True(p.Bytes <= total));
+        for (int i = 1; i < emitted.Count; i++) Assert.True(emitted[i].Bytes >= emitted[i - 1].Bytes);
+        Assert.Equal(total, emitted.Last().Bytes);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Scanning/ScanRunnerFatalTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Scanning/ScanRunnerFatalTests.cs
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Mail2Pst.Core.Parsing;
+using Mail2Pst.Core.Scanning;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Scanning;
+
+public class ScanRunnerFatalTests
+{
+    // Minimal test seam: a parser whose ScanRange throws (per-path), injected via the internal
+    // virtual ResolveScanParser hook on ScanRunner. Production resolution is untouched.
+    private sealed class ThrowOnScanParser : MboxParser
+    {
+        private readonly Func<string, Exception> _ex;
+        public ThrowOnScanParser(Func<string, Exception> ex) : base(measureOnly: true) => _ex = ex;
+
+        public override RangeScanResult ScanRange(string path, long startOffset, long endOffset, Action<long>? onBytesRead)
+            => throw _ex(path);
+    }
+
+    private sealed class SeamScanRunner : ScanRunner
+    {
+        private readonly MboxParser _parser;
+        public SeamScanRunner(MboxParser parser) => _parser = parser;
+        internal override MboxParser ResolveScanParser(string sourceType) => _parser;
+    }
+
+    private static string WriteTempMbox(string body)
+    {
+        string path = Path.Combine(Path.GetTempPath(), "m2p-fatal-" + Guid.NewGuid() + ".mbox");
+        File.WriteAllText(path,
+            "From a@b.com Mon Jan 01 00:00:00 2024\r\nSubject: s\r\n\r\n" + body + "\r\n");
+        return path;
+    }
+
+    [Fact]
+    public void UnexpectedException_IsFatal_LowestSourceIndexWins()
+    {
+        // Two sources both throw. The merge must surface the lowest-(sourceIndex, offset) one,
+        // i.e. source 0's exception — not source 1's.
+        string p0 = WriteTempMbox("zero");
+        string p1 = WriteTempMbox("one");
+        var parser = new ThrowOnScanParser(path =>
+            new InvalidOperationException("boom for " + path));
+        var runner = new SeamScanRunner(parser);
+        try
+        {
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => runner.Scan(new[] { p0, p1 }, "mbox"));
+            Assert.Contains(p0, ex.Message);        // source 0 wins
+            Assert.DoesNotContain(p1, ex.Message);  // source 1 does NOT surface
+        }
+        finally { File.Delete(p0); File.Delete(p1); }
+    }
+
+    [Fact]
+    public void SpillIoFailure_IsFatal_AndEmitsNoFinalProgress()
+    {
+        // A RawMessageSpillException (operational spill failure) is NOT a per-message skip — it must
+        // surface as fatal, and because the rethrow happens BEFORE EmitFinal, no (total,total) lands.
+        string p = WriteTempMbox("spill");
+        var parser = new ThrowOnScanParser(_ =>
+            new RawMessageSpillException("temp spill failed", new IOException("disk full")));
+        var runner = new SeamScanRunner(parser);
+        var progresses = new List<ScanProgress>();
+        try
+        {
+            Assert.Throws<RawMessageSpillException>(
+                () => runner.Scan(new[] { p }, "mbox", progresses.Add));
+            // No success progress was emitted: in particular EmitFinal never fired (no 100% event).
+            Assert.DoesNotContain(progresses, e => e.Bytes == e.TotalBytes);
+        }
+        finally { File.Delete(p); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Scanning/ScanRunnerParallelTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Scanning/ScanRunnerParallelTests.cs
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Mail2Pst.Core.Scanning;
+using Mail2Pst.Core.Reporting;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Scanning;
+
+public class ScanRunnerParallelTests
+{
+    private static string Msg(string id, int body) =>
+        $"From {id}@b Thu Jan 01 00:00:00 2026\r\nMessage-ID: <{id}>\r\nSubject: {id}\r\n\r\n{new string('x', body)}\r\n";
+
+    private static ScanReport ScanWith(string path, long chunk) =>
+        new ScanRunner(new ScanRunnerOptions { TargetChunkBytes = chunk, MaxDegreeOfParallelism = 4 })
+            .Scan(new[] { path }, "mbox");
+
+    [Fact]
+    public void TinyChunks_ForceManyRanges_ProduceIdenticalReportToWholeFile()
+    {
+        var sb = new StringBuilder();
+        for (int i = 0; i < 500; i++) sb.Append(Msg("m" + i, 2000));   // ~1.1 MB
+        string path = Path.Combine(Path.GetTempPath(), "m2p-par-" + Guid.NewGuid() + ".mbox");
+        File.WriteAllText(path, sb.ToString());
+        try
+        {
+            long len = new FileInfo(path).Length;
+            // Prove tiny chunks actually split into many ranges (else the comparison proves nothing).
+            Assert.True(MboxMessageSplitter.ComputeRanges(path, len, 32 * 1024).Count > 1);
+
+            ScanReport whole = ScanWith(path, long.MaxValue);   // one range  (whole-file baseline)
+            ScanReport split = ScanWith(path, 32 * 1024);       // many ranges (parallel path)
+
+            Assert.Equal(whole.Totals.Messages, split.Totals.Messages);
+            Assert.Equal(whole.Totals.Bytes, split.Totals.Bytes);
+            Assert.Equal(whole.Totals.SourceBytes, split.Totals.SourceBytes);
+            Assert.Equal(500, split.Totals.Messages);
+            Assert.Empty(split.Skipped);
+        }
+        finally { File.Delete(path); }
+    }
+
+    // [R4] Blocker-1 guard: a skipped message must keep the RAW ordinal for both its #N identifier and the
+    // message count, identical between the split (parallel) and whole-file paths. Build a 3-message fixture
+    // whose middle message triggers a parse skip (reuse the malformed-message pattern from MboxParserTests).
+    [Fact]
+    public void SkippedMiddleMessage_RawOrdinalAndCount_MatchWholeFile()
+    {
+        // msg1 valid, msg2 MALFORMED (colon-less header lines -> MimeKit FormatException -> skip), msg3 valid.
+        string mbox =
+            "From a@b.com Mon Jan 01 00:00:00 2024\r\n" +
+            "From: alice@example.com\r\n" +
+            "Subject: Good1\r\n" +
+            "\r\n" +
+            "hello one\r\n" +
+            "\r\n" +
+            "From a@b.com Mon Jan 01 00:00:01 2024\r\n" +
+            "ThisLineHasNoColon\r\n" +
+            "NeitherDoesThisOne\r\n" +
+            "\r\n" +
+            "garbage\r\n" +
+            "\r\n" +
+            "From a@b.com Mon Jan 01 00:00:02 2024\r\n" +
+            "From: alice@example.com\r\n" +
+            "Subject: Good3\r\n" +
+            "\r\n" +
+            "hello three\r\n";
+        string path = Path.Combine(Path.GetTempPath(), "m2p-par-skip-" + Guid.NewGuid() + ".mbox");
+        File.WriteAllText(path, mbox);
+        try
+        {
+            ScanReport whole = ScanWith(path, long.MaxValue);
+            ScanReport split = ScanWith(path, 64);     // force msg2/msg3 into separate ranges
+            Assert.Equal(whole.Totals.Messages, split.Totals.Messages);          // raw count incl. the skip
+            Assert.Equal(3, split.Totals.Messages);
+            var skip = Assert.Single(split.Skipped);
+            Assert.Equal("message #2", skip.Identifier);                          // raw ordinal preserved
+            Assert.Equal(whole.Skipped.Single().Identifier, skip.Identifier);
+        }
+        finally { File.Delete(path); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Scanning/ScanRunnerParallelTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Scanning/ScanRunnerParallelTests.cs
@@ -77,6 +77,9 @@ public class ScanRunnerParallelTests
         {
             ScanReport whole = ScanWith(path, long.MaxValue);
             ScanReport split = ScanWith(path, 64);     // force msg2/msg3 into separate ranges
+            // Prove the tiny chunk actually splits into >1 range (else this test proves nothing if the
+            // splitter ever fail-closed-collapsed to the whole-file range). [final-review finding #6]
+            Assert.True(MboxMessageSplitter.ComputeRanges(path, new FileInfo(path).Length, 64).Count > 1);
             Assert.Equal(whole.Totals.Messages, split.Totals.Messages);          // raw count incl. the skip
             Assert.Equal(3, split.Totals.Messages);
             var skip = Assert.Single(split.Skipped);

--- a/tests/Mail2Pst.Core.Tests/Scanning/ScanRunnerProgressTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Scanning/ScanRunnerProgressTests.cs
@@ -25,10 +25,10 @@ public class ScanRunnerProgressTests
 
         runner.Scan(new[] { a, b }, "mbox", progresses.Add);
 
-        // Two tiny (<64 MB) sources → exactly one guaranteed file-end emit each,
-        // no throttle, no duplicate at the boundary. Asserting the exact count
-        // (not just NotEmpty) locks in the de-dup / one-emit-per-file behavior.
-        Assert.Equal(2, progresses.Count);
+        // Under parallel range aggregation the exact emit count is no longer fixed (it depends on
+        // range tiling + the byte throttle), so assert the DURABLE invariants instead: at least one
+        // emit, every emit clamped to total, non-decreasing, and the final EmitFinal reaches 100%.
+        Assert.NotEmpty(progresses);
         Assert.All(progresses, p => Assert.Equal(total, p.TotalBytes));
         Assert.All(progresses, p => Assert.True(p.Bytes <= p.TotalBytes, "bytes must be clamped to total"));
         for (int i = 1; i < progresses.Count; i++)


### PR DESCRIPTION
## 0.2.2

### Parallel byte-range scan
The dry-run scan (CLI `scan` + the desktop pre-conversion scan) now partitions each mbox into message-aligned byte ranges and parses them across CPU cores (DOP = min(cores, 8)) instead of one sequential pass, with per-message RAM bounded by a 4 MB raw-message spill threshold.

- **Faster:** ~3.5× end-to-end on a 4.5 GB Gmail export (~47 s → ~13.5 s), no single-folder floor.
- **Bounded memory:** peak working set is size-independent (163/314 MB workstation/Server GC for a 4.5 GB corpus incl. a 1.5 GB single mbox); large messages spill to temp rather than residing in memory.
- **Identical results:** counts, size estimates, dates, warnings, skips, and `message #N` ids are byte-for-byte identical to the sequential scan. CLI scan JSON and the GUI scan contract are unchanged.
- Server GC enabled on the CLI (measured wall-clock win).

### Also in this release
- Fix: "Import category colours" no longer hangs when colours already exist in Outlook.
- Fix: Thunderbird `.msf` reading no longer fails on a reparsed folder (table-rebuild fragment is folded into the real table).

### Verification
Full Core suite 712 pass / 1 skip; Integration 80 pass / 8 skip. Byte-identity proven on the real 4.5 GB corpus. Independent-reader gate unaffected (scan-only path). Version bumped to 0.2.2 across CLI + desktop; CHANGELOG updated.