### PR TITLE
Release 0.2.3 — cross-platform CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] — 2026-06-28
+
+### Added
+- **The command-line converter now runs on Linux and macOS**, not just Windows. The engine is fully
+  cross-platform; prebuilt single-file CLI binaries are published for Windows, Linux, and macOS. (The
+  desktop app remains Windows-only for now.)
+
 ### Changed
-- The desktop app's conversion step is slightly faster to start: it now reuses the message total from the
+- The desktop app's conversion step is slightly faster to start: it reuses the message total from the
   scan it just ran instead of counting every mailbox a second time before converting. Behaviour and
   progress reporting are otherwise unchanged. (Direct CLI users can do the same with a new
   `convert --expected-total <n>` flag.)
 
+### Fixed
+- **Inline images that are also real attachments stay visible.** A part that was both referenced inline
+  (CID) and present as an explicit attachment was being hidden, so it could go missing from the
+  attachment list. Such parts are now kept visible; purely-inline images remain hidden as before.
+- **More accurate size/count estimates for forwarded-as-attachment messages.** The `scan` estimate no
+  longer decodes the body of an embedded (`message/rfc822`) message just to measure it — improving both
+  accuracy and scan memory use.
+- **Cancelling a conversion no longer leaves a stray temp file.** Cancelling while an attachment was
+  mid-flight could leak one temporary file; it is now disposed on cancel.
+
 ### Internal
-- CI now runs the desktop Rust unit and sidecar-integration tests (a Windows `cargo test` job), so the
-  Tauri-side contract is gated on every push/PR.
-- The CLI engine now builds, tests, and runs on Linux and macOS, gated by a CI OS matrix
-  (windows/ubuntu/macos, each leg also publishing the CLI single-file and smoke-running `scan`).
-  Removed the unused Windows-only `System.ServiceProcess.ServiceController` dependency. (No user-facing
-  change yet — the desktop app remains Windows-only; cross-platform packaging is a later step.)
+- CI runs the desktop Rust unit and sidecar-integration tests (a Windows `cargo test` job), and builds +
+  tests the engine on a Windows/Linux/macOS matrix (each leg also publishing the CLI single-file and
+  smoke-running `scan`). Removed the unused Windows-only `System.ServiceProcess.ServiceController`
+  dependency.
 
 ## [0.2.2] — 2026-06-28
 

--- a/NOTICE
+++ b/NOTICE
@@ -51,6 +51,13 @@ Mork reader (src/Mail2Pst.Core/Mork/)
   This is project-native GPL-3.0-or-later code; the public-domain origin imposes
   no obligation, but the provenance is recorded for hygiene.
 -------------------------------------------------------------------------------
