### PR TITLE
Desktop: reuse scan total in convert (--expected-total) + gate desktop Rust tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,11 +69,6 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
-      # Build the CLI so the Rust sidecar-integration tests find Mail2Pst.Cli.dll
-      # (via locate_cli's dotnet fallback) and RUN instead of self-skipping.
-      - name: Build CLI (Release)
-        run: dotnet build src/Mail2Pst.Cli -c Release
-
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
@@ -81,13 +76,24 @@ jobs:
           cache: npm
           cache-dependency-path: desktop/package-lock.json
 
-      # tauri-build (the app crate's build script) requires the frontendDist (../dist)
-      # to exist; build the real frontend assets so `cargo test` can compile the crate.
+      - name: Install npm deps
+        working-directory: desktop
+        run: npm ci
+
+      # Publish the CLI sidecar into src-tauri/binaries/ (+ stage resources/sample.mbox).
+      # tauri-build validates that the externalBin + resources declared in tauri.conf.json
+      # exist on disk, so the sidecar must be built BEFORE cargo test or the crate won't
+      # compile. This also makes the Rust sidecar-integration tests use the real sidecar
+      # binary (locate_cli's primary path) rather than the dotnet-dll fallback.
+      - name: Build CLI sidecar
+        working-directory: desktop
+        run: npm run sidecar
+
+      # tauri-build also requires the frontendDist (../dist) to exist; build the real
+      # frontend assets so cargo test can compile the crate.
       - name: Build frontend dist
         working-directory: desktop
-        run: |
-          npm ci
-          npm run build
+        run: npm run build
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,42 @@ jobs:
       - name: Test (Vitest)
         working-directory: desktop
         run: npm test
+
+  desktop-rust:
+    name: Test (desktop Rust)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up .NET 8 SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
+      # Build the CLI so the Rust sidecar-integration tests find Mail2Pst.Cli.dll
+      # (via locate_cli's dotnet fallback) and RUN instead of self-skipping.
+      - name: Build CLI (Release)
+        run: dotnet build src/Mail2Pst.Cli -c Release
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+          cache: npm
+          cache-dependency-path: desktop/package-lock.json
+
+      # tauri-build (the app crate's build script) requires the frontendDist (../dist)
+      # to exist; build the real frontend assets so `cargo test` can compile the crate.
+      - name: Build frontend dist
+        working-directory: desktop
+        run: |
+          npm ci
+          npm run build
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cargo test
+        working-directory: desktop/src-tauri
+        run: cargo test --locked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The desktop app's conversion step is slightly faster to start: it now reuses the message total from the
+  scan it just ran instead of counting every mailbox a second time before converting. Behaviour and
+  progress reporting are otherwise unchanged. (Direct CLI users can do the same with a new
+  `convert --expected-total <n>` flag.)
+
+### Internal
+- CI now runs the desktop Rust unit and sidecar-integration tests (a Windows `cargo test` job), so the
+  Tauri-side contract is gated on every push/PR.
+
 ## [0.2.2] — 2026-06-28
 
 ### Changed

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -49,15 +49,22 @@ fn scan_args(paths: &[String]) -> Vec<String> {
     args
 }
 
