### PR TITLE
WS2 Tier 1: CLI engine cross-platform (Linux/macOS) + CI OS matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,18 @@ concurrency:
 
 jobs:
   build-test:
-    name: Build & test (engine)
-    runs-on: windows-latest
+    name: Build & test (engine, ${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            rid: win-x64
+          - os: ubuntu-latest
+            rid: linux-x64
+          - os: macos-latest
+            rid: osx-arm64
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -34,6 +44,30 @@ jobs:
 
       - name: Test (Release)
         run: dotnet test Mail2Pst.sln -c Release --no-build
+
+      # Prove the actual published CLI runs end-to-end on this OS, not just unit tests.
+      # Use the SAME single-file self-contained packaging shape as the desktop sidecar
+      # (PublishSingleFile + IncludeNativeLibrariesForSelfExtract, no trimming) so this also
+      # de-risks Tier 2's per-RID sidecar cross-compile. `scan` without --progress pretty-prints
+      # a multi-line JSON object, so parse the WHOLE stdout as one document. shell: pwsh
+      # (PowerShell Core) is on every GitHub runner.
+      - name: Publish-smoke scan
+        shell: pwsh
+        env:
+          RID: ${{ matrix.rid }}
+        run: |
+          dotnet publish src/Mail2Pst.Cli -c Release -r $env:RID `
+            --self-contained true `
+            -p:PublishSingleFile=true `
+            -p:IncludeNativeLibrariesForSelfExtract=true `
+            -p:PublishTrimmed=false `
+            -o publish-smoke
+          $exe = if ($env:RID -like 'win-*') { ".\publish-smoke\Mail2Pst.Cli.exe" } else { "./publish-smoke/Mail2Pst.Cli" }
+          $json = & $exe scan --input fixtures/sample.mbox
+          if ($LASTEXITCODE -ne 0) { throw "scan exited $LASTEXITCODE" }
+          $obj = $json | ConvertFrom-Json
+          if ($obj.type -ne "scan") { throw "Expected type=scan, got $($obj.type)" }
+          if ($obj.totals.messages -le 0) { throw "Expected positive totals.messages" }
 
   desktop-test:
     name: Test (desktop frontend)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,10 @@
 name: CI
 
-# CI (right-sized, advisory): build + test the engine on Windows (engine uses Windows-only PST
-# APIs) and run the desktop frontend unit tests (Vitest). Both jobs run on windows-latest — the
-# only supported platform — for every push and PR to master (private repo) and main (public repo).
-# See docs/repo-health-roadmap.md §3. Remaining optional add-on: a hygiene grep step.
+# CI (right-sized, advisory): build + test the engine on a windows/linux/macos matrix — the CLI engine
+# is cross-platform (net8.0); each leg also publishes the CLI single-file and smoke-runs `scan`. The
+# desktop frontend (Vitest) and desktop Rust (cargo) jobs stay windows-only — the Tauri GUI + sidecar
+# are Windows-only for now. Runs on every push and PR to master (private repo) and main (public repo).
+# See docs/repo-health-roadmap.md §3.
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ reviews/
 .rules/
 CLAUDE.md
 todo.md
+/publish-smoke/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Internal
 - CI now runs the desktop Rust unit and sidecar-integration tests (a Windows `cargo test` job), so the
   Tauri-side contract is gated on every push/PR.
+- The CLI engine now builds, tests, and runs on Linux and macOS, gated by a CI OS matrix
+  (windows/ubuntu/macos, each leg also publishing the CLI single-file and smoke-running `scan`).
+  Removed the unused Windows-only `System.ServiceProcess.ServiceController` dependency. (No user-facing
+  change yet — the desktop app remains Windows-only; cross-platform packaging is a later step.)
 
 ## [0.2.2] — 2026-06-28
 

--- a/src/Mail2Pst.Core/Mail2Pst.Core.csproj
+++ b/src/Mail2Pst.Core/Mail2Pst.Core.csproj
@@ -11,7 +11,6 @@
     <Compile Remove="../../vendor/PSTFileFormat/Properties/**/*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="10.0.9" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="10.0.9" />
     <PackageReference Include="MimeKit" Version="4.17.0" />
   </ItemGroup>

--- a/src/Mail2Pst.Core/Writing/TransientFileRetry.cs
+++ b/src/Mail2Pst.Core/Writing/TransientFileRetry.cs
@@ -42,6 +42,10 @@ internal static class TransientFileRetry
 
     private static bool IsTransientFileLock(IOException ex)
     {
+        // Win32 ERROR_SHARING_VIOLATION (32) / ERROR_LOCK_VIOLATION (33) live in the low word of
+        // HResult on Windows only (e.g. an AV scanner holding a freshly-written PST open). On
+        // Linux/macOS IOException.HResult carries a different (errno-derived) value, so this never
+        // matches and the retry is a deliberate no-op there — that hold-open is a Windows phenomenon.
         int lowWord = ex.HResult & 0xFFFF;
         return lowWord == ErrorSharingViolation || lowWord == ErrorLockViolation;
     }

--- a/tests/Mail2Pst.Core.Tests/Mork/MorkReaderSharedReadTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mork/MorkReaderSharedReadTests.cs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
 // SPDX-License-Identifier: GPL-3.0-or-later
+using System;
 using System.IO;
 using Mail2Pst.Core.Mork;
 using Xunit;
@@ -33,6 +34,10 @@ public class MorkReaderSharedReadTests
     {
         // Documents WHY the shared variant exists: plain Parse (File.OpenRead -> FileShare.Read) cannot
         // open a file another handle holds with write access.
+        // Windows-only: file-share locking is mandatory on Windows (FileShare.Read vs the holder's
+        // ReadWrite -> sharing violation -> IOException). On Linux/macOS locks are advisory, so the
+        // open succeeds and no exception is thrown — the documented failure mode doesn't exist there.
+        if (!OperatingSystem.IsWindows()) return;
         string path = Path.GetTempFileName();
         try
         {

--- a/vendor/PSTFileFormat-MODIFICATIONS.md
+++ b/vendor/PSTFileFormat-MODIFICATIONS.md
@@ -134,6 +134,8 @@ authoritative description of the local PSTFileFormat modifications.
     `m_isWindowsDesktopSearchQueuing = false`, so WDS update-queuing is permanently disabled and
     the `SearchDomainObject.ContainsNode`-driven queue path is unchanged. This lets the
     Windows-only `System.ServiceProcess.ServiceController` NuGet ref be dropped from
-    `Mail2Pst.Core.csproj` for the Linux/macOS port.
+    `Mail2Pst.Core.csproj` for the Linux/macOS port. The vestigial `System.ServiceProcess`
+    `<Reference>` in the non-building upstream `PSTFileFormat.csproj` (the legacy old-style
+    project file, not part of the Mail2Pst build) was also cleared for consistency.
 
 See the project git history (`git log -- vendor/PSTFileFormat`) for the full diffs.

--- a/vendor/PSTFileFormat-MODIFICATIONS.md
+++ b/vendor/PSTFileFormat-MODIFICATIONS.md
@@ -125,4 +125,15 @@ authoritative description of the local PSTFileFormat modifications.
     int maxFreeGeneral, int maxFreeAligned)` for in-memory AMap pages and free-index list
     lengths cached on the file object. Read-only snapshot.
 
+- Cross-platform hygiene — removed the dead Windows-only Desktop-Search service probe
+  (ContinuMail, 2026):
+  - `SearchManagementQueue.cs`: deleted the unreachable static helpers
+    `IsWindowsDesktopSearchIndexingEnabled()` and `FindService(string)` (the only
+    `System.ServiceProcess.ServiceController` callers) and the `using System.ServiceProcess;`.
+    They were reachable only from a commented-out ctor line; the ctor hardcodes
+    `m_isWindowsDesktopSearchQueuing = false`, so WDS update-queuing is permanently disabled and
+    the `SearchDomainObject.ContainsNode`-driven queue path is unchanged. This lets the
+    Windows-only `System.ServiceProcess.ServiceController` NuGet ref be dropped from
+    `Mail2Pst.Core.csproj` for the Linux/macOS port.
+
 See the project git history (`git log -- vendor/PSTFileFormat`) for the full diffs.

--- a/vendor/PSTFileFormat/Messaging/Search/SearchManagementQueue.cs
+++ b/vendor/PSTFileFormat/Messaging/Search/SearchManagementQueue.cs
@@ -8,7 +8,6 @@
  */
 using System;
 using System.Collections.Generic;
-using System.ServiceProcess;
 using System.Text;
 using Utilities;
 
@@ -23,10 +22,11 @@ namespace PSTFileFormat
         public SearchManagementQueue(PSTFile file)
         {
             m_file = file;
-            // http://social.msdn.microsoft.com/Forums/en-US/os_binaryfile/thread/a5f9c653-40f5-4638-85d3-00c54607d984/
-            // Outlook 2007+ queue some SUDs if WDS is enabled.
-            //m_isWindowsDesktopSearchQueuing = file.WriterCompatibilityMode >= WriterCompatibilityMode.Outlook2007RTM && IsWindowsDesktopSearchIndexingEnabled();
-            m_isWindowsDesktopSearchQueuing = false; // I couldn't find a reason to queue these SUDs
+            // Windows Desktop Search update-queuing is permanently disabled (the original WDS probe,
+            // which used System.ServiceProcess.ServiceController, was removed for the cross-platform
+            // port — it was unreachable with this flag false). The SearchDomainObject.ContainsNode
+            // queue path is unaffected.
+            m_isWindowsDesktopSearchQueuing = false;
         }
 
         // http://social.msdn.microsoft.com/Forums/en-US/os_binaryfile/thread/a5f9c653-40f5-4638-85d3-00c54607d984/
@@ -129,31 +129,5 @@ namespace PSTFileFormat
             }
         }
 
