### PR TITLE
Foundation audit fixes: CID attachment fidelity, cancel temp-leak, embedded-msg measure-only, convert double-scan

### DIFF
--- a/src/Mail2Pst.Cli/ConvertCommand.cs
+++ b/src/Mail2Pst.Cli/ConvertCommand.cs
@@ -107,7 +107,7 @@ internal static class ConvertCommand
                         CliArgs.WriteJsonLine(new { type = "warning", source = w.Source, identifier = w.Identifier, reason = w.Reason });
                         break;
                 }
-            }, cts.Token);
+            }, cts.Token, precomputedTotalMessages: resolved.ExpectedTotal);
 
             stopwatch.Stop();
 

--- a/src/Mail2Pst.Cli/ConvertInput.cs
+++ b/src/Mail2Pst.Cli/ConvertInput.cs
@@ -8,8 +8,9 @@ using Mail2Pst.Core.Discovery;
 
 namespace Mail2Pst.Cli;
 
-/// <summary>Resolved convert inputs, or a user-facing Error string. Pure (no signals/conversion).</summary>
-internal sealed record ConvertResolution(ConversionConfig? Config, string? OutputDir, string? InputLabel, string? Error);
+/// <summary>Resolved convert inputs, or a user-facing Error string. Pure (no signals/conversion).
+/// <paramref name="ExpectedTotal"/> is an optional precomputed message count (-1 = count on demand).</summary>
+internal sealed record ConvertResolution(ConversionConfig? Config, string? OutputDir, string? InputLabel, string? Error, int ExpectedTotal = -1);
 
 /// <summary>
 /// Resolves `convert` arguments into a ConversionConfig (or an error), supporting --config (existing),