-// The exact CLI argument vector for a conversion run.
-fn convert_args(config_path: &str, output_dir: &str) -> Vec<String> {
-    vec![
+// The exact CLI argument vector for a conversion run. `expected_total`, when present,
+// passes the GUI's already-known message count so the engine skips its convert-time
+// boundary count pass; None preserves the count-on-demand behaviour. Some(0) is valid.
+fn convert_args(config_path: &str, output_dir: &str, expected_total: Option<i32>) -> Vec<String> {
+    let mut args = vec![
         "convert".into(),
         "--config".into(),
         config_path.into(),
         "--output".into(),
         output_dir.into(),
-    ]
+    ];
+    if let Some(n) = expected_total {
+        args.push("--expected-total".into());
+        args.push(n.to_string());
+    }
+    args
 }
 
 // Like run_sidecar, but returns stdout even when the sidecar exits nonzero AS LONG AS it printed
@@ -291,6 +298,7 @@ async fn start_convert(
     app: AppHandle,
     config: serde_json::Value,
     output_dir: String,
+    expected_total: Option<i32>,
     state: State<'_, ConvertState>,
 ) -> Result<(), String> {
     // Reject a second concurrent run.
@@ -322,7 +330,7 @@ async fn start_convert(
             let _ = std::fs::remove_file(&config_path);
             format!("sidecar not found: {e}")
         })?
-        .args(convert_args(&config_path_str, &output_dir))
+        .args(convert_args(&config_path_str, &output_dir, expected_total))
         .spawn()
         .map_err(|e| {
             let _ = std::fs::remove_file(&config_path);
@@ -736,10 +744,27 @@ mod tests {
     }
 
     #[test]
-    fn convert_args_config_and_output_flags() {
+    fn convert_args_without_expected_total_omits_flag() {
         assert_eq!(
-            convert_args("C:/tmp/cfg.json", "C:/out"),
+            convert_args("C:/tmp/cfg.json", "C:/out", None),
             vec!["convert", "--config", "C:/tmp/cfg.json", "--output", "C:/out"]
+        );
+    }
+
+    #[test]
+    fn convert_args_with_expected_total_appends_flag() {
+        assert_eq!(
+            convert_args("C:/tmp/cfg.json", "C:/out", Some(123)),
+            vec!["convert", "--config", "C:/tmp/cfg.json", "--output", "C:/out", "--expected-total", "123"]
+        );
+    }
+
+    #[test]
+    fn convert_args_with_zero_expected_total_still_appends_flag() {
+        // 0 is a valid precomputed total (empty-but-valid conversion); only None omits it.
+        assert_eq!(
+            convert_args("C:/tmp/cfg.json", "C:/out", Some(0)),
+            vec!["convert", "--config", "C:/tmp/cfg.json", "--output", "C:/out", "--expected-total", "0"]
         );
     }
 

--- a/desktop/src/components/views/OptionsView.tsx
+++ b/desktop/src/components/views/OptionsView.tsx
@@ -14,6 +14,7 @@ import {
   findDuplicateFolderIds,
   type OptionsState,
 } from "@/lib/options";
+import { expectedTotalMessages } from "@/lib/review";
 import type { ConversionConfig, SourceRow } from "@/lib/types";
 import type { ScanResult } from "@/lib/parse";
 
@@ -26,7 +27,7 @@ interface OptionsViewProps {
   options: OptionsState;
   onSetOptions: (patch: Partial<OptionsState>) => void;
   onSetRename: (sourceId: string, name: string) => void;
-  onStart: (config: ConversionConfig, outputDir: string) => void;
+  onStart: (config: ConversionConfig, outputDir: string, expectedTotal?: number) => void;
   onBack: () => void;
 }
 
@@ -64,7 +65,8 @@ export function OptionsView({
       const { config, outputDir } = buildConfigFromOptions(
         scan.sources, checkedIds, skipEmpty, options, outputPath,
       );
-      onStart(config, outputDir);
+      const expectedTotal = expectedTotalMessages(scan.sources, checkedIds, skipEmpty);
+      onStart(config, outputDir, expectedTotal);
     } catch (e) {
       setStartError(e instanceof ConvertConfigError ? e.message : "Could not start the conversion.");
     }

--- a/desktop/src/components/views/ProfileOptionsView.tsx
+++ b/desktop/src/components/views/ProfileOptionsView.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { HelpTip } from "@/components/ui/help-tip";
 import { SplitSizeControl } from "@/components/ui/split-size-control";
 import { buildProfileConfig, buildProfileConfigMulti } from "@/lib/profileConfig";
-import { effectiveRows } from "@/lib/review";
+import { effectiveRows, expectedTotalMessages } from "@/lib/review";
 import { ConvertConfigError, deriveOutputTarget, splitPath, joinOutputPstPath } from "@/lib/convert";
 import { formatBytes } from "@/lib/format";
 import { openJunkHelp, pickOutputPst } from "@/lib/engine";
@@ -24,7 +24,7 @@ interface ProfileOptionsViewProps {
   skipEmpty: boolean;
   options: OptionsState;
   onSetOptions: (patch: Partial<OptionsState>) => void;
-  onStart: (config: ConversionConfig, outputDir: string) => void;
+  onStart: (config: ConversionConfig, outputDir: string, expectedTotal?: number) => void;
   onBack: () => void;
   // multi-account (optional — only present in profile mode with ≥2 accounts)
   accounts?: Account[];
@@ -106,7 +106,7 @@ export function ProfileOptionsView({
           const combineRows = rows.filter((r) => keys.has(accountKeyForRow(r)));
           const path = joinOutputPstPath(folderDir, sanitizedCombineName);
           const { config, outputDir } = buildProfileConfig(combineRows, checkedIds, skipEmpty, options, path, profileRoot);
-          onStart(config, outputDir);
+          onStart(config, outputDir, expectedTotalMessages(combineRows, checkedIds, skipEmpty));
         } else {
           const accs = accounts ?? [];
           const names = pstNames ?? {};
@@ -116,7 +116,8 @@ export function ProfileOptionsView({
           const { config, outputDir } = buildProfileConfigMulti({
             groups: selectedGroups, checkedIds, skipEmpty, options, target: outputTarget, profileRoot,
           });
-          onStart(config, outputDir);
+          const splitRows = selectedGroups.flatMap((g) => g.rows);
+          onStart(config, outputDir, expectedTotalMessages(splitRows, checkedIds, skipEmpty));
         }
       } catch (e) {
         setStartError(e instanceof ConvertConfigError ? e.message : "Could not start the conversion.");
@@ -130,7 +131,7 @@ export function ProfileOptionsView({
     }
     try {
       const { config, outputDir } = buildProfileConfig(rows, checkedIds, skipEmpty, options, outputPath, profileRoot);
-      onStart(config, outputDir);
+      onStart(config, outputDir, expectedTotalMessages(rows, checkedIds, skipEmpty));
     } catch (e) {
       setStartError(e instanceof ConvertConfigError ? e.message : "Could not start the conversion.");
     }

--- a/desktop/src/lib/engine.test.ts
+++ b/desktop/src/lib/engine.test.ts
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// engine.ts imports Tauri runtime modules at load; stub them so this
+// test needs no Tauri host.
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+vi.mock("@tauri-apps/api/event", () => ({ listen: vi.fn() }));
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn(), save: vi.fn() }));
+
+import { invoke } from "@tauri-apps/api/core";
+import { buildStartConvertPayload, startConvert } from "./engine";
+import type { ConversionConfig } from "./types";
+
+const config = { outputs: [] } as unknown as ConversionConfig;
+const invokeMock = vi.mocked(invoke);
+
+describe("buildStartConvertPayload", () => {
+  it("omits expectedTotal when undefined", () => {
+    const p = buildStartConvertPayload(config, "C:/out", undefined);
+    expect(p).toEqual({ config, outputDir: "C:/out" });
+    expect("expectedTotal" in p).toBe(false);
+  });
+
+  it("includes expectedTotal when provided (including 0)", () => {
+    expect(buildStartConvertPayload(config, "C:/out", 123)).toEqual({ config, outputDir: "C:/out", expectedTotal: 123 });
+    expect(buildStartConvertPayload(config, "C:/out", 0)).toEqual({ config, outputDir: "C:/out", expectedTotal: 0 });
+  });
+});
+
+// Guard the actual seam: startConvert must hand the conditional payload to invoke.
+describe("startConvert", () => {
+  beforeEach(() => invokeMock.mockReset());
+
+  it("invokes start_convert with expectedTotal when provided", async () => {
+    invokeMock.mockResolvedValueOnce(undefined);
+    await startConvert(config, "C:/out", 123);
+    expect(invokeMock).toHaveBeenCalledWith("start_convert", { config, outputDir: "C:/out", expectedTotal: 123 });
+  });
+
+  it("omits expectedTotal from the invoke payload when undefined", async () => {
+    invokeMock.mockResolvedValueOnce(undefined);
+    await startConvert(config, "C:/out");
+    expect(invokeMock).toHaveBeenCalledWith("start_convert", { config, outputDir: "C:/out" });
+  });
+});

--- a/desktop/src/lib/engine.ts
+++ b/desktop/src/lib/engine.ts
@@ -145,10 +145,27 @@ export async function pickOutputFolder(): Promise<string | null> {
   return typeof result === "string" ? result : null;
 }
 
-export function startConvert(config: ConversionConfig, outputDir: string): Promise<void> {
+/** The exact Tauri invoke payload for a conversion run. expectedTotal is OMITTED
+ * (not sent as undefined) when absent, so the Rust side receives None and the
+ * engine counts on demand. Exported for unit testing the flag contract. */
+export function buildStartConvertPayload(
+  config: ConversionConfig,
+  outputDir: string,
+  expectedTotal?: number,
+) {
+  return expectedTotal === undefined
+    ? { config, outputDir }
+    : { config, outputDir, expectedTotal };
+}
+
+export function startConvert(
+  config: ConversionConfig,
+  outputDir: string,
+  expectedTotal?: number,
+): Promise<void> {
   // Tauri v2 auto-converts camelCase JS arg keys to snake_case Rust params, so
-  // `outputDir` here maps to the Rust `output_dir` parameter.
-  return invoke<void>("start_convert", { config, outputDir });
+  // `outputDir`/`expectedTotal` map to `output_dir`/`expected_total`.
+  return invoke<void>("start_convert", buildStartConvertPayload(config, outputDir, expectedTotal));
 }
 
 export function cancelConvert(): Promise<void> {

--- a/desktop/src/lib/review.test.ts
+++ b/desktop/src/lib/review.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { describe, it, expect } from "vitest";
-import { effectiveRows, calculateReviewTotals, sortSources, nextSort } from "./review";
+import { effectiveRows, calculateReviewTotals, sortSources, nextSort, expectedTotalMessages } from "./review";
 import type { SourceRow } from "./types";
 
 function row(over: Partial<SourceRow>): SourceRow {
@@ -105,5 +105,31 @@ describe("nextSort", () => {
   });
   it("clicking a different active column resets to ascending", () => {
     expect(nextSort("date", "desc", "name")).toEqual({ field: "name", dir: "asc" });
+  });
+});
+
+describe("expectedTotalMessages", () => {
+  const rows = [
+    row({ id: "a", path: "a.mbox", displayName: "a", messages: 5 }),
+    row({ id: "b", path: "b.mbox", displayName: "b", messages: 0 }),
+    row({ id: "c", path: "c.mbox", displayName: "c", messages: 7 }),
+  ];
+
+  it("sums messages over checked rows", () => {
+    expect(expectedTotalMessages(rows, new Set(["a", "c"]), false)).toBe(12);
+  });
+
+  it("excludes unchecked rows (the multi-account split case)", () => {
+    // Only account 'a' selected → 'c' must NOT inflate the denominator.
+    expect(expectedTotalMessages(rows, new Set(["a"]), false)).toBe(5);
+  });
+
+  it("skipEmpty does not change the sum (empty rows contribute 0)", () => {
+    expect(expectedTotalMessages(rows, new Set(["a", "b", "c"]), true)).toBe(12);
+    expect(expectedTotalMessages(rows, new Set(["a", "b", "c"]), false)).toBe(12);
+  });
+
+  it("is 0 when nothing is checked", () => {
+    expect(expectedTotalMessages(rows, new Set(), false)).toBe(0);
   });
 });

--- a/desktop/src/lib/review.ts
+++ b/desktop/src/lib/review.ts
@@ -24,6 +24,19 @@ export function effectiveRows(
   );
 }
 
+/** Sum of messages over the rows that will actually be converted (checked, and
+ * non-empty when skipEmpty). Same `effectiveRows` predicate that backs the config,
+ * so this equals the engine's boundary count for those sources — the value passed
+ * as --expected-total. Callers pass the EXACT row set feeding their config (e.g. a
+ * single account's rows in multi-account mode), never the all-accounts row set. */
+export function expectedTotalMessages(
+  sources: SourceRow[],
+  checkedIds: Set<string>,
+  skipEmpty: boolean,
+): number {
+  return effectiveRows(sources, checkedIds, skipEmpty).reduce((n, r) => n + r.messages, 0);
+}
+
 export function calculateReviewTotals(
   sources: SourceRow[],
   checkedIds: Set<string>,

--- a/desktop/src/lib/useConvert.ts
+++ b/desktop/src/lib/useConvert.ts
@@ -145,11 +145,11 @@ export function useConvert() {
     };
   }, []);
 
-  const start = useCallback(async (config: ConversionConfig, outputDir: string) => {
+  const start = useCallback(async (config: ConversionConfig, outputDir: string, expectedTotal?: number) => {
     schemaWarnedRef.current = false;
     setState({ ...initialConvertState, phase: "running", outputDir, startedAtMs: Date.now() });
     try {
-      await startConvert(config, outputDir);
+      await startConvert(config, outputDir, expectedTotal);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       setState((s) => ({ ...s, phase: "error", errorMessage: message }));


### PR DESCRIPTION
## Problem
The desktop app runs a `scan` (which counts messages per source) before converting, but `convert` then re-counted every mailbox a second time. The engine/CLI seam to skip that pass (`ConversionRunner.Run(precomputedTotalMessages)` + `convert --expected-total <n>`) already shipped, but the GUI never supplied the number — so the optimisation only helped direct CLI users. Separately, the desktop Rust unit + sidecar-integration tests (added earlier) ran locally only, ungated by CI.

## Fix
Thread the GUI's already-known message total through the convert call as an optional `--expected-total`, and add a CI job for the Rust layer.

- **Rust:** `convert_args`/`start_convert` take `Option<i32>`; the flag is appended only when present (`Some(0)` is valid; only `None` omits).
- **TS:** `startConvert` forwards an optional `expectedTotal`, omitting the key entirely when absent (no `{expectedTotal: undefined}` reaching `invoke`).
- **Number correctness:** a shared `expectedTotalMessages` helper sums `messages` over `effectiveRows` (the same predicate the config builders use). Both option views pass the total computed over the **exact selected rows feeding each config** — per-branch in multi-account mode (combine / split / single), never the all-accounts total. So the progress denominator can't drift from what's actually converted.
- **CI:** new windows-only `desktop-rust` job — builds the CLI (so the sidecar-integration tests run, not skip) and the frontend dist (which `tauri-build` needs), then `cargo test`. OS matrix (linux/mac) deferred.

## Effect
Optional end-to-end and non-breaking: absent ⇒ the engine counts on demand exactly as before. Passing the raw boundary count reproduces today's progress behaviour (bars may still stop <100% under `.msf`/expunged/junk drops — unchanged). No change to write semantics — only the redundant count pass is skipped.

## Tests
- Desktop: `npm test` 222 pass (incl. new `engine.test.ts`, `review.test.ts` cases); `cargo test` 15/15 with sidecar-integration tests running.
- Engine (.NET) untouched.