### PR TITLE
test: cover cancel contract, scan memory-safety, sidecar wiring

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -35,6 +35,31 @@ fn drain_lines(buf: &mut String) -> Vec<String> {
     out
 }
 
+// The exact CLI argument vector for a streaming scan. The GUI ALWAYS passes
+// `--progress` (the Rust reader consumes the advisory `scanProgress` lines plus
+// the final authoritative `scan` object). Pure + unit-tested so the contract the
+// sidecar is invoked with can't drift silently.
+fn scan_args(paths: &[String]) -> Vec<String> {
+    let mut args: Vec<String> = vec!["scan".into()];
+    for p in paths {
+        args.push("--input".into());
+        args.push(p.clone());
+    }
+    args.push("--progress".into());
+    args
+}
+
+// The exact CLI argument vector for a conversion run.
+fn convert_args(config_path: &str, output_dir: &str) -> Vec<String> {
+    vec![
+        "convert".into(),
+        "--config".into(),
+        config_path.into(),
+        "--output".into(),
+        output_dir.into(),
+    ]
+}
+
 // Like run_sidecar, but returns stdout even when the sidecar exits nonzero AS LONG AS it printed
 // something — import-colours' handled failures exit 1 while emitting a structured {type:"error"} JSON
 // object the frontend needs. Err only on a spawn failure or a nonzero exit with no stdout.
@@ -196,12 +221,7 @@ async fn start_scan(
         return Err("A scan is already running.".into());
     }
 
-    let mut args: Vec<String> = vec!["scan".into()];
-    for p in paths {
-        args.push("--input".into());
-        args.push(p);
-    }
-    args.push("--progress".into());
+    let args = scan_args(&paths);
 
     let (mut rx, child) = app
         .shell()
@@ -302,7 +322,7 @@ async fn start_convert(
             let _ = std::fs::remove_file(&config_path);
             format!("sidecar not found: {e}")
         })?