@@ -20,7 +21,7 @@ internal sealed record ConvertResolution(ConversionConfig? Config, string? Outpu
 internal static class ConvertInput
 {
     private static readonly System.Collections.Generic.HashSet<string> KnownFlags =
-        new(StringComparer.Ordinal) { "--config", "--profile", "--output" };
+        new(StringComparer.Ordinal) { "--config", "--profile", "--output", "--expected-total" };
 
     internal static ConvertResolution Resolve(string[] args)
     {
@@ -32,6 +33,17 @@ internal static class ConvertInput
         string? configPath = CliArgs.Flag(args, "--config");
         string? profileDir = CliArgs.Flag(args, "--profile");
         string? outputDir = CliArgs.Flag(args, "--output");
+
+        // Optional precomputed message count (non-negative). Lets a caller that already scanned skip the
+        // convert-time count pass; omitted -> -1 -> count on demand. Direct CLI users are unaffected.
+        int expectedTotal = -1;
+        string? expectedTotalRaw = CliArgs.Flag(args, "--expected-total");
+        if (expectedTotalRaw is not null &&
+            (!int.TryParse(expectedTotalRaw, System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out expectedTotal) || expectedTotal < 0))
+        {
+            return new(null, null, null, $"Invalid --expected-total value: {expectedTotalRaw}");
+        }
 
         if (outputDir is null)
             return new(null, null, null, "Missing --output <dir>.");
@@ -56,7 +68,7 @@ internal static class ConvertInput
             {
                 DiscoveryResult discovery = MailProfileDiscovery.Discover(profileDir);
                 ConversionConfig config = ConfigFromDiscovery.Build(discovery, template);
-                return new(config, outputDir, profileDir, null);
+                return new(config, outputDir, profileDir, null, expectedTotal);
             }
             catch (Exception ex)
             {
@@ -70,7 +82,7 @@ internal static class ConvertInput
         try
         {
             ConversionConfig config = ConfigLoader.Load(configPath!);
-            return new(config, outputDir, configPath, null);
+            return new(config, outputDir, configPath, null, expectedTotal);
         }
         catch (Exception ex)
         {

--- a/src/Mail2Pst.Core/ConversionRunner.cs
+++ b/src/Mail2Pst.Core/ConversionRunner.cs
@@ -31,7 +31,7 @@ public class ConversionRunner
         _writer = new PstWriter(checkIntervalMessages, progressIntervalMessages);
     }
 
-    public ConversionReport Run(ConversionConfig config, string outputDirectory, Action<ConversionProgressEvent>? onProgress = null, CancellationToken cancellationToken = default, DurableMemoryObserver? memoryObserver = null)
+    public ConversionReport Run(ConversionConfig config, string outputDirectory, Action<ConversionProgressEvent>? onProgress = null, CancellationToken cancellationToken = default, DurableMemoryObserver? memoryObserver = null, int precomputedTotalMessages = -1)
     {
         // Validate the config up front (output names, duplicates, sizes, sources)
         // so problems fail loudly before any output file is created.
@@ -60,17 +60,27 @@ public class ConversionRunner
         int total = 0;
         if (onProgress is not null)
         {
-            foreach (PstOutputPlan plan in plans)
+            if (precomputedTotalMessages >= 0)
             {
-                foreach (SourceMapping mapping in plan.SourceMappings)
+                // A caller that already counted (e.g. the GUI's preceding `scan`) passes the total here,
+                // so a progress-mode convert skips a full second boundary pass over every source. When
+                // omitted (-1, the default and the direct-CLI path) we count on demand as before.
+                total = precomputedTotalMessages;
+            }
+            else
+            {
+                foreach (PstOutputPlan plan in plans)
                 {
-                    try
+                    foreach (SourceMapping mapping in plan.SourceMappings)
                     {
-                        total += ParserRegistry.Get(mapping.Source.Type).CountMessages(mapping.Source.Path);
-                    }
-                    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-                    {
-                        // best-effort: missing/unreadable source contributes 0 to the total
+                        try
+                        {
+                            total += ParserRegistry.Get(mapping.Source.Type).CountMessages(mapping.Source.Path);
+                        }
+                        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                        {
+                            // best-effort: missing/unreadable source contributes 0 to the total
+                        }
                     }
                 }
             }

--- a/src/Mail2Pst.Core/Parsing/Mime/MimeMessageMapper.cs
+++ b/src/Mail2Pst.Core/Parsing/Mime/MimeMessageMapper.cs
@@ -163,14 +163,11 @@ public class MimeMessageMapper
                 const string embeddedMimeType = "message/rfc822";
                 try
                 {
-                    using var messageBytes = new MemoryStream();
-                    messagePart.Message.WriteTo(messageBytes);
-
                     attachments.Add(new MailAttachment
                     {
                         FileName = embeddedFileName,
                         MimeType = embeddedMimeType,
-                        Content = ToAttachmentContent(messageBytes),
+                        Content = WriteEmbeddedMessageContent(messagePart),
                     });
                 }
                 catch (Exception ex)
@@ -245,7 +242,11 @@ public class MimeMessageMapper
                     MimeType = mimeType,
                     ContentId = contentId,
                     ContentLocation = part.ContentLocation?.ToString(),
-                    IsInline = isInlineDisposition || contentId is not null,
+                    // A Content-ID marks a part inline (body-embedded, hidden, no paperclip) ONLY when
+                    // it is not also an explicit attachment. Many mailers attach genuine files (PDFs,
+                    // ICS invites, signed parts) that carry BOTH Content-Disposition: attachment and a
+                    // Content-ID — those must stay visible, so the explicit attachment disposition wins.
+                    IsInline = isInlineDisposition || (contentId is not null && !isAttachmentDisposition),
                     Content = content,
                 });
             }
@@ -271,6 +272,28 @@ public class MimeMessageMapper
         }
         using var buffer = new MemoryStream();
         part.Content!.DecodeTo(buffer);
+        return ToAttachmentContent(buffer);
+    }
+
+    // Same measure-only contract as DecodeContent, for an embedded message/rfc822 attachment: in scan
+    // measure-only mode, serialize the embedded message into a CountingStream to capture its exact length
+    // while retaining nothing — otherwise a large forwarded .eml would be fully buffered (and temp-spilled
+    // past the threshold) per scan worker, defeating the parallel-scan memory-safety guarantee.
+    private AttachmentContent WriteEmbeddedMessageContent(MessagePart messagePart)
+    {
+        // A message/rfc822 part with no parsed inner message has nothing to attach; surface it as a
+        // dropped-attachment warning (the caller catches this) rather than NRE-ing on WriteTo.
+        MimeMessage message = messagePart.Message
+            ?? throw new InvalidOperationException("embedded message/rfc822 part has no message content");
+
+        if (_measureOnly)
+        {
+            var counter = new CountingStream();
+            message.WriteTo(counter);
+            return AttachmentContent.FromLengthOnly(counter.BytesWritten);
+        }
+        using var buffer = new MemoryStream();
+        message.WriteTo(buffer);
         return ToAttachmentContent(buffer);
     }
 

--- a/src/Mail2Pst.Core/Writing/PstWriter.cs
+++ b/src/Mail2Pst.Core/Writing/PstWriter.cs
@@ -93,12 +93,26 @@ public class PstWriter
 
         var producer = Task.Run(() =>
         {
+            // Tracks the message currently being handed to the bounded queue. On cancel/fatal while the
+            // queue is full, queue.Add throws OperationCanceledException with this message NOT enqueued —
+            // so the consumer's drain loop never sees it. Dispose its (possibly temp-backed) attachments
+            // here, or that one in-flight message's temp file would leak.
+            PlannedMessage? inFlight = null;
             try
             {
                 foreach (PlannedMessage msg in messages)
+                {
+                    inFlight = msg;
                     queue.Add(msg, cts.Token);
+                    inFlight = null;
+                }
             }
-            catch (OperationCanceledException) { }
+            catch (OperationCanceledException)
+            {
+                if (inFlight is not null)
+                    foreach (MailAttachment attachment in inFlight.Message.Attachments)
+                        attachment.Content.Dispose();
+            }
             catch (Exception ex) { producerException = ex; }
             finally { queue.CompleteAdding(); }
         });

--- a/tests/Mail2Pst.Core.Tests/ConversionRunnerTests.cs
+++ b/tests/Mail2Pst.Core.Tests/ConversionRunnerTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Threading;
 using Mail2Pst.Core;
 using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Progress;
 using Mail2Pst.Core.Reporting;
 using PSTFileFormat;
 using Xunit;
@@ -340,6 +341,71 @@ public class ConversionRunnerTests
         {
             Directory.Delete(outputDir, true);
         }
+    }
+
+    [Fact]
+    public void Run_WithPrecomputedTotal_EmitsItAndSkipsCountPass()
+    {
+        // sample.mbox really holds 2 messages. Passing a deliberately different precomputed total and
+        // asserting the ScanEvent carries THAT value proves the convert-time count pass was skipped in
+        // favour of the supplied number (the GUI's preceding `scan` already paid for it).
+        string fixturePath = Path.Combine(AppContext.BaseDirectory, "fixtures", "sample.mbox");
+        string outputDir = Path.Combine(Path.GetTempPath(), "mail2pst-tests-" + Guid.NewGuid());
+        Directory.CreateDirectory(outputDir);
+        try
+        {
+            var config = new ConversionConfig
+            {
+                Outputs = new List<OutputGroupConfig>
+                {
+                    new()
+                    {
+                        Name = "Personal", MaxSizeMB = 100, FolderMapping = FolderMappingMode.Mirror,
+                        Sources = new List<SourceConfig> { new() { Type = "mbox", Path = fixturePath } },
+                    },
+                },
+            };
+
+            int? emittedTotal = null;
+            ConversionReport report = new ConversionRunner().Run(
+                config, outputDir,
+                onProgress: evt => { if (evt is ScanEvent s) emittedTotal = s.TotalMessages; },
+                precomputedTotalMessages: 999);
+
+            Assert.Equal(999, emittedTotal);     // supplied total used verbatim
+            Assert.Equal(2, report.ConvertedCount); // real conversion + independent verify still correct
+        }
+        finally { Directory.Delete(outputDir, true); }
+    }
+
+    [Fact]
+    public void Run_WithoutPrecomputedTotal_CountsOnDemand()
+    {
+        string fixturePath = Path.Combine(AppContext.BaseDirectory, "fixtures", "sample.mbox");
+        string outputDir = Path.Combine(Path.GetTempPath(), "mail2pst-tests-" + Guid.NewGuid());
+        Directory.CreateDirectory(outputDir);
+        try
+        {
+            var config = new ConversionConfig
+            {
+                Outputs = new List<OutputGroupConfig>
+                {
+                    new()
+                    {
+                        Name = "Personal", MaxSizeMB = 100, FolderMapping = FolderMappingMode.Mirror,
+                        Sources = new List<SourceConfig> { new() { Type = "mbox", Path = fixturePath } },
+                    },
+                },
+            };
+
+            int? emittedTotal = null;
+            new ConversionRunner().Run(
+                config, outputDir,
+                onProgress: evt => { if (evt is ScanEvent s) emittedTotal = s.TotalMessages; });
+
+            Assert.Equal(2, emittedTotal);   // default (-1) -> count on demand, the real message count
+        }
+        finally { Directory.Delete(outputDir, true); }
     }
 
     [Fact]