+Microsoft .NET runtime & libraries (bundled in the self-contained CLI binaries)
+  Copyright (c) .NET Foundation and Contributors
+  The cross-platform command-line release binaries are published self-contained and
+  bundle the .NET 8 runtime plus Microsoft-provided libraries (including
+  System.Text.Encoding.CodePages), licensed under the MIT License.
+  License text: https://github.com/dotnet/runtime/blob/main/LICENSE.TXT
+-------------------------------------------------------------------------------
 
 The developer/test-only tool tools/pst-validate depends on the "outlook-pst" crate by Microsoft,
 licensed MIT. The tool's own source is GPL-3.0-or-later (ContinuMail project code). It is used

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 [![License: GPL-3.0-or-later](https://img.shields.io/badge/License-GPL--3.0--or--later-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/ContinuMail/continumail-converter?label=release)](../../releases/latest)
-[![Platform: Windows 10/11](https://img.shields.io/badge/platform-Windows%2010%2F11-0078D6)](#-download--install)
+[![Desktop app: Windows 10/11](https://img.shields.io/badge/desktop%20app-Windows%2010%2F11-0078D6)](#-download--install)
+[![CLI: Windows · Linux · macOS](https://img.shields.io/badge/CLI-Windows%20%C2%B7%20Linux%20%C2%B7%20macOS-2ea44f)](#-download--install)
 [![Website: continumail.com](https://img.shields.io/badge/web-continumail.com-b05a36)](https://www.continumail.com/)
 
 <p align="center">
@@ -30,12 +31,39 @@ Most free/open options write PST by remote-controlling a running copy of Outlook
 
 ## 📥 Download & install
 
+### Desktop app (Windows 10/11)
+
 1. Download the latest installer from the [**Releases**](../../releases/latest) page: `ContinuMail Converter_<version>_x64-setup.exe`.
 2. Run it. ContinuMail installs for the current user (no admin needed) and adds a Start-menu shortcut. Windows 10/11, 64-bit.
 
 > **"Windows protected your PC"?** This early release is **not yet code-signed**, so SmartScreen may warn about an "unknown publisher." If you trust this source, click **More info → Run anyway**. (Code signing is [on the roadmap](#-roadmap).)
 
-Prefer the command line? See [Command-line interface](#-command-line-interface).
+### Command-line (Windows · Linux · macOS)
+
+The converter's engine is fully cross-platform. Grab the single-file CLI for your OS from the [**Releases**](../../releases/latest) page (on Windows, the desktop installer above already includes it):
+
+| OS | Binary |
+|----|--------|
+| Windows | `mail2pst-cli-<version>-win-x64.exe` |
+| Linux (x64) | `mail2pst-cli-<version>-linux-x64` |
+| macOS (Apple Silicon) | `mail2pst-cli-<version>-osx-arm64` |
+
+**Linux** — the self-contained runtime needs ICU; install it once if your distro doesn't ship it (`sudo apt install -y libicu-dev` on Debian/Ubuntu), then:
+
+```bash
+chmod +x mail2pst-cli-<version>-linux-x64
+./mail2pst-cli-<version>-linux-x64 scan --input mail.mbox
+```
+
+**macOS** — the binary is **unsigned**, so Gatekeeper quarantines a browser-downloaded copy. Clear the quarantine flag once (or right-click → Open the first time):
+
+```bash
+xattr -dr com.apple.quarantine ./mail2pst-cli-<version>-osx-arm64
+chmod +x mail2pst-cli-<version>-osx-arm64
+./mail2pst-cli-<version>-osx-arm64 scan --input mail.mbox
+```
+
+See [Command-line interface](#-command-line-interface) for the full `scan` / `convert` usage.
 
 ## 🚀 Using the app
 
@@ -197,7 +225,7 @@ npm test              # frontend unit tests (Vitest)
 npm run tauri build   # release build + NSIS installer
 ```
 
-> The CLI sidecar build is Windows / win-x64 only (matching the v1 Windows-first scope) and runs automatically before `tauri dev`/`build`. Cross-platform builds are deferred to a future release.
+> The **CLI engine builds and publishes on Windows, Linux, and macOS** — e.g. `dotnet publish src/Mail2Pst.Cli -c Release -r <rid> --self-contained` (`win-x64` / `linux-x64` / `osx-arm64`). Only the **desktop GUI** is Windows-only for now; its sidecar build (`npm run sidecar`) targets `win-x64` and runs automatically before `tauri dev`/`build`.
 
 ## 🔒 Privacy & disclaimer
 
@@ -211,7 +239,7 @@ ContinuMail Converter aims to be a genuinely **free, open alternative to the pai
 
 - **More formats** — EML and MSG input next (mbox-only today).
 - **Code signing** of the installer (to remove the SmartScreen prompt).
-- **Cross-platform** builds (Windows-only today).
+- **Cross-platform desktop app** — the command-line converter already runs on Windows, Linux, and macOS; bringing the desktop GUI to Linux/macOS (packaging + signing) is next.
 
 The converter is free and open-source and stays that way. (ContinuMail follows an open-core model: this converter is free forever; any paid products are separate.)
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ The output directory also gets `conversion-report.txt` (human-readable) and `con
 
 ## 🔧 Build from source
 
-**Engine + CLI** — requires the [.NET 8 SDK](https://dotnet.microsoft.com/download). Windows is the primary target (the PST engine uses some Windows APIs).
+**Engine + CLI** — requires the [.NET 8 SDK](https://dotnet.microsoft.com/download). Builds and runs on Windows, Linux, and macOS (the PST engine is platform-independent; only the optional Outlook category-colour import is Windows-only — see [Limitations](#-limitations)).
 
 ```bash
 dotnet build Mail2Pst.sln
@@ -231,7 +231,7 @@ npm run tauri build   # release build + NSIS installer
 
 ContinuMail Converter reads your archive locally and writes the PST locally. It makes **no network connections** and **uploads nothing**; your originals are only ever read, never modified. See [`SECURITY.md`](SECURITY.md) for the app's security posture and Content Security Policy.
 
-It is free software, provided **"as is", without warranty of any kind** (see [`LICENSE`](LICENSE)). Email history matters, so please **keep a backup** of your originals, **validate** the output (open the PST, or import into a test Outlook profile), and **review the conversion report** before relying on converted data. The installer is not yet code-signed (see [Download & install](#-download--install)).
+It is free software, provided **"as is", without warranty of any kind** (see [`LICENSE`](LICENSE)). Email history matters, so please **keep a backup** of your originals, **validate** the output (open the PST, or import into a test Outlook profile), and **review the conversion report** before relying on converted data. The installer and the CLI binaries are not yet code-signed (see [Download & install](#-download--install)).
 
 ## 🗺️ Roadmap
 

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.2.2"
+version = "0.2.3"
 description = "ContinuMail Converter — convert mbox mail archives to Outlook PST"
 authors = ["Aksel Visby <aksel@visby.it>"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ContinuMail Converter",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "identifier": "com.continumail.converter",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/Mail2Pst.Cli/Mail2Pst.Cli.csproj
+++ b/src/Mail2Pst.Cli/Mail2Pst.Cli.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Mail2Pst.Cli</RootNamespace>
-    <Version>0.2.2</Version>
+    <Version>0.2.3</Version>
     <!-- Server GC: measured win on the parallel byte-range scan (4.5 GB gmail corpus:
          ~19s -> ~13.5s wall-clock, ~30% faster). Peak working set rises 163 -> 314 MB,
          still size-independent and modest. See docs/pst-engine-benchmarks.md. -->


### PR DESCRIPTION
Release-prep for **v0.2.3** (version bump + docs). Bundles the four post-0.2.2 PRs: #44 (attachment-fidelity fixes), #45 (faster convert / `--expected-total`), #46 (cross-platform CLI + CI matrix), #43 (test-only).

## Changes
- **Version → 0.2.3** in `Mail2Pst.Cli.csproj`, `tauri.conf.json`, `Cargo.toml` (+ Cargo.lock).
- **CHANGELOG** — new `[0.2.3]` section; **backfilled the #44 fixes** (inline-CID attachment visibility, embedded-message scan accuracy, cancel-time temp-file leak) that were missing from `[Unreleased]`. Headline: the CLI now runs on Linux/macOS.
- **README** — GUI (Windows) vs CLI (Windows/Linux/macOS) split made explicit: new badges, restructured Download & install, Linux (`libicu`) + macOS (`xattr` quarantine, unsigned) quick-starts, corrected build-from-source + roadmap notes, broadened code-signing disclaimer to cover CLI binaries.
- **NOTICE** — acknowledge the bundled .NET runtime + `System.Text.Encoding.CodePages` (Microsoft, MIT) in the self-contained CLI binaries.

## Notes
- The actual release cut (tag `v0.2.3`, GUI installer, the three CLI binaries, GitHub Release) happens off `main` after this merges — including a fresh **0.2.3 NSIS** installer and an owner-run `scanpst.exe` validation.
- No engine behaviour change here; CI matrix (win/linux/mac) gates as usual.