-        public static bool IsWindowsDesktopSearchIndexingEnabled()
-        {
-            ServiceController service = FindService("WSearch");
-            if (service != null)
-            {
-                if (service.Status == ServiceControllerStatus.Running)
-                {
-                    // FIXME - For now we assume Outlook is being indexed
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        public static ServiceController FindService(string serviceName)
-        {
-            ServiceController[] services = ServiceController.GetServices();
-            foreach (ServiceController service in services)
-            {
-                if (service.ServiceName.Equals(serviceName, StringComparison.InvariantCultureIgnoreCase))
-                {
-                    return service;
-                }
-            }
-            return null;
-        }
     }
 }

--- a/vendor/PSTFileFormat/Messaging/Search/SearchManagementQueue.cs
+++ b/vendor/PSTFileFormat/Messaging/Search/SearchManagementQueue.cs
@@ -22,10 +22,9 @@ namespace PSTFileFormat
         public SearchManagementQueue(PSTFile file)
         {
             m_file = file;
-            // Windows Desktop Search update-queuing is permanently disabled (the original WDS probe,
-            // which used System.ServiceProcess.ServiceController, was removed for the cross-platform
-            // port — it was unreachable with this flag false). The SearchDomainObject.ContainsNode
-            // queue path is unaffected.
+            // Windows Desktop Search update-queuing is permanently disabled (the original WDS service
+            // probe, which this flag short-circuited, was removed for the cross-platform port). The
+            // SearchDomainObject.ContainsNode queue path is unaffected.
             m_isWindowsDesktopSearchQueuing = false;
         }
 

--- a/vendor/PSTFileFormat/PSTFileFormat.csproj
+++ b/vendor/PSTFileFormat/PSTFileFormat.csproj
@@ -33,7 +33,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\CalendarShare-Client\Components\System.Core.dll</HintPath>
     </Reference>
-    <Reference Include="System.ServiceProcess" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ListsTablesAndProperties\BTreeOnHeap\BTreeOnHeap.cs" />


### PR DESCRIPTION
## Problem
The CLI engine was only ever built and tested on Windows, and still carried a Windows-only NuGet dependency (`System.ServiceProcess.ServiceController`) — even though the convert/scan path has no real Windows coupling. This blocked cross-platform work (Tier 2 desktop, more formats) from standing on a proven-portable engine.

## Fix
Make the engine provably cross-platform and gate it on CI.

- **Drop the dead Windows-only dependency.** The vendored `SearchManagementQueue` carried a Windows Desktop Search service probe (`ServiceController`) that was already unreachable (`m_isWindowsDesktopSearchQueuing` hardcoded `false`; the only callers were reachable solely from a commented-out ctor line). Removed the two dead static helpers + the `using` + the `System.ServiceProcess.ServiceController` package ref, and a vestigial `<Reference>` in the non-building upstream `PSTFileFormat.csproj`. **Behaviour-preserving** — the live `SearchDomainObject.ContainsNode` queue path and all `QueueSearchUpdateDescriptor`/`AddFolder`/`AddMessage` machinery are untouched. Logged in `PSTFileFormat-MODIFICATIONS.md`.
- **CI: engine `build-test` job → 3-OS matrix** (windows/ubuntu/macos × win-x64/linux-x64/osx-arm64), each leg also doing a **single-file self-contained publish + `scan` smoke** (mirrors the desktop sidecar packaging). Desktop jobs stay windows-only.
- **One Linux-specific test guard:** `Parse_FileHeldOpenReadWrite_ThrowsIOException` documents Windows *mandatory* file-locking (no `IOException` on Linux, where locks are advisory) — guarded to Windows, matching the existing `OperatingSystem.IsWindows()` pattern.
- Annotated `TransientFileRetry` (its HResult check is a deliberate no-op off-Windows).

## Effect
The CLI engine builds, tests, and runs on Linux/macOS; no behaviour change on any platform (PST output is byte-identical — the removed code was dead on every OS). No user-facing change yet — the desktop app remains Windows-only (cross-platform packaging = Tier 2).

## Validation
- **Windows:** full suite green locally; `win-x64` single-file publish + `scan` smoke green.
- **Linux (real Ubuntu 26.04 VM):** `dotnet build` clean; **Core 720/0/0, Integration 84 pass / 8 skip / 0 fail**; `linux-x64` single-file publish (ELF) + `scan` smoke green (`type=scan`, `messages=2`). This run caught the Mork locking test above, now fixed.
- **macOS:** proven by the `macos-latest` matrix leg in this PR's CI.

## ⚠️ Owner action required before merge
This renames the engine status check `Build & test (engine)` → `Build & test (engine, windows-latest)` / `(ubuntu-latest)` / `(macos-latest)`. The `main` branch-protection **required status checks** must be updated to the three new names, or the old name will never report and block the merge.