--- a/tests/Mail2Pst.Core.Tests/Parsing/Mime/MimeMessageMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Parsing/Mime/MimeMessageMapperTests.cs
@@ -231,6 +231,36 @@ public class MimeMessageMapperTests
     }
 
     [Fact]
+    public void ExtractAttachments_AttachmentDispositionWithContentId_IsNotInline()
+    {
+        // A genuine attachment (Content-Disposition: attachment) that also carries a
+        // Content-ID — common for PDFs, ICS invites and signed parts — must stay VISIBLE,
+        // not be classified inline (which would write it hidden and drop it from the
+        // paperclip/HASATTACH computation). The explicit attachment disposition wins over
+        // the Content-ID inline heuristic.
+        var mime = new MimeMessage();
+        var multipart = new Multipart("mixed");
+        multipart.Add(new TextPart("plain") { Text = "body" });
+
+        var part = new MimePart("application", "pdf")
+        {
+            FileName = "invoice.pdf",
+            Content = new MimeContent(new MemoryStream(Encoding.ASCII.GetBytes("%PDF-1.4 data"))),
+            ContentDisposition = new ContentDisposition(ContentDisposition.Attachment),
+            ContentId = "part1.body@example.com",
+        };
+        multipart.Add(part);
+        mime.Body = multipart;
+
+        var warnings = new List<string>();
+        List<MailAttachment> attachments = new MimeMessageMapper().ExtractAttachments(mime, warnings);
+
+        MailAttachment att = Assert.Single(attachments);
+        Assert.False(att.IsInline);                              // explicit attachment disposition wins
+        Assert.Equal("part1.body@example.com", att.ContentId);  // Content-ID still preserved for reference
+    }
+
+    [Fact]
     public void ExtractAttachments_PartWithContentLocation_PopulatesContentLocation()
     {
         var mime = new MimeMessage();

--- a/tests/Mail2Pst.Core.Tests/Parsing/MimeMessageMapperMeasureOnlyTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Parsing/MimeMessageMapperMeasureOnlyTests.cs
@@ -47,6 +47,54 @@ public class MimeMessageMapperMeasureOnlyTests
         Assert.Throws<InvalidOperationException>(() => content.OpenRead());
     }
 