-        .args(["convert", "--config", &config_path_str, "--output", &output_dir])
+        .args(convert_args(&config_path_str, &output_dir))
         .spawn()
         .map_err(|e| {
             let _ = std::fs::remove_file(&config_path);
@@ -697,7 +717,31 @@ Path=Profiles/xyz.dev\n";
 
 #[cfg(test)]
 mod tests {
-    use super::drain_lines;
+    use super::{convert_args, drain_lines, scan_args};
+
+    #[test]
+    fn scan_args_one_input_passes_progress_flag() {
+        assert_eq!(
+            scan_args(&["a.mbox".to_string()]),
+            vec!["scan", "--input", "a.mbox", "--progress"]
+        );
+    }
+
+    #[test]
+    fn scan_args_repeats_input_flag_per_path_in_order() {
+        assert_eq!(
+            scan_args(&["a.mbox".to_string(), "b.mbox".to_string()]),
+            vec!["scan", "--input", "a.mbox", "--input", "b.mbox", "--progress"]
+        );
+    }
+
+    #[test]
+    fn convert_args_config_and_output_flags() {
+        assert_eq!(
+            convert_args("C:/tmp/cfg.json", "C:/out"),
+            vec!["convert", "--config", "C:/tmp/cfg.json", "--output", "C:/out"]
+        );
+    }
 
     #[test]
     fn drain_lines_splits_batched_records_and_keeps_partial() {
@@ -722,5 +766,111 @@ mod tests {
         let lines = drain_lines(&mut buf);
         assert_eq!(lines, vec!["a", "b"]);
         assert_eq!(buf, "");
+    }
+}
+
+// Exercises the REAL CLI sidecar the GUI spawns, proving the JSON-Lines contract the
+// Rust readers depend on: every emitted line is JSON carrying `schemaVersion`; a
+// `scan --progress` stream ends with the authoritative single `scan` object; advisory
+// `scanProgress` lines clamp `bytes` to `totalBytes`. Locates the published Tauri
+// sidecar binary, else falls back to the dotnet build output; SKIPS (no failure) if
+// neither is present (a checkout where the engine hasn't been built). Run with
+// `cargo test` — not currently wired into CI (see roadmap: add a cargo-test job).
+#[cfg(test)]
+mod sidecar_integration_tests {
+    use super::{drain_lines, scan_args};
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    fn manifest() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    }
+
+    // (program, leading args) to invoke the CLI, or None if no build is present.
+    fn locate_cli() -> Option<(String, Vec<String>)> {
+        // 1) Published Tauri sidecar: binaries/mail2pst-cli-<target-triple>[.exe]
+        if let Ok(entries) = std::fs::read_dir(manifest().join("binaries")) {
+            for e in entries.flatten() {
+                let name = e.file_name().to_string_lossy().to_string();
+                if name.starts_with("mail2pst-cli") && (name.ends_with(".exe") || !name.contains('.')) {
+                    return Some((e.path().to_string_lossy().to_string(), vec![]));
+                }
+            }
+        }
+        // 2) Fallback: run the dotnet build output directly.
+        for cfg in ["Debug", "Release"] {
+            let dll = manifest()
+                .join("../../src/Mail2Pst.Cli/bin")
+                .join(cfg)
+                .join("net8.0/Mail2Pst.Cli.dll");
+            if dll.exists() {
+                return Some(("dotnet".to_string(), vec![dll.to_string_lossy().to_string()]));
+            }
+        }
+        None
+    }
+
+    fn run(program: &str, lead: &[String], args: &[String]) -> (i32, Vec<String>) {
+        let out = Command::new(program)
+            .args(lead)
+            .args(args)
+            .output()
+            .expect("failed to spawn CLI");
+        let mut buf = String::from_utf8_lossy(&out.stdout).to_string();
+        if !buf.ends_with('\n') {
+            buf.push('\n'); // ensure a final unterminated line still drains
+        }
+        (out.status.code().unwrap_or(-1), drain_lines(&mut buf))
+    }
+
+    #[test]
+    fn version_emits_one_versioned_json_line() {
+        let Some((prog, lead)) = locate_cli() else {
+            eprintln!("skipping: no CLI build found (sidecar binary or dotnet dll)");
+            return;
+        };
+        let (code, lines) = run(&prog, &lead, &["version".to_string()]);
+        assert_eq!(code, 0, "version should exit 0");
+        assert_eq!(lines.len(), 1, "version prints exactly one line");
+        let v: serde_json::Value = serde_json::from_str(&lines[0]).expect("version line is JSON");
+        assert_eq!(v["type"], "version");
+        assert!(v["schemaVersion"].as_i64().unwrap_or(0) >= 1);
+    }
+
+    #[test]
+    fn scan_progress_stream_is_jsonlines_and_ends_with_scan() {
+        let Some((prog, lead)) = locate_cli() else {
+            eprintln!("skipping: no CLI build found (sidecar binary or dotnet dll)");
+            return;
+        };
+        let sample = manifest().join("../../fixtures/sample.mbox");
+        if !sample.exists() {
+            eprintln!("skipping: fixtures/sample.mbox not found");
+            return;
+        }
+
+        let args = scan_args(&[sample.to_string_lossy().to_string()]);
+        let (code, lines) = run(&prog, &lead, &args);
+        assert_eq!(code, 0, "scan should exit 0");
+        assert!(!lines.is_empty(), "scan --progress emits at least the final scan line");
+
+        for line in &lines {
+            let v: serde_json::Value =
+                serde_json::from_str(line).unwrap_or_else(|_| panic!("not JSON: {line}"));
+            assert!(
+                v["schemaVersion"].as_i64().unwrap_or(0) >= 1,
+                "line missing schemaVersion: {line}"
+            );
+            if v["type"] == "scanProgress" {
+                let b = v["bytes"].as_i64().unwrap_or(0);
+                let t = v["totalBytes"].as_i64().unwrap_or(0);
+                assert!(b <= t, "scanProgress bytes {b} exceeds total {t}");
+            }
+        }
+
+        // The LAST line is the authoritative single `scan` object.
+        let last: serde_json::Value = serde_json::from_str(lines.last().unwrap()).unwrap();
+        assert_eq!(last["type"], "scan", "final line must be the scan result");
+        assert!(last["totals"]["messages"].as_i64().unwrap_or(-1) >= 0);
     }
 }

--- a/tests/Mail2Pst.Core.Tests/Cli/CliE2EProcess.cs
+++ b/tests/Mail2Pst.Core.Tests/Cli/CliE2EProcess.cs
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#nullable enable
+using System;
+using System.IO;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Cli;
+
+/// <summary>Shared helpers for end-to-end tests that spawn the real built CLI
+/// (`dotnet Mail2Pst.Cli.dll …`). Locating the repo root + the build output is
+/// identical across E2E suites; keeping it in one place avoids drift.</summary>
+internal static class CliE2EProcess
+{
+    internal static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Mail2Pst.sln")))
+            dir = dir.Parent;
+        return dir?.FullName ?? throw new InvalidOperationException("Could not locate repo root (Mail2Pst.sln).");
+    }
+
+    internal static string CliDllPath()
+    {
+        string config = AppContext.BaseDirectory.Replace('\\', '/').Contains("/bin/Release/") ? "Release" : "Debug";
+        string dll = Path.Combine(RepoRoot(), "src", "Mail2Pst.Cli", "bin", config, "net8.0", "Mail2Pst.Cli.dll");
+        Assert.True(File.Exists(dll), $"CLI build output not found at {dll}");
+        return dll;
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Cli/CliSchemaVersionE2ETests.cs
+++ b/tests/Mail2Pst.Core.Tests/Cli/CliSchemaVersionE2ETests.cs
@@ -16,33 +16,14 @@ namespace Mail2Pst.Core.Tests.Cli;
 // emission site that bypasses the serializer would be caught.
 public class CliSchemaVersionE2ETests
 {
-    private static string RepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Mail2Pst.sln")))
-        {
-            dir = dir.Parent;
-        }
-
-        return dir?.FullName ?? throw new InvalidOperationException("Could not locate repo root (Mail2Pst.sln).");
-    }
-
-    private static string CliDllPath()
-    {
-        string config = AppContext.BaseDirectory.Replace('\\', '/').Contains("/bin/Release/") ? "Release" : "Debug";
-        string dll = Path.Combine(RepoRoot(), "src", "Mail2Pst.Cli", "bin", config, "net8.0", "Mail2Pst.Cli.dll");
-        Assert.True(File.Exists(dll), $"CLI build output not found at {dll}");
-        return dll;
-    }
-
     private static (int exitCode, List<string> jsonLines) RunCli(string args)
     {
-        var psi = new ProcessStartInfo("dotnet", $"\"{CliDllPath()}\" {args}")
+        var psi = new ProcessStartInfo("dotnet", $"\"{CliE2EProcess.CliDllPath()}\" {args}")
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
-            WorkingDirectory = RepoRoot(),
+            WorkingDirectory = CliE2EProcess.RepoRoot(),
         };
 
         using Process proc = Process.Start(psi)!;

--- a/tests/Mail2Pst.Core.Tests/Cli/ConvertCancelE2ETests.cs
+++ b/tests/Mail2Pst.Core.Tests/Cli/ConvertCancelE2ETests.cs
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Cli;
+
+// End-to-end guard for the `convert` CANCEL contract the GUI depends on. The
+// writer-level cancel→delete-in-progress-part path is unit-tested
+// (PstWriterCancellationTests); this pins the CLI process behaviour: a `cancel`
+// line on stdin mid-write must produce the terminal `cancelled` event (with
+// deleted[]/outputs[]), exit code 2, NO `done`, and NO success report on disk.
+public class ConvertCancelE2ETests
+{
+    // Large enough that a 500-message checkpoint (where cancellation is observed)
+    // lands well before the write finishes, with bodies sized so writing takes
+    // longer than the stdin cancel round-trip. Cancel is sent on the first
+    // `progress` event (writing underway → the in-progress part exists).
+    private const int MessageCount = 5000;
+
+    private static string WriteLargeMbox(int count)
+    {
+        string path = Path.Combine(Path.GetTempPath(), "m2p-cancel-" + Guid.NewGuid() + ".mbox");
+        var body = new string('x', 400);
+        var sb = new StringBuilder(count * 600);
+        for (int i = 0; i < count; i++)
+        {
+            sb.Append("From s").Append(i).Append("@example.com Mon Jan 01 00:00:00 2024\r\n");
+            sb.Append("From: s").Append(i).Append("@example.com\r\n");
+            sb.Append("Subject: Message ").Append(i).Append("\r\n");
+            sb.Append("Date: Mon, 01 Jan 2024 00:00:00 +0000\r\n\r\n");
+            sb.Append(body).Append("\r\n\r\n");
+        }
+        File.WriteAllText(path, sb.ToString());
+        return path;
+    }
+
+    [Fact]
+    public void Convert_CancelOnStdinMidWrite_EmitsCancelled_DeletesPart_Exit2_NoDoneNoReport()
+    {
+        string mbox = WriteLargeMbox(MessageCount);
+        string outDir = Path.Combine(Path.GetTempPath(), "m2p-cancel-out-" + Guid.NewGuid());
+        string config = Path.Combine(Path.GetTempPath(), "m2p-cancel-cfg-" + Guid.NewGuid() + ".json");
+        // maxSizeMB generous so the run produces a single part (no split) — the
+        // cancelled in-progress part is then deleted with no completed parts left.
+        string json =
+            "{\"outputs\":[{\"name\":\"Personal\",\"maxSizeMB\":1024,\"folderMapping\":\"mirror\"," +
+            "\"sources\":[{\"path\":" + JsonSerializer.Serialize(mbox) + ",\"type\":\"mbox\"}]}]}";
+        File.WriteAllText(config, json);
+
+        try
+        {
+            var psi = new ProcessStartInfo("dotnet",
+                $"\"{CliE2EProcess.CliDllPath()}\" convert --config \"{config}\" --output \"{outDir}\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                RedirectStandardInput = true,
+                UseShellExecute = false,
+                WorkingDirectory = CliE2EProcess.RepoRoot(),
+            };
+
+            using Process proc = Process.Start(psi)!;
+            // Drain stderr on a thread so a full stderr buffer can never deadlock the run.
+            var stderr = new StringBuilder();
+            var errThread = new Thread(() => { try { stderr.Append(proc.StandardError.ReadToEnd()); } catch { } })
+            { IsBackground = true };
+            errThread.Start();
+
+            var lines = new List<string>();
+            bool cancelSent = false;
+            string? raw;
+            while ((raw = proc.StandardOutput.ReadLine()) is not null)
+            {
+                string line = raw.Trim();
+                if (line.Length == 0) continue;
+                lines.Add(line);
+                if (!cancelSent && line.Contains("\"type\":\"progress\""))
+                {
+                    proc.StandardInput.WriteLine("cancel");
+                    proc.StandardInput.Flush();
+                    cancelSent = true;
+                }
+            }
+
+            Assert.True(proc.WaitForExit(120_000), "convert did not exit in time");
+            errThread.Join(5_000);
+
+            Assert.True(cancelSent, "no `progress` event observed — the test never exercised a mid-write cancel");
+            Assert.Equal(2, proc.ExitCode);
+
+            // Terminal event is `cancelled`, never `done` (mutually exclusive).
+            string? cancelledLine = lines.Find(l => l.Contains("\"type\":\"cancelled\""));
+            Assert.True(cancelledLine is not null, $"no `cancelled` event. stderr: {stderr}");
+            Assert.DoesNotContain(lines, l => l.Contains("\"type\":\"done\""));
+
+            using JsonDocument doc = JsonDocument.Parse(cancelledLine!);
+            JsonElement root = doc.RootElement;
+            Assert.Equal("cancelled", root.GetProperty("type").GetString());
+            Assert.Equal(JsonValueKind.Array, root.GetProperty("deleted").ValueKind);
+            Assert.Equal(JsonValueKind.Array, root.GetProperty("outputs").ValueKind);
+            // The in-progress single part was deleted; no completed parts survive.
+            Assert.True(root.GetProperty("deleted").GetArrayLength() >= 1,
+                "cancelled must report the deleted in-progress part");
+            Assert.Equal(0, root.GetProperty("outputs").GetArrayLength());
+
+            // No success report written on cancel, and the in-progress .pst is gone from disk.
+            Assert.False(File.Exists(Path.Combine(outDir, "conversion-report.json")),
+                "success report must not be written when cancelled");
+            Assert.True(!Directory.Exists(outDir) || Directory.GetFiles(outDir, "*.pst").Length == 0,
+                "in-progress .pst must be deleted on cancel");
+        }
+        finally
+        {
+            if (File.Exists(mbox)) File.Delete(mbox);
+            if (File.Exists(config)) File.Delete(config);
+            if (Directory.Exists(outDir)) Directory.Delete(outDir, true);
+        }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Scanning/ScanRunnerSpillNoLeakTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Scanning/ScanRunnerSpillNoLeakTests.cs
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Mail2Pst.Core.Parsing;
+using Mail2Pst.Core.Parsing.Mbox;
+using Mail2Pst.Core.Scanning;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Scanning;
+
+// Runs serially against the whole suite: the no-leak assertion snapshots the shared
+// temp dir for `mail2pst-raw-*` files, and several other tests spill there too —
+// DisableParallelization guarantees no concurrent creator races the snapshot.
+[CollectionDefinition("ScanNoLeakSerial", DisableParallelization = true)]
+public class ScanNoLeakSerialCollection { }
+
+// Memory-safety regression for the parallel byte-range scan (Plan 2): a scan that
+// spills (large messages) must leave NO `mail2pst-raw-*` temp files behind — every
+// per-message spill buffer is disposed (the `using` in ScanRange/Parse) — and the
+// spill must not alter results. Codifies the Task-8 manual check as an automated guard.
+[Collection("ScanNoLeakSerial")]
+public class ScanRunnerSpillNoLeakTests
+{
+    // Injects a tiny raw-message spill threshold into the scan parser so ordinary
+    // small messages spill, exercising the spill→OpenRead→Dispose→delete cycle
+    // through the real parallel ScanRunner path without needing a multi-MB fixture.
+    private sealed class TinySpillScanRunner : ScanRunner
+    {
+        private readonly long _threshold;
+        public TinySpillScanRunner(ScanRunnerOptions options, long spillThreshold) : base(options)
+            => _threshold = spillThreshold;
+        internal override MboxParser ResolveScanParser(string sourceType)
+            => new MboxParser(measureOnly: true, rawSpillThreshold: _threshold);
+    }
+
+    private static string WriteMbox(int count, int bodyBytes)
+    {
+        string path = Path.Combine(Path.GetTempPath(), "m2p-scanleak-" + Guid.NewGuid() + ".mbox");
+        string body = new string('x', bodyBytes);
+        var sb = new StringBuilder(count * (bodyBytes + 200));
+        for (int i = 0; i < count; i++)
+        {
+            sb.Append("From s").Append(i).Append("@b Thu Jan 01 00:00:00 2026\r\n");
+            sb.Append("Subject: m").Append(i).Append("\r\n\r\n");
+            sb.Append(body).Append("\r\n\r\n");
+        }
+        File.WriteAllText(path, sb.ToString());
+        return path;
+    }
+
+    private static string[] RawTempFiles() =>
+        Directory.GetFiles(Path.GetTempPath(), "mail2pst-raw-*");
+
+    [Fact]
+    public void ParallelScan_ForcedSpill_LeavesNoTempFiles_AndMatchesNoSpill()
+    {
+        const long spillThreshold = 256;     // << body size, so every message spills
+        const int bodyBytes = 2000;
+
+        // Sanity: confirm these sizes really do spill (else the no-leak check is vacuous).
+        using (var buf = new SpillableMessageBuffer(spillThreshold))
+        {
+            buf.Write(new byte[bodyBytes]);
+            Assert.True(buf.SpilledToDisk, "test sizing is wrong — the buffer did not spill");
+        }
+
+        string mbox = WriteMbox(count: 40, bodyBytes: bodyBytes);
+        try
+        {
+            var before = new HashSet<string>(RawTempFiles());
+
+            // Tiny TargetChunkBytes forces many ranges → the parallel path; tiny threshold forces spills.
+            var spillOpts = new ScanRunnerOptions { TargetChunkBytes = 4096, MaxDegreeOfParallelism = 4 };
+            ScanReport spilled = new TinySpillScanRunner(spillOpts, spillThreshold).Scan(new[] { mbox }, "mbox");
+
+            // No spill temp file created by this scan survives.
+            string[] leaked = RawTempFiles().Where(f => !before.Contains(f)).ToArray();
+            Assert.True(leaked.Length == 0, "scan leaked spill temp files: " + string.Join(", ", leaked));
+
+            // Spilling did not alter results: byte-identical to a sequential, no-spill scan.
+            var baseOpts = new ScanRunnerOptions { TargetChunkBytes = long.MaxValue, MaxDegreeOfParallelism = 1 };
+            ScanReport noSpill = new TinySpillScanRunner(baseOpts, long.MaxValue).Scan(new[] { mbox }, "mbox");
+
+            Assert.Equal(40, spilled.Totals.Messages);
+            Assert.Equal(noSpill.Totals.Messages, spilled.Totals.Messages);
+            Assert.Equal(noSpill.Totals.Bytes, spilled.Totals.Bytes);
+            Assert.Equal(noSpill.Totals.SourceBytes, spilled.Totals.SourceBytes);
+            Assert.Equal(noSpill.Skipped.Count, spilled.Skipped.Count);
+        }
+        finally { File.Delete(mbox); }
+    }
+}


### PR DESCRIPTION
Targeted test-coverage additions for the high-risk process/seam boundaries (coverage is already broad at the unit level; these pin the seams).

## Added
- **CLI convert cancel contract (E2E)** — spawns the real CLI, sends `cancel` on stdin mid-write, asserts the `cancelled` event (`deleted[]`/`outputs[]`), exit 2, no `done`, no success report, in-progress part deleted. Writer internals were already unit-tested; this pins the CLI process behaviour the GUI depends on.
- **Parallel-scan memory-safety regression** — forces spills through the real parallel `ScanRunner` (via the `ResolveScanParser` seam) and proves no `mail2pst-raw-*` temp leaks + byte-identical results vs no-spill. Isolated with a `DisableParallelization` collection so the temp snapshot can't race other spill tests. Codifies the Plan-2 Task-8 manual check.
- **Desktop sidecar wiring** — extracted `scan_args`/`convert_args` as pure functions (pins the exact CLI flags the GUI sends) with unit tests, plus real-sidecar integration tests verifying the `version` and `scan --progress` JSON-Lines contracts end-to-end (skip-if-not-built).
- De-duped the shared CLI E2E helper.

## Verification
Core 714 pass / 1 skip; Integration 80 pass / 8 skip; desktop Vitest 214 pass; Rust `cargo test` 13 pass (incl. the 2 new sidecar integration tests run against the real binary). Behavior-preserving refactor only (arg-builder extraction).

## Follow-up (not in this PR)
Rust tests run via `cargo test` locally but aren't gated in CI (no cargo job). Adding a Tauri cargo-test CI job would gate them — flagged in the roadmap for a cost/benefit decision.