+    // An embedded message/rfc822 attachment (a forwarded .eml), explicitly attached.
+    private static MimeMessage MsgWithEmbeddedMessageAttachment()
+    {
+        var original = new MimeMessage { Subject = "Original" };
+        original.From.Add(new MailboxAddress("O", "o@example.com"));
+        original.Body = new TextPart("plain") { Text = new string('x', 500) };
+
+        var mixed = new Multipart("mixed");
+        mixed.Add(new TextPart("plain") { Text = "see attached" });
+        mixed.Add(new MessagePart
+        {
+            Message = original,
+            ContentDisposition = new ContentDisposition(ContentDisposition.Attachment),
+        });
+
+        var outer = new MimeMessage { Subject = "fwd" };
+        outer.From.Add(new MailboxAddress("A", "a@example.com"));
+        outer.Body = mixed;
+        return outer;
+    }
+
+    [Fact]
+    public void MeasureOnly_EmbeddedMessage_LengthMatchesMaterialized_ButWritesNoTempFile()
+    {
+        var src = new SourceReference { SourcePath = "p", Identifier = "message #1" };
+
+        // Build ONCE and map twice: MimeKit assigns per-construction boundaries, so two separate
+        // constructions could serialize to different lengths. Mapping the same message guarantees a
+        // byte-identical WriteTo and a deterministic length comparison.
+        MimeMessage mime = MsgWithEmbeddedMessageAttachment();
+
+        // Materialize at threshold 1: the embedded message is fully buffered and spills to a temp file.
+        var materialized = new MimeMessageMapper(tempFileThresholdBytes: 1).Map(mime, src, new List<string>());
+        MailAttachment matAtt = Assert.Single(materialized.Attachments);
+        long materializedLen = matAtt.Content.Length;
+        Assert.True(matAtt.Content.IsTempFileBacked, "materialize mode should spill the embedded message");
+        matAtt.Content.Dispose();
+
+        // Measure-only at threshold 1: exact length retained, but NOTHING buffered or spilled — the
+        // measure-only/parallel-scan memory-safety guarantee must hold for embedded messages too.
+        var measured = new MimeMessageMapper(tempFileThresholdBytes: 1, measureOnly: true).Map(mime, src, new List<string>());
+        AttachmentContent content = Assert.Single(measured.Attachments).Content;
+
+        Assert.False(content.IsTempFileBacked, "measure-only must not spill the embedded message");
+        Assert.Equal(materializedLen, content.Length);   // byte-identical estimate input
+        Assert.Throws<InvalidOperationException>(() => content.OpenRead());
+    }
+
     [Fact]
     public void MeasureOnly_WritesNoAttachmentTempFile_EvenAtTinyThreshold()
     {

--- a/tests/Mail2Pst.Core.Tests/Writing/PstWriterDisposalTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/PstWriterDisposalTests.cs
@@ -180,4 +180,68 @@ public class PstWriterDisposalTests
                 if (File.Exists(tp)) File.Delete(tp);
         }
     }
+
+    [Fact]
+    public void WritePlan_FatalErrorWhileProducerBlockedOnFullQueue_DisposesInFlightAttachmentTempFile()
+    {
+        string outputDir = Path.Combine(Path.GetTempPath(), "mail2pst-disposal-inflight-" + Guid.NewGuid());
+        Directory.CreateDirectory(outputDir);
+
+        var createdTempPaths = new System.Collections.Concurrent.ConcurrentBag<string>();
+
+        // A LAZY producer mirroring production (EnumeratePlannedMessages yields): a temp file is
+        // created only when a message is actually pulled. The bounded parse queue (capacity 32)
+        // fills while the consumer is stuck in the throwing progress callback, leaving the NEXT
+        // message blocked mid-Add. That in-flight message is never enqueued (so the drain loop
+        // can't see it) and was never dequeued — its temp-backed attachment must still be cleaned up.
+        IEnumerable<PlannedMessage> LazyMessages()
+        {
+            for (int i = 0; i < 60; i++)
+            {
+                string tp = Path.GetTempFileName();
+                File.WriteAllBytes(tp, [1, 2, 3]);
+                createdTempPaths.Add(tp);
+                yield return new PlannedMessage
+                {
+                    TargetFolderPath = new[] { "Inbox" },
+                    Message = new MailMessage
+                    {
+                        Subject = $"m{i}",
+                        Source = new SourceReference { SourcePath = "test.mbox", Identifier = $"#{i}" },
+                        Attachments =
+                        [
+                            new MailAttachment
+                            {
+                                FileName = $"f{i}.bin",
+                                MimeType = "application/octet-stream",
+                                Content = AttachmentContent.FromTempFile(tp, 3),
+                            },
+                        ],
+                    },
+                };
+            }
+        }
+
+        try
+        {
+            var plan = new PstOutputPlan { Name = "Test", MaxSizeBytes = 100L * 1024 * 1024 };
+            // checkInterval=1 so the first written message hits a checkpoint and fires the progress
+            // callback, which sleeps (letting the producer fill the queue and block on the next Add)
+            // then throws — a fatal error that cancels the producer mid-Add.
+            var writer = new PstWriter(checkIntervalMessages: 1);
+
+            Assert.ThrowsAny<Exception>(() => writer.WritePlan(
+                plan, LazyMessages(), outputDir, new ConversionReport(), totalMessages: 60,
+                onProgress: _ => { Thread.Sleep(100); throw new InvalidOperationException("boom"); }));
+
+            foreach (string tp in createdTempPaths)
+                Assert.False(File.Exists(tp), $"in-flight/queued temp file leaked after fatal error: {tp}");
+        }
+        finally
+        {
+            Directory.Delete(outputDir, true);
+            foreach (string tp in createdTempPaths)
+                if (File.Exists(tp)) File.Delete(tp);
+        }
+    }
 }

--- a/tests/Mail2Pst.Integration.Tests/ConvertInputTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/ConvertInputTests.cs
@@ -96,4 +96,48 @@ public class ConvertInputTests
         ConvertResolution r = ConvertInput.Resolve(new[] { "--config", "--output", "out" });
         Assert.NotNull(r.Error);
     }
+
+    [Fact]
+    public void Resolve_ExpectedTotal_ParsedOnSuccess()
+    {
+        string profile = MakeProfile();
+        try
+        {
+            ConvertResolution r = ConvertInput.Resolve(
+                new[] { "--profile", profile, "--output", "out", "--expected-total", "42" });
+            Assert.Null(r.Error);
+            Assert.Equal(42, r.ExpectedTotal);
+        }
+        finally { Directory.Delete(profile, true); }
+    }
+
+    [Fact]
+    public void Resolve_NoExpectedTotal_DefaultsToMinusOne()
+    {
+        string profile = MakeProfile();
+        try
+        {
+            ConvertResolution r = ConvertInput.Resolve(new[] { "--profile", profile, "--output", "out" });
+            Assert.Null(r.Error);
+            Assert.Equal(-1, r.ExpectedTotal);   // sentinel -> count on demand
+        }
+        finally { Directory.Delete(profile, true); }
+    }
+
+    [Fact]
+    public void Resolve_NonNumericExpectedTotal_Error()
+    {
+        ConvertResolution r = ConvertInput.Resolve(
+            new[] { "--config", "c.json", "--output", "out", "--expected-total", "notanumber" });
+        Assert.NotNull(r.Error);
+        Assert.Contains("expected-total", r.Error!);
+    }
+
+    [Fact]
+    public void Resolve_NegativeExpectedTotal_Error()
+    {
+        ConvertResolution r = ConvertInput.Resolve(
+            new[] { "--config", "c.json", "--output", "out", "--expected-total", "-5" });
+        Assert.NotNull(r.Error);
+    }
 }


### PR DESCRIPTION
Four fixes from the v0.2.2 PST-engine audit, landed BEFORE broadening input formats. No high-severity defects existed in the core write/round-trip path; these are the worthwhile mediums. TDD throughout (red → green); full solution suite green (**803 passed / 9 skipped / 0 failed**). Vendored `PSTFileFormat` untouched.

## Fixes

**1 — CID attachment stays visible** (`MimeMessageMapper.cs`)
A part with both `Content-Disposition: attachment` and a `Content-ID` was marked inline → written hidden, dropped from `MSGFLAG_HASATTACH`. Real files (PDFs, ICS invites, signed parts) vanished in Outlook with no paperclip. Explicit attachment disposition now wins over the Content-ID heuristic. *(the only finding with user-visible fidelity loss)*

**2 — In-flight attachment temp-leak on cancel** (`PstWriter.cs`)
When the producer is blocked in `queue.Add` on a full bounded queue and the run cancels/faults, the in-flight message was dropped without disposing its temp-backed attachment. Now tracked and disposed in the cancel path.

**3 — Convert double-scan** (`ConversionRunner.cs` + CLI)
Progress-mode `convert` re-counted every source despite the GUI already having that number from its `scan`. New optional `precomputedTotalMessages` param + non-breaking `--expected-total` CLI flag; default (`-1`) keeps count-on-demand. Wire contract unchanged. **GUI last-mile (threading the scan total through `start_convert`) is a deferred `/desktop` follow-up** — until then this benefits direct CLI users only.

**4 — Embedded `message/rfc822` honors `_measureOnly`** (`MimeMessageMapper.cs`)
The embedded-message branch ignored measure-only, buffering and temp-spilling each forwarded `.eml` during scan — defeating the parallel-scan memory-safety guarantee. Now measured via `CountingStream` + `FromLengthOnly`. Also guards nullable `MessagePart.Message` (clears a pre-existing CS8602).

## Tests
New coverage per fix (mapper IsInline, in-flight leak via lazy producer, precomputed-total + `--expected-total` parsing, embedded measure-only). One self-inflicted flaky test caught by the full-suite gate (built the MIME message twice → non-deterministic serialized length under MimeKit's per-construction boundaries) and fixed to build-once-map-twice.

10 files, +332/−21 (5 source, 5 test).

Rebase-merge to keep `main` linear (3 logically-scoped commits).