### PR TITLE
Thunderbird calendar and tasks to PST conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ fixtures/takeout-test-config.json
 _manualtest/
 
 # Private dev artifacts — single public-primary repo model (2026-06-18). Kept local on disk,
+# Stryker.NET mutation-testing output (regenerable; the run is driven by the committed
+# tests/Mail2Pst.Core.Tests/stryker-config.json — see TESTING.md).
+StrykerOutput/
+
 # OneDrive-synced, NEVER committed. The .githooks/ leak-check enforces this mechanically.
 docs/
 reviews/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   supported. When you convert a Thunderbird profile, contacts are included automatically; a
   `--no-contacts` flag (and a future GUI toggle) opts out. Contacts land in an `IPF.Contact` folder per
   address book and validate cleanly in Outlook and `scanpst.exe`.
+- **Thunderbird to-dos now convert to PST.** Non-recurring tasks from a Thunderbird calendar store
+  (`local.sqlite`/`cache.sqlite`) become Outlook tasks (`IPM.Task`) in a per-calendar Tasks folder,
+  carrying subject, start/due/completed dates, status, percent-complete, priority, sensitivity (incl.
+  Private), reminder, body, and categories. Tasks are included automatically when you convert a profile;
+  a `--no-tasks` flag opts out. _Recurring tasks are deferred to a later release._
 
 ### Internal
 - New contact pipeline (`ContactRecord` model, SQLite + Mork readers, a shared vCard mapper, and an
@@ -23,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sparse card still yields a usable contact. Adds two pinned, GPL-compatible NuGet dependencies —
   `Microsoft.Data.Sqlite` and `FolkerKinzel.VCards` (both MIT-family) — recorded in `NOTICE`. The
   independent `pst-validate` round-trip gate now covers contact folders.
+- New task pipeline (`TaskRecord` model, `CalendarTaskMapper` over the SQLite calendar reader, an
+  `IPM.Task` vendor factory + `TaskWriter`) added as a distinct write phase reusing the shared
+  precreation / size-split / checkpoint / reporting machinery. The MAPI property recipe (absolute task
+  reminders, date-only start/due, the completed-task recipe, `PidLidPrivate` coupling, percent as
+  `PtypFloating64`, `Keywords` categories) was pinned against a real Outlook task export. The independent
+  `pst-validate` round-trip gate now covers `IPF.Task` folder counts.
 
 ## [0.2.3] — 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,17 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   supported. When you convert a Thunderbird profile, contacts are included automatically; a
   `--no-contacts` flag (and a future GUI toggle) opts out. Contacts land in an `IPF.Contact` folder per
   address book and validate cleanly in Outlook and `scanpst.exe`.
-- **Thunderbird to-dos now convert to PST.** Non-recurring tasks from a Thunderbird calendar store
+- **Thunderbird to-dos now convert to PST.** Tasks from a Thunderbird calendar store
   (`local.sqlite`/`cache.sqlite`) become Outlook tasks (`IPM.Task`) in a per-calendar Tasks folder,
   carrying subject, start/due/completed dates, status, percent-complete, priority, sensitivity (incl.
   Private), reminder, body, and categories. Tasks are included automatically when you convert a profile;
-  a `--no-tasks` flag opts out. _Recurring tasks are deferred to a later release._
-- **Thunderbird calendar events now convert to PST.** Non-recurring events from a Thunderbird calendar
+  a `--no-tasks` flag opts out.
+- **Thunderbird calendar events now convert to PST.** Events from a Thunderbird calendar
   store (`local.sqlite`/`cache.sqlite`) become Outlook appointments (`IPM.Appointment`) in a per-calendar
   Calendar folder, carrying subject, start/end with **timezone**, **all-day**, location, busy/free, sensitivity
   (incl. Private), importance, body (plain **and** HTML), categories, and reminder. Events are included
-  automatically when you convert a profile; a `--no-appointments` flag opts out. _Recurring events,
-  attendees, and attachments are deferred to later releases._
+  automatically when you convert a profile; a `--no-appointments` flag opts out. _Event attachments and
+  online-meeting links (Teams/Google Meet) are deferred to a later release._
 - **Meeting attendees now convert to PST appointment recipients.** Events with attendees become proper
   Outlook meetings (`IPM.Appointment` with meeting-request state). Required, optional, and resource
   attendees map to the correct MAPI recipient types (To/Cc/Bcc); the organizer is recorded in the
@@ -40,6 +40,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   local time. All-day recurring events carry both a recurrence blob and `PidLidAppointmentSubType`.
   Unsupported patterns (BYSETPOS, multi-RRULE, etc.) degrade gracefully to a single occurrence with
   a warning rather than being skipped.
+- **Recurring tasks now convert to PST.** Daily, weekly, monthly, and yearly recurring to-dos become
+  proper Outlook recurring tasks (`IPM.Task`) carrying a `PidLidTaskRecurrence` pattern, so Outlook
+  regenerates the next occurrence when you complete one. A recurring task with deleted or overridden
+  occurrences, a completed recurring task, or an unrepresentable rule is written as a single task with
+  a warning rather than being dropped.
 
 ### Internal
 - New contact pipeline (`ContactRecord` model, SQLite + Mork readers, a shared vCard mapper, and an
@@ -68,6 +73,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `PidLidResponseStatus` registration. Case-insensitive email dedup (attendees vs organizer). Attendee-only
   events with no valid email are skipped with a warning; organizer-only events (zero attendees) remain
   plain appointments. Received-meeting response status is deferred (requires identity resolution).
+- Recurrence pipeline: a shared `RecurrenceMapping` translates iCal `RRULE`/`EXDATE` into a typed
+  `RecurrenceSpec`, consumed by both the appointment writer (the full `PidLidAppointmentRecur` blob with
+  deleted/modified instances, embedded exception attachments, and IANA→Windows timezone definitions) and
+  the task writer (the bare MS-OXOCAL `RecurrencePattern` prefix for `PidLidTaskRecurrence` +
+  `PidLidTaskFRecurring`, split out of the vendored appointment serializer). Both blob encodings are
+  byte-gated against real Outlook ground-truth exports. Unrepresentable rules and task-level exceptions
+  (EXDATE/RDATE/overrides, completed-recurring) degrade to a single item plus a warning — counted as
+  converted, never silently dropped. The independent `pst-validate` gate confirms recurrence adds no
+  phantom folder items.
 
 ## [0.2.3] — 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   carrying subject, start/due/completed dates, status, percent-complete, priority, sensitivity (incl.
   Private), reminder, body, and categories. Tasks are included automatically when you convert a profile;
   a `--no-tasks` flag opts out. _Recurring tasks are deferred to a later release._
+- **Thunderbird calendar events now convert to PST.** Non-recurring events from a Thunderbird calendar
+  store (`local.sqlite`/`cache.sqlite`) become Outlook appointments (`IPM.Appointment`) in a per-calendar
+  Calendar folder, carrying subject, start/end with **timezone**, **all-day**, location, busy/free, sensitivity
+  (incl. Private), importance, body (plain **and** HTML), categories, and reminder. Events are included
+  automatically when you convert a profile; a `--no-appointments` flag opts out. _Recurring events,
+  attendees, and attachments are deferred to later releases._
 
 ### Internal
 - New contact pipeline (`ContactRecord` model, SQLite + Mork readers, a shared vCard mapper, and an
@@ -34,6 +40,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reminders, date-only start/due, the completed-task recipe, `PidLidPrivate` coupling, percent as
   `PtypFloating64`, `Keywords` categories) was pinned against a real Outlook task export. The independent
   `pst-validate` round-trip gate now covers `IPF.Task` folder counts.
+- New appointment pipeline (`AppointmentRecord` model, `CalendarEventMapper` over the SQLite calendar
+  reader, an `AppointmentWriter` driving the vendored `SingleAppointment` MS-OXOCAL substrate) added as a
+  distinct write phase reusing the shared precreation / size-split / checkpoint / reporting machinery. The
+  MAPI recipe (timezone-definition blobs, all-day local-midnight semantics, minutes-before reminder delta,
+  busy/free, `PidLidPrivate` coupling, HTML/ALTREP body) was pinned against a real Outlook appointment
+  export; timezones resolve cross-platform without the Win32 registry. The independent `pst-validate`
+  round-trip gate now covers `IPF.Appointment` folder counts.
 
 ## [0.2.3] — 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   organizer field and as an organizer-copy recipient row. Per-attendee PARTSTAT (accepted/declined/tentative
   etc.) maps to both `PidLidResponseStatus` and the track-status column on each recipient row.
   Attendee-free events remain plain appointments (no meeting state, no extra properties).
+- **Recurring appointments now convert to PST.** Daily, weekly, monthly, and yearly recurrence rules
+  from Thunderbird calendar events become proper Outlook recurring appointments (`IPM.Appointment`)
+  with a `PidLidAppointmentRecur` blob. EXDATE-deleted occurrences are encoded as deleted-instance
+  dates. Overridden occurrences become embedded exception attachments (modified instances).
+  Timezone definitions (IANA → Windows mapping) are written to `PidLidTimeZoneStruct` and
+  `PidLidAppointmentTimeZoneDefinitionStartDisplay` so Outlook displays occurrences in the correct
+  local time. All-day recurring events carry both a recurrence blob and `PidLidAppointmentSubType`.
+  Unsupported patterns (BYSETPOS, multi-RRULE, etc.) degrade gracefully to a single occurrence with
+  a warning rather than being skipped.
 
 ### Internal
 - New contact pipeline (`ContactRecord` model, SQLite + Mork readers, a shared vCard mapper, and an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (incl. Private), importance, body (plain **and** HTML), categories, and reminder. Events are included
   automatically when you convert a profile; a `--no-appointments` flag opts out. _Recurring events,
   attendees, and attachments are deferred to later releases._
+- **Meeting attendees now convert to PST appointment recipients.** Events with attendees become proper
+  Outlook meetings (`IPM.Appointment` with meeting-request state). Required, optional, and resource
+  attendees map to the correct MAPI recipient types (To/Cc/Bcc); the organizer is recorded in the
+  organizer field and as an organizer-copy recipient row. Per-attendee PARTSTAT (accepted/declined/tentative
+  etc.) maps to both `PidLidResponseStatus` and the track-status column on each recipient row.
+  Attendee-free events remain plain appointments (no meeting state, no extra properties).
 
 ### Internal
 - New contact pipeline (`ContactRecord` model, SQLite + Mork readers, a shared vCard mapper, and an
@@ -47,6 +53,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   busy/free, `PidLidPrivate` coupling, HTML/ALTREP body) was pinned against a real Outlook appointment
   export; timezones resolve cross-platform without the Win32 registry. The independent `pst-validate`
   round-trip gate now covers `IPF.Appointment` folder counts.
+- Meeting attendee pipeline: `AppointmentAttendee`/`AttendeeKind`/`AttendeeResponse` model from
+  `cal_attendees` rows; `AppointmentWriter.WriteAttendees` sets recipient rows (`MAPI_TO`/`CC`/`BCC`),
+  organizer fields, meeting-request object type/subtype, and per-recipient track-status via a vendored
+  `PidLidResponseStatus` registration. Case-insensitive email dedup (attendees vs organizer). Attendee-only
+  events with no valid email are skipped with a warning; organizer-only events (zero attendees) remain
+  plain appointments. Received-meeting response status is deferred (requires identity resolution).
 
 ## [0.2.3] — 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   store (`local.sqlite`/`cache.sqlite`) become Outlook appointments (`IPM.Appointment`) in a per-calendar
   Calendar folder, carrying subject, start/end with **timezone**, **all-day**, location, busy/free, sensitivity
   (incl. Private), importance, body (plain **and** HTML), categories, and reminder. Events are included
-  automatically when you convert a profile; a `--no-appointments` flag opts out. _Event attachments and
-  online-meeting links (Teams/Google Meet) are deferred to a later release._
+  automatically when you convert a profile; a `--no-appointments` flag opts out.
 - **Meeting attendees now convert to PST appointment recipients.** Events with attendees become proper
   Outlook meetings (`IPM.Appointment` with meeting-request state). Required, optional, and resource
   attendees map to the correct MAPI recipient types (To/Cc/Bcc); the organizer is recorded in the
@@ -45,6 +44,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   regenerates the next occurrence when you complete one. A recurring task with deleted or overridden
   occurrences, a completed recurring task, or an unrepresentable rule is written as a single task with
   a warning rather than being dropped.
+- **Calendar and task attachments now convert to PST.** File attachments on Thunderbird events and to-dos
+  are written into the appointment/task as normal Outlook attachments. Embedded/inline attachments are
+  decoded and attached; a **remote-URL** attachment (e.g. a Google-Drive link) is preserved as a link in
+  the item body — the converter **never fetches from the network**; and a **local-file** attachment is
+  embedded only when the file still exists and resolves **inside the Thunderbird profile** (symlinks and
+  out-of-profile paths are refused), otherwise its reference is preserved in the body with a warning.
+- **Online-meeting join links are preserved.** When a Thunderbird event carries a Microsoft Teams or
+  Google Meet link, the join URL is kept clickable in the appointment body. (Classic Outlook — which is
+  what opens a local PST — has no separate "Join" button; the link in the body is what actually works.)
+  Ordinary links in an event are left as-is and never misidentified as an online meeting.
+- **Cached Exchange meetings keep their identity.** For events synced from an Exchange/Microsoft 365
+  calendar, the meeting's global object identifier is carried across (`PidLidGlobalObjectId` /
+  `PidLidCleanGlobalObjectId`) so Outlook recognises it as the same meeting. Local calendar events are
+  unaffected — Outlook assigns identity on demand as usual.
+- **Item relations are preserved.** Thunderbird `RELATED-TO` links between calendar items — which have no
+  native Outlook equivalent — are preserved as a readable note appended to the item body, with a warning,
+  rather than being silently dropped.
 
 ### Internal
 - New contact pipeline (`ContactRecord` model, SQLite + Mork readers, a shared vCard mapper, and an
@@ -82,6 +98,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (EXDATE/RDATE/overrides, completed-recurring) degrade to a single item plus a warning — counted as
   converted, never silently dropped. The independent `pst-validate` gate confirms recurrence adds no
   phantom folder items.
+- Edge-fidelity pipeline: the mail and contact attachment writers were consolidated into one shared
+  `AttachmentWriter` (behavior-preserving), which the calendar/task writers reuse. A pure, root-aware
+  `CalendarAttachmentResolver` classifies each iCal `ATTACH` into embedded-bytes / in-profile-file /
+  link-only, enforcing the security boundaries (no network fetch, no path traversal, symlinks refused,
+  oversized attachments degraded to a link). Link-only attachments and preserved `RELATED-TO` relations
+  share one dedup-aware `CalendarBodyAppendix` applied to both the plain and HTML body. `GlobalObjectId`
+  is hex-decoded verbatim from the cached-Exchange source id (never synthesized). Online-meeting handling
+  writes no native props by design — docs confirm classic Outlook renders no Join affordance from them,
+  so the join URL is preserved in the body. Unicode round-trip locks and an opt-in real-corpus smoke pin
+  the behavior.
 
 ## [0.2.3] — 2026-06-28
 

--- a/CONVERSION-FIDELITY.md
+++ b/CONVERSION-FIDELITY.md
@@ -1,0 +1,171 @@
+# ContinuMail Converter — Conversion Fidelity
+
+_What gets converted from Thunderbird into an Outlook PST, field by field — and what doesn't, with the reason why._
+
+---
+
+## ✉️ Mail
+
+_Thunderbird messages → PST mail items_
+
+**Status:** Full fidelity. `.msf` enrichment supplies authoritative read/flag/tag state when a profile is used.
+
+```
+┌─────────────────────────┬───────────────────────────┬───────────┬─────────────────────────────┬───────────────────────────────────────┐
+│ Source field            │ Goes to                   │ Status    │ Notes / Why                 │ MAPI property                         │
+├─────────────────────────┼───────────────────────────┼───────────┼─────────────────────────────┼───────────────────────────────────────┤
+│ Subject                 │ Subject                   │ Converted │                             │ PidTagSubject                         │
+├─────────────────────────┼───────────────────────────┼───────────┼─────────────────────────────┼───────────────────────────────────────┤
+│ From / To / Cc / Bcc    │ Sender + recipients       │ Converted │                             │ recipients / PidTagSenderEmailAddress │
+├─────────────────────────┼───────────────────────────┼───────────┼─────────────────────────────┼───────────────────────────────────────┤
+│ Date sent / received    │ Sent & received time      │ Converted │ Clamped to valid range      │ PidTagClientSubmitTime                │
+├─────────────────────────┼───────────────────────────┼───────────┼─────────────────────────────┼───────────────────────────────────────┤
+│ HTML body               │ HTML body                 │ Converted │                             │ PidTagHtml                            │
+├─────────────────────────┼───────────────────────────┼───────────┼─────────────────────────────┼───────────────────────────────────────┤
+│ Plain-text body         │ Plain-text body           │ Converted │ Derived from HTML if absent │ PidTagBody                            │
+├─────────────────────────┼───────────────────────────┼───────────┼─────────────────────────────┼───────────────────────────────────────┤
+│ Attachments             │ Attachments               │ Converted │ Filename guessed if missing │ (attachment table)                    │
+├─────────────────────────┼───────────────────────────┼───────────┼─────────────────────────────┼───────────────────────────────────────┤
+│ Inline (CID) images     │ Hidden inline attachments │ Converted │ No phantom paperclip        │ PidTagAttachmentHidden                │
+├─────────────────────────┼───────────────────────────┼───────────┼─────────────────────────────┼───────────────────────────────────────┤
+│ Message-ID / References │ Threading + conversation  │ Converted │                             │ PidTagInternetMessageId               │
+├─────────────────────────┼───────────────────────────┼───────────┼─────────────────────────────┼───────────────────────────────────────┤
+│ Read / unread           │ Read state                │ Converted │ From .msf or headers        │ PidTagMessageFlags                    │
+├─────────────────────────┼───────────────────────────┼───────────┼─────────────────────────────┼───────────────────────────────────────┤
+│ Replied / forwarded     │ Reply / forward icons     │ Converted │                             │ PidTagLastVerbExecuted                │
+├─────────────────────────┼───────────────────────────┼───────────┼─────────────────────────────┼───────────────────────────────────────┤
+│ Flagged / starred       │ Follow-up flag            │ Converted │                             │ PidTagFlagStatus                      │
+├─────────────────────────┼───────────────────────────┼───────────┼─────────────────────────────┼───────────────────────────────────────┤
+│ Importance / priority   │ Importance                │ Converted │                             │ PidTagImportance                      │
+├─────────────────────────┼───────────────────────────┼───────────┼─────────────────────────────┼───────────────────────────────────────┤
+│ Tags / labels           │ Categories                │ Converted │ Names from prefs.js         │ PidNameKeywords                       │
+├─────────────────────────┼───────────────────────────┼───────────┼─────────────────────────────┼───────────────────────────────────────┤
+│ Junk status             │ Junk category / folder    │ Converted │ Configurable                │ PidNameKeywords / folder              │
+├─────────────────────────┼───────────────────────────┼───────────┼─────────────────────────────┼───────────────────────────────────────┤
+│ Expunged messages       │ (optionally dropped)      │ Partial   │ Dropped if configured       │ —                                     │
+├─────────────────────────┼───────────────────────────┼───────────┼─────────────────────────────┼───────────────────────────────────────┤
+│ Folder structure        │ PST folder tree           │ Converted │ mirror or flatten           │ (folder hierarchy)                    │
+└─────────────────────────┴───────────────────────────┴───────────┴─────────────────────────────┴───────────────────────────────────────┘
+```
+
+---
+
+## 📅 Calendar
+
+_Thunderbird events → PST appointments_
+
+**Status:** Full fidelity for core fields, recurrence + exceptions, time zones, attendees and attachments. Online-meeting join links and item relations are preserved in the body (no native Outlook slot exists for them).
+
+```
+┌─────────────────────────────┬───────────────────────────────┬───────────┬────────────────────────────────────┬───────────────────────────────────┐
+│ Source field                │ Goes to                       │ Status    │ Notes / Why                        │ MAPI property                     │
+├─────────────────────────────┼───────────────────────────────┼───────────┼────────────────────────────────────┼───────────────────────────────────┤
+│ Title                       │ Appointment subject           │ Converted │                                    │ PidTagSubject                     │
+├─────────────────────────────┼───────────────────────────────┼───────────┼────────────────────────────────────┼───────────────────────────────────┤
+│ Start / end + time zone     │ Start & end, with time zone   │ Converted │ Time zone preserved                │ AppointmentStartWhole/EndWhole    │
+├─────────────────────────────┼───────────────────────────────┼───────────┼────────────────────────────────────┼───────────────────────────────────┤
+│ All-day flag                │ Shown as all-day event        │ Converted │ Local-midnight start/end           │ AppointmentSubType                │
+├─────────────────────────────┼───────────────────────────────┼───────────┼────────────────────────────────────┼───────────────────────────────────┤
+│ Priority                    │ Importance                    │ Converted │                                    │ PidTagImportance                  │
+├─────────────────────────────┼───────────────────────────────┼───────────┼────────────────────────────────────┼───────────────────────────────────┤
+│ Privacy / class             │ Sensitivity + private flag    │ Converted │                                    │ PidTagSensitivity + PidLidPrivate │
+├─────────────────────────────┼───────────────────────────────┼───────────┼────────────────────────────────────┼───────────────────────────────────┤
+│ Free / busy status          │ Show-as free/busy/tentative   │ Converted │                                    │ PidLidBusyStatus                  │
+├─────────────────────────────┼───────────────────────────────┼───────────┼────────────────────────────────────┼───────────────────────────────────┤
+│ Description                 │ Body (plain + HTML)           │ Partial   │ Plain text derived from HTML       │ PidTagBody (+PidTagHtml)          │
+├─────────────────────────────┼───────────────────────────────┼───────────┼────────────────────────────────────┼───────────────────────────────────┤
+│ Location                    │ Location                      │ Converted │ Plain text                         │ PidLidLocation                    │
+├─────────────────────────────┼───────────────────────────────┼───────────┼────────────────────────────────────┼───────────────────────────────────┤
+│ Categories                  │ Categories                    │ Converted │                                    │ PidNameKeywords                   │
+├─────────────────────────────┼───────────────────────────────┼───────────┼────────────────────────────────────┼───────────────────────────────────┤
+│ Reminders (alarms)          │ Reminder + lead time          │ Partial   │ After-start alarm dropped + warn   │ PidLidReminderSet + Delta         │
+├─────────────────────────────┼───────────────────────────────┼───────────┼────────────────────────────────────┼───────────────────────────────────┤
+│ Attendees + responses       │ Meeting recipients + tracking │ Converted │ ROLE + PARTSTAT preserved          │ recipients / ResponseStatus       │
+├─────────────────────────────┼───────────────────────────────┼───────────┼────────────────────────────────────┼───────────────────────────────────┤
+│ Recurrence (RRULE) + exc.   │ Recurring series + exceptions │ Converted │ EXDATE + modified occurrences      │ PidLidAppointmentRecur            │
+├─────────────────────────────┼───────────────────────────────┼───────────┼────────────────────────────────────┼───────────────────────────────────┤
+│ Event attachments           │ PST attachments               │ Converted │ Inline embedded; links in body     │ (attachment table)                │
+├─────────────────────────────┼───────────────────────────────┼───────────┼────────────────────────────────────┼───────────────────────────────────┤
+│ Teams / Google Meet link    │ Join link in the body         │ Partial   │ Classic Outlook has no Join button │ PidTagBody (+PidTagHtml)          │
+├─────────────────────────────┼───────────────────────────────┼───────────┼────────────────────────────────────┼───────────────────────────────────┤
+│ Meeting identity (GOID)     │ Meeting global object id      │ Converted │ Exchange/M365-cached events only   │ PidLidGlobalObjectId              │
+├─────────────────────────────┼───────────────────────────────┼───────────┼────────────────────────────────────┼───────────────────────────────────┤
+│ Item relations (RELATED-TO) │ Preserved note in body        │ Partial   │ No native Outlook relation slot    │ PidTagBody                        │
+├─────────────────────────────┼───────────────────────────────┼───────────┼────────────────────────────────────┼───────────────────────────────────┤
+│ CalDAV sync ETag / href     │ (nothing - dropped)           │ Not conv. │ Server-only; no PST slot           │ —                                 │
+└─────────────────────────────┴───────────────────────────────┴───────────┴────────────────────────────────────┴───────────────────────────────────┘
+```
+
+---
+
+## 👥 Contacts
+
+_Thunderbird address book → PST contacts_
+
+**Status:** Shipped. Distribution lists / groups are a deferred follow-up.
+
+```
+┌─────────────────────────────┬────────────────────────┬───────────┬────────────────────┬─────────────────────────────────────┐
+│ Source field                │ Goes to                │ Status    │ Notes / Why        │ MAPI property                       │
+├─────────────────────────────┼────────────────────────┼───────────┼────────────────────┼─────────────────────────────────────┤
+│ Display name                │ Full name              │ Converted │                    │ PidTagDisplayName                   │
+├─────────────────────────────┼────────────────────────┼───────────┼────────────────────┼─────────────────────────────────────┤
+│ First / middle / last       │ Name parts             │ Converted │                    │ PidTagGivenName / Surname           │
+├─────────────────────────────┼────────────────────────┼───────────┼────────────────────┼─────────────────────────────────────┤
+│ Email addresses             │ Email 1 / 2 / 3        │ Converted │                    │ PidLidEmail1EmailAddress            │
+├─────────────────────────────┼────────────────────────┼───────────┼────────────────────┼─────────────────────────────────────┤
+│ Phone numbers               │ Phone fields           │ Converted │ Mapped by type     │ PidTagBusinessTelephoneNumber       │
+├─────────────────────────────┼────────────────────────┼───────────┼────────────────────┼─────────────────────────────────────┤
+│ Mailing address             │ Address fields         │ Converted │                    │ PidLidWorkAddress*                  │
+├─────────────────────────────┼────────────────────────┼───────────┼────────────────────┼─────────────────────────────────────┤
+│ Organization / title        │ Company + job title    │ Converted │                    │ PidTagCompanyName / Title           │
+├─────────────────────────────┼────────────────────────┼───────────┼────────────────────┼─────────────────────────────────────┤
+│ Photo                       │ Contact photo          │ Converted │                    │ PidLidHasPicture + attachment       │
+├─────────────────────────────┼────────────────────────┼───────────┼────────────────────┼─────────────────────────────────────┤
+│ Notes                       │ Notes body             │ Converted │                    │ PidTagBody                          │
+├─────────────────────────────┼────────────────────────┼───────────┼────────────────────┼─────────────────────────────────────┤
+│ Birthday / anniversary      │ Date fields            │ Converted │                    │ PidTagBirthday / WeddingAnniversary │
+├─────────────────────────────┼────────────────────────┼───────────┼────────────────────┼─────────────────────────────────────┤
+│ Website / IM                │ URL / IM fields        │ Converted │                    │ PidLidHtml / PidLidInstantMessaging │
+├─────────────────────────────┼────────────────────────┼───────────┼────────────────────┼─────────────────────────────────────┤
+│ Distribution lists / groups │ PST distribution lists │ Planned   │ Deferred follow-up │ PidLidDistributionListMembers       │
+└─────────────────────────────┴────────────────────────┴───────────┴────────────────────┴─────────────────────────────────────┘
+```
+
+---
+
+## ☑️ Tasks
+
+_Thunderbird to-dos → PST tasks_
+
+**Status:** Full fidelity, including recurring tasks and attachments. Item relations are preserved in the body (no native Outlook slot).
+
+```
+┌─────────────────────────────┬────────────────────────┬───────────┬────────────────────────────────────┬─────────────────────────────┐
+│ Source field                │ Goes to                │ Status    │ Notes / Why                        │ MAPI property               │
+├─────────────────────────────┼────────────────────────┼───────────┼────────────────────────────────────┼─────────────────────────────┤
+│ Title                       │ Task subject           │ Converted │                                    │ PidTagSubject               │
+├─────────────────────────────┼────────────────────────┼───────────┼────────────────────────────────────┼─────────────────────────────┤
+│ Notes / description         │ Body                   │ Converted │                                    │ PidTagBody                  │
+├─────────────────────────────┼────────────────────────┼───────────┼────────────────────────────────────┼─────────────────────────────┤
+│ Due date                    │ Due date               │ Converted │                                    │ PidLidTaskDueDate           │
+├─────────────────────────────┼────────────────────────┼───────────┼────────────────────────────────────┼─────────────────────────────┤
+│ Start date                  │ Start date             │ Converted │                                    │ PidLidTaskStartDate         │
+├─────────────────────────────┼────────────────────────┼───────────┼────────────────────────────────────┼─────────────────────────────┤
+│ Completed flag              │ Status = complete      │ Converted │                                    │ PidLidTaskComplete / Status │
+├─────────────────────────────┼────────────────────────┼───────────┼────────────────────────────────────┼─────────────────────────────┤
+│ Percent complete            │ % complete             │ Converted │                                    │ PidLidPercentComplete       │
+├─────────────────────────────┼────────────────────────┼───────────┼────────────────────────────────────┼─────────────────────────────┤
+│ Priority                    │ Importance             │ Converted │                                    │ PidTagImportance            │
+├─────────────────────────────┼────────────────────────┼───────────┼────────────────────────────────────┼─────────────────────────────┤
+│ Categories                  │ Categories             │ Converted │                                    │ PidNameKeywords             │
+├─────────────────────────────┼────────────────────────┼───────────┼────────────────────────────────────┼─────────────────────────────┤
+│ Reminders                   │ Reminder               │ Converted │                                    │ PidLidReminderSet           │
+├─────────────────────────────┼────────────────────────┼───────────┼────────────────────────────────────┼─────────────────────────────┤
+│ Recurring tasks             │ Recurring task series  │ Converted │ Master pattern; exceptions degrade │ PidLidTaskRecurrence        │
+├─────────────────────────────┼────────────────────────┼───────────┼────────────────────────────────────┼─────────────────────────────┤
+│ Task attachments            │ PST attachments        │ Converted │ Inline embedded; links in body     │ (attachment table)          │
+├─────────────────────────────┼────────────────────────┼───────────┼────────────────────────────────────┼─────────────────────────────┤
+│ Item relations (RELATED-TO) │ Preserved note in body │ Partial   │ No native Outlook relation slot    │ PidTagBody                  │
+└─────────────────────────────┴────────────────────────┴───────────┴────────────────────────────────────┴─────────────────────────────┘
+```

--- a/NOTICE
+++ b/NOTICE
@@ -64,6 +64,13 @@ Microsoft.Data.Sqlite / Microsoft.Data.Sqlite.Core (8.0.28)
   License text: https://github.com/dotnet/efcore/blob/main/LICENSE.txt
   Used to read Thunderbird SQLite address books (contacts import).
 -------------------------------------------------------------------------------
+Microsoft.Win32.Registry (5.0.0)
+  Copyright (c) .NET Foundation and Contributors
+  Licensed under the MIT License.
+  License text: https://github.com/dotnet/runtime/blob/main/LICENSE.TXT
+  Used by the vendored PSTFileFormat time-zone helpers (calendar import) to read
+  Windows time-zone rules; registry calls are Windows-only at runtime.
+-------------------------------------------------------------------------------
 SQLitePCLRaw.core / SQLitePCLRaw.bundle_e_sqlite3 /
 SQLitePCLRaw.lib.e_sqlite3 / SQLitePCLRaw.provider.e_sqlite3 (2.1.6)
   Copyright (c) Zumero Systems LLC (Eric Sink)

--- a/NOTICE
+++ b/NOTICE
@@ -83,6 +83,16 @@ SQLitePCLRaw.lib.e_sqlite3 / SQLitePCLRaw.provider.e_sqlite3 (2.1.6)
   by its authors and contributors. The SQLitePCLRaw packaging itself
   is licensed Apache-2.0 as above.
 -------------------------------------------------------------------------------
+Ical.Net (5.2.2)
+  Copyright (c) Rian Stockbower and contributors
+  Licensed under the MIT License.
+  License text: https://github.com/ical-org/ical.net/blob/main/license.md
+  Used to parse Thunderbird calendar iCal fragments (recurrence/attendees/alarms/attachments).
+
+  Transitive dependencies (verified via `dotnet list ... --include-transitive`):
+  NodaTime (3.2.2) — Copyright (c) The Noda Time Authors — Apache License 2.0
+  License text: https://www.apache.org/licenses/LICENSE-2.0
+-------------------------------------------------------------------------------
 FolkerKinzel.VCards (8.1.1) and its transitive dependencies:
   FolkerKinzel.DataUrls (2.0.4), FolkerKinzel.Helpers (1.1.0),
   FolkerKinzel.MimeTypes (5.5.0), FolkerKinzel.Strings (9.4.1)

--- a/TESTING.md
+++ b/TESTING.md
@@ -67,6 +67,26 @@ fully-filled contact shows every field AND its photo on the contact card. `pst-v
 proves structure and message/contact counts only, not photo rendering, so this manual
 check is required before a release that includes contacts.
 
+## Mutation testing (Stryker.NET) — manual quality gate
+
+The calendar/tasks code has a scoped [Stryker.NET](https://stryker-mutator.io/docs/stryker-net/)
+config so you can check how well the tests actually *catch* changes (not just that they pass).
+It is a **manual** gate — a full run takes ~15–20 min (it instruments the whole `Mail2Pst.Core`
+project once to capture coverage), so it is **not** wired into CI.
+
+```bash
+dotnet tool install -g dotnet-stryker      # one-time
+cd tests/Mail2Pst.Core.Tests
+dotnet-stryker                             # uses the committed stryker-config.json
+# HTML report -> tests/Mail2Pst.Core.Tests/StrykerOutput/<timestamp>/reports/mutation-report.html
+```
+
+`stryker-config.json` scopes mutation to the calendar/task source (the vendored
+`PSTFileFormat` byte-writers are byte-gated separately and excluded). `StrykerOutput/` is
+gitignored. Mutation score is a **diagnostic, not a pass/fail metric** (`break` threshold is
+`0`): warning-string and defensive-branch mutants survive by design and aren't worth chasing —
+use the surviving-mutant list to find genuinely under-tested *logic*.
+
 ## Validating your own conversion
 
 You can build the same confidence with your own mail:

--- a/src/Mail2Pst.Cli/ConvertCommand.cs
+++ b/src/Mail2Pst.Cli/ConvertCommand.cs
@@ -115,7 +115,7 @@ internal static class ConvertCommand
                         CliArgs.WriteJsonLine(new { type = "warning", source = w.Source, identifier = w.Identifier, reason = w.Reason });
                         break;
                 }
-            }, cts.Token, precomputedTotalMessages: resolved.ExpectedTotal);
+            }, cts.Token, precomputedTotalMessages: resolved.ExpectedTotal, skipTasks: resolved.NoTasks);
 
             stopwatch.Stop();
 

--- a/src/Mail2Pst.Cli/ConvertCommand.cs
+++ b/src/Mail2Pst.Cli/ConvertCommand.cs
@@ -105,7 +105,11 @@ internal static class ConvertCommand
                             // additive, non-breaking (schemaVersion stays 1):
                             contactsConverted = p.ContactsConverted,
                             contactsTotal = p.ContactsTotal,
-                            phase = p.Phase });
+                            phase = p.Phase,
+                            appointmentsConverted = p.AppointmentsConverted,
+                            appointmentsTotal = p.AppointmentsTotal,
+                            tasksConverted = p.TasksConverted,
+                            tasksTotal = p.TasksTotal });
                         break;
                     case WarningEvent w:
                         CliArgs.WriteJsonLine(new { type = "warning", source = w.Source, identifier = w.Identifier, reason = w.Reason });
@@ -156,6 +160,13 @@ internal static class ConvertCommand
                 contactsConverted = report.ContactsConverted,
                 contactsSkipped = report.ContactsSkipped,
                 contactWarnings = report.ContactWarningCount,
+                // additive appointment/task summary fields (non-breaking; schemaVersion stays 1):
+                appointmentsConverted = report.AppointmentsConverted,
+                appointmentsSkipped = report.AppointmentsSkipped,
+                appointmentWarnings = report.AppointmentWarningCount,
+                tasksConverted = report.TasksConverted,
+                tasksSkipped = report.TasksSkipped,
+                taskWarnings = report.TaskWarningCount,
             });
 
             return 0;

--- a/src/Mail2Pst.Cli/ConvertCommand.cs
+++ b/src/Mail2Pst.Cli/ConvertCommand.cs
@@ -115,7 +115,7 @@ internal static class ConvertCommand
                         CliArgs.WriteJsonLine(new { type = "warning", source = w.Source, identifier = w.Identifier, reason = w.Reason });
                         break;
                 }
-            }, cts.Token, precomputedTotalMessages: resolved.ExpectedTotal, skipTasks: resolved.NoTasks);
+            }, cts.Token, precomputedTotalMessages: resolved.ExpectedTotal, skipTasks: resolved.NoTasks, skipAppointments: resolved.NoAppointments);
 
             stopwatch.Stop();
 

--- a/src/Mail2Pst.Cli/ConvertInput.cs
+++ b/src/Mail2Pst.Cli/ConvertInput.cs
@@ -11,8 +11,10 @@ namespace Mail2Pst.Cli;
 /// <summary>Resolved convert inputs, or a user-facing Error string. Pure (no signals/conversion).
 /// <paramref name="ExpectedTotal"/> is an optional precomputed message count (-1 = count on demand).
 /// <paramref name="NoTasks"/> reflects the <c>--no-tasks</c> flag; the runner uses this to skip task
-/// assembly even for explicit-config mode where synthesis was never attempted.</summary>
-internal sealed record ConvertResolution(ConversionConfig? Config, string? OutputDir, string? InputLabel, string? Error, int ExpectedTotal = -1, bool NoTasks = false);
+/// assembly even for explicit-config mode where synthesis was never attempted.
+/// <paramref name="NoAppointments"/> reflects the <c>--no-appointments</c> flag; the runner uses this
+/// to skip appointment assembly even for explicit-config mode.</summary>
+internal sealed record ConvertResolution(ConversionConfig? Config, string? OutputDir, string? InputLabel, string? Error, int ExpectedTotal = -1, bool NoTasks = false, bool NoAppointments = false);
 
 /// <summary>
 /// Resolves `convert` arguments into a ConversionConfig (or an error), supporting --config (existing),
@@ -28,7 +30,7 @@ internal static class ConvertInput
 
     // Flags that are standalone (no value token consumed).
     private static readonly System.Collections.Generic.HashSet<string> ValuelessFlags =
-        new(StringComparer.Ordinal) { "--no-contacts", "--no-tasks" };
+        new(StringComparer.Ordinal) { "--no-contacts", "--no-tasks", "--no-appointments" };
 
     internal static ConvertResolution Resolve(string[] args)
     {
@@ -70,6 +72,11 @@ internal static class ConvertInput
             // to skip task mappings entirely in explicit-config mode.
             bool noTasks = args.Contains("--no-tasks", StringComparer.Ordinal);
 
+            // --no-appointments opts out of appointment synthesis in discovery mode and instructs
+            // the runner to skip appointment mappings entirely in explicit-config mode.
+            // Tasks are controlled separately by --no-tasks.
+            bool noAppointments = args.Contains("--no-appointments", StringComparer.Ordinal);
+
             ConversionConfig? template = null;
             if (configPath is not null)
             {
@@ -83,8 +90,8 @@ internal static class ConvertInput
             {
                 DiscoveryResult discovery = MailProfileDiscovery.Discover(profileDir);
                 ConversionConfig config = ConfigFromDiscovery.Build(discovery, template,
-                    includeContacts: !noContacts, includeTasks: !noTasks);
-                return new(config, outputDir, profileDir, null, expectedTotal, NoTasks: noTasks);
+                    includeContacts: !noContacts, includeTasks: !noTasks, includeAppointments: !noAppointments);
+                return new(config, outputDir, profileDir, null, expectedTotal, NoTasks: noTasks, NoAppointments: noAppointments);
             }
             catch (Exception ex)
             {
@@ -93,14 +100,16 @@ internal static class ConvertInput
         }
 
         // --config only (existing behaviour).
-        // --no-tasks still applies here: the runner ignores task mappings even for explicit configs.
+        // --no-tasks and --no-appointments still apply here: the runner ignores those
+        // mappings even for explicit configs.
         bool noTasksExplicit = args.Contains("--no-tasks", StringComparer.Ordinal);
+        bool noAppointmentsExplicit = args.Contains("--no-appointments", StringComparer.Ordinal);
         if (!File.Exists(configPath!))
             return new(null, null, null, $"Config not found: {configPath}");
         try
         {
             ConversionConfig config = ConfigLoader.Load(configPath!);
-            return new(config, outputDir, configPath, null, expectedTotal, NoTasks: noTasksExplicit);
+            return new(config, outputDir, configPath, null, expectedTotal, NoTasks: noTasksExplicit, NoAppointments: noAppointmentsExplicit);
         }
         catch (Exception ex)
         {

--- a/src/Mail2Pst.Cli/ConvertInput.cs
+++ b/src/Mail2Pst.Cli/ConvertInput.cs
@@ -101,14 +101,18 @@ internal static class ConvertInput
 
         // --config only (existing behaviour).
         // --no-tasks and --no-appointments still apply here: the runner ignores those
-        // mappings even for explicit configs.
+        // mappings even for explicit configs. --no-contacts is honored by stripping the config's
+        // contact sources (there is no runner-level contact skip flag; the end result is identical).
         bool noTasksExplicit = args.Contains("--no-tasks", StringComparer.Ordinal);
         bool noAppointmentsExplicit = args.Contains("--no-appointments", StringComparer.Ordinal);
+        bool noContactsExplicit = args.Contains("--no-contacts", StringComparer.Ordinal);
         if (!File.Exists(configPath!))
             return new(null, null, null, $"Config not found: {configPath}");
         try
         {
             ConversionConfig config = ConfigLoader.Load(configPath!);
+            if (noContactsExplicit)
+                foreach (OutputGroupConfig o in config.Outputs) o.Contacts.Clear();
             return new(config, outputDir, configPath, null, expectedTotal, NoTasks: noTasksExplicit, NoAppointments: noAppointmentsExplicit);
         }
         catch (Exception ex)

--- a/src/Mail2Pst.Cli/ConvertInput.cs
+++ b/src/Mail2Pst.Cli/ConvertInput.cs
@@ -9,8 +9,10 @@ using Mail2Pst.Core.Discovery;
 namespace Mail2Pst.Cli;
 
 /// <summary>Resolved convert inputs, or a user-facing Error string. Pure (no signals/conversion).
-/// <paramref name="ExpectedTotal"/> is an optional precomputed message count (-1 = count on demand).</summary>
-internal sealed record ConvertResolution(ConversionConfig? Config, string? OutputDir, string? InputLabel, string? Error, int ExpectedTotal = -1);
+/// <paramref name="ExpectedTotal"/> is an optional precomputed message count (-1 = count on demand).
+/// <paramref name="NoTasks"/> reflects the <c>--no-tasks</c> flag; the runner uses this to skip task
+/// assembly even for explicit-config mode where synthesis was never attempted.</summary>
+internal sealed record ConvertResolution(ConversionConfig? Config, string? OutputDir, string? InputLabel, string? Error, int ExpectedTotal = -1, bool NoTasks = false);
 
 /// <summary>
 /// Resolves `convert` arguments into a ConversionConfig (or an error), supporting --config (existing),
@@ -26,7 +28,7 @@ internal static class ConvertInput
 
     // Flags that are standalone (no value token consumed).
     private static readonly System.Collections.Generic.HashSet<string> ValuelessFlags =
-        new(StringComparer.Ordinal) { "--no-contacts" };
+        new(StringComparer.Ordinal) { "--no-contacts", "--no-tasks" };
 
     internal static ConvertResolution Resolve(string[] args)
     {
@@ -64,6 +66,10 @@ internal static class ConvertInput
             // It only applies on the profile/discovery path; explicit --config contacts are unaffected.
             bool noContacts = args.Contains("--no-contacts", StringComparer.Ordinal);
 
+            // --no-tasks opts out of task synthesis in discovery mode and instructs the runner
+            // to skip task mappings entirely in explicit-config mode.
+            bool noTasks = args.Contains("--no-tasks", StringComparer.Ordinal);
+
             ConversionConfig? template = null;
             if (configPath is not null)
             {
@@ -76,8 +82,9 @@ internal static class ConvertInput
             try
             {
                 DiscoveryResult discovery = MailProfileDiscovery.Discover(profileDir);
-                ConversionConfig config = ConfigFromDiscovery.Build(discovery, template, includeContacts: !noContacts);
-                return new(config, outputDir, profileDir, null, expectedTotal);
+                ConversionConfig config = ConfigFromDiscovery.Build(discovery, template,
+                    includeContacts: !noContacts, includeTasks: !noTasks);
+                return new(config, outputDir, profileDir, null, expectedTotal, NoTasks: noTasks);
             }
             catch (Exception ex)
             {
@@ -86,12 +93,14 @@ internal static class ConvertInput
         }
 
         // --config only (existing behaviour).
+        // --no-tasks still applies here: the runner ignores task mappings even for explicit configs.
+        bool noTasksExplicit = args.Contains("--no-tasks", StringComparer.Ordinal);
         if (!File.Exists(configPath!))
             return new(null, null, null, $"Config not found: {configPath}");
         try
         {
             ConversionConfig config = ConfigLoader.Load(configPath!);
-            return new(config, outputDir, configPath, null, expectedTotal);
+            return new(config, outputDir, configPath, null, expectedTotal, NoTasks: noTasksExplicit);
         }
         catch (Exception ex)
         {

--- a/src/Mail2Pst.Cli/DiscoverCommand.cs
+++ b/src/Mail2Pst.Cli/DiscoverCommand.cs
@@ -60,6 +60,15 @@ internal static class DiscoverCommand
                     unpairedMboxCount = r.Pairing.UnpairedMboxCount,
                     orphanMsfCount = r.Pairing.OrphanMsfCount,
                 },
+                calendars = r.Calendars.Select(c => new
+                {
+                    calId = c.CalId, displayName = c.DisplayName, storeKind = c.StoreKind,
+                    storePath = c.StorePath, calendarType = c.CalendarType,
+                    isVisibleInThunderbird = c.IsVisibleInThunderbird,
+                    eventCount = c.EventCount, taskCount = c.TaskCount,
+                    defaultCalendarFolderPath = c.DefaultCalendarFolderPath,
+                    defaultTaskFolderPath = c.DefaultTaskFolderPath,
+                }),
             };
             Console.WriteLine(CliEventSerializer.Serialize(output, indented: true));
             return 0;

--- a/src/Mail2Pst.Core/Calendar/CalendarAttachmentResolver.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarAttachmentResolver.cs
@@ -44,7 +44,8 @@ public sealed class CalendarAttachmentResolver
             {
                 if (p.InlineData.Length > _maxEmbedBytes)
                 {
-                    warns.Add($"attachment on '{subjectForWarnings}': inline attachment too large to embed — preserved as link");
+                    // Inline data has no external reference, so it is dropped (not "preserved as link").
+                    warns.Add($"attachment on '{subjectForWarnings}': inline attachment too large to embed — dropped");
                     atts.Add(new CalendarAttachment(CalendarAttachmentKind.LinkOnly, fileName, mime, null, null, null));
                     continue;
                 }
@@ -87,6 +88,15 @@ public sealed class CalendarAttachmentResolver
     private static readonly StringComparison RootComparison =
         OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 
+    // Defense-in-depth: Thunderbird credential/key stores that must never be embedded even when a
+    // file:// ATTACH resolves to one inside the export root (a crafted calendar could otherwise
+    // exfiltrate secrets into the output PST). Matched by file name, case-insensitively.
+    private static readonly HashSet<string> SensitiveFileNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "logins.json", "logins-backup.json", "key3.db", "key4.db",
+        "cert8.db", "cert9.db", "signons.sqlite", "credentialstate.sqlite",
+    };
+
     private (CalendarAttachmentKind, string?, string?) ResolveLocalFile(string fileUri)
     {
         if (_exportRoot is null) return (CalendarAttachmentKind.LinkOnly, null, "local file outside export root");
@@ -98,6 +108,8 @@ public sealed class CalendarAttachmentResolver
             ? _exportRoot! : _exportRoot! + Path.DirectorySeparatorChar;
         if (!full.StartsWith(rootWithSep, RootComparison))
             return (CalendarAttachmentKind.LinkOnly, null, "local file outside export root");
+        if (SensitiveFileNames.Contains(Path.GetFileName(full)))
+            return (CalendarAttachmentKind.LinkOnly, null, "sensitive profile file, not embedded");
         if (!File.Exists(full))
             return (CalendarAttachmentKind.LinkOnly, null, "local file missing / unreadable");
         // Reject symlinks/reparse points — a link inside the root can target a file OUTSIDE it (escape),

--- a/src/Mail2Pst.Core/Calendar/CalendarAttachmentResolver.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarAttachmentResolver.cs
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Mail2Pst.Core.Models;
+
+namespace Mail2Pst.Core.Calendar;
+
+public sealed class CalendarAttachmentResolver
+{
+    private readonly string? _exportRoot;   // canonical full path; null ⇒ no file resolution allowed
+    public CalendarAttachmentResolver(string? exportRoot) =>
+        _exportRoot = string.IsNullOrWhiteSpace(exportRoot) ? null : Path.GetFullPath(exportRoot);
+
+    public (IReadOnlyList<CalendarAttachment> Attachments, IReadOnlyList<string> Warnings)
+        ResolveAll(IEnumerable<RawSideText> rawAttachLines, string subjectForWarnings)
+    {
+        var atts = new List<CalendarAttachment>();
+        var warns = new List<string>();
+        foreach (RawSideText raw in rawAttachLines)
+        {
+            if (string.IsNullOrWhiteSpace(raw.IcalString)) continue;
+            var parsed = ICalTextParser.ParseAttachment(raw.IcalString!);
+            if (parsed.Value is null)
+            {
+                var errorMsg = parsed.Warnings.Count > 0 ? parsed.Warnings[0] : "parse error";
+                warns.Add($"attachment on '{subjectForWarnings}': parse failed ({errorMsg}) — preserved raw ATTACH text in body");
+                atts.Add(new CalendarAttachment(CalendarAttachmentKind.LinkOnly,
+                    FileNameOrDefault(null), "application/octet-stream", null, null, raw.IcalString));
+                continue;
+            }
+            ParsedAttachment p = parsed.Value;
+            string fileName = FileNameOrDefault(p.FileName);
+            string mime = string.IsNullOrWhiteSpace(p.FormatType) ? "application/octet-stream" : p.FormatType!;
+
+            if (p.InlineData is { Length: > 0 })
+            {
+                atts.Add(new CalendarAttachment(CalendarAttachmentKind.InlineBytes, fileName, mime, p.InlineData, null, null));
+                continue;
+            }
+
+            string? uri = p.Uri;
+            if (uri is not null && uri.StartsWith("file:", StringComparison.OrdinalIgnoreCase))
+            {
+                (CalendarAttachmentKind kind, string? localPath, string? reason) = ResolveLocalFile(uri);
+                if (kind == CalendarAttachmentKind.LocalFileByValue)
+                {
+                    atts.Add(new CalendarAttachment(kind, fileName, mime, null, localPath, null));
+                }
+                else
+                {
+                    warns.Add($"attachment on '{subjectForWarnings}': {reason} — preserved as link");
+                    atts.Add(new CalendarAttachment(CalendarAttachmentKind.LinkOnly, fileName, mime, null, null, uri));
+                }
+                continue;
+            }
+
+            // Remote URL (http/https/webcal/…): never fetched.
+            warns.Add($"attachment on '{subjectForWarnings}': remote URL preserved as link, not fetched");
+            atts.Add(new CalendarAttachment(CalendarAttachmentKind.LinkOnly, fileName, mime, null, null, uri));
+        }
+        return (atts, warns);
+    }
+
+    // Path comparison is a SAFETY boundary: case-insensitive on Windows (its FS is), case-sensitive
+    // elsewhere (Linux/macOS FS is) — OrdinalIgnoreCase everywhere would be more permissive than the FS.
+    private static readonly StringComparison RootComparison =
+        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+    private (CalendarAttachmentKind, string?, string?) ResolveLocalFile(string fileUri)
+    {
+        if (_exportRoot is null) return (CalendarAttachmentKind.LinkOnly, null, "local file outside export root");
+        string full;
+        try { full = Path.GetFullPath(new Uri(fileUri).LocalPath); }
+        catch (Exception) { return (CalendarAttachmentKind.LinkOnly, null, "local file path unreadable"); }
+
+        string rootWithSep = _exportRoot!.EndsWith(Path.DirectorySeparatorChar)
+            ? _exportRoot! : _exportRoot! + Path.DirectorySeparatorChar;
+        if (!full.StartsWith(rootWithSep, RootComparison))
+            return (CalendarAttachmentKind.LinkOnly, null, "local file outside export root");
+        if (!File.Exists(full))
+            return (CalendarAttachmentKind.LinkOnly, null, "local file missing / unreadable");
+        // Reject symlinks/reparse points — a link inside the root can target a file OUTSIDE it (escape),
+        // and the StartsWith check above only guards the LITERAL path, not the link's target. Mirrors the
+        // existing MailTreeDiscovery/MailProfileDiscovery symlink-skip policy.
+        try { if ((File.GetAttributes(full) & FileAttributes.ReparsePoint) != 0)
+            return (CalendarAttachmentKind.LinkOnly, null, "local file is a symlink/reparse point"); }
+        catch (Exception) { return (CalendarAttachmentKind.LinkOnly, null, "local file missing / unreadable"); }
+        try { using var _ = File.OpenRead(full); }
+        catch (Exception) { return (CalendarAttachmentKind.LinkOnly, null, "local file missing / unreadable"); }
+        return (CalendarAttachmentKind.LocalFileByValue, full, null);
+    }
+
+    private static string FileNameOrDefault(string? n) =>
+        string.IsNullOrWhiteSpace(n) ? "attachment" : n!;
+}

--- a/src/Mail2Pst.Core/Calendar/CalendarAttachmentResolver.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarAttachmentResolver.cs
@@ -11,8 +11,13 @@ namespace Mail2Pst.Core.Calendar;
 public sealed class CalendarAttachmentResolver
 {
     private readonly string? _exportRoot;   // canonical full path; null ⇒ no file resolution allowed
-    public CalendarAttachmentResolver(string? exportRoot) =>
+    private readonly long _maxEmbedBytes;   // attachments larger than this degrade to LinkOnly
+
+    public CalendarAttachmentResolver(string? exportRoot, long maxEmbedBytes = int.MaxValue)
+    {
         _exportRoot = string.IsNullOrWhiteSpace(exportRoot) ? null : Path.GetFullPath(exportRoot);
+        _maxEmbedBytes = maxEmbedBytes;
+    }
 
     public (IReadOnlyList<CalendarAttachment> Attachments, IReadOnlyList<string> Warnings)
         ResolveAll(IEnumerable<RawSideText> rawAttachLines, string subjectForWarnings)
@@ -37,6 +42,12 @@ public sealed class CalendarAttachmentResolver
 
             if (p.InlineData is { Length: > 0 })
             {
+                if (p.InlineData.Length > _maxEmbedBytes)
+                {
+                    warns.Add($"attachment on '{subjectForWarnings}': inline attachment too large to embed — preserved as link");
+                    atts.Add(new CalendarAttachment(CalendarAttachmentKind.LinkOnly, fileName, mime, null, null, null));
+                    continue;
+                }
                 atts.Add(new CalendarAttachment(CalendarAttachmentKind.InlineBytes, fileName, mime, p.InlineData, null, null));
                 continue;
             }
@@ -90,6 +101,8 @@ public sealed class CalendarAttachmentResolver
         catch (Exception) { return (CalendarAttachmentKind.LinkOnly, null, "local file missing / unreadable"); }
         try { using var _ = File.OpenRead(full); }
         catch (Exception) { return (CalendarAttachmentKind.LinkOnly, null, "local file missing / unreadable"); }
+        if (new FileInfo(full).Length > _maxEmbedBytes)
+            return (CalendarAttachmentKind.LinkOnly, null, "local file too large to embed (>2 GB)");
         return (CalendarAttachmentKind.LocalFileByValue, full, null);
     }
 

--- a/src/Mail2Pst.Core/Calendar/CalendarAttachmentResolver.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarAttachmentResolver.cs
@@ -58,6 +58,13 @@ public sealed class CalendarAttachmentResolver
                 (CalendarAttachmentKind kind, string? localPath, string? reason) = ResolveLocalFile(uri);
                 if (kind == CalendarAttachmentKind.LocalFileByValue)
                 {
+                    // Thunderbird stores only the URI (no FILENAME param) — an embedded file must
+                    // carry its real basename or Outlook gets an extensionless "attachment".
+                    if (string.IsNullOrWhiteSpace(p.FileName))
+                    {
+                        string basename = Path.GetFileName(localPath!);
+                        if (!string.IsNullOrWhiteSpace(basename)) fileName = basename;
+                    }
                     atts.Add(new CalendarAttachment(kind, fileName, mime, null, localPath, null));
                 }
                 else

--- a/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
@@ -60,6 +60,9 @@ public static class CalendarEventMapper
         if (rz.Warning is { } rzWarn)
             w.Add(rzWarn);
 
+        // allDayFloating: an all-day event with no resolvable source zone. Anchored to the machine
+        // LOCAL zone (local-midnight-in-UTC), NOT UTC — see the all-day computation below.
+        bool allDayFloating = false;
         TimeZoneInfo? resolvedZone;
         if (rz.Zone != null && !rz.IsFloating)
         {
@@ -68,11 +71,14 @@ public static class CalendarEventMapper
         }
         else if (isAllDay)
         {
-            // All-day needs a zone for midnight boundaries; UTC is deterministic
-            resolvedZone   = TimeZoneInfo.Utc;
-            appt.TimeZone  = TimeZoneInfo.Utc;
-            if (rz.Zone == null || rz.IsFloating)
-                w.Add($"all-day event '{title}': unresolved timezone — using UTC for date boundaries");
+            // All-day floating/unresolved: anchor midnight boundaries to the machine local zone and
+            // carry that zone in the tz blob — this is how Outlook authors an all-day event. UTC would
+            // place midnight at the wrong instant for any viewer east of UTC, straddling two calendar
+            // days. (The resolver already warned for a bogus id; genuine floating is normal, so silent.)
+            // See docs/research/2026-06-30-thunderbird-calendar-findings.md ("all-day is NOT floating").
+            resolvedZone   = TimeZoneInfo.Local;
+            appt.TimeZone  = TimeZoneInfo.Local;
+            allDayFloating = true;
         }
         else
         {
@@ -92,11 +98,15 @@ public static class CalendarEventMapper
 
             var tz = resolvedZone ?? TimeZoneInfo.Utc;
 
-            // Convert UTC instant to local date in tz
+            // For a floating all-day event the raw micros ARE the intended wall-clock date; reading it
+            // through the display zone would shift the date across the UTC boundary for negative-offset
+            // zones. For a resolved zone, the stored instant is interpreted in that zone.
+            DateTime AllDayDate(DateTime rawUtc) =>
+                allDayFloating ? rawUtc.Date : TimeZoneInfo.ConvertTimeFromUtc(rawUtc, tz).Date;
+
             if (startOffset is null)
                 w.Add($"all-day event '{title}': missing start — using sentinel date");
-            var startLocalDate = TimeZoneInfo.ConvertTimeFromUtc(
-                startOffset?.UtcDateTime ?? default, tz).Date;
+            var startLocalDate = AllDayDate(startOffset?.UtcDateTime ?? default);
 
             // Build local midnight
             var startLocalMidnight = new DateTime(
@@ -109,7 +119,7 @@ public static class CalendarEventMapper
             DateTime? endLocalMidnight = null;
             if (endOffset is { } eo)
             {
-                var endLocalDate = TimeZoneInfo.ConvertTimeFromUtc(eo.UtcDateTime, tz).Date;
+                var endLocalDate = AllDayDate(eo.UtcDateTime);
                 endLocalMidnight = new DateTime(
                     endLocalDate.Year, endLocalDate.Month, endLocalDate.Day,
                     0, 0, 0, DateTimeKind.Unspecified);

--- a/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
@@ -688,7 +688,7 @@ public static class CalendarEventMapper
             : appt.StartUtc;
 
         var (spec, degradeReason) = RecurrenceMapping.FromIcal(
-            lines, appt.StartUtc, firstStartLocal, appt.TimeZone, master.EventStartTz);
+            lines, appt.StartUtc, firstStartLocal, appt.TimeZone, master.EventStartTz, p);   // reuse the parse above
 
         if (degradeReason is not null)
         {

--- a/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
@@ -93,8 +93,10 @@ public static class CalendarEventMapper
             var tz = resolvedZone ?? TimeZoneInfo.Utc;
 
             // Convert UTC instant to local date in tz
+            if (startOffset is null)
+                w.Add($"all-day event '{title}': missing start — using sentinel date");
             var startLocalDate = TimeZoneInfo.ConvertTimeFromUtc(
-                startOffset?.UtcDateTime ?? DateTime.UtcNow, tz).Date;
+                startOffset?.UtcDateTime ?? default, tz).Date;
 
             // Build local midnight
             var startLocalMidnight = new DateTime(

--- a/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
@@ -250,7 +250,97 @@ public static class CalendarEventMapper
             }
         }
 
+        // --- Attendees (after reminder block, before return) ---
+        var attendeeLines = master.Attendees
+            .Select(s => s.IcalString)
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Select(s => s!)
+            .ToList();
+        if (attendeeLines.Count > 0)
+        {
+            var parsed = ICalTextParser.ParseAttendees(attendeeLines);
+            foreach (var warning in parsed.Warnings) w.Add($"event '{appt.Subject}': {warning}");
+
+            var all = parsed.Value ?? Array.Empty<ParsedAttendee>();
+            AppointmentAttendee? organizer = null;
+            var attendees = new List<AppointmentAttendee>();
+            // Dedup non-organizer attendees by normalized email (case-insensitive, first wins). Pre-seed with the
+            // organizer's email so a duplicate ATTENDEE row for the organizer is dropped (common in CalDAV data).
+            var seenEmails = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            // Organizer first (so its email pre-seeds the dedup set). Organizer MAY be display-only (no email);
+            // the writer simply omits the organizer recipient row when the email is empty.
+            foreach (ParsedAttendee p in all)
+            {
+                if (!p.IsOrganizer) continue;
+                string email = (p.Email ?? "").Trim();
+                string display = !string.IsNullOrWhiteSpace(p.CommonName) ? p.CommonName!.Trim() : email;
+                if (display.Length == 0) break;                       // neither name nor email → no usable organizer
+                organizer = new AppointmentAttendee
+                {
+                    DisplayName = display, Email = email,
+                    Kind = AttendeeKind.Required, Response = AttendeeResponse.Organized, IsOrganizer = true,
+                };
+                if (email.Length > 0) seenEmails.Add(email);
+                break;                                                // only one organizer
+            }
+
+            // Non-organizer attendees: REQUIRE an email (an Outlook recipient row with an empty address is invalid).
+            foreach (ParsedAttendee p in all)
+            {
+                if (p.IsOrganizer) continue;
+                string email = (p.Email ?? "").Trim();
+                if (email.Length == 0)
+                {
+                    w.Add($"event '{appt.Subject}': attendee '{p.CommonName}' has no email — skipped");
+                    continue;
+                }
+                if (!seenEmails.Add(email))                           // case-insensitive dedup (incl. vs the organizer)
+                {
+                    w.Add($"event '{appt.Subject}': duplicate attendee {email} skipped");
+                    continue;
+                }
+                attendees.Add(new AppointmentAttendee
+                {
+                    DisplayName = !string.IsNullOrWhiteSpace(p.CommonName) ? p.CommonName!.Trim() : email,
+                    Email = email,
+                    Kind = MapKind(p.Role, p.CuType),
+                    Response = MapResponse(p.ParticipationStatus, isOrganizer: false),
+                });
+            }
+
+            appt.Organizer = organizer;
+            appt.Attendees = attendees;
+        }
+
         return appt;
+    }
+
+    // ---------------------------------------------------------------------------
+    // Attendee mapping helpers
+    // ---------------------------------------------------------------------------
+
+    // CUTYPE wins (a room is a resource regardless of ROLE); else ROLE; default Required.
+    private static AttendeeKind MapKind(string? role, string? cuType)
+    {
+        string c = (cuType ?? "").Trim().ToUpperInvariant();
+        if (c is "ROOM" or "RESOURCE") return AttendeeKind.Resource;
+        string r = (role ?? "").Trim().ToUpperInvariant();
+        if (r is "OPT-PARTICIPANT" or "NON-PARTICIPANT") return AttendeeKind.Optional;
+        return AttendeeKind.Required;
+    }
+
+    private static AttendeeResponse MapResponse(string? partStat, bool isOrganizer)
+    {
+        if (isOrganizer) return AttendeeResponse.Organized;
+        return (partStat ?? "").Trim().ToUpperInvariant() switch
+        {
+            "ACCEPTED"     => AttendeeResponse.Accepted,
+            "DECLINED"     => AttendeeResponse.Declined,
+            "TENTATIVE"    => AttendeeResponse.Tentative,
+            "NEEDS-ACTION" => AttendeeResponse.NotResponded,
+            _              => AttendeeResponse.None,
+        };
     }
 
     // ---------------------------------------------------------------------------

--- a/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
@@ -1,0 +1,293 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Mail2Pst.Core.Models;
+
+namespace Mail2Pst.Core.Calendar;
+
+public static class CalendarEventMapper
+{
+    private const int EventAllDay = 4;
+
+    public static AppointmentRecord? Map(RawEventGroup group, out IReadOnlyList<string> warnings)
+    {
+        var w = new List<string>();
+        warnings = w;
+
+        RawEvent? master = group.Master;
+        string title = master?.Title ?? "";
+
+        // Group-skip rules (order matters)
+        if (master is null)
+        {
+            w.Add("orphan event override (no master) skipped");
+            return null;
+        }
+        if (group.Overrides.Count > 0)
+        {
+            w.Add($"recurring event '{title}' with exceptions deferred to PR7");
+            return null;
+        }
+        if (master.Recurrence.Count > 0)
+        {
+            w.Add($"recurring event '{title}' deferred to PR7");
+            return null;
+        }
+        if (master.RecurrenceId is not null)
+        {
+            w.Add("event override row deferred to PR7");
+            return null;
+        }
+
+        var appt = new AppointmentRecord
+        {
+            Subject  = title,
+            SourceId = master.Id ?? "",
+        };
+
+        // All-day flag
+        bool isAllDay = (master.Flags & EventAllDay) != 0;
+        appt.IsAllDay = isAllDay;
+
+        // Timezone resolution — always resolve from EventStartTz
+        var rz = TimeZoneResolver.Resolve(master.EventStartTz);
+
+        if (rz.Warning is { } rzWarn)
+            w.Add(rzWarn);
+
+        TimeZoneInfo? resolvedZone;
+        if (rz.Zone != null && !rz.IsFloating)
+        {
+            resolvedZone   = rz.Zone;
+            appt.TimeZone  = rz.Zone;
+        }
+        else if (isAllDay)
+        {
+            // All-day needs a zone for midnight boundaries; UTC is deterministic
+            resolvedZone   = TimeZoneInfo.Utc;
+            appt.TimeZone  = TimeZoneInfo.Utc;
+            if (rz.Zone == null || rz.IsFloating)
+                w.Add($"all-day event '{title}': unresolved timezone — using UTC for date boundaries");
+        }
+        else
+        {
+            // Timed floating/unresolved — keep UTC instant, no display zone
+            resolvedZone   = null;
+            appt.TimeZone  = null;
+            w.Add($"event '{title}': floating/unresolved timezone — stored as a fixed UTC instant");
+        }
+
+        // Start / End
+        if (isAllDay)
+        {
+            // All-day: interpret the raw micros as a calendar date in resolvedZone,
+            // then compute midnight boundaries.
+            var startOffset = PrTime.FromMicros(master.EventStart);
+            var endOffset   = PrTime.FromMicros(master.EventEnd);
+
+            var tz = resolvedZone ?? TimeZoneInfo.Utc;
+
+            // Convert UTC instant to local date in tz
+            var startLocalDate = TimeZoneInfo.ConvertTimeFromUtc(
+                startOffset?.UtcDateTime ?? DateTime.UtcNow, tz).Date;
+
+            // Build local midnight
+            var startLocalMidnight = new DateTime(
+                startLocalDate.Year, startLocalDate.Month, startLocalDate.Day,
+                0, 0, 0, DateTimeKind.Unspecified);
+
+            appt.StartUtc = TimeZoneInfo.ConvertTimeToUtc(startLocalMidnight, tz);
+
+            // Compute end local midnight
+            DateTime? endLocalMidnight = null;
+            if (endOffset is { } eo)
+            {
+                var endLocalDate = TimeZoneInfo.ConvertTimeFromUtc(eo.UtcDateTime, tz).Date;
+                endLocalMidnight = new DateTime(
+                    endLocalDate.Year, endLocalDate.Month, endLocalDate.Day,
+                    0, 0, 0, DateTimeKind.Unspecified);
+            }
+
+            // If end <= start (in local) or end is null → one-day boundary
+            if (endLocalMidnight is null || endLocalMidnight.Value <= startLocalMidnight)
+                appt.EndUtc = appt.StartUtc.AddDays(1);
+            else
+                appt.EndUtc = TimeZoneInfo.ConvertTimeToUtc(endLocalMidnight.Value, tz);
+        }
+        else
+        {
+            // Timed events
+            appt.StartUtc = PrTime.FromMicros(master.EventStart)?.UtcDateTime ?? default;
+            appt.EndUtc   = PrTime.FromMicros(master.EventEnd)?.UtcDateTime   ?? appt.StartUtc;
+
+            if (appt.EndUtc < appt.StartUtc)
+            {
+                w.Add($"event '{title}': end precedes start — clamped to start");
+                appt.EndUtc = appt.StartUtc;
+            }
+            else if (appt.EndUtc == appt.StartUtc)
+            {
+                w.Add($"event '{title}': zero-length event");
+            }
+        }
+
+        // Body (DESCRIPTION property)
+        appt.Body = PropValue(master, "DESCRIPTION");
+
+        // BodyHtml — ALTREP data:text/html on DESCRIPTION parameter
+        var altrep = master.Parameters.FirstOrDefault(p =>
+            string.Equals(p.Key1, "DESCRIPTION", StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(p.Key2, "ALTREP",      StringComparison.OrdinalIgnoreCase));
+
+        if (altrep?.Value is { } altrepUri &&
+            altrepUri.StartsWith("data:", StringComparison.OrdinalIgnoreCase) &&
+            IcalDataUri.TryDecode(altrepUri, out var altrepMediaType, out var altrepBytes) &&
+            altrepMediaType.StartsWith("text/html", StringComparison.OrdinalIgnoreCase))
+        {
+            appt.BodyHtml = Encoding.UTF8.GetString(altrepBytes);
+        }
+
+        // Location
+        appt.Location = PropValue(master, "LOCATION");
+
+        // Categories
+        var cats = PropValue(master, "CATEGORIES");
+        appt.Categories = cats is not null ? SplitCategories(cats) : Array.Empty<string>();
+
+        // BusyStatus (explicit precedence)
+        // 1. TENTATIVE status → 1
+        // 2. TRANSP=TRANSPARENT → 0 (Free)
+        // 3. default → 2 (Busy)
+        if (string.Equals(master.IcalStatus, "TENTATIVE", StringComparison.OrdinalIgnoreCase))
+            appt.BusyStatus = 1;
+        else if (string.Equals(PropValue(master, "TRANSP"), "TRANSPARENT", StringComparison.OrdinalIgnoreCase))
+            appt.BusyStatus = 0;
+        else
+            appt.BusyStatus = 2;
+
+        // Importance from iCal PRIORITY
+        appt.Importance = master.Priority switch
+        {
+            >= 1 and <= 4 => 2, // high
+            >= 6 and <= 9 => 0, // low
+            _             => 1, // normal (5 or null)
+        };
+
+        // Sensitivity from CLASS (Privacy column first, then CLASS property)
+        var cls = master.Privacy ?? PropValue(master, "CLASS");
+        appt.Sensitivity = cls?.ToUpperInvariant() switch
+        {
+            "PRIVATE"      => 2,
+            "CONFIDENTIAL" => 3,
+            _              => 0,
+        };
+
+        // Reminder — map first VALARM; warn if multiple alarms present
+        if (master.Alarms.Count > 1)
+            w.Add($"event '{title}': multiple Thunderbird alarms — only the first is converted");
+
+        if (master.Alarms.Count > 0)
+        {
+            var rawBlock   = master.Alarms[0].IcalString ?? "";
+            var alarmResult = ICalTextParser.ParseAlarm(rawBlock);
+
+            foreach (var aw in alarmResult.Warnings)
+                w.Add(aw);
+
+            if (alarmResult.Value is { } alarm)
+            {
+                if (alarm.AbsoluteTimeUtc is { } absUtc)
+                {
+                    // Absolute trigger — compute minutes before StartUtc
+                    appt.ReminderSet = true;
+                    appt.ReminderMinutesBefore =
+                        (int)Math.Max(0, Math.Round((appt.StartUtc - absUtc).TotalMinutes));
+                }
+                else if (alarm.RelativeOffset is { } offset)
+                {
+                    // Relative trigger — anchor by Related
+                    DateTime anchor = alarm.Related switch
+                    {
+                        "END"   => appt.EndUtc,
+                        _       => appt.StartUtc, // START or default
+                    };
+
+                    if (offset < TimeSpan.Zero)
+                    {
+                        // Negative offset — fires before anchor; valid reminder
+                        appt.ReminderSet = true;
+                        appt.ReminderMinutesBefore = (int)Math.Round(-offset.TotalMinutes);
+                    }
+                    else
+                    {
+                        // Zero or positive — fires at/after anchor; skip reminder
+                        w.Add($"event '{title}': reminder fires at/after the anchor — not converted");
+                        AppendRawTriggerToBody(appt, rawBlock);
+                    }
+                }
+            }
+            else
+            {
+                // Parse failed; warnings already added above; preserve raw trigger in body.
+                AppendRawTriggerToBody(appt, rawBlock);
+            }
+        }
+
+        return appt;
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private static string? PropValue(RawEvent ev, string key)
+    {
+        RawProperty? p = ev.Properties.FirstOrDefault(
+            x => string.Equals(x.Key, key, StringComparison.OrdinalIgnoreCase));
+        return p?.Value is { } b ? Encoding.UTF8.GetString(b) : null;
+    }
+
+    /// <summary>
+    /// Splits a CATEGORIES value on commas that are NOT escaped by a preceding backslash,
+    /// then unescapes each token's \, sequences.  Trims whitespace and drops empty tokens
+    /// and X-MOZ-* prefixed categories.
+    /// </summary>
+    private static IReadOnlyList<string> SplitCategories(string raw)
+    {
+        var parts  = Regex.Split(raw, @"(?<!\\),");
+        var result = new List<string>(parts.Length);
+        foreach (var part in parts)
+        {
+            var cat = part.Replace("\\,", ",").Trim();
+            if (!string.IsNullOrEmpty(cat) &&
+                !cat.StartsWith("X-MOZ-", StringComparison.OrdinalIgnoreCase))
+                result.Add(cat);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Extracts the raw TRIGGER line from a VALARM block and appends a
+    /// "not converted" notice to the appointment body.
+    /// </summary>
+    private static void AppendRawTriggerToBody(AppointmentRecord appt, string rawBlock)
+    {
+        string? triggerLine = null;
+        foreach (var line in rawBlock.Split('\n'))
+        {
+            var trimmed = line.TrimEnd('\r').Trim();
+            if (trimmed.StartsWith("TRIGGER", StringComparison.OrdinalIgnoreCase))
+            {
+                triggerLine = trimmed;
+                break;
+            }
+        }
+        if (triggerLine is not null)
+            appt.Body = (appt.Body ?? "") + $"\n[Thunderbird alarm not converted: {triggerLine}]";
+    }
+}

--- a/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
@@ -229,10 +229,19 @@ public static class CalendarEventMapper
             {
                 if (alarm.AbsoluteTimeUtc is { } absUtc)
                 {
-                    // Absolute trigger — compute minutes before StartUtc
-                    appt.ReminderSet = true;
-                    appt.ReminderMinutesBefore =
-                        (int)Math.Max(0, Math.Round((appt.StartUtc - absUtc).TotalMinutes));
+                    // Absolute trigger — minutes before StartUtc. A trigger at/after start would clamp to
+                    // fire-at-start; drop it with a warning instead (symmetry with the relative path).
+                    double minutesBefore = (appt.StartUtc - absUtc).TotalMinutes;
+                    if (minutesBefore > 0)
+                    {
+                        appt.ReminderSet = true;
+                        appt.ReminderMinutesBefore = (int)Math.Round(minutesBefore);
+                    }
+                    else
+                    {
+                        w.Add($"event '{title}': reminder fires at/after the event start — not converted");
+                        AppendRawTriggerToBody(appt, rawBlock);
+                    }
                 }
                 else if (alarm.RelativeOffset is { } offset)
                 {
@@ -260,6 +269,12 @@ public static class CalendarEventMapper
                         w.Add($"event '{title}': reminder fires at/after the anchor — not converted");
                         AppendRawTriggerToBody(appt, rawBlock);
                     }
+                }
+                else
+                {
+                    // Parsed but no usable trigger (e.g. a VALARM with no TRIGGER line); don't drop silently.
+                    w.Add($"event '{title}': alarm has no usable trigger — not converted");
+                    AppendRawTriggerToBody(appt, rawBlock);
                 }
             }
             else
@@ -480,9 +495,13 @@ public static class CalendarEventMapper
     /// For date-only values (<paramref name="isDateOnly"/>), the local midnight in
     /// <paramref name="tzId"/> is used as the reference point.
     /// </summary>
-    private static RecurrenceInstanceId ToInstanceId(string value, string? tzId, bool isDateOnly)
+    // Returns null when the value cannot be parsed, so the caller skips that EXDATE with a warning
+    // instead of emitting a default(0001-01-01) date that would break the vendored serializer.
+    // internal for direct unit testing (via InternalsVisibleTo).
+    internal static RecurrenceInstanceId? ToInstanceId(string value, string? tzId, bool isDateOnly)
     {
         var zone = ResolveZone(tzId);
+        value = value?.Trim() ?? "";   // tolerate whitespace-padded EXDATE tokens
 
         if (isDateOnly)
         {
@@ -494,7 +513,7 @@ public static class CalendarEventMapper
                 var utc = TimeZoneInfo.ConvertTimeToUtc(localMidnight, zone);
                 return new RecurrenceInstanceId(utc, localMidnight, tzId, IsDateOnly: true);
             }
-            return new RecurrenceInstanceId(default, default, tzId, IsDateOnly: true);
+            return null;
         }
         else
         {
@@ -521,7 +540,7 @@ public static class CalendarEventMapper
                 }
                 return new RecurrenceInstanceId(utc, local, tzId, IsDateOnly: false);
             }
-            return new RecurrenceInstanceId(default, default, tzId, IsDateOnly: false);
+            return null;
         }
     }
 
@@ -686,10 +705,16 @@ public static class CalendarEventMapper
         appt.Recurrence = spec;
 
         // Map EXDATEs to deleted-occurrence identities (appointment-only; stays here).
-        appt.DeletedOccurrences = p.ExDates
-            .SelectMany(dl => dl.Values.Select(v =>
-                ToInstanceId(v, dl.TzId ?? master.EventStartTz, dl.IsDateOnly)))
-            .ToList();
+        // An unparseable EXDATE is skipped with a warning rather than emitted as a default(0001-01-01).
+        var deleted = new List<RecurrenceInstanceId>();
+        foreach (var dl in p.ExDates)
+            foreach (var v in dl.Values)
+            {
+                var id = ToInstanceId(v, dl.TzId ?? master.EventStartTz, dl.IsDateOnly);
+                if (id is not null) deleted.Add(id);
+                else w.Add($"event '{appt.Subject}': unparseable EXDATE '{v}' skipped");
+            }
+        appt.DeletedOccurrences = deleted;
 
         // Map override exceptions (appointment-only; stays here).
         appt.Exceptions = group.Overrides

--- a/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
@@ -327,6 +327,33 @@ public static class CalendarEventMapper
             appt.Attendees = attendees;
         }
 
+        // --- Online-meeting join URL (Teams / Google Meet) ---
+        // Only these two provider X-props trigger URL preservation; ordinary URLs in
+        // DESCRIPTION or LOCATION are not promoted (no over-promotion rule).
+        var joinUrl =
+            PropValue(master, "X-MICROSOFT-SKYPETEAMSMEETINGURL") ??
+            PropValue(master, "X-GOOGLE-CONFERENCE");
+
+        if (joinUrl is { Length: > 0 })
+        {
+            // Plain body: append if the URL is not already present in Body or Location.
+            bool inBody     = appt.Body     is { } b && b.Contains(joinUrl, StringComparison.Ordinal);
+            bool inLocation = appt.Location is { } l && l.Contains(joinUrl, StringComparison.Ordinal);
+
+            if (!inBody && !inLocation)
+                appt.Body = (appt.Body ?? "") + $"\nJoin online meeting: {joinUrl}";
+
+            // HTML body: append an anchor block if BodyHtml is present and URL not already there.
+            if (appt.BodyHtml is { Length: > 0 } html &&
+                !html.Contains(joinUrl, StringComparison.Ordinal))
+            {
+                var escapedUrl   = HtmlEscape(joinUrl);
+                var escapedLabel = HtmlEscape($"Join online meeting: {joinUrl}");
+                appt.BodyHtml = html +
+                    $"<p><a href=\"{escapedUrl}\">{escapedLabel}</a></p>";
+            }
+        }
+
         return appt;
     }
 
@@ -367,6 +394,13 @@ public static class CalendarEventMapper
             x => string.Equals(x.Key, key, StringComparison.OrdinalIgnoreCase));
         return p?.Value is { } b ? Encoding.UTF8.GetString(b) : null;
     }
+
+    /// <summary>
+    /// Minimal HTML escaping for placing text or a URL attribute value into an HTML fragment.
+    /// Escapes &amp;, &lt;, and &gt; — sufficient for the join-URL anchor appended by the mapper.
+    /// </summary>
+    private static string HtmlEscape(string s) =>
+        s.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
 
     /// <summary>
     /// Splits a CATEGORIES value on commas that are NOT escaped by a preceding backslash,

--- a/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
@@ -771,7 +771,9 @@ public static class CalendarEventMapper
 
         // Build the RRULE body for Ical.Net (strip the "RRULE:" prefix).
         string rruleLine = lines.First(l => l.StartsWith("RRULE", StringComparison.OrdinalIgnoreCase));
-        string rawRRuleBody = StripRRulePrefix(IcalParseSupport.UnfoldIcalLines(rruleLine));
+        // Trim() strips the trailing CRLF Mozilla stores on each property so the RRULE body embedded
+        // in the COUNT-enumeration VCALENDAR text is a clean single line.
+        string rawRRuleBody = StripRRulePrefix(IcalParseSupport.UnfoldIcalLines(rruleLine).Trim());
 
         var spec = new RecurrenceSpec
         {

--- a/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
@@ -458,9 +458,9 @@ public static class CalendarEventMapper
 
         if (p.Frequency == ParsedFrequency.Yearly)
         {
-            // YearlyNth: one BYDAY with a supported offset + one BYMONTH.
-            if (p.ByDay.Count == 1 && p.ByDay[0].Offset is not null && p.ByMonth.Count == 1)
-                return null;
+            // YearlyNth: one BYDAY with a supported offset (1..4 or -1) + one BYMONTH.
+            if (p.ByDay.Count == 1 && p.ByDay[0].Offset is { } off && p.ByMonth.Count == 1)
+                return (off is >= 1 and <= 4 or -1) ? null : "unrepresentable monthly/yearly pattern";
 
             // Yearly: one BYMONTH + one BYMONTHDAY, no BYDAY.
             if (p.ByMonth.Count == 1 && p.ByMonthDay.Count == 1 && p.ByDay.Count == 0)

--- a/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
@@ -245,9 +245,14 @@ public static class CalendarEventMapper
 
                     if (offset < TimeSpan.Zero)
                     {
-                        // Negative offset — fires before anchor; valid reminder
+                        // Negative offset — fires before the anchor; valid reminder. PidLidReminderDelta is
+                        // minutes-before-START, so an END anchor must be re-expressed relative to start:
+                        // delta = Start − (anchor + offset). For START this is just −offset (unchanged); for
+                        // END on a timed event it can be negative (fires after start, before end) — the
+                        // writer's PidLidReminderSignalTime = Start − delta still lands on the correct instant.
                         appt.ReminderSet = true;
-                        appt.ReminderMinutesBefore = (int)Math.Round(-offset.TotalMinutes);
+                        DateTime signalTime = anchor + offset;
+                        appt.ReminderMinutesBefore = (int)Math.Round((appt.StartUtc - signalTime).TotalMinutes);
                     }
                     else
                     {

--- a/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
@@ -3,9 +3,13 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using Ical.Net.CalendarComponents;
+using Ical.Net.DataTypes;
+using IcalCalendar = Ical.Net.Calendar;
 using Mail2Pst.Core.Models;
 
 namespace Mail2Pst.Core.Calendar;
@@ -28,19 +32,11 @@ public static class CalendarEventMapper
             w.Add("orphan event override (no master) skipped");
             return null;
         }
-        if (group.Overrides.Count > 0)
-        {
-            w.Add($"recurring event '{title}' with exceptions deferred to PR7");
-            return null;
-        }
-        if (master.Recurrence.Count > 0)
-        {
-            w.Add($"recurring event '{title}' deferred to PR7");
-            return null;
-        }
+        // Defensive guard: a lone override mis-grouped as master (RECURRENCE-ID set on the master row).
+        // This should not occur after correct grouping, but guard against it defensively.
         if (master.RecurrenceId is not null)
         {
-            w.Add("event override row deferred to PR7");
+            w.Add("event override row mis-grouped as master; skipped");
             return null;
         }
 
@@ -143,6 +139,13 @@ public static class CalendarEventMapper
                 w.Add($"event '{title}': zero-length event");
             }
         }
+
+        // Preserve the originating timezone id verbatim (canonical IANA/Olson or tzone:// id from TB).
+        appt.OriginatingTimeZoneId = master.EventStartTz;
+
+        // Apply recurrence (RRULE/EXDATE) and exception overrides when present.
+        if (master.Recurrence.Count > 0 || group.Overrides.Count > 0)
+            ApplyRecurrence(appt, master, group, w);
 
         // Body (DESCRIPTION property)
         appt.Body = PropValue(master, "DESCRIPTION");
@@ -391,5 +394,417 @@ public static class CalendarEventMapper
         }
         if (triggerLine is not null)
             appt.Body = (appt.Body ?? "") + $"\n[Thunderbird alarm not converted: {triggerLine}]";
+    }
+
+    // ---------------------------------------------------------------------------
+    // Recurrence helpers
+    // ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// Resolves a timezone id string to a <see cref="TimeZoneInfo"/> using the same
+    /// rules as <see cref="TimeZoneResolver"/>. Falls back to UTC when unresolvable.
+    /// </summary>
+    private static TimeZoneInfo ResolveZone(string? tzId) =>
+        TimeZoneResolver.Resolve(tzId).Zone ?? TimeZoneInfo.Utc;
+
+    /// <summary>
+    /// Strips the <c>RRULE:</c> prefix (case-insensitive) from a raw iCal RRULE line,
+    /// returning the bare rule body consumed by <see cref="RecurrencePattern"/>.
+    /// </summary>
+    private static string StripRRulePrefix(string line)
+    {
+        const string prefix = "RRULE:";
+        return line.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            ? line.Substring(prefix.Length)
+            : line;
+    }
+
+    /// <summary>
+    /// Returns a non-null reason string when the parsed recurrence cannot be faithfully
+    /// represented in the <see cref="RecurrenceSpec"/> model, or <c>null</c> when the
+    /// rule is mappable.
+    /// </summary>
+    private static string? DegradeReason(ParsedRecurrence p, List<string> lines)
+    {
+        // 1. Unknown FREQ (ical.net returned ParsedFrequency.Unknown for an unrecognised value).
+        if (p.Frequency == ParsedFrequency.Unknown) return "Unknown FREQ";
+
+        // 2. BYSETPOS (e.g. "last Monday of month") — not representable in RecurrenceSpec.
+        if (p.BySetPosition.Count > 0) return "BYSETPOS";
+
+        // 3. RDATE — additional explicit dates outside of the RRULE pattern.
+        if (p.RDates.Count > 0) return "RDATE";
+
+        // 4. Multiple RRULE lines — we only handle a single rule.
+        int rruleCount = lines.Count(l => l.StartsWith("RRULE", StringComparison.OrdinalIgnoreCase));
+        if (rruleCount > 1) return "multiple RRULE";
+
+        // 5. WKST when INTERVAL > 1 — the work-week start shifts grouping boundaries; degrade.
+        bool hasWkst = lines.Any(l => l.Contains("WKST=", StringComparison.OrdinalIgnoreCase));
+        if (hasWkst && p.Interval > 1) return "WKST interval-sensitive";
+
+        // 6 & 7. Cardinality rules for Monthly / Yearly.
+        if (p.Frequency == ParsedFrequency.Monthly)
+        {
+            // MonthlyNth: exactly one BYDAY with a supported offset (1..4 or -1).
+            if (p.ByDay.Count == 1 && p.ByDay[0].Offset is { } off)
+                return (off is >= 1 and <= 4 or -1) ? null : "unrepresentable monthly/yearly pattern";
+
+            // Monthly-by-day: exactly one BYMONTHDAY, no BYDAY.
+            if (p.ByMonthDay.Count == 1 && p.ByDay.Count == 0) return null;
+
+            return "unrepresentable monthly/yearly pattern";
+        }
+
+        if (p.Frequency == ParsedFrequency.Yearly)
+        {
+            // YearlyNth: one BYDAY with a supported offset + one BYMONTH.
+            if (p.ByDay.Count == 1 && p.ByDay[0].Offset is not null && p.ByMonth.Count == 1)
+                return null;
+
+            // Yearly: one BYMONTH + one BYMONTHDAY, no BYDAY.
+            if (p.ByMonth.Count == 1 && p.ByMonthDay.Count == 1 && p.ByDay.Count == 0)
+                return null;
+
+            return "unrepresentable monthly/yearly pattern";
+        }
+
+        // Daily / Weekly — always mappable.
+        return null;
+    }
+
+    /// <summary>Maps a <see cref="ParsedRecurrence"/> frequency to the model enum.
+    /// <see cref="DegradeReason"/> must return <c>null</c> before this is called.</summary>
+    private static AppointmentRecurrenceFrequency MapFreq(ParsedRecurrence p) => p.Frequency switch
+    {
+        ParsedFrequency.Daily   => AppointmentRecurrenceFrequency.Daily,
+        ParsedFrequency.Weekly  => AppointmentRecurrenceFrequency.Weekly,
+        ParsedFrequency.Monthly =>
+            p.ByDay.Count == 1 && p.ByDay[0].Offset is not null
+                ? AppointmentRecurrenceFrequency.MonthlyNth
+                : AppointmentRecurrenceFrequency.Monthly,
+        ParsedFrequency.Yearly  =>
+            p.ByDay.Count == 1 && p.ByDay[0].Offset is not null
+                ? AppointmentRecurrenceFrequency.YearlyNth
+                : AppointmentRecurrenceFrequency.Yearly,
+        _ => throw new InvalidOperationException($"Unmapped ParsedFrequency: {p.Frequency}"),
+    };
+
+    /// <summary>
+    /// Computes the UTC start of the last occurrence of a recurrence rule.
+    /// Returns <c>null</c> for <see cref="RecurrenceEndKind.NoEnd"/>.
+    /// For <see cref="RecurrenceEndKind.Until"/> returns <see cref="RecurrenceSpec.UntilUtc"/> directly
+    /// (no enumeration).  For <see cref="RecurrenceEndKind.Count"/> enumerates the COUNT-th raw occurrence
+    /// (EXDATE does NOT reduce the COUNT).
+    /// </summary>
+    private static DateTime? ComputeLastInstanceUtc(RecurrenceSpec s)
+    {
+        switch (s.EndKind)
+        {
+            case RecurrenceEndKind.NoEnd:
+                return null;
+
+            case RecurrenceEndKind.Until:
+                // UNTIL bound is the last-occurrence date: no enumeration needed.
+                return s.UntilUtc;
+
+            case RecurrenceEndKind.Count:
+            {
+                // Build a minimal VCALENDAR anchored at FirstStartLocal (floating — no TZ suffix)
+                // so Ical.Net enumerates in local time without any IANA / Windows zone lookups.
+                // Calendar.GetOccurrences respects COUNT: it will return exactly COUNT occurrences.
+                var anchor = s.FirstStartLocal;
+                string dtFmt = anchor.ToString("yyyyMMddTHHmmss", CultureInfo.InvariantCulture);
+                string calText =
+                    "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//ContinuMail//recurrence//EN\r\n" +
+                    "BEGIN:VEVENT\r\nUID:count-enum@continmail\r\n" +
+                    $"DTSTART:{dtFmt}\r\n" +
+                    $"DTEND:{dtFmt}\r\n" +
+                    $"RRULE:{s.RawRRuleBody}\r\n" +
+                    "END:VEVENT\r\nEND:VCALENDAR\r\n";
+
+                try
+                {
+                    var enumCal = IcalCalendar.Load(calText);
+                    if (enumCal?.Events.Count == 0) return null;
+
+                    // In Ical.Net 5.x, GetOccurrences(CalDateTime startTime) returns all occurrences
+                    // from startTime onward, respecting COUNT. No end-date parameter needed.
+                    var startDt = new CalDateTime(
+                        anchor.Year, anchor.Month, anchor.Day,
+                        anchor.Hour, anchor.Minute, anchor.Second, string.Empty);
+
+                    var occs = enumCal.GetOccurrences(startDt)
+                                      .OrderBy(o => o.Period.StartTime)
+                                      .ToList();
+
+                    int idx = (s.Count ?? 0) - 1;
+                    if (idx < 0 || idx >= occs.Count) return null;
+
+                    var lastLocalRaw = occs[idx].Period.StartTime.Value;
+                    var lastLocal    = new DateTime(
+                        lastLocalRaw.Year, lastLocalRaw.Month, lastLocalRaw.Day,
+                        lastLocalRaw.Hour, lastLocalRaw.Minute, lastLocalRaw.Second,
+                        DateTimeKind.Unspecified);
+
+                    return s.TimeZone != null
+                        ? TimeZoneInfo.ConvertTimeToUtc(lastLocal, s.TimeZone)
+                        : DateTime.SpecifyKind(lastLocal, DateTimeKind.Utc);
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+
+            default:
+                return null;
+        }
+    }
+
+    /// <summary>
+    /// Converts a raw EXDATE date/datetime string to a <see cref="RecurrenceInstanceId"/>.
+    /// For date-only values (<paramref name="isDateOnly"/>), the local midnight in
+    /// <paramref name="tzId"/> is used as the reference point.
+    /// </summary>
+    private static RecurrenceInstanceId ToInstanceId(string value, string? tzId, bool isDateOnly)
+    {
+        var zone = ResolveZone(tzId);
+
+        if (isDateOnly)
+        {
+            if (DateTime.TryParseExact(value, "yyyyMMdd", CultureInfo.InvariantCulture,
+                DateTimeStyles.None, out var date))
+            {
+                var localMidnight = new DateTime(date.Year, date.Month, date.Day,
+                    0, 0, 0, DateTimeKind.Unspecified);
+                var utc = TimeZoneInfo.ConvertTimeToUtc(localMidnight, zone);
+                return new RecurrenceInstanceId(utc, localMidnight, tzId, IsDateOnly: true);
+            }
+            return new RecurrenceInstanceId(default, default, tzId, IsDateOnly: true);
+        }
+        else
+        {
+            // yyyyMMddTHHmmssZ (UTC) or yyyyMMddTHHmmss (local in tzId zone)
+            bool isUtc = value.EndsWith("Z", StringComparison.OrdinalIgnoreCase);
+            string valueTrimmed = isUtc ? value.TrimEnd('z', 'Z') : value;
+
+            if (DateTime.TryParseExact(valueTrimmed, "yyyyMMddTHHmmss", CultureInfo.InvariantCulture,
+                DateTimeStyles.None, out var parsed))
+            {
+                DateTime utc, local;
+                if (isUtc)
+                {
+                    utc   = DateTime.SpecifyKind(parsed, DateTimeKind.Utc);
+                    local = new DateTime(
+                        TimeZoneInfo.ConvertTimeFromUtc(utc, zone).Ticks,
+                        DateTimeKind.Unspecified);
+                }
+                else
+                {
+                    local = new DateTime(parsed.Year, parsed.Month, parsed.Day,
+                        parsed.Hour, parsed.Minute, parsed.Second, DateTimeKind.Unspecified);
+                    utc = TimeZoneInfo.ConvertTimeToUtc(local, zone);
+                }
+                return new RecurrenceInstanceId(utc, local, tzId, IsDateOnly: false);
+            }
+            return new RecurrenceInstanceId(default, default, tzId, IsDateOnly: false);
+        }
+    }
+
+    /// <summary>
+    /// Maps a RECURRENCE-ID override <see cref="RawEvent"/> to an <see cref="AppointmentException"/>.
+    /// Returns <c>null</c> when the override has no <c>RECURRENCE-ID</c> (should not happen after
+    /// correct grouping, but guard defensively).
+    /// Emits a warning into <paramref name="w"/> for fields that are not encoded by the writer in
+    /// this release (Body, Reminder, Sensitivity, Categories).
+    /// </summary>
+    private static AppointmentException? ToException(RawEvent o, List<string> w)
+    {
+        if (o.RecurrenceId is null) return null;
+
+        // Resolve the original-instance identity from the override's RECURRENCE-ID micros.
+        var zone    = ResolveZone(o.RecurrenceIdTz);
+        var utc     = PrTime.FromMicros(o.RecurrenceId)?.UtcDateTime ?? default;
+        var localRaw = TimeZoneInfo.ConvertTimeFromUtc(utc, zone);
+        var local   = new DateTime(localRaw.Year, localRaw.Month, localRaw.Day,
+            localRaw.Hour, localRaw.Minute, localRaw.Second, DateTimeKind.Unspecified);
+        var instanceId = new RecurrenceInstanceId(utc, local, o.RecurrenceIdTz, IsDateOnly: false);
+
+        var flags  = AppointmentExceptionChangeFlags.None;
+        string?  subject  = null;
+        string?  location = null;
+        string?  body     = null;
+        int?     busyStatus = null;
+        DateTime? newStart = null;
+        DateTime? newEnd   = null;
+
+        // Subject
+        if (!string.IsNullOrEmpty(o.Title))
+        {
+            subject = o.Title;
+            flags |= AppointmentExceptionChangeFlags.Subject;
+        }
+
+        // StartEnd
+        if (o.EventStart.HasValue || o.EventEnd.HasValue)
+        {
+            newStart = PrTime.FromMicros(o.EventStart)?.UtcDateTime;
+            newEnd   = PrTime.FromMicros(o.EventEnd)?.UtcDateTime;
+            flags |= AppointmentExceptionChangeFlags.StartEnd;
+        }
+
+        // Location
+        byte[]? locVal = o.Properties
+            .FirstOrDefault(p => string.Equals(p.Key, "LOCATION", StringComparison.OrdinalIgnoreCase))?.Value;
+        if (locVal is not null)
+        {
+            location = Encoding.UTF8.GetString(locVal);
+            flags |= AppointmentExceptionChangeFlags.Location;
+        }
+
+        // Body (DESCRIPTION) — stored in model but not encoded by the writer; warn.
+        byte[]? bodyVal = o.Properties
+            .FirstOrDefault(p => string.Equals(p.Key, "DESCRIPTION", StringComparison.OrdinalIgnoreCase))?.Value;
+        if (bodyVal is not null)
+        {
+            body = Encoding.UTF8.GetString(bodyVal);
+            flags |= AppointmentExceptionChangeFlags.Body;
+            w.Add($"exception for '{o.Title}': changed Body not encoded in this version; stored in model only");
+        }
+
+        // BusyStatus (from TENTATIVE status or TRANSP)
+        string? transp = null;
+        byte[]? transpVal = o.Properties
+            .FirstOrDefault(p => string.Equals(p.Key, "TRANSP", StringComparison.OrdinalIgnoreCase))?.Value;
+        if (transpVal is not null) transp = Encoding.UTF8.GetString(transpVal);
+
+        if (string.Equals(o.IcalStatus, "TENTATIVE", StringComparison.OrdinalIgnoreCase))
+        { busyStatus = 1; flags |= AppointmentExceptionChangeFlags.BusyStatus; }
+        else if (string.Equals(transp, "TRANSPARENT", StringComparison.OrdinalIgnoreCase))
+        { busyStatus = 0; flags |= AppointmentExceptionChangeFlags.BusyStatus; }
+        else if (string.Equals(transp, "OPAQUE", StringComparison.OrdinalIgnoreCase))
+        { busyStatus = 2; flags |= AppointmentExceptionChangeFlags.BusyStatus; }
+
+        // Reminder — stored in model but not encoded by the writer; warn.
+        if (o.Alarms.Count > 0)
+        {
+            flags |= AppointmentExceptionChangeFlags.Reminder;
+            w.Add($"exception for '{o.Title}': changed Reminder not encoded in this version; stored in model only");
+        }
+
+        // Sensitivity — stored in model but not encoded by the writer; warn.
+        if (!string.IsNullOrEmpty(o.Privacy))
+        {
+            flags |= AppointmentExceptionChangeFlags.Sensitivity;
+            w.Add($"exception for '{o.Title}': changed Sensitivity not encoded in this version; stored in model only");
+        }
+
+        // Categories — stored in model but not encoded by the writer; warn.
+        byte[]? catsVal = o.Properties
+            .FirstOrDefault(p => string.Equals(p.Key, "CATEGORIES", StringComparison.OrdinalIgnoreCase))?.Value;
+        if (catsVal is not null)
+        {
+            flags |= AppointmentExceptionChangeFlags.Categories;
+            w.Add($"exception for '{o.Title}': changed Categories not encoded in this version; stored in model only");
+        }
+
+        return new AppointmentException
+        {
+            OriginalInstance       = instanceId,
+            NewStartUtc            = newStart,
+            NewEndUtc              = newEnd,
+            Subject                = subject,
+            Location               = location,
+            Body                   = body,
+            BusyStatus             = busyStatus,
+            ChangeFlags            = flags,
+        };
+    }
+
+    /// <summary>
+    /// Applies RRULE/EXDATE recurrence data and override exceptions to <paramref name="appt"/>.
+    /// Degrades to a single occurrence (no <c>Recurrence</c> set) with a warning when the rule
+    /// cannot be faithfully mapped; a degraded result is still returned (never null).
+    /// </summary>
+    private static void ApplyRecurrence(
+        AppointmentRecord appt, RawEvent master, RawEventGroup group, List<string> w)
+    {
+        var lines = master.Recurrence
+            .Select(s => s.IcalString)
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Select(s => s!)
+            .ToList();
+
+        ParseResult<ParsedRecurrence> pr = ICalTextParser.ParseRecurrence(lines);
+        foreach (var pw in pr.Warnings) w.Add(pw);
+        ParsedRecurrence? p = pr.Value;
+
+        if (p is null)
+        {
+            // No mappable RRULE (parse failure or no RRULE line); event is a single occurrence.
+            if (group.Overrides.Count > 0)
+                w.Add($"recurrence: overrides dropped (no recurrence pattern) for '{appt.Subject}'");
+            return;
+        }
+
+        string? reason = DegradeReason(p, lines);
+        if (reason is not null)
+        {
+            w.Add($"recurrence unsupported ({reason}); wrote first occurrence only: '{appt.Subject}'");
+            return;  // appt.Recurrence remains null — degraded single occurrence
+        }
+
+        // Build the RRULE body for Ical.Net (strip the "RRULE:" prefix).
+        string rruleLine = lines.First(l => l.StartsWith("RRULE", StringComparison.OrdinalIgnoreCase));
+        string rawRRuleBody = StripRRulePrefix(IcalParseSupport.UnfoldIcalLines(rruleLine));
+
+        var spec = new RecurrenceSpec
+        {
+            Frequency    = MapFreq(p),
+            Interval     = Math.Max(1, p.Interval),
+            DaysOfWeek   = p.ByDay.Select(d => d.DayOfWeek).Distinct().ToArray(),
+            DayOfMonth   = p.ByMonthDay.Count == 1 ? p.ByMonthDay[0] : (int?)null,
+            NthOccurrence = p.ByDay.Count == 1 ? p.ByDay[0].Offset : null,
+            Month        = p.ByMonth.Count == 1 ? p.ByMonth[0] : (int?)null,
+            FirstStartUtc   = appt.StartUtc,
+            FirstStartLocal = appt.TimeZone is { } tz0
+                ? TimeZoneInfo.ConvertTimeFromUtc(appt.StartUtc, tz0)
+                : appt.StartUtc,
+            TimeZone             = appt.TimeZone,
+            OriginatingTimeZoneId = master.EventStartTz,
+            RawRRuleBody         = rawRRuleBody,
+        };
+
+        if (p.Count > 0)
+        {
+            spec.EndKind = RecurrenceEndKind.Count;
+            spec.Count   = p.Count;
+        }
+        else if (p.UntilUtc is { } until)
+        {
+            spec.EndKind  = RecurrenceEndKind.Until;
+            spec.UntilUtc = until;
+        }
+        else
+        {
+            spec.EndKind = RecurrenceEndKind.NoEnd;
+        }
+
+        spec.LastInstanceStartUtc = ComputeLastInstanceUtc(spec);
+        appt.Recurrence = spec;
+
+        // Map EXDATEs to deleted-occurrence identities.
+        appt.DeletedOccurrences = p.ExDates
+            .SelectMany(dl => dl.Values.Select(v =>
+                ToInstanceId(v, dl.TzId ?? master.EventStartTz, dl.IsDateOnly)))
+            .ToList();
+
+        // Map override exceptions.
+        appt.Exceptions = group.Overrides
+            .Select(o => ToException(o, w))
+            .Where(e => e is not null)
+            .Select(e => e!)
+            .ToList();
     }
 }

--- a/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
@@ -115,9 +115,15 @@ public static class CalendarEventMapper
                     0, 0, 0, DateTimeKind.Unspecified);
             }
 
-            // If end <= start (in local) or end is null → one-day boundary
+            // If end <= start (in local) or end is null → one-day boundary (DST-aware: next local midnight in tz).
             if (endLocalMidnight is null || endLocalMidnight.Value <= startLocalMidnight)
-                appt.EndUtc = appt.StartUtc.AddDays(1);
+            {
+                var startLocalDate2 = TimeZoneInfo.ConvertTimeFromUtc(appt.StartUtc, tz).Date;
+                var nextLocalMidnight = new DateTime(
+                    startLocalDate2.Year, startLocalDate2.Month, startLocalDate2.Day,
+                    0, 0, 0, DateTimeKind.Unspecified).AddDays(1);
+                appt.EndUtc = TimeZoneInfo.ConvertTimeToUtc(nextLocalMidnight, tz);
+            }
             else
                 appt.EndUtc = TimeZoneInfo.ConvertTimeToUtc(endLocalMidnight.Value, tz);
         }
@@ -162,15 +168,19 @@ public static class CalendarEventMapper
         appt.Categories = cats is not null ? SplitCategories(cats) : Array.Empty<string>();
 
         // BusyStatus (explicit precedence)
-        // 1. TENTATIVE status → 1
+        // 1. TENTATIVE status → 1 (Tentative)
         // 2. TRANSP=TRANSPARENT → 0 (Free)
-        // 3. default → 2 (Busy)
+        // 3. TRANSP=OPAQUE → 2 (Busy) — explicit wins over all-day default
+        // 4. no explicit TRANSP → all-day defaults to 0 (Free); timed defaults to 2 (Busy)
+        var transp = PropValue(master, "TRANSP");
         if (string.Equals(master.IcalStatus, "TENTATIVE", StringComparison.OrdinalIgnoreCase))
             appt.BusyStatus = 1;
-        else if (string.Equals(PropValue(master, "TRANSP"), "TRANSPARENT", StringComparison.OrdinalIgnoreCase))
+        else if (string.Equals(transp, "TRANSPARENT", StringComparison.OrdinalIgnoreCase))
             appt.BusyStatus = 0;
-        else
+        else if (string.Equals(transp, "OPAQUE", StringComparison.OrdinalIgnoreCase))
             appt.BusyStatus = 2;
+        else
+            appt.BusyStatus = isAllDay ? 0 : 2; // all-day events default to Free; timed events default to Busy
 
         // Importance from iCal PRIORITY
         appt.Importance = master.Priority switch

--- a/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
@@ -16,7 +16,11 @@ namespace Mail2Pst.Core.Calendar;
 
 public static class CalendarEventMapper
 {
-    private const int EventAllDay = 4;
+    // Mozilla calStorageCalendar flag bits (see calStorageCalendar.sys.mjs CAL_ITEM_FLAG):
+    // 1=PRIVATE, 2=HAS_ATTENDEES, 4=HAS_PROPERTIES, 8=EVENT_ALLDAY, 16=HAS_RECURRENCE,
+    // 32=HAS_EXCEPTIONS, 64=HAS_ATTACHMENTS, 128=HAS_RELATIONS, 256=HAS_ALARMS.
+    // NOTE: HAS_PROPERTIES (4) is set on nearly every real event, so all-day MUST key on bit 8.
+    private const int EventAllDay = 8;
 
     public static AppointmentRecord? Map(RawEventGroup group, out IReadOnlyList<string> warnings)
     {

--- a/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
@@ -467,6 +467,10 @@ public static class CalendarEventMapper
             // Monthly-by-day: exactly one BYMONTHDAY, no BYDAY.
             if (p.ByMonthDay.Count == 1 && p.ByDay.Count == 0) return null;
 
+            // Bare FREQ=MONTHLY (no BY* parts): RFC 5545 recurs on the DTSTART day-of-month.
+            // The writer defaults RecurringAppointment.Day to FirstStartUtc.Day.
+            if (p.ByDay.Count == 0 && p.ByMonthDay.Count == 0) return null;
+
             return "unrepresentable monthly/yearly pattern";
         }
 
@@ -479,6 +483,10 @@ public static class CalendarEventMapper
             // Yearly: one BYMONTH + one BYMONTHDAY, no BYDAY.
             if (p.ByMonth.Count == 1 && p.ByMonthDay.Count == 1 && p.ByDay.Count == 0)
                 return null;
+
+            // Bare FREQ=YEARLY (no BY* parts): RFC 5545 recurs on the DTSTART month + day-of-month.
+            // The writer defaults Day to FirstStartUtc.Day; Outlook derives the month from the start date.
+            if (p.ByDay.Count == 0 && p.ByMonth.Count == 0 && p.ByMonthDay.Count == 0) return null;
 
             return "unrepresentable monthly/yearly pattern";
         }

--- a/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
@@ -796,6 +796,16 @@ public static class CalendarEventMapper
         }
 
         spec.LastInstanceStartUtc = ComputeLastInstanceUtc(spec);
+
+        // Defensive guard: ComputeLastInstanceUtc failed (near-unreachable path — requires
+        // Ical.Net to throw during COUNT enumeration). Degrade to single occurrence rather
+        // than silently producing an unbounded series via the NoEnd sentinel.
+        if (spec.EndKind == RecurrenceEndKind.Count && spec.LastInstanceStartUtc is null)
+        {
+            w.Add($"recurrence COUNT could not be resolved; wrote first occurrence only: '{appt.Subject}'");
+            return;
+        }
+
         appt.Recurrence = spec;
 
         // Map EXDATEs to deleted-occurrence identities.

--- a/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
@@ -327,6 +327,13 @@ public static class CalendarEventMapper
             appt.Attendees = attendees;
         }
 
+        // --- GlobalObjectId (Exchange-cached events only) ---
+        // For Exchange/Owl-cached events the id IS the GlobalObjectId, uppercase-hex-encoded
+        // (112 chars = 56 bytes, EDK prefix 040000008200E00074C5B7101A82E008).
+        // Mozilla UUIDs and CalDAV UIDs do not match; TryDecode returns false and GlobalObjectId stays null.
+        if (GlobalObjectIdCodec.TryDecode(group.Master?.Id, out var goid, out _))
+            appt.GlobalObjectId = goid;
+
         // --- Online-meeting join URL (Teams / Google Meet) ---
         // Only these two provider X-props trigger URL preservation; ordinary URLs in
         // DESCRIPTION or LOCATION are not promoted (no over-promotion rule).

--- a/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
@@ -7,9 +7,6 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using Ical.Net.CalendarComponents;
-using Ical.Net.DataTypes;
-using IcalCalendar = Ical.Net.Calendar;
 using Mail2Pst.Core.Models;
 
 namespace Mail2Pst.Core.Calendar;
@@ -422,169 +419,6 @@ public static class CalendarEventMapper
         TimeZoneResolver.Resolve(tzId).Zone ?? TimeZoneInfo.Utc;
 
     /// <summary>
-    /// Strips the <c>RRULE:</c> prefix (case-insensitive) from a raw iCal RRULE line,
-    /// returning the bare rule body consumed by <see cref="RecurrencePattern"/>.
-    /// </summary>
-    private static string StripRRulePrefix(string line)
-    {
-        const string prefix = "RRULE:";
-        return line.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
-            ? line.Substring(prefix.Length)
-            : line;
-    }
-
-    /// <summary>
-    /// Returns a non-null reason string when the parsed recurrence cannot be faithfully
-    /// represented in the <see cref="RecurrenceSpec"/> model, or <c>null</c> when the
-    /// rule is mappable.
-    /// </summary>
-    private static string? DegradeReason(ParsedRecurrence p, List<string> lines)
-    {
-        // 1. Unknown FREQ (ical.net returned ParsedFrequency.Unknown for an unrecognised value).
-        if (p.Frequency == ParsedFrequency.Unknown) return "Unknown FREQ";
-
-        // 2. BYSETPOS (e.g. "last Monday of month") — not representable in RecurrenceSpec.
-        if (p.BySetPosition.Count > 0) return "BYSETPOS";
-
-        // 3. RDATE — additional explicit dates outside of the RRULE pattern.
-        if (p.RDates.Count > 0) return "RDATE";
-
-        // 4. Multiple RRULE lines — we only handle a single rule.
-        int rruleCount = lines.Count(l => l.StartsWith("RRULE", StringComparison.OrdinalIgnoreCase));
-        if (rruleCount > 1) return "multiple RRULE";
-
-        // 5. WKST when INTERVAL > 1 — the work-week start shifts grouping boundaries; degrade.
-        bool hasWkst = lines.Any(l => l.Contains("WKST=", StringComparison.OrdinalIgnoreCase));
-        if (hasWkst && p.Interval > 1) return "WKST interval-sensitive";
-
-        // 6 & 7. Cardinality rules for Monthly / Yearly.
-        if (p.Frequency == ParsedFrequency.Monthly)
-        {
-            // MonthlyNth: exactly one BYDAY with a supported offset (1..4 or -1).
-            if (p.ByDay.Count == 1 && p.ByDay[0].Offset is { } off)
-                return (off is >= 1 and <= 4 or -1) ? null : "unrepresentable monthly/yearly pattern";
-
-            // Monthly-by-day: exactly one BYMONTHDAY, no BYDAY.
-            if (p.ByMonthDay.Count == 1 && p.ByDay.Count == 0) return null;
-
-            // Bare FREQ=MONTHLY (no BY* parts): RFC 5545 recurs on the DTSTART day-of-month.
-            // The writer defaults RecurringAppointment.Day to FirstStartUtc.Day.
-            if (p.ByDay.Count == 0 && p.ByMonthDay.Count == 0) return null;
-
-            return "unrepresentable monthly/yearly pattern";
-        }
-
-        if (p.Frequency == ParsedFrequency.Yearly)
-        {
-            // YearlyNth: one BYDAY with a supported offset (1..4 or -1) + one BYMONTH.
-            if (p.ByDay.Count == 1 && p.ByDay[0].Offset is { } off && p.ByMonth.Count == 1)
-                return (off is >= 1 and <= 4 or -1) ? null : "unrepresentable monthly/yearly pattern";
-
-            // Yearly: one BYMONTH + one BYMONTHDAY, no BYDAY.
-            if (p.ByMonth.Count == 1 && p.ByMonthDay.Count == 1 && p.ByDay.Count == 0)
-                return null;
-
-            // Bare FREQ=YEARLY (no BY* parts): RFC 5545 recurs on the DTSTART month + day-of-month.
-            // The writer defaults Day to FirstStartUtc.Day; Outlook derives the month from the start date.
-            if (p.ByDay.Count == 0 && p.ByMonth.Count == 0 && p.ByMonthDay.Count == 0) return null;
-
-            return "unrepresentable monthly/yearly pattern";
-        }
-
-        // Daily / Weekly — always mappable.
-        return null;
-    }
-
-    /// <summary>Maps a <see cref="ParsedRecurrence"/> frequency to the model enum.
-    /// <see cref="DegradeReason"/> must return <c>null</c> before this is called.</summary>
-    private static AppointmentRecurrenceFrequency MapFreq(ParsedRecurrence p) => p.Frequency switch
-    {
-        ParsedFrequency.Daily   => AppointmentRecurrenceFrequency.Daily,
-        ParsedFrequency.Weekly  => AppointmentRecurrenceFrequency.Weekly,
-        ParsedFrequency.Monthly =>
-            p.ByDay.Count == 1 && p.ByDay[0].Offset is not null
-                ? AppointmentRecurrenceFrequency.MonthlyNth
-                : AppointmentRecurrenceFrequency.Monthly,
-        ParsedFrequency.Yearly  =>
-            p.ByDay.Count == 1 && p.ByDay[0].Offset is not null
-                ? AppointmentRecurrenceFrequency.YearlyNth
-                : AppointmentRecurrenceFrequency.Yearly,
-        _ => throw new InvalidOperationException($"Unmapped ParsedFrequency: {p.Frequency}"),
-    };
-
-    /// <summary>
-    /// Computes the UTC start of the last occurrence of a recurrence rule.
-    /// Returns <c>null</c> for <see cref="RecurrenceEndKind.NoEnd"/>.
-    /// For <see cref="RecurrenceEndKind.Until"/> returns <see cref="RecurrenceSpec.UntilUtc"/> directly
-    /// (no enumeration).  For <see cref="RecurrenceEndKind.Count"/> enumerates the COUNT-th raw occurrence
-    /// (EXDATE does NOT reduce the COUNT).
-    /// </summary>
-    private static DateTime? ComputeLastInstanceUtc(RecurrenceSpec s)
-    {
-        switch (s.EndKind)
-        {
-            case RecurrenceEndKind.NoEnd:
-                return null;
-
-            case RecurrenceEndKind.Until:
-                // UNTIL bound is the last-occurrence date: no enumeration needed.
-                return s.UntilUtc;
-
-            case RecurrenceEndKind.Count:
-            {
-                // Build a minimal VCALENDAR anchored at FirstStartLocal (floating — no TZ suffix)
-                // so Ical.Net enumerates in local time without any IANA / Windows zone lookups.
-                // Calendar.GetOccurrences respects COUNT: it will return exactly COUNT occurrences.
-                var anchor = s.FirstStartLocal;
-                string dtFmt = anchor.ToString("yyyyMMddTHHmmss", CultureInfo.InvariantCulture);
-                string calText =
-                    "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//ContinuMail//recurrence//EN\r\n" +
-                    "BEGIN:VEVENT\r\nUID:count-enum@continmail\r\n" +
-                    $"DTSTART:{dtFmt}\r\n" +
-                    $"DTEND:{dtFmt}\r\n" +
-                    $"RRULE:{s.RawRRuleBody}\r\n" +
-                    "END:VEVENT\r\nEND:VCALENDAR\r\n";
-
-                try
-                {
-                    var enumCal = IcalCalendar.Load(calText);
-                    if (enumCal?.Events.Count == 0) return null;
-
-                    // In Ical.Net 5.x, GetOccurrences(CalDateTime startTime) returns all occurrences
-                    // from startTime onward, respecting COUNT. No end-date parameter needed.
-                    var startDt = new CalDateTime(
-                        anchor.Year, anchor.Month, anchor.Day,
-                        anchor.Hour, anchor.Minute, anchor.Second, string.Empty);
-
-                    var occs = enumCal.GetOccurrences(startDt)
-                                      .OrderBy(o => o.Period.StartTime)
-                                      .ToList();
-
-                    int idx = (s.Count ?? 0) - 1;
-                    if (idx < 0 || idx >= occs.Count) return null;
-
-                    var lastLocalRaw = occs[idx].Period.StartTime.Value;
-                    var lastLocal    = new DateTime(
-                        lastLocalRaw.Year, lastLocalRaw.Month, lastLocalRaw.Day,
-                        lastLocalRaw.Hour, lastLocalRaw.Minute, lastLocalRaw.Second,
-                        DateTimeKind.Unspecified);
-
-                    return s.TimeZone != null
-                        ? TimeZoneInfo.ConvertTimeToUtc(lastLocal, s.TimeZone)
-                        : DateTime.SpecifyKind(lastLocal, DateTimeKind.Utc);
-                }
-                catch
-                {
-                    return null;
-                }
-            }
-
-            default:
-                return null;
-        }
-    }
-
-    /// <summary>
     /// Converts a raw EXDATE date/datetime string to a <see cref="RecurrenceInstanceId"/>.
     /// For date-only values (<paramref name="isDateOnly"/>), the local midnight in
     /// <paramref name="tzId"/> is used as the reference point.
@@ -748,6 +582,8 @@ public static class CalendarEventMapper
     /// Applies RRULE/EXDATE recurrence data and override exceptions to <paramref name="appt"/>.
     /// Degrades to a single occurrence (no <c>Recurrence</c> set) with a warning when the rule
     /// cannot be faithfully mapped; a degraded result is still returned (never null).
+    /// Spec-building is delegated to <see cref="RecurrenceMapping.FromIcal"/>;
+    /// EXDATE/override mapping (appointment-only concerns) stays here.
     /// </summary>
     private static void ApplyRecurrence(
         AppointmentRecord appt, RawEvent master, RawEventGroup group, List<string> w)
@@ -758,6 +594,7 @@ public static class CalendarEventMapper
             .Select(s => s!)
             .ToList();
 
+        // Parse first to emit any parse warnings and to obtain p.ExDates for later use.
         ParseResult<ParsedRecurrence> pr = ICalTextParser.ParseRecurrence(lines);
         foreach (var pw in pr.Warnings) w.Add(pw);
         ParsedRecurrence? p = pr.Value;
@@ -770,75 +607,34 @@ public static class CalendarEventMapper
             return;
         }
 
-        string? reason = DegradeReason(p, lines);
-        if (reason is not null)
+        DateTime firstStartLocal = appt.TimeZone is { } tz0
+            ? TimeZoneInfo.ConvertTimeFromUtc(appt.StartUtc, tz0)
+            : appt.StartUtc;
+
+        var (spec, degradeReason) = RecurrenceMapping.FromIcal(
+            lines, appt.StartUtc, firstStartLocal, appt.TimeZone, master.EventStartTz);
+
+        if (degradeReason is not null)
         {
-            w.Add($"recurrence unsupported ({reason}); wrote first occurrence only: '{appt.Subject}'");
+            if (degradeReason == "COUNT enumeration failed")
+                w.Add($"recurrence COUNT could not be resolved; wrote first occurrence only: '{appt.Subject}'");
+            else
+                w.Add($"recurrence unsupported ({degradeReason}); wrote first occurrence only: '{appt.Subject}'");
             return;  // appt.Recurrence remains null — degraded single occurrence
         }
 
-        // Build the RRULE body for Ical.Net (strip the "RRULE:" prefix).
-        string rruleLine = lines.First(l => l.StartsWith("RRULE", StringComparison.OrdinalIgnoreCase));
-        // Trim() strips the trailing CRLF Mozilla stores on each property so the RRULE body embedded
-        // in the COUNT-enumeration VCALENDAR text is a clean single line.
-        string rawRRuleBody = StripRRulePrefix(IcalParseSupport.UnfoldIcalLines(rruleLine).Trim());
-
-        var spec = new RecurrenceSpec
-        {
-            Frequency    = MapFreq(p),
-            Interval     = Math.Max(1, p.Interval),
-            DaysOfWeek   = p.ByDay.Select(d => d.DayOfWeek).Distinct().ToArray(),
-            DayOfMonth   = p.ByMonthDay.Count == 1 ? p.ByMonthDay[0] : (int?)null,
-            NthOccurrence = p.ByDay.Count == 1 ? p.ByDay[0].Offset : null,
-            Month        = p.ByMonth.Count == 1 ? p.ByMonth[0] : (int?)null,
-            FirstStartUtc   = appt.StartUtc,
-            FirstStartLocal = appt.TimeZone is { } tz0
-                ? TimeZoneInfo.ConvertTimeFromUtc(appt.StartUtc, tz0)
-                : appt.StartUtc,
-            TimeZone             = appt.TimeZone,
-            OriginatingTimeZoneId = master.EventStartTz,
-            RawRRuleBody         = rawRRuleBody,
-        };
-
-        // RFC 5545 §3.3.10: a bare FREQ=WEEKLY with no BYDAY recurs on the DTSTART weekday.
-        if (spec.Frequency == AppointmentRecurrenceFrequency.Weekly && spec.DaysOfWeek.Length == 0)
-            spec.DaysOfWeek = new[] { spec.FirstStartLocal.DayOfWeek };
-
-        if (p.Count > 0)
-        {
-            spec.EndKind = RecurrenceEndKind.Count;
-            spec.Count   = p.Count;
-        }
-        else if (p.UntilUtc is { } until)
-        {
-            spec.EndKind  = RecurrenceEndKind.Until;
-            spec.UntilUtc = until;
-        }
-        else
-        {
-            spec.EndKind = RecurrenceEndKind.NoEnd;
-        }
-
-        spec.LastInstanceStartUtc = ComputeLastInstanceUtc(spec);
-
-        // Defensive guard: ComputeLastInstanceUtc failed (near-unreachable path — requires
-        // Ical.Net to throw during COUNT enumeration). Degrade to single occurrence rather
-        // than silently producing an unbounded series via the NoEnd sentinel.
-        if (spec.EndKind == RecurrenceEndKind.Count && spec.LastInstanceStartUtc is null)
-        {
-            w.Add($"recurrence COUNT could not be resolved; wrote first occurrence only: '{appt.Subject}'");
-            return;
-        }
+        if (spec is null)
+            return; // (null, null) — near-unreachable; p was non-null but FromIcal found nothing mappable
 
         appt.Recurrence = spec;
 
-        // Map EXDATEs to deleted-occurrence identities.
+        // Map EXDATEs to deleted-occurrence identities (appointment-only; stays here).
         appt.DeletedOccurrences = p.ExDates
             .SelectMany(dl => dl.Values.Select(v =>
                 ToInstanceId(v, dl.TzId ?? master.EventStartTz, dl.IsDateOnly)))
             .ToList();
 
-        // Map override exceptions.
+        // Map override exceptions (appointment-only; stays here).
         appt.Exceptions = group.Overrides
             .Select(o => ToException(o, w))
             .Where(e => e is not null)

--- a/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
@@ -334,6 +334,17 @@ public static class CalendarEventMapper
         if (GlobalObjectIdCodec.TryDecode(group.Master?.Id, out var goid, out _))
             appt.GlobalObjectId = goid;
 
+        // --- Relations (cal_relations side-table: RELATED-TO etc.) ---
+        // Classic Outlook has no native related-appointment surface; preserve raw relation lines
+        // in the body appendix (via CalendarBodyAppendix in AppointmentWriter) + warn once per line.
+        appt.Relations = master.Relations
+            .Select(r => r.IcalString)
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Select(s => s!)
+            .ToList();
+        foreach (var rel in appt.Relations)
+            w.Add($"relation on '{appt.Subject}': preserved (not natively converted)");
+
         // --- Online-meeting join URL (Teams / Google Meet) ---
         // Only these two provider X-props trigger URL preservation; ordinary URLs in
         // DESCRIPTION or LOCATION are not promoted (no over-promotion rule).

--- a/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
@@ -776,6 +776,10 @@ public static class CalendarEventMapper
             RawRRuleBody         = rawRRuleBody,
         };
 
+        // RFC 5545 §3.3.10: a bare FREQ=WEEKLY with no BYDAY recurs on the DTSTART weekday.
+        if (spec.Frequency == AppointmentRecurrenceFrequency.Weekly && spec.DaysOfWeek.Length == 0)
+            spec.DaysOfWeek = new[] { spec.FirstStartLocal.DayOfWeek };
+
         if (p.Count > 0)
         {
             spec.EndKind = RecurrenceEndKind.Count;

--- a/src/Mail2Pst.Core/Calendar/CalendarReadResult.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarReadResult.cs
@@ -23,9 +23,12 @@ public readonly record struct CalendarItemKey(
 public static class PrTime
 {
     /// <summary>Thunderbird PRTime = microseconds since the Unix epoch (UTC). Raw model keeps the
-    /// long? micros; this helper is for later mapping/tests. Null -> null.</summary>
+    /// long? micros; this helper is for later mapping/tests. Null -> null. Uses ticks (1 µs = 10 ticks)
+    /// so sub-millisecond precision is preserved and pre-1970 (negative) values are not truncated toward
+    /// zero. `checked` makes an absurd out-of-range micros throw (contained per-item by the runner)
+    /// rather than silently wrapping.</summary>
     public static System.DateTimeOffset? FromMicros(long? micros) =>
-        micros is null ? null : System.DateTimeOffset.FromUnixTimeMilliseconds(micros.Value / 1000L);
+        micros is null ? null : System.DateTimeOffset.UnixEpoch.AddTicks(checked(micros.Value * 10L));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/Mail2Pst.Core/Calendar/CalendarReadResult.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarReadResult.cs
@@ -51,6 +51,8 @@ public sealed record RawParameter(
 // Raw event — maps 1:1 to cal_events columns + side collections.
 // ---------------------------------------------------------------------------
 
+/// <summary>Carries raw cal_events COLUMNS only; iCal-level fields (description, location,
+/// organizer, categories…) live in Properties/Attendees and are resolved in PR3b.</summary>
 public sealed class RawEvent
 {
     // Core identity / scheduling
@@ -62,20 +64,12 @@ public sealed class RawEvent
     public string? EventEndTz { get; set; }
     public string? Title { get; set; }
     public int? Flags { get; set; }
-    public int? EventStatus { get; set; }
     public long? RecurrenceId { get; set; }
     public string? RecurrenceIdTz { get; set; }
     public long? TimeCreated { get; set; }
     public long? LastModified { get; set; }
-    public string? Alarm { get; set; }
-    public string? Organizer { get; set; }
-    public string? Description { get; set; }
-    public string? Location { get; set; }
-    public string? Categories { get; set; }
-    public string? Url { get; set; }
     public int? Priority { get; set; }
     public string? Privacy { get; set; }
-    public int? Sequence { get; set; }
     public string? IcalStatus { get; set; }
 
     // Side collections (default to empty list)
@@ -92,6 +86,8 @@ public sealed class RawEvent
 // Raw todo — maps 1:1 to cal_todos columns + side collections.
 // ---------------------------------------------------------------------------
 
+/// <summary>Carries raw cal_todos COLUMNS only; iCal-level fields (description, location,
+/// organizer, categories…) live in Properties/Attendees and are resolved in PR3b.</summary>
 public sealed class RawTodo
 {
     // Core identity

--- a/src/Mail2Pst.Core/Calendar/CalendarReadResult.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarReadResult.cs
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System.Collections.Generic;
+
+namespace Mail2Pst.Core.Calendar;
+
+// ---------------------------------------------------------------------------
+// Typed side-table key — uniquely identifies an event/todo row across tables.
+// ---------------------------------------------------------------------------
+
+public readonly record struct CalendarItemKey(
+    string? CalId,
+    string ItemId,
+    long? RecurrenceId,
+    string? RecurrenceIdTz);
+
+// ---------------------------------------------------------------------------
+// PRTime helper — Thunderbird stores times as microseconds since Unix epoch.
+// The raw model keeps long? micros; this helper is for mapping/tests only.
+// ---------------------------------------------------------------------------
+
+public static class PrTime
+{
+    /// <summary>Thunderbird PRTime = microseconds since the Unix epoch (UTC). Raw model keeps the
+    /// long? micros; this helper is for later mapping/tests. Null -> null.</summary>
+    public static System.DateTimeOffset? FromMicros(long? micros) =>
+        micros is null ? null : System.DateTimeOffset.FromUnixTimeMilliseconds(micros.Value / 1000L);
+}
+
+// ---------------------------------------------------------------------------
+// Side-table raw carriers (dumb data, no logic).
+// ---------------------------------------------------------------------------
+
+public sealed record RawSideText(string? IcalString);
+
+public sealed record RawProperty(
+    string Key,
+    byte[]? Value,
+    long? RecurrenceId,
+    string? RecurrenceIdTz);
+
+public sealed record RawParameter(
+    string Key1,
+    string Key2,
+    string? Value,
+    long? RecurrenceId,
+    string? RecurrenceIdTz);
+
+// ---------------------------------------------------------------------------
+// Raw event — maps 1:1 to cal_events columns + side collections.
+// ---------------------------------------------------------------------------
+
+public sealed class RawEvent
+{
+    // Core identity / scheduling
+    public string? CalId { get; set; }
+    public string? Id { get; set; }
+    public long? EventStart { get; set; }
+    public string? EventStartTz { get; set; }
+    public long? EventEnd { get; set; }
+    public string? EventEndTz { get; set; }
+    public string? Title { get; set; }
+    public int? Flags { get; set; }
+    public int? EventStatus { get; set; }
+    public string? RecurrenceId { get; set; }
+    public string? RecurrenceIdTz { get; set; }
+    public long? TimeCreated { get; set; }
+    public long? LastModified { get; set; }
+    public string? Alarm { get; set; }
+    public string? Organizer { get; set; }
+    public string? Description { get; set; }
+    public string? Location { get; set; }
+    public string? Categories { get; set; }
+    public string? Url { get; set; }
+    public int? Priority { get; set; }
+    public int? Privacy { get; set; }
+    public int? Sequence { get; set; }
+    public string? IcalStatus { get; set; }
+
+    // Side collections (default to empty list)
+    public List<RawSideText> Recurrence { get; set; } = new();
+    public List<RawSideText> Attendees { get; set; } = new();
+    public List<RawSideText> Alarms { get; set; } = new();
+    public List<RawSideText> Attachments { get; set; } = new();
+    public List<RawSideText> Relations { get; set; } = new();
+    public List<RawProperty> Properties { get; set; } = new();
+    public List<RawParameter> Parameters { get; set; } = new();
+}
+
+// ---------------------------------------------------------------------------
+// Raw todo — maps 1:1 to cal_todos columns + side collections.
+// ---------------------------------------------------------------------------
+
+public sealed class RawTodo
+{
+    // Core identity
+    public string? CalId { get; set; }
+    public string? Id { get; set; }
+    public string? Title { get; set; }
+    public int? Priority { get; set; }
+    public int? Privacy { get; set; }
+    public string? IcalStatus { get; set; }
+    public int? Flags { get; set; }
+    public string? RecurrenceId { get; set; }
+    public string? RecurrenceIdTz { get; set; }
+    public long? TimeCreated { get; set; }
+    public long? LastModified { get; set; }
+
+    // Todo-specific date columns
+    public long? TodoEntry { get; set; }
+    public string? TodoEntryTz { get; set; }
+    public long? TodoDue { get; set; }
+    public string? TodoDueTz { get; set; }
+    public long? TodoCompleted { get; set; }
+    public string? TodoCompletedTz { get; set; }
+    public int? TodoComplete { get; set; }
+
+    // Side collections (default to empty list)
+    public List<RawSideText> Recurrence { get; set; } = new();
+    public List<RawSideText> Attendees { get; set; } = new();
+    public List<RawSideText> Alarms { get; set; } = new();
+    public List<RawSideText> Attachments { get; set; } = new();
+    public List<RawSideText> Relations { get; set; } = new();
+    public List<RawProperty> Properties { get; set; } = new();
+    public List<RawParameter> Parameters { get; set; } = new();
+}
+
+// ---------------------------------------------------------------------------
+// Grouping wrappers — one master occurrence + zero-or-more overrides.
+// ---------------------------------------------------------------------------
+
+public sealed class RawEventGroup
+{
+    public RawEvent? Master { get; set; }
+    public List<RawEvent> Overrides { get; set; } = new();
+}
+
+public sealed class RawTodoGroup
+{
+    public RawTodo? Master { get; set; }
+    public List<RawTodo> Overrides { get; set; } = new();
+}
+
+// ---------------------------------------------------------------------------
+// Per-calendar read result, then the top-level return type.
+// ---------------------------------------------------------------------------
+
+public sealed class RawCalendarRead
+{
+    public string CalId { get; set; } = "";
+    public List<RawEventGroup> EventGroups { get; set; } = new();
+    public List<RawTodoGroup> TodoGroups { get; set; } = new();
+}
+
+public sealed class CalendarReadResult
+{
+    public List<RawCalendarRead> Calendars { get; set; } = new();
+    public List<string> Warnings { get; set; } = new();
+}

--- a/src/Mail2Pst.Core/Calendar/CalendarReadResult.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarReadResult.cs
@@ -74,7 +74,7 @@ public sealed class RawEvent
     public string? Categories { get; set; }
     public string? Url { get; set; }
     public int? Priority { get; set; }
-    public int? Privacy { get; set; }
+    public string? Privacy { get; set; }
     public int? Sequence { get; set; }
     public string? IcalStatus { get; set; }
 
@@ -99,7 +99,7 @@ public sealed class RawTodo
     public string? Id { get; set; }
     public string? Title { get; set; }
     public int? Priority { get; set; }
-    public int? Privacy { get; set; }
+    public string? Privacy { get; set; }
     public string? IcalStatus { get; set; }
     public int? Flags { get; set; }
     public long? RecurrenceId { get; set; }

--- a/src/Mail2Pst.Core/Calendar/CalendarReadResult.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarReadResult.cs
@@ -63,7 +63,7 @@ public sealed class RawEvent
     public string? Title { get; set; }
     public int? Flags { get; set; }
     public int? EventStatus { get; set; }
-    public string? RecurrenceId { get; set; }
+    public long? RecurrenceId { get; set; }
     public string? RecurrenceIdTz { get; set; }
     public long? TimeCreated { get; set; }
     public long? LastModified { get; set; }
@@ -102,7 +102,7 @@ public sealed class RawTodo
     public int? Privacy { get; set; }
     public string? IcalStatus { get; set; }
     public int? Flags { get; set; }
-    public string? RecurrenceId { get; set; }
+    public long? RecurrenceId { get; set; }
     public string? RecurrenceIdTz { get; set; }
     public long? TimeCreated { get; set; }
     public long? LastModified { get; set; }

--- a/src/Mail2Pst.Core/Calendar/CalendarRegistryReader.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarRegistryReader.cs
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using Mail2Pst.Core.Msf;   // PrefsJsEscape
+
+namespace Mail2Pst.Core.Calendar;
+
+public sealed record CalendarRegistryEntry(
+    string CalId, string DisplayName, string CalendarType, string Uri, bool VisibleInThunderbird);
+
+/// <summary>
+/// Reads <c>calendar.registry.&lt;id&gt;.{name,type,uri,calendar-main-in-composite}</c> from prefs.js.
+/// Line-oriented user_pref recognition (does NOT execute JS); mirrors PrefsTagReader and reuses
+/// PrefsJsEscape for \uXXXX / \" / \\ etc. One entry per cal_id that has a name OR type. Missing
+/// file -> empty list.
+/// </summary>
+public static class CalendarRegistryReader
+{
+    private static readonly Regex Line = new(
+        "^\\s*user_pref\\s*\\(\\s*\"calendar\\.registry\\.(?<id>[^.\"]+)\\.(?<key>[^\"]+)\"\\s*,\\s*(?:\"(?<sval>(?:\\\\.|[^\"\\\\])*)\"|(?<bval>true|false|-?\\d+))\\s*\\)\\s*;?\\s*$",
+        RegexOptions.CultureInvariant);
+
+    private sealed class Builder { public string Name = ""; public string Type = ""; public string Uri = ""; public bool Visible; }
+
+    public static IReadOnlyList<CalendarRegistryEntry> Read(string prefsJsPath)
+    {
+        try { return ParseText(File.ReadAllText(prefsJsPath)); }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        { return Array.Empty<CalendarRegistryEntry>(); }
+    }
+
+    public static IReadOnlyList<CalendarRegistryEntry> ParseText(string content)
+    {
+        var byId = new Dictionary<string, Builder>(StringComparer.Ordinal);
+        foreach (string raw in content.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None))
+        {
+            Match m = Line.Match(raw);
+            if (!m.Success) continue;
+            string id = m.Groups["id"].Value, key = m.Groups["key"].Value;
+            string val;
+            if (m.Groups["sval"].Success)
+            {
+                if (!PrefsJsEscape.TryUnescape(m.Groups["sval"].Value, out val)) continue; // bad escape -> skip line
+            }
+            else val = m.Groups["bval"].Value;
+
+            if (!byId.TryGetValue(id, out Builder? b)) byId[id] = b = new Builder();
+            switch (key)
+            {
+                case "name": b.Name = val; break;
+                case "type": b.Type = val; break;
+                case "uri":  b.Uri = val; break;
+                case "calendar-main-in-composite": b.Visible = string.Equals(val, "true", StringComparison.Ordinal); break;
+            }
+        }
+
+        var result = new List<CalendarRegistryEntry>(byId.Count);
+        foreach (var (id, b) in byId)
+            if (b.Name.Length > 0 || b.Type.Length > 0)
+                result.Add(new CalendarRegistryEntry(id, b.Name, b.Type, b.Uri, b.Visible));
+        return result;
+    }
+}

--- a/src/Mail2Pst.Core/Calendar/CalendarTaskMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarTaskMapper.cs
@@ -12,6 +12,11 @@ namespace Mail2Pst.Core.Calendar;
 
 public static class CalendarTaskMapper
 {
+    // Completing a recurring task triggers Outlook live-regeneration (advance current +
+    // spawn a TaskDeadOccurrence=true copy) — a converter must not author that lifecycle.
+    // Keep false: completed recurring tasks degrade to a single completed non-recurring task.
+    private const bool CompletedRecurringSupported = false;
+
     public static TaskRecord? Map(RawTodoGroup group, out IReadOnlyList<string> warnings)
     {
         var w = new List<string>();
@@ -20,9 +25,8 @@ public static class CalendarTaskMapper
         RawTodo? master = group.Master;
         string title = master?.Title ?? "";
         if (master is null) { w.Add("orphan task override (no master) skipped"); return null; }
-        if (group.Overrides.Count > 0) { w.Add($"recurring task '{title}' with exceptions deferred to PR7"); return null; }
-        if (master.Recurrence.Count > 0) { w.Add($"recurring task '{title}' deferred to PR7"); return null; }
-        if (master.RecurrenceId is not null) { w.Add("task override row deferred to PR7"); return null; }
+        // A task with RecurrenceId is an override row that got mis-grouped as a master; skip it.
+        if (master.RecurrenceId is not null) { w.Add("task override row mis-grouped as master; skipped"); return null; }
 
         var t = new TaskRecord { Subject = title, SourceId = master.Id ?? "" };
 
@@ -130,6 +134,57 @@ public static class CalendarTaskMapper
         }
 
         // Task attendees/assignment deferred: Outlook task assignment is a separate MAPI surface (not PR6).
+
+        // Recurrence — map RRULE if present, degrade on exceptions/completions/unrepresentable rules.
+        bool hasRrule = master.Recurrence.Any(s =>
+            (s.IcalString ?? "").TrimStart().StartsWith("RRULE", StringComparison.OrdinalIgnoreCase));
+
+        if (hasRrule)
+        {
+            bool hasExdateOrRdate = master.Recurrence.Any(s =>
+                (s.IcalString ?? "").TrimStart().StartsWith("EXDATE", StringComparison.OrdinalIgnoreCase) ||
+                (s.IcalString ?? "").TrimStart().StartsWith("RDATE",  StringComparison.OrdinalIgnoreCase));
+            bool hasOverrides = group.Overrides.Count > 0;
+
+            // Warning precedence (most-specific first): exceptions/deletions, then completed-recurring,
+            // then rule-degrade. Short-circuit so only one reason is reported.
+            if (hasExdateOrRdate || hasOverrides)
+            {
+                w.Add($"recurring task '{title}': deletions/exceptions not supported — wrote a single task");
+            }
+            else if (t.Status == TaskStatusKind.Complete && !CompletedRecurringSupported)
+            {
+                w.Add($"recurring task '{title}': completed recurring tasks not supported — wrote a single completed task");
+            }
+            else
+            {
+                // Prefer DueDate as anchor; fall back to StartDate.
+                var anchor = t.DueDate ?? t.StartDate;
+                if (anchor is null)
+                {
+                    w.Add($"recurring task '{title}': no due/start date to anchor recurrence — wrote a single task");
+                }
+                else
+                {
+                    // Task dates are DATE-ONLY; anchor at UTC-midnight of that calendar day (deterministic,
+                    // consistent with PR4 which stores task dates as UTC-midnight).
+                    var utcMidnight = new DateTime(
+                        anchor.Value.Year, anchor.Value.Month, anchor.Value.Day,
+                        0, 0, 0, DateTimeKind.Utc);
+                    var lines = master.Recurrence
+                        .Select(s => s.IcalString)
+                        .Where(s => !string.IsNullOrWhiteSpace(s))
+                        .Select(s => s!)
+                        .ToList();
+                    var (spec, reason) = RecurrenceMapping.FromIcal(
+                        lines, utcMidnight, utcMidnight, TimeZoneInfo.Utc, originatingTzId: null);
+                    if (reason is not null)
+                        w.Add($"recurring task '{title}': {reason}; wrote a single task");
+                    else
+                        t.Recurrence = spec;
+                }
+            }
+        }
 
         return t;
     }

--- a/src/Mail2Pst.Core/Calendar/CalendarTaskMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarTaskMapper.cs
@@ -129,6 +129,8 @@ public static class CalendarTaskMapper
             }
         }
 
+        // Task attendees/assignment deferred: Outlook task assignment is a separate MAPI surface (not PR6).
+
         return t;
     }
 

--- a/src/Mail2Pst.Core/Calendar/CalendarTaskMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarTaskMapper.cs
@@ -122,7 +122,11 @@ public static class CalendarTaskMapper
                     }
                 }
             }
-            // If alarmResult.Value is null, parse failed; warnings already added; preserve trigger if we can
+            else
+            {
+                // Parse failed; warnings already added above; preserve raw trigger in body.
+                AppendRawTriggerToBody(t, rawBlock);
+            }
         }
 
         return t;
@@ -151,7 +155,8 @@ public static class CalendarTaskMapper
         foreach (var part in parts)
         {
             var cat = part.Replace("\\,", ",").Trim();
-            if (!string.IsNullOrEmpty(cat))
+            if (!string.IsNullOrEmpty(cat) &&
+                !cat.StartsWith("X-MOZ-", StringComparison.OrdinalIgnoreCase))
                 result.Add(cat);
         }
         return result;

--- a/src/Mail2Pst.Core/Calendar/CalendarTaskMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarTaskMapper.cs
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Mail2Pst.Core.Models;
+
+namespace Mail2Pst.Core.Calendar;
+
+public static class CalendarTaskMapper
+{
+    public static TaskRecord? Map(RawTodoGroup group, out IReadOnlyList<string> warnings)
+    {
+        var w = new List<string>();
+        warnings = w;
+
+        RawTodo? master = group.Master;
+        string title = master?.Title ?? "";
+        if (master is null) { w.Add("orphan task override (no master) skipped"); return null; }
+        if (group.Overrides.Count > 0) { w.Add($"recurring task '{title}' with exceptions deferred to PR7"); return null; }
+        if (master.Recurrence.Count > 0) { w.Add($"recurring task '{title}' deferred to PR7"); return null; }
+        if (master.RecurrenceId is not null) { w.Add("task override row deferred to PR7"); return null; }
+
+        var t = new TaskRecord { Subject = title, SourceId = master.Id ?? "" };
+
+        // Body (DESCRIPTION property)
+        t.Body = PropValue(master, "DESCRIPTION");
+
+        // Categories: split on unescaped commas, unescape \,, drop X-MOZ-* keys (CATEGORIES only)
+        var cats = PropValue(master, "CATEGORIES");
+        t.Categories = cats is not null ? SplitCategories(cats) : Array.Empty<string>();
+
+        // Status
+        t.Status = master.IcalStatus?.ToUpperInvariant() switch
+        {
+            "COMPLETED"  => TaskStatusKind.Complete,
+            "IN-PROCESS" => TaskStatusKind.InProgress,
+            "CANCELLED"  => TaskStatusKind.Deferred,
+            _            => TaskStatusKind.NotStarted, // NEEDS-ACTION, null, unknown
+        };
+
+        // PercentComplete
+        t.PercentComplete = Math.Clamp(master.TodoComplete ?? 0, 0, 100);
+
+        // Status/percent invariants (Outlook treats these as coupled)
+        if (t.PercentComplete == 100)
+            t.Status = TaskStatusKind.Complete;
+        if (t.Status == TaskStatusKind.Complete && t.PercentComplete < 100)
+            t.PercentComplete = 100;
+
+        // Dates
+        t.StartDate     = PrTime.FromMicros(master.TodoEntry);
+        t.DueDate       = PrTime.FromMicros(master.TodoDue);
+        t.CompletedDate = PrTime.FromMicros(master.TodoCompleted);
+
+        // Importance from iCal PRIORITY column
+        t.Importance = master.Priority switch
+        {
+            >= 1 and <= 4 => 2, // high
+            >= 6 and <= 9 => 0, // low
+            _             => 1, // normal (5 or null)
+        };
+
+        // Sensitivity from CLASS (Privacy column first, then CLASS property)
+        var cls = master.Privacy ?? PropValue(master, "CLASS");
+        t.Sensitivity = cls?.ToUpperInvariant() switch
+        {
+            "PRIVATE"      => 2,
+            "CONFIDENTIAL" => 3,
+            _              => 0,
+        };
+
+        // Reminder — map first VALARM; warn if multiple alarms present
+        if (master.Alarms.Count > 1)
+            w.Add($"task '{title}': multiple Thunderbird alarms — only the first is converted");
+
+        if (master.Alarms.Count > 0)
+        {
+            var rawBlock = master.Alarms[0].IcalString ?? "";
+            var alarmResult = ICalTextParser.ParseAlarm(rawBlock);
+
+            foreach (var aw in alarmResult.Warnings)
+                w.Add(aw);
+
+            if (alarmResult.Value is { } alarm)
+            {
+                if (alarm.AbsoluteTimeUtc is { } absUtc)
+                {
+                    // Absolute trigger
+                    t.ReminderSet  = true;
+                    t.ReminderTime = new DateTimeOffset(absUtc, TimeSpan.Zero);
+                }
+                else if (alarm.RelativeOffset is { } offset)
+                {
+                    // Relative trigger — resolve anchor
+                    DateTimeOffset? anchor = alarm.Related switch
+                    {
+                        "START" => t.StartDate,
+                        "END"   => t.DueDate,
+                        _       => t.DueDate ?? t.StartDate, // default: DueDate ?? StartDate
+                    };
+
+                    if (anchor is null)
+                    {
+                        w.Add($"task '{title}': alarm has no anchor date — not converted");
+                        AppendRawTriggerToBody(t, rawBlock);
+                    }
+                    else if (offset < TimeSpan.Zero)
+                    {
+                        // Negative offset — fires before anchor; valid reminder
+                        t.ReminderSet  = true;
+                        t.ReminderTime = anchor.Value + offset;
+                    }
+                    else
+                    {
+                        // Zero or positive — fires at/after anchor; skip reminder
+                        w.Add($"task '{title}': reminder fires at/after the anchor — not converted");
+                        AppendRawTriggerToBody(t, rawBlock);
+                    }
+                }
+            }
+            // If alarmResult.Value is null, parse failed; warnings already added; preserve trigger if we can
+        }
+
+        return t;
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private static string? PropValue(RawTodo todo, string key)
+    {
+        RawProperty? p = todo.Properties.FirstOrDefault(
+            x => string.Equals(x.Key, key, StringComparison.OrdinalIgnoreCase));
+        return p?.Value is { } b ? Encoding.UTF8.GetString(b) : null;
+    }
+
+    /// <summary>
+    /// Splits a CATEGORIES value on commas that are NOT escaped by a preceding backslash,
+    /// then unescapes each token's \, sequences.  Trims whitespace and drops empty tokens.
+    /// </summary>
+    private static IReadOnlyList<string> SplitCategories(string raw)
+    {
+        // Lookbehind for backslash: split on commas not preceded by '\'
+        var parts = Regex.Split(raw, @"(?<!\\),");
+        var result = new List<string>(parts.Length);
+        foreach (var part in parts)
+        {
+            var cat = part.Replace("\\,", ",").Trim();
+            if (!string.IsNullOrEmpty(cat))
+                result.Add(cat);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Extracts the raw TRIGGER line from a VALARM block and appends a
+    /// "not converted" notice to the task body.
+    /// </summary>
+    private static void AppendRawTriggerToBody(TaskRecord t, string rawBlock)
+    {
+        string? triggerLine = null;
+        foreach (var line in rawBlock.Split('\n'))
+        {
+            var trimmed = line.TrimEnd('\r').Trim();
+            if (trimmed.StartsWith("TRIGGER", StringComparison.OrdinalIgnoreCase))
+            {
+                triggerLine = trimmed;
+                break;
+            }
+        }
+        if (triggerLine is not null)
+            t.Body = (t.Body ?? "") + $"\n[Thunderbird alarm not converted: {triggerLine}]";
+    }
+}

--- a/src/Mail2Pst.Core/Calendar/CalendarTaskMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarTaskMapper.cs
@@ -133,6 +133,17 @@ public static class CalendarTaskMapper
             }
         }
 
+        // --- Relations (cal_relations side-table: RELATED-TO etc.) ---
+        // Classic Outlook has no native related-task surface; preserve raw relation lines
+        // in the body appendix (via CalendarBodyAppendix in TaskWriter) + warn once per line.
+        t.Relations = master.Relations
+            .Select(r => r.IcalString)
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Select(s => s!)
+            .ToList();
+        foreach (var rel in t.Relations)
+            w.Add($"relation on '{t.Subject}': preserved (not natively converted)");
+
         // Task attendees/assignment deferred: Outlook task assignment is a separate MAPI surface (not PR6).
 
         // Recurrence — map RRULE if present, degrade on exceptions/completions/unrepresentable rules.

--- a/src/Mail2Pst.Core/Calendar/CalendarTaskMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarTaskMapper.cs
@@ -46,8 +46,12 @@ public static class CalendarTaskMapper
             _            => TaskStatusKind.NotStarted, // NEEDS-ACTION, null, unknown
         };
 
-        // PercentComplete
-        t.PercentComplete = Math.Clamp(master.TodoComplete ?? 0, 0, 100);
+        // PercentComplete — cal_todos.todo_complete when populated; otherwise fall back to the
+        // PERCENT-COMPLETE cal_properties row, which is where Thunderbird's storage calendar
+        // actually persists it (leaving the column NULL — observed on a real TB 140 profile).
+        int percent = master.TodoComplete
+            ?? (int.TryParse(PropValue(master, "PERCENT-COMPLETE"), out int pc) ? pc : 0);
+        t.PercentComplete = Math.Clamp(percent, 0, 100);
 
         // Status/percent invariants (Outlook treats these as coupled)
         if (t.PercentComplete == 100)

--- a/src/Mail2Pst.Core/Calendar/CalendarTaskMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarTaskMapper.cs
@@ -180,6 +180,9 @@ public static class CalendarTaskMapper
                         lines, utcMidnight, utcMidnight, TimeZoneInfo.Utc, originatingTzId: null);
                     if (reason is not null)
                         w.Add($"recurring task '{title}': {reason}; wrote a single task");
+                    else if (spec is null)
+                        // hasRrule is true, so RRULE was present — (null,null) uniquely means parse failure.
+                        w.Add($"recurring task '{title}': RRULE could not be parsed — wrote a single task");
                     else
                         t.Recurrence = spec;
                 }

--- a/src/Mail2Pst.Core/Calendar/GlobalObjectIdCodec.cs
+++ b/src/Mail2Pst.Core/Calendar/GlobalObjectIdCodec.cs
@@ -34,8 +34,19 @@ public static class GlobalObjectIdCodec
         if (!id.StartsWith(EdkPrefix, System.StringComparison.OrdinalIgnoreCase)) return false;
         try { goid = System.Convert.FromHexString(id); } catch { return false; }
         if (goid.Length != 56) { goid = System.Array.Empty<byte>(); return false; }
-        cleanGoid = (byte[])goid.Clone();
-        for (int i = 16; i < 20; i++) cleanGoid[i] = 0;   // clean = exception-date bytes zeroed
+        cleanGoid = ToCleanGlobalObjectId(goid);
         return true;
+    }
+
+    /// <summary>
+    /// Returns a clone of <paramref name="goid"/> with the exception-date bytes [16..20) zeroed —
+    /// the <c>PidLidCleanGlobalObjectId</c> derivation. Shared by <see cref="TryDecode"/> and the
+    /// appointment writer so the derivation lives in exactly one place.
+    /// </summary>
+    public static byte[] ToCleanGlobalObjectId(byte[] goid)
+    {
+        byte[] clean = (byte[])goid.Clone();
+        for (int i = 16; i < 20 && i < clean.Length; i++) clean[i] = 0;
+        return clean;
     }
 }

--- a/src/Mail2Pst.Core/Calendar/GlobalObjectIdCodec.cs
+++ b/src/Mail2Pst.Core/Calendar/GlobalObjectIdCodec.cs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+namespace Mail2Pst.Core.Calendar;
+
+/// <summary>
+/// Detects and hex-decodes a Thunderbird <c>cal_events.id</c> that is an Exchange-cached
+/// GlobalObjectId (uppercase-hex, 112 chars = 56 bytes, EDK prefix
+/// <c>040000008200E00074C5B7101A82E008</c>).
+///
+/// Mozilla UUIDs, CalDAV UIDs, and any other string that does not start with the prefix
+/// (or is not exactly 112 hex chars) return <c>false</c>.
+/// </summary>
+public static class GlobalObjectIdCodec
+{
+    private const string EdkPrefix = "040000008200E00074C5B7101A82E008";   // GOID byte-array class id (hex)
+
+    /// <summary>
+    /// Attempts to decode <paramref name="id"/> as a 56-byte Exchange GlobalObjectId.
+    /// </summary>
+    /// <param name="id">The raw <c>cal_events.id</c> value (may be null).</param>
+    /// <param name="goid">
+    /// On success: the verbatim 56-byte GOID blob (<c>PidLidGlobalObjectId</c>).
+    /// On failure: <see cref="System.Array.Empty{T}()"/>.
+    /// </param>
+    /// <param name="cleanGoid">
+    /// On success: a clone of <paramref name="goid"/> with exception-date bytes [16..20) zeroed
+    /// (<c>PidLidCleanGlobalObjectId</c>). On failure: <see cref="System.Array.Empty{T}()"/>.
+    /// </param>
+    /// <returns><c>true</c> iff <paramref name="id"/> is a valid Exchange GOID hex string.</returns>
+    public static bool TryDecode(string? id, out byte[] goid, out byte[] cleanGoid)
+    {
+        goid = System.Array.Empty<byte>(); cleanGoid = System.Array.Empty<byte>();
+        if (id is null || id.Length != 112) return false;
+        if (!id.StartsWith(EdkPrefix, System.StringComparison.OrdinalIgnoreCase)) return false;
+        try { goid = System.Convert.FromHexString(id); } catch { return false; }
+        if (goid.Length != 56) { goid = System.Array.Empty<byte>(); return false; }
+        cleanGoid = (byte[])goid.Clone();
+        for (int i = 16; i < 20; i++) cleanGoid[i] = 0;   // clean = exception-date bytes zeroed
+        return true;
+    }
+}

--- a/src/Mail2Pst.Core/Calendar/ICalTextParser.cs
+++ b/src/Mail2Pst.Core/Calendar/ICalTextParser.cs
@@ -92,8 +92,11 @@ public static class ICalTextParser
 
         foreach (var raw in icalLines)
         {
-            // Unfold each individual line (handles wrapped continuations).
-            var line = IcalParseSupport.UnfoldIcalLines(raw);
+            // Unfold each individual line (handles wrapped continuations), then strip any trailing
+            // line terminator. Mozilla's cal_recurrence stores each property with a trailing CRLF;
+            // left in place it corrupts the final RRULE token (Ical.Net rejects "SU\r\n") and every
+            // EXDATE/RDATE value (the date parse fails and the deletion is silently lost).
+            var line = IcalParseSupport.UnfoldIcalLines(raw).Trim();
             if (line.StartsWith("RRULE:", StringComparison.OrdinalIgnoreCase))
             {
                 rruleLine ??= line;   // first RRULE wins

--- a/src/Mail2Pst.Core/Calendar/ICalTextParser.cs
+++ b/src/Mail2Pst.Core/Calendar/ICalTextParser.cs
@@ -33,6 +33,7 @@ public sealed record ParsedRecurrence(
     IReadOnlyList<ParsedByDay> ByDay,
     IReadOnlyList<int> ByMonth,
     IReadOnlyList<int> ByMonthDay,
+    IReadOnlyList<int> BySetPosition,
     IReadOnlyList<ParsedDateList> ExDates,
     IReadOnlyList<ParsedDateList> RDates);
 
@@ -130,22 +131,24 @@ public static class ICalTextParser
                 }
             }
 
-            var byMonth    = (IReadOnlyList<int>)(rr.ByMonth    is { Count: > 0 } bm  ? bm  : Array.Empty<int>());
-            var byMonthDay = (IReadOnlyList<int>)(rr.ByMonthDay is { Count: > 0 } bmd ? bmd : Array.Empty<int>());
+            var byMonth      = (IReadOnlyList<int>)(rr.ByMonth      is { Count: > 0 } bm  ? bm  : Array.Empty<int>());
+            var byMonthDay   = (IReadOnlyList<int>)(rr.ByMonthDay   is { Count: > 0 } bmd ? bmd : Array.Empty<int>());
+            var bySetPosition = (IReadOnlyList<int>)(rr.BySetPosition is { Count: > 0 } bsp ? bsp.ToList() : Array.Empty<int>());
 
             DateTime? untilUtc = rr.Until is not null ? rr.Until.AsUtc : null;
 
             var recurrence = new ParsedRecurrence(
-                Frequency:    freq,
-                RawFrequency: rr.Frequency.ToString(),
-                Interval:     rr.Interval,
-                Count:        rr.Count ?? 0,
-                UntilUtc:     untilUtc,
-                ByDay:        byDay,
-                ByMonth:      byMonth,
-                ByMonthDay:   byMonthDay,
-                ExDates:      exDates,
-                RDates:       rDates);
+                Frequency:     freq,
+                RawFrequency:  rr.Frequency.ToString(),
+                Interval:      rr.Interval,
+                Count:         rr.Count ?? 0,
+                UntilUtc:      untilUtc,
+                ByDay:         byDay,
+                ByMonth:       byMonth,
+                ByMonthDay:    byMonthDay,
+                BySetPosition: bySetPosition,
+                ExDates:       exDates,
+                RDates:        rDates);
 
             return ParseResult<ParsedRecurrence>.Ok(recurrence);
         }

--- a/src/Mail2Pst.Core/Calendar/ICalTextParser.cs
+++ b/src/Mail2Pst.Core/Calendar/ICalTextParser.cs
@@ -3,6 +3,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Text;
 using Ical.Net.DataTypes;
 using IcalCalendar = Ical.Net.Calendar;
 
@@ -56,6 +57,20 @@ public sealed record ParsedAlarm(
     DateTime? AbsoluteTimeUtc,
     string? Related,
     string? Description);
+
+// ---------------------------------------------------------------------------
+// Domain type for parsed attachment data.
+// ---------------------------------------------------------------------------
+
+/// <summary>
+/// Represents a parsed ATTACH property.  Exactly one of <see cref="Uri"/> or
+/// <see cref="InlineData"/> is non-null.
+/// </summary>
+public sealed record ParsedAttachment(
+    string? Uri,
+    byte[]? InlineData,
+    string? FileName,
+    string? FormatType);
 
 // ---------------------------------------------------------------------------
 // ICalTextParser — first slice: ParseRecurrence.
@@ -237,6 +252,111 @@ public static class ICalTextParser
             Description:     alarm.Description);
 
         return ParseResult<ParsedAlarm>.Ok(parsed);
+    }
+
+    /// <summary>
+    /// Parses a single raw ATTACH property line and classifies the attachment
+    /// as a URI link, inline binary (ENCODING=BASE64;VALUE=BINARY), or a
+    /// <c>data:</c> URI decoded to inline bytes.
+    /// Returns <c>Value=null</c> with a warning when loading or classification fails.
+    /// </summary>
+    public static ParseResult<ParsedAttachment> ParseAttachment(string attachLine)
+    {
+        Ical.Net.CalendarComponents.CalendarEvent? evt;
+        try
+        {
+            var cal = IcalCalendar.Load(IcalParseSupport.WrapVevent(attachLine));
+            evt = cal?.Events.Count > 0 ? cal.Events[0] : null;
+        }
+        catch (Exception ex)
+        {
+            return ParseResult<ParsedAttachment>.Fail($"ATTACH parse failed: {ex.Message}");
+        }
+
+        if (evt is null)
+            return ParseResult<ParsedAttachment>.Fail("ATTACH: no VEVENT found after wrapping.");
+
+        if (evt.Attachments is null || evt.Attachments.Count == 0)
+            return ParseResult<ParsedAttachment>.Fail("ATTACH: no ATTACH property found in VEVENT.");
+
+        var att = evt.Attachments[0];
+
+        var fileName   = att.Parameters?.Get("FILENAME");
+        var formatType = att.FormatType;
+
+        try
+        {
+            // Case 1: inline binary — Ical.Net decoded ENCODING=BASE64;VALUE=BINARY into att.Data.
+            if (att.Data is { Length: > 0 })
+            {
+                return ParseResult<ParsedAttachment>.Ok(
+                    new ParsedAttachment(null, att.Data, fileName, formatType));
+            }
+
+            // Case 2: data: URI — Ical.Net leaves the raw URI in att.Uri without decoding.
+            var uriStr = att.Uri?.ToString();
+            if (uriStr is not null &&
+                uriStr.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+            {
+                // Format: data:[<mediatype>][;base64],<data>
+                var commaIdx = uriStr.IndexOf(',');
+                if (commaIdx < 0)
+                    return ParseResult<ParsedAttachment>.Fail($"ATTACH: malformed data: URI (no comma): {uriStr}");
+
+                var meta    = uriStr.Substring(0, commaIdx);   // e.g. "data:text/plain;base64"
+                var payload = uriStr.Substring(commaIdx + 1);  // e.g. "aGk="
+
+                // Extract media type from the meta segment (strip leading "data:").
+                var metaBody = meta.Length > "data:".Length
+                    ? meta.Substring("data:".Length)
+                    : string.Empty;
+                // metaBody is e.g. "text/plain;base64" — the media type is everything before the first ";"
+                var semicolonIdx = metaBody.IndexOf(';');
+                var mediaType    = semicolonIdx >= 0
+                    ? metaBody.Substring(0, semicolonIdx)
+                    : metaBody;
+
+                // Use the data: media type as FormatType when Ical.Net didn't provide one.
+                var resolvedFormatType = string.IsNullOrEmpty(formatType) && !string.IsNullOrEmpty(mediaType)
+                    ? mediaType
+                    : formatType;
+
+                byte[] inlineData;
+                if (meta.Contains("base64", StringComparison.OrdinalIgnoreCase))
+                {
+                    try
+                    {
+                        inlineData = Convert.FromBase64String(payload);
+                    }
+                    catch (FormatException ex)
+                    {
+                        return ParseResult<ParsedAttachment>.Fail(
+                            $"ATTACH: invalid base64 in data: URI: {ex.Message}");
+                    }
+                }
+                else
+                {
+                    // Percent-decoded UTF-8 text payload.
+                    inlineData = Encoding.UTF8.GetBytes(Uri.UnescapeDataString(payload));
+                }
+
+                return ParseResult<ParsedAttachment>.Ok(
+                    new ParsedAttachment(null, inlineData, fileName, resolvedFormatType));
+            }
+
+            // Case 3: remote/external URI.
+            if (uriStr is not null)
+            {
+                return ParseResult<ParsedAttachment>.Ok(
+                    new ParsedAttachment(uriStr, null, fileName, formatType));
+            }
+
+            return ParseResult<ParsedAttachment>.Fail("ATTACH: no data, no URI — unrecognised attachment.");
+        }
+        catch (Exception ex)
+        {
+            return ParseResult<ParsedAttachment>.Fail($"ATTACH classification failed: {ex.Message}");
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/src/Mail2Pst.Core/Calendar/ICalTextParser.cs
+++ b/src/Mail2Pst.Core/Calendar/ICalTextParser.cs
@@ -3,7 +3,6 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Ical.Net.DataTypes;
 using IcalCalendar = Ical.Net.Calendar;
 
@@ -296,47 +295,13 @@ public static class ICalTextParser
             if (uriStr is not null &&
                 uriStr.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
             {
-                // Format: data:[<mediatype>][;base64],<data>
-                var commaIdx = uriStr.IndexOf(',');
-                if (commaIdx < 0)
-                    return ParseResult<ParsedAttachment>.Fail($"ATTACH: malformed data: URI (no comma): {uriStr}");
-
-                var meta    = uriStr.Substring(0, commaIdx);   // e.g. "data:text/plain;base64"
-                var payload = uriStr.Substring(commaIdx + 1);  // e.g. "aGk="
-
-                // Extract media type from the meta segment (strip leading "data:").
-                var metaBody = meta.Length > "data:".Length
-                    ? meta.Substring("data:".Length)
-                    : string.Empty;
-                // metaBody is e.g. "text/plain;base64" — the media type is everything before the first ";"
-                var semicolonIdx = metaBody.IndexOf(';');
-                var mediaType    = semicolonIdx >= 0
-                    ? metaBody.Substring(0, semicolonIdx)
-                    : metaBody;
+                if (!IcalDataUri.TryDecode(uriStr, out var mediaType, out var inlineData))
+                    return ParseResult<ParsedAttachment>.Fail($"ATTACH: malformed or undecodable data: URI: {uriStr}");
 
                 // Use the data: media type as FormatType when Ical.Net didn't provide one.
                 var resolvedFormatType = string.IsNullOrEmpty(formatType) && !string.IsNullOrEmpty(mediaType)
                     ? mediaType
                     : formatType;
-
-                byte[] inlineData;
-                if (meta.Contains("base64", StringComparison.OrdinalIgnoreCase))
-                {
-                    try
-                    {
-                        inlineData = Convert.FromBase64String(payload);
-                    }
-                    catch (FormatException ex)
-                    {
-                        return ParseResult<ParsedAttachment>.Fail(
-                            $"ATTACH: invalid base64 in data: URI: {ex.Message}");
-                    }
-                }
-                else
-                {
-                    // Percent-decoded UTF-8 text payload.
-                    inlineData = Encoding.UTF8.GetBytes(Uri.UnescapeDataString(payload));
-                }
 
                 return ParseResult<ParsedAttachment>.Ok(
                     new ParsedAttachment(null, inlineData, fileName, resolvedFormatType));

--- a/src/Mail2Pst.Core/Calendar/ICalTextParser.cs
+++ b/src/Mail2Pst.Core/Calendar/ICalTextParser.cs
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using Ical.Net.DataTypes;
+
+namespace Mail2Pst.Core.Calendar;
+
+// ---------------------------------------------------------------------------
+// Domain types for parsed recurrence data.
+// ---------------------------------------------------------------------------
+
+public enum ParsedFrequency { Unknown, Daily, Weekly, Monthly, Yearly }
+
+public sealed record ParsedByDay(DayOfWeek DayOfWeek, int? Offset);
+
+/// <summary>Structured representation of an EXDATE or RDATE line.</summary>
+public sealed record ParsedDateList(
+    string Raw,
+    string? TzId,
+    bool IsDateOnly,
+    IReadOnlyList<string> Values);
+
+/// <summary>Full parsed recurrence for one VEVENT.</summary>
+public sealed record ParsedRecurrence(
+    ParsedFrequency Frequency,
+    string RawFrequency,
+    int Interval,
+    int Count,
+    DateTime? UntilUtc,
+    IReadOnlyList<ParsedByDay> ByDay,
+    IReadOnlyList<int> ByMonth,
+    IReadOnlyList<int> ByMonthDay,
+    IReadOnlyList<ParsedDateList> ExDates,
+    IReadOnlyList<ParsedDateList> RDates);
+
+// ---------------------------------------------------------------------------
+// ICalTextParser — first slice: ParseRecurrence.
+// ---------------------------------------------------------------------------
+
+public static class ICalTextParser
+{
+    /// <summary>
+    /// Parses recurrence from a flat list of iCal property lines (already
+    /// belonging to one VEVENT — no BEGIN/END envelope needed).
+    /// Lines are individually unfolded before inspection.
+    /// Returns <c>Value=null</c> (no warnings) when no RRULE line is present.
+    /// </summary>
+    public static ParseResult<ParsedRecurrence> ParseRecurrence(IReadOnlyList<string> icalLines)
+    {
+        string? rruleLine = null;
+        var exDates = new List<ParsedDateList>();
+        var rDates  = new List<ParsedDateList>();
+
+        foreach (var raw in icalLines)
+        {
+            // Unfold each individual line (handles wrapped continuations).
+            var line = IcalParseSupport.UnfoldIcalLines(raw);
+            if (line.StartsWith("RRULE:", StringComparison.OrdinalIgnoreCase))
+            {
+                rruleLine ??= line;   // first RRULE wins
+            }
+            else if (line.StartsWith("EXDATE", StringComparison.OrdinalIgnoreCase))
+            {
+                exDates.Add(ParseDateListLine(line));
+            }
+            else if (line.StartsWith("RDATE", StringComparison.OrdinalIgnoreCase))
+            {
+                rDates.Add(ParseDateListLine(line));
+            }
+        }
+
+        // No RRULE — normal (single-occurrence event); return null value, no warning.
+        if (rruleLine is null)
+            return new ParseResult<ParsedRecurrence>(null, Array.Empty<string>());
+
+        // Strip the "RRULE:" prefix to get the bare rule body.
+        var ruleBody = rruleLine.Substring("RRULE:".Length);
+
+        RecurrencePattern rr;
+        try
+        {
+            rr = new RecurrencePattern(ruleBody);
+        }
+        catch (Exception ex)
+        {
+            return ParseResult<ParsedRecurrence>.Fail(
+                $"RRULE parse failed: {ex.Message} (rule: {ruleBody})");
+        }
+
+        var freq = MapFrequency(rr.Frequency);
+
+        var byDay = new List<ParsedByDay>(rr.ByDay?.Count ?? 0);
+        if (rr.ByDay is not null)
+        {
+            foreach (var wd in rr.ByDay)
+            {
+                int? offset = wd.Offset == int.MinValue ? null : wd.Offset;
+                byDay.Add(new ParsedByDay(wd.DayOfWeek, offset));
+            }
+        }
+
+        var byMonth    = (IReadOnlyList<int>)(rr.ByMonth    is { Count: > 0 } bm  ? bm  : Array.Empty<int>());
+        var byMonthDay = (IReadOnlyList<int>)(rr.ByMonthDay is { Count: > 0 } bmd ? bmd : Array.Empty<int>());
+
+        DateTime? untilUtc = rr.Until is not null ? rr.Until.AsUtc : null;
+
+        var recurrence = new ParsedRecurrence(
+            Frequency:    freq,
+            RawFrequency: rr.Frequency.ToString(),
+            Interval:     rr.Interval,
+            Count:        rr.Count ?? 0,
+            UntilUtc:     untilUtc,
+            ByDay:        byDay,
+            ByMonth:      byMonth,
+            ByMonthDay:   byMonthDay,
+            ExDates:      exDates,
+            RDates:       rDates);
+
+        return ParseResult<ParsedRecurrence>.Ok(recurrence);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Parses a single EXDATE or RDATE line into a <see cref="ParsedDateList"/>.
+    /// Format: NAME[;param;param]:value,value,...
+    /// Recognised params: TZID=..., VALUE=DATE.
+    /// </summary>
+    internal static ParsedDateList ParseDateListLine(string line)
+    {
+        // Find the colon that separates property (name + params) from value.
+        // A TZID param value may itself contain a colon on some broken TZIDs, but
+        // RFC 5545 §3.1 says the first unescaped colon delimits the value.
+        int colonIdx = line.IndexOf(':');
+        if (colonIdx < 0)
+        {
+            // Malformed — return empty.
+            return new ParsedDateList(line, null, false, Array.Empty<string>());
+        }
+
+        var propSection  = line.Substring(0, colonIdx);   // e.g. "EXDATE;TZID=Europe/Oslo;VALUE=DATE"
+        var valueSection = line.Substring(colonIdx + 1);  // e.g. "20250516,20250523"
+
+        // Split propSection on ';' — first token is the property name, rest are params.
+        var parts = propSection.Split(';');
+
+        string? tzId = null;
+        bool isDateOnly = false;
+
+        for (int i = 1; i < parts.Length; i++)
+        {
+            var param = parts[i];
+            if (param.StartsWith("TZID=", StringComparison.OrdinalIgnoreCase))
+                tzId = param.Substring("TZID=".Length);
+            else if (param.Equals("VALUE=DATE", StringComparison.OrdinalIgnoreCase))
+                isDateOnly = true;
+        }
+
+        var values = valueSection.Length > 0
+            ? (IReadOnlyList<string>)valueSection.Split(',')
+            : Array.Empty<string>();
+
+        return new ParsedDateList(line, tzId, isDateOnly, values);
+    }
+
+    private static ParsedFrequency MapFrequency(Ical.Net.FrequencyType ft) => ft switch
+    {
+        Ical.Net.FrequencyType.Daily   => ParsedFrequency.Daily,
+        Ical.Net.FrequencyType.Weekly  => ParsedFrequency.Weekly,
+        Ical.Net.FrequencyType.Monthly => ParsedFrequency.Monthly,
+        Ical.Net.FrequencyType.Yearly  => ParsedFrequency.Yearly,
+        _                              => ParsedFrequency.Unknown,
+    };
+}

--- a/src/Mail2Pst.Core/Calendar/ICalTextParser.cs
+++ b/src/Mail2Pst.Core/Calendar/ICalTextParser.cs
@@ -115,47 +115,46 @@ public static class ICalTextParser
         // Strip the "RRULE:" prefix to get the bare rule body.
         var ruleBody = rruleLine.Substring("RRULE:".Length);
 
-        RecurrencePattern rr;
         try
         {
-            rr = new RecurrencePattern(ruleBody);
+            var rr = new RecurrencePattern(ruleBody);
+
+            var freq = MapFrequency(rr.Frequency);
+
+            var byDay = new List<ParsedByDay>(rr.ByDay?.Count ?? 0);
+            if (rr.ByDay is not null)
+            {
+                foreach (var wd in rr.ByDay)
+                {
+                    int? offset = wd.Offset == int.MinValue ? null : wd.Offset;
+                    byDay.Add(new ParsedByDay(wd.DayOfWeek, offset));
+                }
+            }
+
+            var byMonth    = (IReadOnlyList<int>)(rr.ByMonth    is { Count: > 0 } bm  ? bm  : Array.Empty<int>());
+            var byMonthDay = (IReadOnlyList<int>)(rr.ByMonthDay is { Count: > 0 } bmd ? bmd : Array.Empty<int>());
+
+            DateTime? untilUtc = rr.Until is not null ? rr.Until.AsUtc : null;
+
+            var recurrence = new ParsedRecurrence(
+                Frequency:    freq,
+                RawFrequency: rr.Frequency.ToString(),
+                Interval:     rr.Interval,
+                Count:        rr.Count ?? 0,
+                UntilUtc:     untilUtc,
+                ByDay:        byDay,
+                ByMonth:      byMonth,
+                ByMonthDay:   byMonthDay,
+                ExDates:      exDates,
+                RDates:       rDates);
+
+            return ParseResult<ParsedRecurrence>.Ok(recurrence);
         }
         catch (Exception ex)
         {
             return ParseResult<ParsedRecurrence>.Fail(
                 $"RRULE parse failed: {ex.Message} (rule: {ruleBody})");
         }
-
-        var freq = MapFrequency(rr.Frequency);
-
-        var byDay = new List<ParsedByDay>(rr.ByDay?.Count ?? 0);
-        if (rr.ByDay is not null)
-        {
-            foreach (var wd in rr.ByDay)
-            {
-                int? offset = wd.Offset == int.MinValue ? null : wd.Offset;
-                byDay.Add(new ParsedByDay(wd.DayOfWeek, offset));
-            }
-        }
-
-        var byMonth    = (IReadOnlyList<int>)(rr.ByMonth    is { Count: > 0 } bm  ? bm  : Array.Empty<int>());
-        var byMonthDay = (IReadOnlyList<int>)(rr.ByMonthDay is { Count: > 0 } bmd ? bmd : Array.Empty<int>());
-
-        DateTime? untilUtc = rr.Until is not null ? rr.Until.AsUtc : null;
-
-        var recurrence = new ParsedRecurrence(
-            Frequency:    freq,
-            RawFrequency: rr.Frequency.ToString(),
-            Interval:     rr.Interval,
-            Count:        rr.Count ?? 0,
-            UntilUtc:     untilUtc,
-            ByDay:        byDay,
-            ByMonth:      byMonth,
-            ByMonthDay:   byMonthDay,
-            ExDates:      exDates,
-            RDates:       rDates);
-
-        return ParseResult<ParsedRecurrence>.Ok(recurrence);
     }
 
     /// <summary>
@@ -212,46 +211,45 @@ public static class ICalTextParser
     /// </summary>
     public static ParseResult<ParsedAlarm> ParseAlarm(string valarmBlock)
     {
-        Ical.Net.CalendarComponents.CalendarEvent? evt;
         try
         {
             var cal = IcalCalendar.Load(IcalParseSupport.WrapVevent(valarmBlock));
-            evt = cal?.Events.Count > 0 ? cal.Events[0] : null;
+            var evt = cal?.Events.Count > 0 ? cal.Events[0] : null;
+
+            if (evt is null)
+                return ParseResult<ParsedAlarm>.Fail("VALARM: no VEVENT found after wrapping.");
+
+            if (evt.Alarms is null || evt.Alarms.Count == 0)
+                return ParseResult<ParsedAlarm>.Fail("VALARM: alarm list is empty.");
+
+            var alarm = evt.Alarms[0];
+
+            // Trigger.Related is a TriggerRelation enum (Start/End); normalise to
+            // uppercase to match the raw iCal convention ("START"/"END").
+            string? related = alarm.Trigger is null
+                ? null
+                : alarm.Trigger.Related.ToString().ToUpperInvariant();
+
+            // Trigger.Duration is Ical.Net.DataTypes.Duration (struct).
+            // ToTimeSpanUnspecified() converts weeks/days/hours/minutes/seconds without
+            // needing a CalDateTime anchor (safe for alarm offsets which never use months/years).
+            TimeSpan? relativeOffset = alarm.Trigger?.Duration is { } dur
+                ? dur.ToTimeSpanUnspecified()
+                : (TimeSpan?)null;
+
+            var parsed = new ParsedAlarm(
+                Action:          alarm.Action,
+                RelativeOffset:  relativeOffset,
+                AbsoluteTimeUtc: alarm.Trigger?.DateTime?.AsUtc,
+                Related:         related,
+                Description:     alarm.Description);
+
+            return ParseResult<ParsedAlarm>.Ok(parsed);
         }
         catch (Exception ex)
         {
             return ParseResult<ParsedAlarm>.Fail($"VALARM parse failed: {ex.Message}");
         }
-
-        if (evt is null)
-            return ParseResult<ParsedAlarm>.Fail("VALARM: no VEVENT found after wrapping.");
-
-        if (evt.Alarms is null || evt.Alarms.Count == 0)
-            return ParseResult<ParsedAlarm>.Fail("VALARM: alarm list is empty.");
-
-        var alarm = evt.Alarms[0];
-
-        // Trigger.Related is a TriggerRelation enum (Start/End); normalise to
-        // uppercase to match the raw iCal convention ("START"/"END").
-        string? related = alarm.Trigger is null
-            ? null
-            : alarm.Trigger.Related.ToString().ToUpperInvariant();
-
-        // Trigger.Duration is Ical.Net.DataTypes.Duration (struct).
-        // ToTimeSpanUnspecified() converts weeks/days/hours/minutes/seconds without
-        // needing a CalDateTime anchor (safe for alarm offsets which never use months/years).
-        TimeSpan? relativeOffset = alarm.Trigger?.Duration is { } dur
-            ? dur.ToTimeSpanUnspecified()
-            : (TimeSpan?)null;
-
-        var parsed = new ParsedAlarm(
-            Action:          alarm.Action,
-            RelativeOffset:  relativeOffset,
-            AbsoluteTimeUtc: alarm.Trigger?.DateTime?.AsUtc,
-            Related:         related,
-            Description:     alarm.Description);
-
-        return ParseResult<ParsedAlarm>.Ok(parsed);
     }
 
     /// <summary>
@@ -287,7 +285,7 @@ public static class ICalTextParser
         try
         {
             // Case 1: inline binary — Ical.Net decoded ENCODING=BASE64;VALUE=BINARY into att.Data.
-            if (att.Data is { Length: > 0 })
+            if (att.Data is not null)
             {
                 return ParseResult<ParsedAttachment>.Ok(
                     new ParsedAttachment(null, att.Data, fileName, formatType));

--- a/src/Mail2Pst.Core/Calendar/ICalTextParser.cs
+++ b/src/Mail2Pst.Core/Calendar/ICalTextParser.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Ical.Net.DataTypes;
+using IcalCalendar = Ical.Net.Calendar;
 
 namespace Mail2Pst.Core.Calendar;
 
@@ -34,6 +35,27 @@ public sealed record ParsedRecurrence(
     IReadOnlyList<int> ByMonthDay,
     IReadOnlyList<ParsedDateList> ExDates,
     IReadOnlyList<ParsedDateList> RDates);
+
+// ---------------------------------------------------------------------------
+// Domain types for attendees and alarms.
+// ---------------------------------------------------------------------------
+
+/// <summary>One participant (attendee or organizer) from a VEVENT.</summary>
+public sealed record ParsedAttendee(
+    string? CommonName,
+    string? Email,
+    string? Role,
+    string? ParticipationStatus,
+    string? CuType,
+    bool IsOrganizer);
+
+/// <summary>Parsed VALARM for a VEVENT.</summary>
+public sealed record ParsedAlarm(
+    string? Action,
+    TimeSpan? RelativeOffset,
+    DateTime? AbsoluteTimeUtc,
+    string? Related,
+    string? Description);
 
 // ---------------------------------------------------------------------------
 // ICalTextParser — first slice: ParseRecurrence.
@@ -121,9 +143,152 @@ public static class ICalTextParser
         return ParseResult<ParsedRecurrence>.Ok(recurrence);
     }
 
+    /// <summary>
+    /// Parses ATTENDEE and ORGANIZER lines from a flat list of iCal property lines.
+    /// All lines are wrapped into one VEVENT and loaded together so that attendees
+    /// and the organizer coexist in one calendar event.  On load failure the method
+    /// falls back to loading each line individually, emitting a warning per failure.
+    /// The returned <c>Value</c> is never null — it may be an empty or partial list.
+    /// </summary>
+    public static ParseResult<IReadOnlyList<ParsedAttendee>> ParseAttendees(IReadOnlyList<string> icalLines)
+    {
+        var warnings = new List<string>();
+        var result   = new List<ParsedAttendee>();
+
+        // Attempt: load all lines in one VEVENT so organizer + attendees coexist.
+        var combined = string.Join("\r\n", icalLines);
+        try
+        {
+            var cal = IcalCalendar.Load(IcalParseSupport.WrapVevent(combined));
+            var evt = cal?.Events.Count > 0 ? cal.Events[0] : null;
+            if (evt is not null)
+                ExtractAttendeesFromEvent(evt, result);
+        }
+        catch (Exception ex)
+        {
+            warnings.Add($"Combined ATTENDEE/ORGANIZER load failed, falling back to per-line: {ex.Message}");
+
+            // Per-line fallback — collect whatever parses.
+            foreach (var line in icalLines)
+            {
+                try
+                {
+                    var cal = IcalCalendar.Load(IcalParseSupport.WrapVevent(line));
+                    var evt = cal?.Events.Count > 0 ? cal.Events[0] : null;
+                    if (evt is not null)
+                        ExtractAttendeesFromEvent(evt, result);
+                }
+                catch (Exception lineEx)
+                {
+                    warnings.Add($"Attendee line parse failed: {lineEx.Message} (line: {line})");
+                }
+            }
+        }
+
+        return new ParseResult<IReadOnlyList<ParsedAttendee>>(result, warnings);
+    }
+
+    /// <summary>
+    /// Parses a raw VALARM block (BEGIN:VALARM … END:VALARM) into a
+    /// <see cref="ParsedAlarm"/>.  The block is wrapped in a VEVENT so that
+    /// relative triggers resolve correctly.
+    /// Returns <c>Value=null</c> with a warning when loading fails or the
+    /// alarm list is empty.
+    /// </summary>
+    public static ParseResult<ParsedAlarm> ParseAlarm(string valarmBlock)
+    {
+        Ical.Net.CalendarComponents.CalendarEvent? evt;
+        try
+        {
+            var cal = IcalCalendar.Load(IcalParseSupport.WrapVevent(valarmBlock));
+            evt = cal?.Events.Count > 0 ? cal.Events[0] : null;
+        }
+        catch (Exception ex)
+        {
+            return ParseResult<ParsedAlarm>.Fail($"VALARM parse failed: {ex.Message}");
+        }
+
+        if (evt is null)
+            return ParseResult<ParsedAlarm>.Fail("VALARM: no VEVENT found after wrapping.");
+
+        if (evt.Alarms is null || evt.Alarms.Count == 0)
+            return ParseResult<ParsedAlarm>.Fail("VALARM: alarm list is empty.");
+
+        var alarm = evt.Alarms[0];
+
+        // Trigger.Related is a TriggerRelation enum (Start/End); normalise to
+        // uppercase to match the raw iCal convention ("START"/"END").
+        string? related = alarm.Trigger is null
+            ? null
+            : alarm.Trigger.Related.ToString().ToUpperInvariant();
+
+        // Trigger.Duration is Ical.Net.DataTypes.Duration (struct).
+        // ToTimeSpanUnspecified() converts weeks/days/hours/minutes/seconds without
+        // needing a CalDateTime anchor (safe for alarm offsets which never use months/years).
+        TimeSpan? relativeOffset = alarm.Trigger?.Duration is { } dur
+            ? dur.ToTimeSpanUnspecified()
+            : (TimeSpan?)null;
+
+        var parsed = new ParsedAlarm(
+            Action:          alarm.Action,
+            RelativeOffset:  relativeOffset,
+            AbsoluteTimeUtc: alarm.Trigger?.DateTime?.AsUtc,
+            Related:         related,
+            Description:     alarm.Description);
+
+        return ParseResult<ParsedAlarm>.Ok(parsed);
+    }
+
     // -----------------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Extracts attendees and the organizer from a calendar event, appending
+    /// <see cref="ParsedAttendee"/> entries to <paramref name="target"/>.
+    /// </summary>
+    private static void ExtractAttendeesFromEvent(
+        Ical.Net.CalendarComponents.CalendarEvent evt,
+        List<ParsedAttendee> target)
+    {
+        if (evt.Attendees is not null)
+        {
+            foreach (var att in evt.Attendees)
+            {
+                target.Add(new ParsedAttendee(
+                    CommonName:          att.CommonName,
+                    Email:               ExtractEmail(att.Value),
+                    Role:                att.Role,
+                    ParticipationStatus: att.ParticipationStatus,
+                    CuType:              att.Parameters?.Get("CUTYPE"),
+                    IsOrganizer:         false));
+            }
+        }
+
+        if (evt.Organizer is not null)
+        {
+            target.Add(new ParsedAttendee(
+                CommonName:          evt.Organizer.CommonName,
+                Email:               ExtractEmail(evt.Organizer.Value),
+                Role:                null,
+                ParticipationStatus: null,
+                CuType:              null,
+                IsOrganizer:         true));
+        }
+    }
+
+    /// <summary>
+    /// Strips a leading <c>mailto:</c> scheme (case-insensitive) and
+    /// percent-decodes the remainder to get a plain e-mail address.
+    /// </summary>
+    private static string? ExtractEmail(Uri? uri)
+    {
+        if (uri is null) return null;
+        var s = uri.ToString();
+        if (s.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase))
+            s = s.Substring("mailto:".Length);
+        return Uri.UnescapeDataString(s);
+    }
 
     /// <summary>
     /// Parses a single EXDATE or RDATE line into a <see cref="ParsedDateList"/>.

--- a/src/Mail2Pst.Core/Calendar/ICalendarReader.cs
+++ b/src/Mail2Pst.Core/Calendar/ICalendarReader.cs
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+namespace Mail2Pst.Core.Calendar;
+public interface ICalendarReader { CalendarReadResult Read(string storePath); }

--- a/src/Mail2Pst.Core/Calendar/IcalDataUri.cs
+++ b/src/Mail2Pst.Core/Calendar/IcalDataUri.cs
@@ -72,7 +72,7 @@ internal static class IcalDataUri
             bytes = Encoding.UTF8.GetBytes(Uri.UnescapeDataString(payload));
             return true;
         }
-        catch
+        catch (UriFormatException)
         {
             return false;
         }

--- a/src/Mail2Pst.Core/Calendar/IcalDataUri.cs
+++ b/src/Mail2Pst.Core/Calendar/IcalDataUri.cs
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Text;
+
+namespace Mail2Pst.Core.Calendar;
+
+/// <summary>
+/// Decodes <c>data:</c> URIs as used in iCal ATTACH and ALTREP properties.
+/// Handles both the <c>;base64</c> and percent-encoded variants, and honours
+/// an optional <c>;charset=…</c> token (currently only read, not used for
+/// decoding — callers handle charset themselves).
+/// </summary>
+internal static class IcalDataUri
+{
+    /// <summary>
+    /// Tries to decode a <c>data:</c> URI into its media type and raw bytes.
+    /// </summary>
+    /// <param name="uri">The raw URI string (e.g. <c>data:text/html;base64,aGk=</c>).</param>
+    /// <param name="mediaType">
+    ///   On success, the bare media type without parameters (e.g. <c>text/html</c>).
+    ///   Empty string when no media type is specified.
+    /// </param>
+    /// <param name="bytes">On success, the decoded payload bytes.</param>
+    /// <returns><c>true</c> when the URI was successfully parsed and decoded.</returns>
+    public static bool TryDecode(string uri, out string mediaType, out byte[] bytes)
+    {
+        mediaType = string.Empty;
+        bytes     = Array.Empty<byte>();
+
+        if (!uri.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var commaIdx = uri.IndexOf(',');
+        if (commaIdx < 0)
+            return false;
+
+        // meta = everything between "data:" and the first comma
+        // e.g. "text/html;charset=utf-8;base64" or "text/plain"
+        var meta    = uri.Substring("data:".Length, commaIdx - "data:".Length);
+        var payload = uri.Substring(commaIdx + 1);
+
+        // Split meta on ';' — first part is the media type, rest are params.
+        var metaParts   = meta.Split(';');
+        mediaType       = metaParts.Length > 0 ? metaParts[0] : string.Empty;
+        bool isBase64   = false;
+
+        for (int i = 1; i < metaParts.Length; i++)
+        {
+            if (metaParts[i].Equals("base64", StringComparison.OrdinalIgnoreCase))
+                isBase64 = true;
+            // charset= is recognised but not used — callers decode bytes themselves.
+        }
+
+        if (isBase64)
+        {
+            try
+            {
+                bytes = Convert.FromBase64String(payload);
+                return true;
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+        }
+
+        // Percent-encoded payload (default for text/* without ;base64).
+        try
+        {
+            bytes = Encoding.UTF8.GetBytes(Uri.UnescapeDataString(payload));
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/Mail2Pst.Core/Calendar/IcalParseSupport.cs
+++ b/src/Mail2Pst.Core/Calendar/IcalParseSupport.cs
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Mail2Pst.Core.Calendar;
+
+// ---------------------------------------------------------------------------
+// ParseResult<T> — lightweight discriminated union for per-item parse outcomes.
+// Ok carries the value; Fail carries a warning and a null value.
+// Multiple warnings can accumulate (e.g. partial parse with fallbacks).
+// ---------------------------------------------------------------------------
+
+public sealed record ParseResult<T>(T? Value, IReadOnlyList<string> Warnings)
+{
+    /// <summary>Successful parse — value present, no warnings.</summary>
+    public static ParseResult<T> Ok(T value) =>
+        new(value, Array.Empty<string>());
+
+    /// <summary>Failed parse — null value, single warning message.</summary>
+    public static ParseResult<T> Fail(string warning) =>
+        new(default, new[] { warning });
+}
+
+// ---------------------------------------------------------------------------
+// IcalParseSupport — low-level iCal text helpers used by the event mapper.
+// ---------------------------------------------------------------------------
+
+public static class IcalParseSupport
+{
+    /// <summary>
+    /// RFC-5545 line unfolding: a line that begins with a SPACE or HTAB is a
+    /// continuation of the previous logical line; the leading whitespace is
+    /// stripped and the remainder is joined directly (no separator).
+    /// Normalises all line endings (\r\n, \r, \n) before folding.
+    /// </summary>
+    public static string UnfoldIcalLines(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return text;
+
+        // Normalise to bare \n so splitting is trivial.
+        var normalised = text.Replace("\r\n", "\n").Replace('\r', '\n');
+
+        var result = new StringBuilder(normalised.Length);
+        bool first = true;
+        foreach (var line in normalised.Split('\n'))
+        {
+            if (!first && line.Length > 0 && (line[0] == ' ' || line[0] == '\t'))
+            {
+                // Continuation: strip leading whitespace, join onto previous.
+                result.Append(line, 1, line.Length - 1);
+            }
+            else
+            {
+                if (!first)
+                    result.Append("\r\n");
+                result.Append(line);
+                first = false;
+            }
+        }
+        return result.ToString();
+    }
+
+    /// <summary>
+    /// Wraps iCal body lines (e.g. a bare SUMMARY/DTSTART snippet) in a
+    /// minimal but loadable VCALENDAR + VEVENT envelope.  DTSTART is
+    /// included so VALARM relative triggers resolve without errors.
+    /// </summary>
+    public static string WrapVevent(string bodyLines)
+    {
+        return
+            "BEGIN:VCALENDAR\r\n" +
+            "VERSION:2.0\r\n" +
+            "PRODID:-//ContinuMail//iCal Fragment Parser//EN\r\n" +
+            "BEGIN:VEVENT\r\n" +
+            "UID:fragment@example.com\r\n" +
+            "DTSTART:20260101T000000Z\r\n" +
+            bodyLines + "\r\n" +
+            "END:VEVENT\r\n" +
+            "END:VCALENDAR\r\n";
+    }
+}

--- a/src/Mail2Pst.Core/Calendar/RecurrenceMapping.cs
+++ b/src/Mail2Pst.Core/Calendar/RecurrenceMapping.cs
@@ -147,6 +147,11 @@ public static class RecurrenceMapping
         bool hasWkst = lines.Any(l => l.Contains("WKST=", StringComparison.OrdinalIgnoreCase));
         if (hasWkst && p.Interval > 1) return "WKST interval-sensitive";
 
+        // 5b. Negative or out-of-range BYMONTHDAY (e.g. -1 = last day of month; emitted by Google
+        // Calendar) is not representable as a fixed day-of-month — (uint)(-1) would corrupt the
+        // recurrence blob. Degrade to a single occurrence + warning.
+        if (p.ByMonthDay.Count == 1 && p.ByMonthDay[0] is < 1 or > 31) return "unrepresentable BYMONTHDAY";
+
         // 6 & 7. Cardinality rules for Monthly / Yearly.
         if (p.Frequency == ParsedFrequency.Monthly)
         {

--- a/src/Mail2Pst.Core/Calendar/RecurrenceMapping.cs
+++ b/src/Mail2Pst.Core/Calendar/RecurrenceMapping.cs
@@ -41,14 +41,16 @@ public static class RecurrenceMapping
         DateTime firstStartUtc,
         DateTime firstStartLocal,
         TimeZoneInfo? zone,
-        string? originatingTzId)
+        string? originatingTzId,
+        ParsedRecurrence? parsedRecurrence = null)
     {
         var lines = icalLines
             .Where(l => !string.IsNullOrWhiteSpace(l))
             .ToList();
 
-        ParseResult<ParsedRecurrence> pr = ICalTextParser.ParseRecurrence(lines);
-        ParsedRecurrence? p = pr.Value;
+        // Reuse a recurrence the caller already parsed (the appointment path parses once up front to
+        // harvest warnings + EXDATEs); only parse here when the caller didn't (the task path).
+        ParsedRecurrence? p = parsedRecurrence ?? ICalTextParser.ParseRecurrence(lines).Value;
 
         if (p is null)
             return (null, null); // no RRULE or parse failure — caller handles

--- a/src/Mail2Pst.Core/Calendar/RecurrenceMapping.cs
+++ b/src/Mail2Pst.Core/Calendar/RecurrenceMapping.cs
@@ -1,0 +1,270 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Ical.Net.CalendarComponents;
+using Ical.Net.DataTypes;
+using IcalCalendar = Ical.Net.Calendar;
+using Mail2Pst.Core.Models;
+
+namespace Mail2Pst.Core.Calendar;
+
+/// <summary>
+/// Pure, stateless helper that maps a set of iCal recurrence lines
+/// (RRULE, EXDATE, etc.) and an event anchor into a <see cref="RecurrenceSpec"/>.
+/// Shared between <see cref="CalendarEventMapper"/> and any future task/todo mapper.
+/// </summary>
+public static class RecurrenceMapping
+{
+    /// <summary>
+    /// Attempts to build a <see cref="RecurrenceSpec"/> from the supplied raw iCal lines
+    /// and event anchor.
+    /// </summary>
+    /// <param name="icalLines">Raw iCal property lines from the event's recurrence block
+    /// (e.g. <c>RRULE:FREQ=WEEKLY;BYDAY=MO;COUNT=5</c>).</param>
+    /// <param name="firstStartUtc">UTC start of the first occurrence.</param>
+    /// <param name="firstStartLocal">Local-time start of the first occurrence
+    /// (in <paramref name="zone"/>; equals <paramref name="firstStartUtc"/> when zone is null).</param>
+    /// <param name="zone">Display timezone, or <c>null</c> for floating/UTC events.</param>
+    /// <param name="originatingTzId">Canonical IANA/Olson or tzone:// id verbatim from the source.</param>
+    /// <returns>
+    /// <c>(Spec, null)</c> when the rule is fully mappable;
+    /// <c>(null, reason)</c> when the rule must be degraded to a single occurrence.
+    /// Returns <c>(null, null)</c> when no RRULE is present or parsing fails
+    /// (caller treats this as a single occurrence with no warning).
+    /// </returns>
+    public static (RecurrenceSpec? Spec, string? DegradeReason) FromIcal(
+        IReadOnlyList<string> icalLines,
+        DateTime firstStartUtc,
+        DateTime firstStartLocal,
+        TimeZoneInfo? zone,
+        string? originatingTzId)
+    {
+        var lines = icalLines
+            .Where(l => !string.IsNullOrWhiteSpace(l))
+            .ToList();
+
+        ParseResult<ParsedRecurrence> pr = ICalTextParser.ParseRecurrence(lines);
+        ParsedRecurrence? p = pr.Value;
+
+        if (p is null)
+            return (null, null); // no RRULE or parse failure — caller handles
+
+        string? degradeReason = ComputeDegradeReason(p, lines);
+        if (degradeReason is not null)
+            return (null, degradeReason);
+
+        // Build the RRULE body for Ical.Net (strip the "RRULE:" prefix).
+        string rruleLine = lines.First(l => l.StartsWith("RRULE", StringComparison.OrdinalIgnoreCase));
+        // Trim() strips the trailing CRLF Mozilla stores on each property so the RRULE body embedded
+        // in the COUNT-enumeration VCALENDAR text is a clean single line.
+        string rawRRuleBody = StripRRulePrefix(IcalParseSupport.UnfoldIcalLines(rruleLine).Trim());
+
+        var spec = new RecurrenceSpec
+        {
+            Frequency     = MapFreq(p),
+            Interval      = Math.Max(1, p.Interval),
+            DaysOfWeek    = p.ByDay.Select(d => d.DayOfWeek).Distinct().ToArray(),
+            DayOfMonth    = p.ByMonthDay.Count == 1 ? p.ByMonthDay[0] : (int?)null,
+            NthOccurrence = p.ByDay.Count == 1 ? p.ByDay[0].Offset : null,
+            Month         = p.ByMonth.Count == 1 ? p.ByMonth[0] : (int?)null,
+            FirstStartUtc         = firstStartUtc,
+            FirstStartLocal       = firstStartLocal,
+            TimeZone              = zone,
+            OriginatingTimeZoneId = originatingTzId,
+            RawRRuleBody          = rawRRuleBody,
+        };
+
+        // RFC 5545 §3.3.10: a bare FREQ=WEEKLY with no BYDAY recurs on the DTSTART weekday.
+        if (spec.Frequency == RecurrenceFrequency.Weekly && spec.DaysOfWeek.Length == 0)
+            spec.DaysOfWeek = new[] { spec.FirstStartLocal.DayOfWeek };
+
+        if (p.Count > 0)
+        {
+            spec.EndKind = RecurrenceEndKind.Count;
+            spec.Count   = p.Count;
+        }
+        else if (p.UntilUtc is { } until)
+        {
+            spec.EndKind  = RecurrenceEndKind.Until;
+            spec.UntilUtc = until;
+        }
+        else
+        {
+            spec.EndKind = RecurrenceEndKind.NoEnd;
+        }
+
+        spec.LastInstanceStartUtc = ComputeLastInstanceUtc(spec);
+
+        // Defensive guard: ComputeLastInstanceUtc failed (near-unreachable path — requires
+        // Ical.Net to throw during COUNT enumeration). Signal as a degrade so the caller
+        // can warn and fall back to a single occurrence.
+        if (spec.EndKind == RecurrenceEndKind.Count && spec.LastInstanceStartUtc is null)
+            return (null, "COUNT enumeration failed");
+
+        return (spec, null);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Internal helpers (pure — no AppointmentRecord coupling)
+    // ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// Strips the <c>RRULE:</c> prefix (case-insensitive) from a raw iCal RRULE line,
+    /// returning the bare rule body.
+    /// </summary>
+    internal static string StripRRulePrefix(string line)
+    {
+        const string prefix = "RRULE:";
+        return line.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            ? line.Substring(prefix.Length)
+            : line;
+    }
+
+    /// <summary>
+    /// Returns a non-null reason string when the parsed recurrence cannot be faithfully
+    /// represented in the <see cref="RecurrenceSpec"/> model, or <c>null</c> when mappable.
+    /// </summary>
+    private static string? ComputeDegradeReason(ParsedRecurrence p, List<string> lines)
+    {
+        // 1. Unknown FREQ (ical.net returned ParsedFrequency.Unknown for an unrecognised value).
+        if (p.Frequency == ParsedFrequency.Unknown) return "Unknown FREQ";
+
+        // 2. BYSETPOS (e.g. "last Monday of month") — not representable in RecurrenceSpec.
+        if (p.BySetPosition.Count > 0) return "BYSETPOS";
+
+        // 3. RDATE — additional explicit dates outside of the RRULE pattern.
+        if (p.RDates.Count > 0) return "RDATE";
+
+        // 4. Multiple RRULE lines — we only handle a single rule.
+        int rruleCount = lines.Count(l => l.StartsWith("RRULE", StringComparison.OrdinalIgnoreCase));
+        if (rruleCount > 1) return "multiple RRULE";
+
+        // 5. WKST when INTERVAL > 1 — the work-week start shifts grouping boundaries; degrade.
+        bool hasWkst = lines.Any(l => l.Contains("WKST=", StringComparison.OrdinalIgnoreCase));
+        if (hasWkst && p.Interval > 1) return "WKST interval-sensitive";
+
+        // 6 & 7. Cardinality rules for Monthly / Yearly.
+        if (p.Frequency == ParsedFrequency.Monthly)
+        {
+            // MonthlyNth: exactly one BYDAY with a supported offset (1..4 or -1).
+            if (p.ByDay.Count == 1 && p.ByDay[0].Offset is { } off)
+                return (off is >= 1 and <= 4 or -1) ? null : "unrepresentable monthly/yearly pattern";
+
+            // Monthly-by-day: exactly one BYMONTHDAY, no BYDAY.
+            if (p.ByMonthDay.Count == 1 && p.ByDay.Count == 0) return null;
+
+            // Bare FREQ=MONTHLY (no BY* parts): RFC 5545 recurs on the DTSTART day-of-month.
+            if (p.ByDay.Count == 0 && p.ByMonthDay.Count == 0) return null;
+
+            return "unrepresentable monthly/yearly pattern";
+        }
+
+        if (p.Frequency == ParsedFrequency.Yearly)
+        {
+            // YearlyNth: one BYDAY with a supported offset (1..4 or -1) + one BYMONTH.
+            if (p.ByDay.Count == 1 && p.ByDay[0].Offset is { } off && p.ByMonth.Count == 1)
+                return (off is >= 1 and <= 4 or -1) ? null : "unrepresentable monthly/yearly pattern";
+
+            // Yearly: one BYMONTH + one BYMONTHDAY, no BYDAY.
+            if (p.ByMonth.Count == 1 && p.ByMonthDay.Count == 1 && p.ByDay.Count == 0)
+                return null;
+
+            // Bare FREQ=YEARLY (no BY* parts): RFC 5545 recurs on the DTSTART month + day-of-month.
+            if (p.ByDay.Count == 0 && p.ByMonth.Count == 0 && p.ByMonthDay.Count == 0) return null;
+
+            return "unrepresentable monthly/yearly pattern";
+        }
+
+        // Daily / Weekly — always mappable.
+        return null;
+    }
+
+    /// <summary>Maps a <see cref="ParsedRecurrence"/> frequency to the model enum.
+    /// <see cref="ComputeDegradeReason"/> must return <c>null</c> before this is called.</summary>
+    private static RecurrenceFrequency MapFreq(ParsedRecurrence p) => p.Frequency switch
+    {
+        ParsedFrequency.Daily   => RecurrenceFrequency.Daily,
+        ParsedFrequency.Weekly  => RecurrenceFrequency.Weekly,
+        ParsedFrequency.Monthly =>
+            p.ByDay.Count == 1 && p.ByDay[0].Offset is not null
+                ? RecurrenceFrequency.MonthlyNth
+                : RecurrenceFrequency.Monthly,
+        ParsedFrequency.Yearly  =>
+            p.ByDay.Count == 1 && p.ByDay[0].Offset is not null
+                ? RecurrenceFrequency.YearlyNth
+                : RecurrenceFrequency.Yearly,
+        _ => throw new InvalidOperationException($"Unmapped ParsedFrequency: {p.Frequency}"),
+    };
+
+    /// <summary>
+    /// Computes the UTC start of the last occurrence of a recurrence rule.
+    /// Returns <c>null</c> for <see cref="RecurrenceEndKind.NoEnd"/>.
+    /// For <see cref="RecurrenceEndKind.Until"/> returns <see cref="RecurrenceSpec.UntilUtc"/> directly.
+    /// For <see cref="RecurrenceEndKind.Count"/> enumerates the COUNT-th raw occurrence
+    /// (EXDATE does NOT reduce the COUNT).
+    /// </summary>
+    private static DateTime? ComputeLastInstanceUtc(RecurrenceSpec s)
+    {
+        switch (s.EndKind)
+        {
+            case RecurrenceEndKind.NoEnd:
+                return null;
+
+            case RecurrenceEndKind.Until:
+                return s.UntilUtc;
+
+            case RecurrenceEndKind.Count:
+            {
+                // Build a minimal VCALENDAR anchored at FirstStartLocal (floating — no TZ suffix)
+                // so Ical.Net enumerates in local time without any IANA / Windows zone lookups.
+                var anchor = s.FirstStartLocal;
+                string dtFmt = anchor.ToString("yyyyMMddTHHmmss", CultureInfo.InvariantCulture);
+                string calText =
+                    "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//ContinuMail//recurrence//EN\r\n" +
+                    "BEGIN:VEVENT\r\nUID:count-enum@continmail\r\n" +
+                    $"DTSTART:{dtFmt}\r\n" +
+                    $"DTEND:{dtFmt}\r\n" +
+                    $"RRULE:{s.RawRRuleBody}\r\n" +
+                    "END:VEVENT\r\nEND:VCALENDAR\r\n";
+
+                try
+                {
+                    var enumCal = IcalCalendar.Load(calText);
+                    if (enumCal?.Events.Count == 0) return null;
+
+                    var startDt = new CalDateTime(
+                        anchor.Year, anchor.Month, anchor.Day,
+                        anchor.Hour, anchor.Minute, anchor.Second, string.Empty);
+
+                    var occs = enumCal.GetOccurrences(startDt)
+                                      .OrderBy(o => o.Period.StartTime)
+                                      .ToList();
+
+                    int idx = (s.Count ?? 0) - 1;
+                    if (idx < 0 || idx >= occs.Count) return null;
+
+                    var lastLocalRaw = occs[idx].Period.StartTime.Value;
+                    var lastLocal    = new DateTime(
+                        lastLocalRaw.Year, lastLocalRaw.Month, lastLocalRaw.Day,
+                        lastLocalRaw.Hour, lastLocalRaw.Minute, lastLocalRaw.Second,
+                        DateTimeKind.Unspecified);
+
+                    return s.TimeZone != null
+                        ? TimeZoneInfo.ConvertTimeToUtc(lastLocal, s.TimeZone)
+                        : DateTime.SpecifyKind(lastLocal, DateTimeKind.Utc);
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+
+            default:
+                return null;
+        }
+    }
+}

--- a/src/Mail2Pst.Core/Calendar/SqliteCalendarReader.cs
+++ b/src/Mail2Pst.Core/Calendar/SqliteCalendarReader.cs
@@ -3,6 +3,8 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
 using Microsoft.Data.Sqlite;
 using Mail2Pst.Core.Storage;
 
@@ -278,6 +280,15 @@ public sealed class SqliteCalendarReader : ICalendarReader
         return dict;
     }
 
+    // Normalises a cal_properties.value cell (BLOB / TEXT / INTEGER / REAL) to UTF-8 bytes so
+    // downstream consumers can decode it as a string regardless of the stored SQLite type.
+    private static byte[] ToValueBytes(object raw) => raw switch
+    {
+        byte[] b => b,
+        string s => Encoding.UTF8.GetBytes(s),
+        _        => Encoding.UTF8.GetBytes(Convert.ToString(raw, CultureInfo.InvariantCulture) ?? ""),
+    };
+
     // Loads cal_properties; value column is BLOB, returned as byte[].
     private static Dictionary<CalendarItemKey, List<RawProperty>> LoadProps(
         SqliteConnection c, List<string> warnings)
@@ -300,7 +311,11 @@ public sealed class SqliteCalendarReader : ICalendarReader
                 string? calId  = rdr.IsDBNull(oCalId)  ? null : rdr.GetString(oCalId);
                 string  itemId = rdr.IsDBNull(oItemId) ? ""   : rdr.GetString(oItemId);
                 string  key    = rdr.IsDBNull(oKey)    ? ""   : rdr.GetString(oKey);
-                byte[]? value  = rdr.IsDBNull(oValue)  ? null : (byte[])rdr.GetValue(oValue);
+                // cal_properties.value has BLOB column affinity, but SQLite's dynamic typing means
+                // Thunderbird stores most values as TEXT (DESCRIPTION/LOCATION/CATEGORIES/…) and some
+                // as INTEGER (e.g. PERCENT-COMPLETE). A hard (byte[]) cast throws on those, and the
+                // whole-table catch would drop EVERY property. Normalise any type to UTF-8 bytes.
+                byte[]? value  = rdr.IsDBNull(oValue) ? null : ToValueBytes(rdr.GetValue(oValue));
                 long?   rid    = rdr.IsDBNull(oRid)    ? null : rdr.GetInt64(oRid);
                 string? ridTz  = rdr.IsDBNull(oRidTz)  ? null : rdr.GetString(oRidTz);
 

--- a/src/Mail2Pst.Core/Calendar/SqliteCalendarReader.cs
+++ b/src/Mail2Pst.Core/Calendar/SqliteCalendarReader.cs
@@ -1,0 +1,348 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using Microsoft.Data.Sqlite;
+using Mail2Pst.Core.Storage;
+
+namespace Mail2Pst.Core.Calendar;
+
+/// <summary>
+/// Reads one Mozilla calendar SQLite store into <see cref="CalendarReadResult"/>.
+/// Side tables are materialized separately (no wide join) to prevent cartesian explosion.
+/// Events and todos are grouped by (cal_id, id): recurrence_id NULL → master;
+/// non-null → override list. Per-item failures are caught and appended as Warnings.
+/// </summary>
+public sealed class SqliteCalendarReader : ICalendarReader
+{
+    public CalendarReadResult Read(string storePath)
+    {
+        var outp = new CalendarReadResult();
+        using SqliteSnapshot snap = SqliteSnapshot.Open(storePath);
+        SqliteConnection c = snap.Connection;
+
+        // Materialize each side table into a keyed lookup before touching events/todos —
+        // this avoids wide joins that would cartesian-multiply multi-attendee + multi-alarm rows.
+        // cal_recurrence has no recurrence_id columns; force null rid/tz so rows attach to the master.
+        var attendees   = LoadSide(c, "cal_attendees",   hasRid: true,  outp.Warnings);
+        var alarms      = LoadSide(c, "cal_alarms",      hasRid: true,  outp.Warnings);
+        var attachments = LoadSide(c, "cal_attachments", hasRid: true,  outp.Warnings);
+        var relations   = LoadSide(c, "cal_relations",   hasRid: true,  outp.Warnings);
+        var recurrence  = LoadSide(c, "cal_recurrence",  hasRid: false, outp.Warnings);
+        var props       = LoadProps(c, outp.Warnings);
+        var parms       = LoadParams(c, outp.Warnings);
+
+        // Lazy calendar-bucket factory.
+        var byCal = new Dictionary<string, RawCalendarRead>(StringComparer.Ordinal);
+        RawCalendarRead Cal(string id)
+        {
+            if (!byCal.TryGetValue(id, out var r))
+                byCal[id] = r = new RawCalendarRead { CalId = id };
+            return r;
+        }
+
+        // Retrieve a pre-materialized list or return an empty list (never null).
+        static List<T> Get<T>(Dictionary<CalendarItemKey, List<T>> dict, CalendarItemKey key)
+            => dict.TryGetValue(key, out var v) ? v : new List<T>();
+
+        // ---- Events ----------------------------------------------------------------
+        var eventGroups = new Dictionary<(string calId, string id), RawEventGroup>();
+        try
+        {
+            using var cmd = c.CreateCommand();
+            cmd.CommandText =
+                "SELECT cal_id, id, title, priority, ical_status, flags, " +
+                "event_start, event_end, event_start_tz, event_end_tz, " +
+                "recurrence_id, recurrence_id_tz, time_created, last_modified " +
+                "FROM cal_events";
+            using var rdr = cmd.ExecuteReader();
+            int oCalId    = rdr.GetOrdinal("cal_id");
+            int oId       = rdr.GetOrdinal("id");
+            int oTitle    = rdr.GetOrdinal("title");
+            int oPriority = rdr.GetOrdinal("priority");
+            int oStatus   = rdr.GetOrdinal("ical_status");
+            int oFlags    = rdr.GetOrdinal("flags");
+            int oStart    = rdr.GetOrdinal("event_start");
+            int oEnd      = rdr.GetOrdinal("event_end");
+            int oStartTz  = rdr.GetOrdinal("event_start_tz");
+            int oEndTz    = rdr.GetOrdinal("event_end_tz");
+            int oRid      = rdr.GetOrdinal("recurrence_id");
+            int oRidTz    = rdr.GetOrdinal("recurrence_id_tz");
+            int oCreated  = rdr.GetOrdinal("time_created");
+            int oModified = rdr.GetOrdinal("last_modified");
+
+            while (rdr.Read())
+            {
+                string? calId = rdr.IsDBNull(oCalId) ? null : rdr.GetString(oCalId);
+                string? id    = rdr.IsDBNull(oId)    ? null : rdr.GetString(oId);
+                if (calId is null || id is null) continue;
+                try
+                {
+                    long?   rid   = rdr.IsDBNull(oRid)   ? null : rdr.GetInt64(oRid);
+                    string? ridTz = rdr.IsDBNull(oRidTz) ? null : rdr.GetString(oRidTz);
+
+                    var itemKey   = new CalendarItemKey(calId, id, rid, ridTz);
+                    var masterKey = new CalendarItemKey(calId, id, null, null);
+
+                    var ev = new RawEvent
+                    {
+                        CalId          = calId,
+                        Id             = id,
+                        Title          = rdr.IsDBNull(oTitle)    ? null : rdr.GetString(oTitle),
+                        Priority       = rdr.IsDBNull(oPriority) ? null : rdr.GetInt32(oPriority),
+                        IcalStatus     = rdr.IsDBNull(oStatus)   ? null : rdr.GetString(oStatus),
+                        Flags          = rdr.IsDBNull(oFlags)    ? null : rdr.GetInt32(oFlags),
+                        EventStart     = rdr.IsDBNull(oStart)    ? null : rdr.GetInt64(oStart),
+                        EventEnd       = rdr.IsDBNull(oEnd)      ? null : rdr.GetInt64(oEnd),
+                        EventStartTz   = rdr.IsDBNull(oStartTz)  ? null : rdr.GetString(oStartTz),
+                        EventEndTz     = rdr.IsDBNull(oEndTz)    ? null : rdr.GetString(oEndTz),
+                        RecurrenceId   = rid,
+                        RecurrenceIdTz = ridTz,
+                        TimeCreated    = rdr.IsDBNull(oCreated)  ? null : rdr.GetInt64(oCreated),
+                        LastModified   = rdr.IsDBNull(oModified) ? null : rdr.GetInt64(oModified),
+                        // Side collections — keyed by this row's own (cal_id,id,rid,ridTz).
+                        // Recurrence lines have no rid in the DB; they land on the null-rid key → master only.
+                        Attendees      = Get(attendees,   itemKey),
+                        Alarms         = Get(alarms,      itemKey),
+                        Attachments    = Get(attachments, itemKey),
+                        Relations      = Get(relations,   itemKey),
+                        Properties     = Get(props,       itemKey),
+                        Parameters     = Get(parms,       itemKey),
+                        Recurrence     = rid is null ? Get(recurrence, masterKey) : new List<RawSideText>(),
+                    };
+
+                    var groupKey = (calId, id);
+                    if (!eventGroups.TryGetValue(groupKey, out var grp))
+                        eventGroups[groupKey] = grp = new RawEventGroup();
+                    if (rid is null) grp.Master = ev;
+                    else             grp.Overrides.Add(ev);
+                }
+                catch (Exception ex)
+                {
+                    outp.Warnings.Add($"event {id} (cal {calId}) skipped: {ex.Message}");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            outp.Warnings.Add($"cal_events could not be read: {ex.Message}");
+        }
+
+        foreach (var (key, grp) in eventGroups)
+            Cal(key.calId).EventGroups.Add(grp);
+
+        // ---- Todos -----------------------------------------------------------------
+        var todoGroups = new Dictionary<(string calId, string id), RawTodoGroup>();
+        try
+        {
+            using var cmd = c.CreateCommand();
+            cmd.CommandText =
+                "SELECT cal_id, id, title, priority, ical_status, flags, " +
+                "todo_entry, todo_due, todo_completed, todo_complete, " +
+                "todo_entry_tz, todo_due_tz, todo_completed_tz, " +
+                "recurrence_id, recurrence_id_tz, time_created, last_modified " +
+                "FROM cal_todos";
+            using var rdr = cmd.ExecuteReader();
+            int oCalId       = rdr.GetOrdinal("cal_id");
+            int oId          = rdr.GetOrdinal("id");
+            int oTitle       = rdr.GetOrdinal("title");
+            int oPriority    = rdr.GetOrdinal("priority");
+            int oStatus      = rdr.GetOrdinal("ical_status");
+            int oFlags       = rdr.GetOrdinal("flags");
+            int oEntry       = rdr.GetOrdinal("todo_entry");
+            int oDue         = rdr.GetOrdinal("todo_due");
+            int oCompleted   = rdr.GetOrdinal("todo_completed");
+            int oComplete    = rdr.GetOrdinal("todo_complete");
+            int oEntryTz     = rdr.GetOrdinal("todo_entry_tz");
+            int oDueTz       = rdr.GetOrdinal("todo_due_tz");
+            int oCompletedTz = rdr.GetOrdinal("todo_completed_tz");
+            int oRid         = rdr.GetOrdinal("recurrence_id");
+            int oRidTz       = rdr.GetOrdinal("recurrence_id_tz");
+            int oCreated     = rdr.GetOrdinal("time_created");
+            int oModified    = rdr.GetOrdinal("last_modified");
+
+            while (rdr.Read())
+            {
+                string? calId = rdr.IsDBNull(oCalId) ? null : rdr.GetString(oCalId);
+                string? id    = rdr.IsDBNull(oId)    ? null : rdr.GetString(oId);
+                if (calId is null || id is null) continue;
+                try
+                {
+                    long?   rid   = rdr.IsDBNull(oRid)   ? null : rdr.GetInt64(oRid);
+                    string? ridTz = rdr.IsDBNull(oRidTz) ? null : rdr.GetString(oRidTz);
+
+                    var itemKey   = new CalendarItemKey(calId, id, rid, ridTz);
+                    var masterKey = new CalendarItemKey(calId, id, null, null);
+
+                    var todo = new RawTodo
+                    {
+                        CalId           = calId,
+                        Id              = id,
+                        Title           = rdr.IsDBNull(oTitle)       ? null : rdr.GetString(oTitle),
+                        Priority        = rdr.IsDBNull(oPriority)    ? null : rdr.GetInt32(oPriority),
+                        IcalStatus      = rdr.IsDBNull(oStatus)      ? null : rdr.GetString(oStatus),
+                        Flags           = rdr.IsDBNull(oFlags)       ? null : rdr.GetInt32(oFlags),
+                        TodoEntry       = rdr.IsDBNull(oEntry)       ? null : rdr.GetInt64(oEntry),
+                        TodoDue         = rdr.IsDBNull(oDue)         ? null : rdr.GetInt64(oDue),
+                        TodoCompleted   = rdr.IsDBNull(oCompleted)   ? null : rdr.GetInt64(oCompleted),
+                        TodoComplete    = rdr.IsDBNull(oComplete)    ? null : rdr.GetInt32(oComplete),
+                        TodoEntryTz     = rdr.IsDBNull(oEntryTz)    ? null : rdr.GetString(oEntryTz),
+                        TodoDueTz       = rdr.IsDBNull(oDueTz)      ? null : rdr.GetString(oDueTz),
+                        TodoCompletedTz = rdr.IsDBNull(oCompletedTz)? null : rdr.GetString(oCompletedTz),
+                        RecurrenceId    = rid,
+                        RecurrenceIdTz  = ridTz,
+                        TimeCreated     = rdr.IsDBNull(oCreated)    ? null : rdr.GetInt64(oCreated),
+                        LastModified    = rdr.IsDBNull(oModified)   ? null : rdr.GetInt64(oModified),
+                        Attendees       = Get(attendees,   itemKey),
+                        Alarms          = Get(alarms,      itemKey),
+                        Attachments     = Get(attachments, itemKey),
+                        Relations       = Get(relations,   itemKey),
+                        Properties      = Get(props,       itemKey),
+                        Parameters      = Get(parms,       itemKey),
+                        Recurrence      = rid is null ? Get(recurrence, masterKey) : new List<RawSideText>(),
+                    };
+
+                    var groupKey = (calId, id);
+                    if (!todoGroups.TryGetValue(groupKey, out var grp))
+                        todoGroups[groupKey] = grp = new RawTodoGroup();
+                    if (rid is null) grp.Master = todo;
+                    else             grp.Overrides.Add(todo);
+                }
+                catch (Exception ex)
+                {
+                    outp.Warnings.Add($"todo {id} (cal {calId}) skipped: {ex.Message}");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            outp.Warnings.Add($"cal_todos could not be read: {ex.Message}");
+        }
+
+        foreach (var (key, grp) in todoGroups)
+            Cal(key.calId).TodoGroups.Add(grp);
+
+        outp.Calendars.AddRange(byCal.Values);
+        return outp;
+    }
+
+    // Loads a side table that carries cal_id + item_id + icalString [+ recurrence_id + recurrence_id_tz].
+    // hasRid=false (cal_recurrence): forces null rid/tz so rows key to the master's null-rid slot.
+    // A SELECT failure (missing table) produces an empty lookup + a warning rather than a throw.
+    private static Dictionary<CalendarItemKey, List<RawSideText>> LoadSide(
+        SqliteConnection c, string table, bool hasRid, List<string> warnings)
+    {
+        var dict = new Dictionary<CalendarItemKey, List<RawSideText>>();
+        try
+        {
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = $"SELECT * FROM {table}";
+            using var rdr = cmd.ExecuteReader();
+            int oCalId  = rdr.GetOrdinal("cal_id");
+            int oItemId = rdr.GetOrdinal("item_id");
+            int oIcal   = rdr.GetOrdinal("icalString");
+            int oRid    = hasRid ? rdr.GetOrdinal("recurrence_id")    : -1;
+            int oRidTz  = hasRid ? rdr.GetOrdinal("recurrence_id_tz") : -1;
+
+            while (rdr.Read())
+            {
+                string? calId  = rdr.IsDBNull(oCalId)  ? null : rdr.GetString(oCalId);
+                string  itemId = rdr.IsDBNull(oItemId) ? ""   : rdr.GetString(oItemId);
+                string? ical   = rdr.IsDBNull(oIcal)   ? null : rdr.GetString(oIcal);
+                long?   rid    = hasRid && !rdr.IsDBNull(oRid)   ? rdr.GetInt64(oRid)    : null;
+                string? ridTz  = hasRid && !rdr.IsDBNull(oRidTz) ? rdr.GetString(oRidTz) : null;
+
+                var key = new CalendarItemKey(calId, itemId, rid, ridTz);
+                if (!dict.TryGetValue(key, out var list))
+                    dict[key] = list = new List<RawSideText>();
+                list.Add(new RawSideText(ical));
+            }
+        }
+        catch (Exception ex)
+        {
+            warnings.Add($"{table} could not be read: {ex.Message}");
+        }
+        return dict;
+    }
+
+    // Loads cal_properties; value column is BLOB, returned as byte[].
+    private static Dictionary<CalendarItemKey, List<RawProperty>> LoadProps(
+        SqliteConnection c, List<string> warnings)
+    {
+        var dict = new Dictionary<CalendarItemKey, List<RawProperty>>();
+        try
+        {
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "SELECT * FROM cal_properties";
+            using var rdr = cmd.ExecuteReader();
+            int oCalId  = rdr.GetOrdinal("cal_id");
+            int oItemId = rdr.GetOrdinal("item_id");
+            int oKey    = rdr.GetOrdinal("key");
+            int oValue  = rdr.GetOrdinal("value");
+            int oRid    = rdr.GetOrdinal("recurrence_id");
+            int oRidTz  = rdr.GetOrdinal("recurrence_id_tz");
+
+            while (rdr.Read())
+            {
+                string? calId  = rdr.IsDBNull(oCalId)  ? null : rdr.GetString(oCalId);
+                string  itemId = rdr.IsDBNull(oItemId) ? ""   : rdr.GetString(oItemId);
+                string  key    = rdr.IsDBNull(oKey)    ? ""   : rdr.GetString(oKey);
+                byte[]? value  = rdr.IsDBNull(oValue)  ? null : (byte[])rdr.GetValue(oValue);
+                long?   rid    = rdr.IsDBNull(oRid)    ? null : rdr.GetInt64(oRid);
+                string? ridTz  = rdr.IsDBNull(oRidTz)  ? null : rdr.GetString(oRidTz);
+
+                var itemKey = new CalendarItemKey(calId, itemId, rid, ridTz);
+                if (!dict.TryGetValue(itemKey, out var list))
+                    dict[itemKey] = list = new List<RawProperty>();
+                list.Add(new RawProperty(key, value, rid, ridTz));
+            }
+        }
+        catch (Exception ex)
+        {
+            warnings.Add($"cal_properties could not be read: {ex.Message}");
+        }
+        return dict;
+    }
+
+    // Loads cal_parameters; key1/key2 are the compound parameter name parts.
+    private static Dictionary<CalendarItemKey, List<RawParameter>> LoadParams(
+        SqliteConnection c, List<string> warnings)
+    {
+        var dict = new Dictionary<CalendarItemKey, List<RawParameter>>();
+        try
+        {
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "SELECT * FROM cal_parameters";
+            using var rdr = cmd.ExecuteReader();
+            int oCalId  = rdr.GetOrdinal("cal_id");
+            int oItemId = rdr.GetOrdinal("item_id");
+            int oKey1   = rdr.GetOrdinal("key1");
+            int oKey2   = rdr.GetOrdinal("key2");
+            int oValue  = rdr.GetOrdinal("value");
+            int oRid    = rdr.GetOrdinal("recurrence_id");
+            int oRidTz  = rdr.GetOrdinal("recurrence_id_tz");
+
+            while (rdr.Read())
+            {
+                string? calId  = rdr.IsDBNull(oCalId)  ? null : rdr.GetString(oCalId);
+                string  itemId = rdr.IsDBNull(oItemId) ? ""   : rdr.GetString(oItemId);
+                string  key1   = rdr.IsDBNull(oKey1)   ? ""   : rdr.GetString(oKey1);
+                string  key2   = rdr.IsDBNull(oKey2)   ? ""   : rdr.GetString(oKey2);
+                string? value  = rdr.IsDBNull(oValue)  ? null : rdr.GetString(oValue);
+                long?   rid    = rdr.IsDBNull(oRid)    ? null : rdr.GetInt64(oRid);
+                string? ridTz  = rdr.IsDBNull(oRidTz)  ? null : rdr.GetString(oRidTz);
+
+                var itemKey = new CalendarItemKey(calId, itemId, rid, ridTz);
+                if (!dict.TryGetValue(itemKey, out var list))
+                    dict[itemKey] = list = new List<RawParameter>();
+                list.Add(new RawParameter(key1, key2, value, rid, ridTz));
+            }
+        }
+        catch (Exception ex)
+        {
+            warnings.Add($"cal_parameters could not be read: {ex.Message}");
+        }
+        return dict;
+    }
+}

--- a/src/Mail2Pst.Core/Calendar/SqliteCalendarReader.cs
+++ b/src/Mail2Pst.Core/Calendar/SqliteCalendarReader.cs
@@ -52,7 +52,7 @@ public sealed class SqliteCalendarReader : ICalendarReader
         {
             using var cmd = c.CreateCommand();
             cmd.CommandText =
-                "SELECT cal_id, id, title, priority, ical_status, flags, " +
+                "SELECT cal_id, id, title, priority, privacy, ical_status, flags, " +
                 "event_start, event_end, event_start_tz, event_end_tz, " +
                 "recurrence_id, recurrence_id_tz, time_created, last_modified " +
                 "FROM cal_events";
@@ -61,6 +61,7 @@ public sealed class SqliteCalendarReader : ICalendarReader
             int oId       = rdr.GetOrdinal("id");
             int oTitle    = rdr.GetOrdinal("title");
             int oPriority = rdr.GetOrdinal("priority");
+            int oPrivacy  = rdr.GetOrdinal("privacy");
             int oStatus   = rdr.GetOrdinal("ical_status");
             int oFlags    = rdr.GetOrdinal("flags");
             int oStart    = rdr.GetOrdinal("event_start");
@@ -76,7 +77,11 @@ public sealed class SqliteCalendarReader : ICalendarReader
             {
                 string? calId = rdr.IsDBNull(oCalId) ? null : rdr.GetString(oCalId);
                 string? id    = rdr.IsDBNull(oId)    ? null : rdr.GetString(oId);
-                if (calId is null || id is null) continue;
+                if (calId is null || id is null)
+                {
+                    outp.Warnings.Add("event row skipped: null cal_id or id");
+                    continue;
+                }
                 try
                 {
                     long?   rid   = rdr.IsDBNull(oRid)   ? null : rdr.GetInt64(oRid);
@@ -91,6 +96,7 @@ public sealed class SqliteCalendarReader : ICalendarReader
                         Id             = id,
                         Title          = rdr.IsDBNull(oTitle)    ? null : rdr.GetString(oTitle),
                         Priority       = rdr.IsDBNull(oPriority) ? null : rdr.GetInt32(oPriority),
+                        Privacy        = rdr.IsDBNull(oPrivacy)  ? null : rdr.GetString(oPrivacy),
                         IcalStatus     = rdr.IsDBNull(oStatus)   ? null : rdr.GetString(oStatus),
                         Flags          = rdr.IsDBNull(oFlags)    ? null : rdr.GetInt32(oFlags),
                         EventStart     = rdr.IsDBNull(oStart)    ? null : rdr.GetInt64(oStart),
@@ -138,7 +144,7 @@ public sealed class SqliteCalendarReader : ICalendarReader
         {
             using var cmd = c.CreateCommand();
             cmd.CommandText =
-                "SELECT cal_id, id, title, priority, ical_status, flags, " +
+                "SELECT cal_id, id, title, priority, privacy, ical_status, flags, " +
                 "todo_entry, todo_due, todo_completed, todo_complete, " +
                 "todo_entry_tz, todo_due_tz, todo_completed_tz, " +
                 "recurrence_id, recurrence_id_tz, time_created, last_modified " +
@@ -148,6 +154,7 @@ public sealed class SqliteCalendarReader : ICalendarReader
             int oId          = rdr.GetOrdinal("id");
             int oTitle       = rdr.GetOrdinal("title");
             int oPriority    = rdr.GetOrdinal("priority");
+            int oPrivacy     = rdr.GetOrdinal("privacy");
             int oStatus      = rdr.GetOrdinal("ical_status");
             int oFlags       = rdr.GetOrdinal("flags");
             int oEntry       = rdr.GetOrdinal("todo_entry");
@@ -166,7 +173,11 @@ public sealed class SqliteCalendarReader : ICalendarReader
             {
                 string? calId = rdr.IsDBNull(oCalId) ? null : rdr.GetString(oCalId);
                 string? id    = rdr.IsDBNull(oId)    ? null : rdr.GetString(oId);
-                if (calId is null || id is null) continue;
+                if (calId is null || id is null)
+                {
+                    outp.Warnings.Add("todo row skipped: null cal_id or id");
+                    continue;
+                }
                 try
                 {
                     long?   rid   = rdr.IsDBNull(oRid)   ? null : rdr.GetInt64(oRid);
@@ -181,6 +192,7 @@ public sealed class SqliteCalendarReader : ICalendarReader
                         Id              = id,
                         Title           = rdr.IsDBNull(oTitle)       ? null : rdr.GetString(oTitle),
                         Priority        = rdr.IsDBNull(oPriority)    ? null : rdr.GetInt32(oPriority),
+                        Privacy         = rdr.IsDBNull(oPrivacy)     ? null : rdr.GetString(oPrivacy),
                         IcalStatus      = rdr.IsDBNull(oStatus)      ? null : rdr.GetString(oStatus),
                         Flags           = rdr.IsDBNull(oFlags)       ? null : rdr.GetInt32(oFlags),
                         TodoEntry       = rdr.IsDBNull(oEntry)       ? null : rdr.GetInt64(oEntry),

--- a/src/Mail2Pst.Core/Calendar/TimeZoneResolver.cs
+++ b/src/Mail2Pst.Core/Calendar/TimeZoneResolver.cs
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+
+namespace Mail2Pst.Core.Calendar;
+
+/// <summary>Carries the result of resolving a Thunderbird timezone string.</summary>
+/// <param name="Zone">Resolved <see cref="TimeZoneInfo"/>; null when unresolved or floating.</param>
+/// <param name="IsFloating">True when the time has no timezone (all-day or legacy "floating").</param>
+/// <param name="OriginalId">The raw string passed by the caller (inline VTIMEZONE block or plain id).</param>
+/// <param name="ResolvedId">The id actually handed to <c>FindSystemTimeZoneById</c>; preserved even on failure
+/// so callers can build a manual-mapping fallback.</param>
+/// <param name="Warning">Non-null when the timezone was silently lost or unresolvable.</param>
+public sealed record TimeZoneResolution(
+    TimeZoneInfo? Zone,
+    bool IsFloating,
+    string? OriginalId,
+    string? ResolvedId,
+    string? Warning);
+
+/// <summary>Turns a Thunderbird timezone string into a <see cref="TimeZoneResolution"/>.
+/// Never throws — unresolvable ids yield a null Zone + Warning instead.</summary>
+public static class TimeZoneResolver
+{
+    private const string VTimezonePrefix = "BEGIN:VTIMEZONE";
+    private const string TzoneMsPrefix   = "tzone://Microsoft/";
+    private const string NoTzDescription = "(no TZ description)";
+
+    /// <summary>Resolves <paramref name="tz"/> using the Thunderbird timezone conventions.</summary>
+    public static TimeZoneResolution Resolve(string? tz)
+    {
+        // 1. Null / empty / "floating" → floating, no warning.
+        if (string.IsNullOrEmpty(tz) ||
+            tz.Equals("floating", StringComparison.OrdinalIgnoreCase))
+            return new TimeZoneResolution(null, IsFloating: true, OriginalId: tz, ResolvedId: null, Warning: null);
+
+        // 2. Inline BEGIN:VTIMEZONE block — extract TZID and recurse, preserving OriginalId.
+        if (tz.StartsWith(VTimezonePrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            string? extracted = ExtractTzId(tz);
+            if (extracted is null)
+                return new TimeZoneResolution(null, IsFloating: true, OriginalId: tz,
+                    ResolvedId: null, Warning: "could not extract TZID from inline VTIMEZONE");
+            var inner = Resolve(extracted);
+            return inner with { OriginalId = tz };
+        }
+
+        // 3. "(no TZ description)" — floating but warn (silent tz loss is worse).
+        if (tz == NoTzDescription)
+            return new TimeZoneResolution(null, IsFloating: true, OriginalId: tz,
+                ResolvedId: null, Warning: "no TZ description");
+
+        // 4. UTC (case-insensitive).
+        if (tz.Equals("UTC", StringComparison.OrdinalIgnoreCase))
+            return new TimeZoneResolution(TimeZoneInfo.Utc, IsFloating: false, OriginalId: tz,
+                ResolvedId: "UTC", Warning: null);
+
+        // 5. tzone://Microsoft/<name>
+        if (tz.StartsWith(TzoneMsPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            string name = tz[TzoneMsPrefix.Length..];
+            if (name.Equals("Utc", StringComparison.OrdinalIgnoreCase))
+                return new TimeZoneResolution(TimeZoneInfo.Utc, IsFloating: false, OriginalId: tz,
+                    ResolvedId: "UTC", Warning: null);
+            var zone = TryFind(name);
+            return zone is not null
+                ? new TimeZoneResolution(zone, IsFloating: false, OriginalId: tz, ResolvedId: zone.Id, Warning: null)
+                : new TimeZoneResolution(null, IsFloating: false, OriginalId: tz,
+                    ResolvedId: name, Warning: $"unresolved Microsoft tz '{name}'");
+        }
+
+        // 6. Olson / other.
+        {
+            var zone = TryFind(tz);
+            return zone is not null
+                ? new TimeZoneResolution(zone, IsFloating: false, OriginalId: tz, ResolvedId: zone.Id, Warning: null)
+                : new TimeZoneResolution(null, IsFloating: false, OriginalId: tz,
+                    ResolvedId: tz, Warning: $"unresolved tz '{tz}'");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /// <summary>Unfolds an iCal block and returns the value after the first TZID: line, or null.</summary>
+    private static string? ExtractTzId(string block)
+    {
+        // RFC 5545 line unfolding: CRLF or LF followed by a single whitespace character is a fold.
+        string unfolded = block
+            .Replace("\r\n ", "")
+            .Replace("\r\n\t", "")
+            .Replace("\n ", "")
+            .Replace("\n\t", "");
+
+        foreach (string line in unfolded.Split('\n'))
+        {
+            string trimmed = line.TrimEnd('\r');
+            if (trimmed.StartsWith("TZID:", StringComparison.OrdinalIgnoreCase))
+                return trimmed["TZID:".Length..];
+        }
+        return null;
+    }
+
+    /// <summary>Wraps <see cref="TimeZoneInfo.FindSystemTimeZoneById"/> — returns null instead of throwing.</summary>
+    private static TimeZoneInfo? TryFind(string id)
+    {
+        try { return TimeZoneInfo.FindSystemTimeZoneById(id); }
+        catch (TimeZoneNotFoundException) { return null; }
+        catch (InvalidTimeZoneException) { return null; }
+    }
+}

--- a/src/Mail2Pst.Core/Config/CalendarSourceConfig.cs
+++ b/src/Mail2Pst.Core/Config/CalendarSourceConfig.cs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System.Collections.Generic;
+
+namespace Mail2Pst.Core.Config;
+
+public class CalendarSourceConfig
+{
+    /// <summary>Path to the calendar SQLite store (local.sqlite or cache.sqlite).</summary>
+    public string StorePath { get; set; } = "";
+
+    /// <summary>
+    /// Registry GUID identifying one calendar within the store.
+    /// Selects rows for that calendar only. Empty string means all calendars in the store,
+    /// but ConfigValidator rejects that combination when TaskFolderPath is also unset.
+    /// </summary>
+    public string CalId { get; set; } = "";
+
+    /// <summary>
+    /// Whether to import calendar appointments. Defaults false.
+    /// PR4 rejects true — appointment writing is wired in PR5.
+    /// </summary>
+    public bool IncludeAppointments { get; set; } = false;
+
+    /// <summary>Whether to import tasks. Defaults true.</summary>
+    public bool IncludeTasks { get; set; } = true;
+
+    /// <summary>Inert in PR4. Reserved for the appointment folder path (PR5).</summary>
+    public IReadOnlyList<string>? AppointmentFolderPath { get; set; }
+
+    /// <summary>
+    /// Explicit PST folder path for tasks.
+    /// Null → MappingEngine defaults to ["Tasks", CalId].
+    /// Discovery always sets this to a human-readable display name;
+    /// the CalId fallback applies only to hand-authored configs.
+    /// </summary>
+    public IReadOnlyList<string>? TaskFolderPath { get; set; }
+}

--- a/src/Mail2Pst.Core/Config/ConfigValidator.cs
+++ b/src/Mail2Pst.Core/Config/ConfigValidator.cs
@@ -39,7 +39,8 @@ public static class ConfigValidator
             bool hasMail = output.Sources is { Count: > 0 };
             bool hasContacts = output.Contacts is { Count: > 0 };
             bool hasTasks = output.Calendars is { Count: > 0 } && output.Calendars.Any(c => c.IncludeTasks);
-            if (!hasMail && !hasContacts && !hasTasks)
+            bool hasAppointments = output.Calendars is { Count: > 0 } && output.Calendars.Any(c => c.IncludeAppointments);
+            if (!hasMail && !hasContacts && !hasTasks && !hasAppointments)
                 throw new ConfigValidationException(
                     $"Output '{output.Name}' has no sources, no contacts, and no calendars.");
 
@@ -48,9 +49,6 @@ public static class ConfigValidator
                 if (string.IsNullOrWhiteSpace(cal.StorePath))
                     throw new ConfigValidationException(
                         $"Output '{output.Name}' has a calendar source with an empty StorePath.");
-                if (cal.IncludeAppointments)
-                    throw new ConfigValidationException(
-                        "Calendar appointment conversion is not supported until the appointment writer PR (PR5).");
                 if (!cal.IncludeTasks && !cal.IncludeAppointments)
                     throw new ConfigValidationException(
                         $"Output '{output.Name}' has a calendar source that contributes nothing (both IncludeTasks and IncludeAppointments are false).");
@@ -59,6 +57,11 @@ public static class ConfigValidator
                         $"Output '{output.Name}' has a calendar source with no CalId (all calendars in the store); it must set TaskFolderPath explicitly.");
                 if (cal.TaskFolderPath is not null)
                     FolderNameValidator.ValidatePath(cal.TaskFolderPath);
+                if (cal.IncludeAppointments && string.IsNullOrEmpty(cal.CalId) && (cal.AppointmentFolderPath is null or { Count: 0 }))
+                    throw new ConfigValidationException(
+                        $"Output '{output.Name}' has a calendar source with no CalId (all calendars in the store); it must set AppointmentFolderPath explicitly.");
+                if (cal.AppointmentFolderPath is not null)
+                    FolderNameValidator.ValidatePath(cal.AppointmentFolderPath);
             }
 
             foreach (ContactSourceConfig contact in output.Contacts ?? new List<ContactSourceConfig>())

--- a/src/Mail2Pst.Core/Config/ConfigValidator.cs
+++ b/src/Mail2Pst.Core/Config/ConfigValidator.cs
@@ -4,6 +4,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Mail2Pst.Core.Config;
 
@@ -37,9 +38,28 @@ public static class ConfigValidator
 
             bool hasMail = output.Sources is { Count: > 0 };
             bool hasContacts = output.Contacts is { Count: > 0 };
-            if (!hasMail && !hasContacts)
+            bool hasTasks = output.Calendars is { Count: > 0 } && output.Calendars.Any(c => c.IncludeTasks);
+            if (!hasMail && !hasContacts && !hasTasks)
                 throw new ConfigValidationException(
-                    $"Output '{output.Name}' has no sources and no contacts.");
+                    $"Output '{output.Name}' has no sources, no contacts, and no calendars.");
+
+            foreach (CalendarSourceConfig cal in output.Calendars ?? new List<CalendarSourceConfig>())
+            {
+                if (string.IsNullOrWhiteSpace(cal.StorePath))
+                    throw new ConfigValidationException(
+                        $"Output '{output.Name}' has a calendar source with an empty StorePath.");
+                if (cal.IncludeAppointments)
+                    throw new ConfigValidationException(
+                        "Calendar appointment conversion is not supported until the appointment writer PR (PR5).");
+                if (!cal.IncludeTasks && !cal.IncludeAppointments)
+                    throw new ConfigValidationException(
+                        $"Output '{output.Name}' has a calendar source that contributes nothing (both IncludeTasks and IncludeAppointments are false).");
+                if (cal.IncludeTasks && string.IsNullOrEmpty(cal.CalId) && (cal.TaskFolderPath is null or { Count: 0 }))
+                    throw new ConfigValidationException(
+                        $"Output '{output.Name}' has a calendar source with no CalId (all calendars in the store); it must set TaskFolderPath explicitly.");
+                if (cal.TaskFolderPath is not null)
+                    FolderNameValidator.ValidatePath(cal.TaskFolderPath);
+            }
 
             foreach (ContactSourceConfig contact in output.Contacts ?? new List<ContactSourceConfig>())
             {

--- a/src/Mail2Pst.Core/Config/FolderNameValidator.cs
+++ b/src/Mail2Pst.Core/Config/FolderNameValidator.cs
@@ -4,6 +4,7 @@
 #nullable enable
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Mail2Pst.Core.Config;
@@ -48,6 +49,24 @@ public static class FolderNameValidator
 
         if (ReservedName.IsMatch(trimmed))
             throw new ConfigValidationException("Folder name is reserved on Windows.");
+    }
+
+    /// <summary>
+    /// Coerces an arbitrary display name (e.g. a Thunderbird calendar name, which may contain '/',
+    /// control chars, leading/trailing spaces or dots, or be a reserved device name) into a folder
+    /// segment that always passes <see cref="Validate"/>. Path separators and control characters become
+    /// spaces; leading/trailing whitespace and dots are trimmed; an empty or reserved result falls back
+    /// to <paramref name="fallback"/>. Used by discovery to synthesize folder paths so a bad calendar
+    /// name can never abort the whole conversion at config validation.
+    /// </summary>
+    public static string Sanitize(string? name, string fallback)
+    {
+        var sb = new StringBuilder((name ?? string.Empty).Length);
+        foreach (char ch in name ?? string.Empty)
+            sb.Append(ch is '/' or '\\' || ch < 0x20 ? ' ' : ch);
+
+        string s = sb.ToString().Trim().Trim('.').Trim();   // no leading/trailing space or dot
+        return s.Length == 0 || ReservedName.IsMatch(s) ? fallback : s;
     }
 
     public const int MaxDepth = 32;

--- a/src/Mail2Pst.Core/Config/OutputGroupConfig.cs
+++ b/src/Mail2Pst.Core/Config/OutputGroupConfig.cs
@@ -18,4 +18,5 @@ public class OutputGroupConfig
 
     public List<SourceConfig> Sources { get; set; } = new();
     public List<ContactSourceConfig> Contacts { get; set; } = new();
+    public List<CalendarSourceConfig> Calendars { get; set; } = new();
 }

--- a/src/Mail2Pst.Core/Contacts/SqliteAddressBookReader.cs
+++ b/src/Mail2Pst.Core/Contacts/SqliteAddressBookReader.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FolkerKinzel.VCards;
 using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Storage;
 using Microsoft.Data.Sqlite;
 
 namespace Mail2Pst.Core.Contacts;

--- a/src/Mail2Pst.Core/ConversionRunner.cs
+++ b/src/Mail2Pst.Core/ConversionRunner.cs
@@ -176,7 +176,7 @@ public class ConversionRunner
                         taskFolders.Add(tm.TargetFolderPath);
                         CalendarReadResult read;
                         try { read = ReadCalendarStore(tm.Source.StorePath, w => report.RecordTaskWarning(w)); }
-                        catch (Exception ex) when (ex is IOException or SqliteException)
+                        catch (Exception ex) when (ex is IOException or SqliteException or UnauthorizedAccessException)
                         {
                             report.RecordTaskWarning($"Calendar store skipped [{tm.Source.StorePath}]: {ex.Message}");
                             continue;
@@ -243,7 +243,7 @@ public class ConversionRunner
                         appointmentFolders.Add(am.TargetFolderPath);
                         CalendarReadResult read;
                         try { read = ReadCalendarStore(am.Source.StorePath, w => report.RecordAppointmentWarning(w)); }
-                        catch (Exception ex) when (ex is IOException or SqliteException)
+                        catch (Exception ex) when (ex is IOException or SqliteException or UnauthorizedAccessException)
                         {
                             report.RecordAppointmentWarning($"Calendar store skipped [{am.Source.StorePath}]: {ex.Message}");
                             continue;

--- a/src/Mail2Pst.Core/ConversionRunner.cs
+++ b/src/Mail2Pst.Core/ConversionRunner.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using Mail2Pst.Core.Calendar;
 using Mail2Pst.Core.Config;
 using Mail2Pst.Core.Contacts;
 using Mail2Pst.Core.Diagnostics;
@@ -34,7 +35,7 @@ public class ConversionRunner
         _writer = new PstWriter(checkIntervalMessages, progressIntervalMessages);
     }
 
-    public ConversionReport Run(ConversionConfig config, string outputDirectory, Action<ConversionProgressEvent>? onProgress = null, CancellationToken cancellationToken = default, DurableMemoryObserver? memoryObserver = null, int precomputedTotalMessages = -1)
+    public ConversionReport Run(ConversionConfig config, string outputDirectory, Action<ConversionProgressEvent>? onProgress = null, CancellationToken cancellationToken = default, DurableMemoryObserver? memoryObserver = null, int precomputedTotalMessages = -1, bool skipTasks = false)
     {
         // Validate the config up front (output names, duplicates, sizes, sources)
         // so problems fail loudly before any output file is created.
@@ -90,6 +91,10 @@ public class ConversionRunner
             onProgress(new ScanEvent(total));
         }
 
+        // Track whether the "tasks disabled by --no-tasks" warning has already been emitted
+        // so we emit it exactly once even when multiple output groups carry task mappings.
+        bool noTasksWarned = false;
+
         try
         {
             foreach (PstOutputPlan plan in plans)
@@ -132,7 +137,80 @@ public class ConversionRunner
                     }
                 }
 
-                List<string> outputFiles = _writer.WritePlan(plan, plannedMessages, planned, contactFolders, outputDirectory, report, total, onProgress, cancellationToken, memoryObserver);
+                // Assemble tasks for this output group.
+                var plannedTasks = new List<PlannedTask>();
+                var taskFolders = new List<IReadOnlyList<string>>();
+
+                if (skipTasks && plan.TaskMappings.Count > 0 && !noTasksWarned)
+                {
+                    report.RecordTaskWarning("tasks disabled by --no-tasks");
+                    noTasksWarned = true;
+                }
+                else if (!skipTasks && plan.TaskMappings.Count > 0)
+                {
+                    // Cache: read each calendar store at most once per output group.
+                    // Cross-platform key: normalize path; on Windows fold case (FS is case-insensitive).
+                    var calendarReadCache = new Dictionary<string, CalendarReadResult>(
+                        OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+
+                    CalendarReadResult ReadStore(string storePath)
+                    {
+                        string key = Path.GetFullPath(storePath);
+                        if (!calendarReadCache.TryGetValue(key, out var r))
+                        {
+                            r = new SqliteCalendarReader().Read(storePath);
+                            calendarReadCache[key] = r;
+                            // Record store-level warnings once (not per-mapping).
+                            foreach (string warn in r.Warnings)
+                                report.RecordTaskWarning(warn);
+                        }
+                        return r;
+                    }
+
+                    foreach (TaskMapping tm in plan.TaskMappings)
+                    {
+                        taskFolders.Add(tm.TargetFolderPath);
+                        CalendarReadResult read;
+                        try { read = ReadStore(tm.Source.StorePath); }
+                        catch (Exception ex) when (ex is IOException or SqliteException)
+                        {
+                            report.RecordTaskWarning($"Calendar store skipped [{tm.Source.StorePath}]: {ex.Message}");
+                            continue;
+                        }
+
+                        // Filter to the specified calendar (or all calendars when CalId is empty).
+                        IEnumerable<RawCalendarRead> cals = string.IsNullOrEmpty(tm.Source.CalId)
+                            ? read.Calendars
+                            : read.Calendars.Where(c => c.CalId == tm.Source.CalId);
+
+                        foreach (RawCalendarRead cal in cals)
+                        {
+                            foreach (RawTodoGroup group in cal.TodoGroups)
+                            {
+                                TaskRecord? mapped = CalendarTaskMapper.Map(group, out IReadOnlyList<string> warns);
+                                foreach (string w in warns)
+                                    report.RecordTaskWarning(w);
+                                if (mapped is null)
+                                {
+                                    // Map returned null; the first warning (if any) describes the reason.
+                                    report.RecordTaskSkipped(
+                                        tm.Source.StorePath,
+                                        warns.Count > 0 ? warns[0] : "unmappable task");
+                                }
+                                else
+                                {
+                                    plannedTasks.Add(new PlannedTask
+                                    {
+                                        Task = mapped,
+                                        TargetFolderPath = tm.TargetFolderPath,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+
+                List<string> outputFiles = _writer.WritePlan(plan, plannedMessages, planned, contactFolders, plannedTasks, taskFolders, outputDirectory, report, total, onProgress, cancellationToken, memoryObserver);
                 report.AddOutputFiles(outputFiles);
             }
 

--- a/src/Mail2Pst.Core/ConversionRunner.cs
+++ b/src/Mail2Pst.Core/ConversionRunner.cs
@@ -142,7 +142,7 @@ public class ConversionRunner
             // it propagates out of Run to the CLI's fatal error path. Runs only here, on the
             // fully-successful path: cancellation throws out of the loop above and never reaches
             // this line, and the writer's own fatal aborts have already propagated.
-            PstOutputVerifier.Verify(report.OutputFiles, report.ConvertedCount + report.ContactsConverted);
+            PstOutputVerifier.Verify(report.OutputFiles, report.TotalWrittenItems);
         }
         catch (OperationCanceledException)
         {

--- a/src/Mail2Pst.Core/ConversionRunner.cs
+++ b/src/Mail2Pst.Core/ConversionRunner.cs
@@ -151,7 +151,9 @@ public class ConversionRunner
                     {
                         r = new SqliteCalendarReader().Read(storePath);
                         calendarReadCache[key] = r;
-                        // Record store-level warnings once (not per-mapping).
+                        // Record store-level warnings once (not per-mapping). For a store backing BOTH a task
+                        // and an appointment mapping, warnings are recorded via the first caller (task loop) —
+                        // the appointment loop skips the cache miss branch entirely. Intentional, not a bug.
                         foreach (string warn in r.Warnings)
                             recordStoreWarning(warn);
                     }

--- a/src/Mail2Pst.Core/ConversionRunner.cs
+++ b/src/Mail2Pst.Core/ConversionRunner.cs
@@ -187,6 +187,7 @@ public class ConversionRunner
                             ? read.Calendars
                             : read.Calendars.Where(c => c.CalId == tm.Source.CalId);
 
+                        var taskAttResolver = new CalendarAttachmentResolver(ResolveCalendarAttachmentRoot(tm.Source, config));
                         foreach (RawCalendarRead cal in cals)
                         {
                             foreach (RawTodoGroup group in cal.TodoGroups)
@@ -203,6 +204,7 @@ public class ConversionRunner
                                 }
                                 else
                                 {
+                                    ApplyCalendarAttachments(mapped, group.Master?.Attachments ?? new List<RawSideText>(), taskAttResolver, report.RecordTaskWarning);
                                     plannedTasks.Add(new PlannedTask
                                     {
                                         Task = mapped,
@@ -241,6 +243,7 @@ public class ConversionRunner
                             ? read.Calendars
                             : read.Calendars.Where(c => c.CalId == am.Source.CalId);
 
+                        var apptAttResolver = new CalendarAttachmentResolver(ResolveCalendarAttachmentRoot(am.Source, config));
                         foreach (RawCalendarRead cal in cals)
                         {
                             foreach (RawEventGroup group in cal.EventGroups)
@@ -257,6 +260,7 @@ public class ConversionRunner
                                 }
                                 else
                                 {
+                                    ApplyCalendarAttachments(mapped, group.Master?.Attachments ?? new List<RawSideText>(), apptAttResolver, report.RecordAppointmentWarning);
                                     plannedAppointments.Add(new PlannedAppointment
                                     {
                                         Appointment = mapped,
@@ -288,6 +292,38 @@ public class ConversionRunner
         }
 
         return report;
+    }
+
+    // …/<profile>/calendar-data/local.sqlite → <profile>. Explicit ProfilePath wins. Returns null when the
+    // store isn't under the expected calendar-data shape → local-file attachments become link-only (safe).
+    internal static string? ResolveCalendarAttachmentRoot(CalendarSourceConfig source, ConversionConfig config)
+    {
+        if (!string.IsNullOrWhiteSpace(config.ProfilePath)) return config.ProfilePath;
+        string? calDataDir = Path.GetDirectoryName(source.StorePath);
+        if (calDataDir is null ||
+            !string.Equals(Path.GetFileName(calDataDir), "calendar-data", StringComparison.OrdinalIgnoreCase))
+            return null;
+        return Path.GetDirectoryName(calDataDir);
+    }
+
+    // The resolve seam (unit-testable). subject used only for warning locality.
+    internal static void ApplyCalendarAttachments(
+        AppointmentRecord record, IEnumerable<RawSideText> raw,
+        CalendarAttachmentResolver resolver, Action<string> recordWarning)
+    {
+        var (atts, warns) = resolver.ResolveAll(raw, record.Subject);
+        record.Attachments = atts;
+        foreach (string w in warns) recordWarning(w);
+    }
+
+    // Overload for TaskRecord (same body; TaskRecord.Attachments / record.Subject).
+    internal static void ApplyCalendarAttachments(
+        TaskRecord record, IEnumerable<RawSideText> raw,
+        CalendarAttachmentResolver resolver, Action<string> recordWarning)
+    {
+        var (atts, warns) = resolver.ResolveAll(raw, record.Subject);
+        record.Attachments = atts;
+        foreach (string w in warns) recordWarning(w);
     }
 
     private static IEnumerable<PlannedMessage> EnumeratePlannedMessages(

--- a/src/Mail2Pst.Core/ConversionRunner.cs
+++ b/src/Mail2Pst.Core/ConversionRunner.cs
@@ -35,7 +35,7 @@ public class ConversionRunner
         _writer = new PstWriter(checkIntervalMessages, progressIntervalMessages);
     }
 
-    public ConversionReport Run(ConversionConfig config, string outputDirectory, Action<ConversionProgressEvent>? onProgress = null, CancellationToken cancellationToken = default, DurableMemoryObserver? memoryObserver = null, int precomputedTotalMessages = -1, bool skipTasks = false)
+    public ConversionReport Run(ConversionConfig config, string outputDirectory, Action<ConversionProgressEvent>? onProgress = null, CancellationToken cancellationToken = default, DurableMemoryObserver? memoryObserver = null, int precomputedTotalMessages = -1, bool skipTasks = false, bool skipAppointments = false)
     {
         // Validate the config up front (output names, duplicates, sizes, sources)
         // so problems fail loudly before any output file is created.
@@ -91,9 +91,10 @@ public class ConversionRunner
             onProgress(new ScanEvent(total));
         }
 
-        // Track whether the "tasks disabled by --no-tasks" warning has already been emitted
-        // so we emit it exactly once even when multiple output groups carry task mappings.
+        // Track whether the "X disabled by --no-X" warning has already been emitted
+        // so each is emitted exactly once even when multiple output groups carry those mappings.
         bool noTasksWarned = false;
+        bool noAppointmentsWarned = false;
 
         try
         {
@@ -137,6 +138,26 @@ public class ConversionRunner
                     }
                 }
 
+                // Shared per-plan calendar read cache: reads each SQLite store at most once
+                // regardless of whether it is accessed by the task loop, the appointment loop,
+                // or both. Cross-platform key: normalize path; on Windows fold case.
+                var calendarReadCache = new Dictionary<string, CalendarReadResult>(
+                    OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+
+                CalendarReadResult ReadCalendarStore(string storePath, Action<string> recordStoreWarning)
+                {
+                    string key = Path.GetFullPath(storePath);
+                    if (!calendarReadCache.TryGetValue(key, out var r))
+                    {
+                        r = new SqliteCalendarReader().Read(storePath);
+                        calendarReadCache[key] = r;
+                        // Record store-level warnings once (not per-mapping).
+                        foreach (string warn in r.Warnings)
+                            recordStoreWarning(warn);
+                    }
+                    return r;
+                }
+
                 // Assemble tasks for this output group.
                 var plannedTasks = new List<PlannedTask>();
                 var taskFolders = new List<IReadOnlyList<string>>();
@@ -148,30 +169,11 @@ public class ConversionRunner
                 }
                 else if (!skipTasks && plan.TaskMappings.Count > 0)
                 {
-                    // Cache: read each calendar store at most once per output group.
-                    // Cross-platform key: normalize path; on Windows fold case (FS is case-insensitive).
-                    var calendarReadCache = new Dictionary<string, CalendarReadResult>(
-                        OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
-
-                    CalendarReadResult ReadStore(string storePath)
-                    {
-                        string key = Path.GetFullPath(storePath);
-                        if (!calendarReadCache.TryGetValue(key, out var r))
-                        {
-                            r = new SqliteCalendarReader().Read(storePath);
-                            calendarReadCache[key] = r;
-                            // Record store-level warnings once (not per-mapping).
-                            foreach (string warn in r.Warnings)
-                                report.RecordTaskWarning(warn);
-                        }
-                        return r;
-                    }
-
                     foreach (TaskMapping tm in plan.TaskMappings)
                     {
                         taskFolders.Add(tm.TargetFolderPath);
                         CalendarReadResult read;
-                        try { read = ReadStore(tm.Source.StorePath); }
+                        try { read = ReadCalendarStore(tm.Source.StorePath, w => report.RecordTaskWarning(w)); }
                         catch (Exception ex) when (ex is IOException or SqliteException)
                         {
                             report.RecordTaskWarning($"Calendar store skipped [{tm.Source.StorePath}]: {ex.Message}");
@@ -210,7 +212,61 @@ public class ConversionRunner
                     }
                 }
 
-                List<string> outputFiles = _writer.WritePlan(plan, plannedMessages, planned, contactFolders, plannedTasks, taskFolders, outputDirectory, report, total, onProgress, cancellationToken, memoryObserver);
+                // Assemble appointments for this output group.
+                var plannedAppointments = new List<PlannedAppointment>();
+                var appointmentFolders = new List<IReadOnlyList<string>>();
+
+                if (skipAppointments && plan.AppointmentMappings.Count > 0 && !noAppointmentsWarned)
+                {
+                    report.RecordAppointmentWarning("appointments disabled by --no-appointments");
+                    noAppointmentsWarned = true;
+                }
+                else if (!skipAppointments && plan.AppointmentMappings.Count > 0)
+                {
+                    foreach (AppointmentMapping am in plan.AppointmentMappings)
+                    {
+                        appointmentFolders.Add(am.TargetFolderPath);
+                        CalendarReadResult read;
+                        try { read = ReadCalendarStore(am.Source.StorePath, w => report.RecordAppointmentWarning(w)); }
+                        catch (Exception ex) when (ex is IOException or SqliteException)
+                        {
+                            report.RecordAppointmentWarning($"Calendar store skipped [{am.Source.StorePath}]: {ex.Message}");
+                            continue;
+                        }
+
+                        // Filter to the specified calendar (or all calendars when CalId is empty).
+                        IEnumerable<RawCalendarRead> cals = string.IsNullOrEmpty(am.Source.CalId)
+                            ? read.Calendars
+                            : read.Calendars.Where(c => c.CalId == am.Source.CalId);
+
+                        foreach (RawCalendarRead cal in cals)
+                        {
+                            foreach (RawEventGroup group in cal.EventGroups)
+                            {
+                                AppointmentRecord? mapped = CalendarEventMapper.Map(group, out IReadOnlyList<string> warns);
+                                foreach (string w in warns)
+                                    report.RecordAppointmentWarning(w);
+                                if (mapped is null)
+                                {
+                                    // Map returned null; the first warning (if any) describes the reason.
+                                    report.RecordAppointmentSkipped(
+                                        am.Source.StorePath,
+                                        warns.Count > 0 ? warns[0] : "unmappable event");
+                                }
+                                else
+                                {
+                                    plannedAppointments.Add(new PlannedAppointment
+                                    {
+                                        Appointment = mapped,
+                                        TargetFolderPath = am.TargetFolderPath,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+
+                List<string> outputFiles = _writer.WritePlan(plan, plannedMessages, planned, contactFolders, plannedTasks, taskFolders, plannedAppointments, appointmentFolders, outputDirectory, report, total, onProgress, cancellationToken, memoryObserver);
                 report.AddOutputFiles(outputFiles);
             }
 

--- a/src/Mail2Pst.Core/ConversionRunner.cs
+++ b/src/Mail2Pst.Core/ConversionRunner.cs
@@ -192,24 +192,35 @@ public class ConversionRunner
                         {
                             foreach (RawTodoGroup group in cal.TodoGroups)
                             {
-                                TaskRecord? mapped = CalendarTaskMapper.Map(group, out IReadOnlyList<string> warns);
-                                foreach (string w in warns)
-                                    report.RecordTaskWarning(w);
-                                if (mapped is null)
+                                // Per-item containment: a single malformed todo must never abort the whole
+                                // conversion (mail/contacts/other calendars). Mirrors SqliteCalendarReader's
+                                // per-row catch — calendar data is fully untrusted.
+                                try
                                 {
-                                    // Map returned null; the first warning (if any) describes the reason.
-                                    report.RecordTaskSkipped(
-                                        tm.Source.StorePath,
-                                        warns.Count > 0 ? warns[0] : "unmappable task");
-                                }
-                                else
-                                {
-                                    ApplyCalendarAttachments(mapped, group.Master?.Attachments ?? new List<RawSideText>(), taskAttResolver, report.RecordTaskWarning);
-                                    plannedTasks.Add(new PlannedTask
+                                    TaskRecord? mapped = CalendarTaskMapper.Map(group, out IReadOnlyList<string> warns);
+                                    foreach (string w in warns)
+                                        report.RecordTaskWarning(w);
+                                    if (mapped is null)
                                     {
-                                        Task = mapped,
-                                        TargetFolderPath = tm.TargetFolderPath,
-                                    });
+                                        // Map returned null; the first warning (if any) describes the reason.
+                                        report.RecordTaskSkipped(
+                                            tm.Source.StorePath,
+                                            warns.Count > 0 ? warns[0] : "unmappable task");
+                                    }
+                                    else
+                                    {
+                                        ApplyCalendarAttachments(mapped, group.Master?.Attachments ?? new List<RawSideText>(), taskAttResolver, report.RecordTaskWarning);
+                                        plannedTasks.Add(new PlannedTask
+                                        {
+                                            Task = mapped,
+                                            TargetFolderPath = tm.TargetFolderPath,
+                                        });
+                                    }
+                                }
+                                catch (Exception ex) when (ex is not OperationCanceledException)
+                                {
+                                    report.RecordTaskSkipped(tm.Source.StorePath,
+                                        $"task '{group.Master?.Id ?? "(unknown)"}' skipped: {ex.Message}");
                                 }
                             }
                         }
@@ -248,24 +259,35 @@ public class ConversionRunner
                         {
                             foreach (RawEventGroup group in cal.EventGroups)
                             {
-                                AppointmentRecord? mapped = CalendarEventMapper.Map(group, out IReadOnlyList<string> warns);
-                                foreach (string w in warns)
-                                    report.RecordAppointmentWarning(w);
-                                if (mapped is null)
+                                // Per-item containment: a single malformed event must never abort the whole
+                                // conversion (mail/contacts/other calendars). Mirrors SqliteCalendarReader's
+                                // per-row catch — calendar data is fully untrusted.
+                                try
                                 {
-                                    // Map returned null; the first warning (if any) describes the reason.
-                                    report.RecordAppointmentSkipped(
-                                        am.Source.StorePath,
-                                        warns.Count > 0 ? warns[0] : "unmappable event");
-                                }
-                                else
-                                {
-                                    ApplyCalendarAttachments(mapped, group.Master?.Attachments ?? new List<RawSideText>(), apptAttResolver, report.RecordAppointmentWarning);
-                                    plannedAppointments.Add(new PlannedAppointment
+                                    AppointmentRecord? mapped = CalendarEventMapper.Map(group, out IReadOnlyList<string> warns);
+                                    foreach (string w in warns)
+                                        report.RecordAppointmentWarning(w);
+                                    if (mapped is null)
                                     {
-                                        Appointment = mapped,
-                                        TargetFolderPath = am.TargetFolderPath,
-                                    });
+                                        // Map returned null; the first warning (if any) describes the reason.
+                                        report.RecordAppointmentSkipped(
+                                            am.Source.StorePath,
+                                            warns.Count > 0 ? warns[0] : "unmappable event");
+                                    }
+                                    else
+                                    {
+                                        ApplyCalendarAttachments(mapped, group.Master?.Attachments ?? new List<RawSideText>(), apptAttResolver, report.RecordAppointmentWarning);
+                                        plannedAppointments.Add(new PlannedAppointment
+                                        {
+                                            Appointment = mapped,
+                                            TargetFolderPath = am.TargetFolderPath,
+                                        });
+                                    }
+                                }
+                                catch (Exception ex) when (ex is not OperationCanceledException)
+                                {
+                                    report.RecordAppointmentSkipped(am.Source.StorePath,
+                                        $"event '{group.Master?.Id ?? "(unknown)"}' skipped: {ex.Message}");
                                 }
                             }
                         }

--- a/src/Mail2Pst.Core/Discovery/ConfigFromDiscovery.cs
+++ b/src/Mail2Pst.Core/Discovery/ConfigFromDiscovery.cs
@@ -20,11 +20,16 @@ namespace Mail2Pst.Core.Discovery;
 /// <see cref="DiscoveredCalendarSource.TaskCount"/> &gt; 0 are synthesized as
 /// <see cref="CalendarSourceConfig"/> entries on each output group that has no explicit
 /// template calendars. Explicit template calendars always win per group.</para>
+/// <para>When <paramref name="includeAppointments"/> is true (default), discovered calendars with
+/// <see cref="DiscoveredCalendarSource.EventCount"/> &gt; 0 are synthesized as
+/// <see cref="CalendarSourceConfig"/> entries carrying appointment fields. One config per calendar
+/// carries both appointments and tasks when both conditions are met. Explicit template calendars
+/// always win per group.</para>
 /// </summary>
 public static class ConfigFromDiscovery
 {
     public static ConversionConfig Build(DiscoveryResult discovery, ConversionConfig? template = null,
-        bool includeContacts = true, bool includeTasks = true)
+        bool includeContacts = true, bool includeTasks = true, bool includeAppointments = true)
     {
         ArgumentNullException.ThrowIfNull(discovery);
 
@@ -93,23 +98,28 @@ public static class ConfigFromDiscovery
             }
         }
 
-        // Synthesize calendar/task sources from discovered calendars that carry tasks.
+        // Synthesize calendar sources from discovered calendars.
+        // One CalendarSourceConfig per source carries whichever of appointments/tasks it has.
         // Explicit template calendars win per group — skip synthesis if the group already has calendars.
-        if (includeTasks)
+        if (includeTasks || includeAppointments)
         {
             foreach (OutputGroupConfig output in config.Outputs)
             {
                 if (output.Calendars.Count > 0) continue; // explicit template calendars win for this group
                 foreach (DiscoveredCalendarSource src in discovery.Calendars)
                 {
-                    if (src.TaskCount <= 0) continue;
+                    bool wantAppts = includeAppointments && src.EventCount > 0;
+                    bool wantTasks = includeTasks && src.TaskCount > 0;
+                    if (!wantAppts && !wantTasks) continue;
+
                     output.Calendars.Add(new CalendarSourceConfig
                     {
                         StorePath = src.StorePath,
                         CalId = src.CalId,
-                        IncludeTasks = true,
-                        IncludeAppointments = false,
-                        TaskFolderPath = src.DefaultTaskFolderPath.ToArray(),
+                        IncludeAppointments = wantAppts,
+                        AppointmentFolderPath = wantAppts ? src.DefaultCalendarFolderPath.ToArray() : null,
+                        IncludeTasks = wantTasks,
+                        TaskFolderPath = wantTasks ? src.DefaultTaskFolderPath.ToArray() : null,
                     });
                 }
             }

--- a/src/Mail2Pst.Core/Discovery/ConfigFromDiscovery.cs
+++ b/src/Mail2Pst.Core/Discovery/ConfigFromDiscovery.cs
@@ -16,11 +16,15 @@ namespace Mail2Pst.Core.Discovery;
 /// <para>When <paramref name="includeContacts"/> is true (default), discovered address books are
 /// synthesized as <see cref="ContactSourceConfig"/> entries on each output group that has no
 /// explicit template contacts. Explicit template contacts always win per group.</para>
+/// <para>When <paramref name="includeTasks"/> is true (default), discovered calendars with
+/// <see cref="DiscoveredCalendarSource.TaskCount"/> &gt; 0 are synthesized as
+/// <see cref="CalendarSourceConfig"/> entries on each output group that has no explicit
+/// template calendars. Explicit template calendars always win per group.</para>
 /// </summary>
 public static class ConfigFromDiscovery
 {
     public static ConversionConfig Build(DiscoveryResult discovery, ConversionConfig? template = null,
-        bool includeContacts = true)
+        bool includeContacts = true, bool includeTasks = true)
     {
         ArgumentNullException.ThrowIfNull(discovery);
 
@@ -86,6 +90,28 @@ public static class ConfigFromDiscovery
                         Format = book.Format,
                         TargetFolderPath = new[] { "Contacts", book.DisplayName },
                     });
+            }
+        }
+
+        // Synthesize calendar/task sources from discovered calendars that carry tasks.
+        // Explicit template calendars win per group — skip synthesis if the group already has calendars.
+        if (includeTasks)
+        {
+            foreach (OutputGroupConfig output in config.Outputs)
+            {
+                if (output.Calendars.Count > 0) continue; // explicit template calendars win for this group
+                foreach (DiscoveredCalendarSource src in discovery.Calendars)
+                {
+                    if (src.TaskCount <= 0) continue;
+                    output.Calendars.Add(new CalendarSourceConfig
+                    {
+                        StorePath = src.StorePath,
+                        CalId = src.CalId,
+                        IncludeTasks = true,
+                        IncludeAppointments = false,
+                        TaskFolderPath = src.DefaultTaskFolderPath.ToArray(),
+                    });
+                }
             }
         }
 

--- a/src/Mail2Pst.Core/Discovery/DiscoveryResult.cs
+++ b/src/Mail2Pst.Core/Discovery/DiscoveryResult.cs
@@ -30,6 +30,26 @@ public sealed class DiscoveredAddressBook
     public string Format { get; set; } = string.Empty; // "thunderbird-sqlite" | "thunderbird-mab"
 }
 
+public sealed class DiscoveredCalendarSource
+{
+    public string CalId { get; init; } = string.Empty;
+    public string DisplayName { get; init; } = string.Empty;
+    public string StoreKind { get; init; } = string.Empty; // e.g. "local" | "caldav"
+    public string StorePath { get; init; } = string.Empty;
+    public string CalendarType { get; init; } = string.Empty; // "calendar" | "task" | "both"
+    public bool IsVisibleInThunderbird { get; init; }
+    public int EventCount { get; init; }
+    public int TaskCount { get; init; }
+    public IReadOnlyList<string> DefaultCalendarFolderPath { get; init; } = System.Array.Empty<string>();
+    public IReadOnlyList<string> DefaultTaskFolderPath { get; init; } = System.Array.Empty<string>();
+}
+
+public sealed class CalendarDiscoveryResult
+{
+    public List<DiscoveredCalendarSource> Calendars { get; init; } = new();
+    public List<DiscoveryWarning> Warnings { get; init; } = new();
+}
+
 public sealed record DiscoveryResult(
     string Root, string Layout,
     IReadOnlyList<DiscoveredSource> Sources,
@@ -39,4 +59,5 @@ public sealed record DiscoveryResult(
 {
     public IReadOnlyList<Account> Accounts { get; init; } = System.Array.Empty<Account>();
     public List<DiscoveredAddressBook> AddressBooks { get; init; } = new();
+    public List<DiscoveredCalendarSource> Calendars { get; init; } = new();
 }

--- a/src/Mail2Pst.Core/Discovery/MailProfileDiscovery.cs
+++ b/src/Mail2Pst.Core/Discovery/MailProfileDiscovery.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Mail2Pst.Core.Calendar;
+using Mail2Pst.Core.Config;
 using Mail2Pst.Core.Msf;
 
 namespace Mail2Pst.Core.Discovery;
@@ -262,6 +263,13 @@ public static class MailProfileDiscovery
             int eventCount = chosenRead.EventGroups.Count;
             int taskCount  = chosenRead.TodoGroups.Count;
 
+            // Sanitize the raw registry name into a valid PST folder segment (it may contain '/',
+            // control chars, etc.). DisplayName keeps the real name for the UI; only the synthesized
+            // folder leaf is coerced, so an odd calendar name can't fail ConfigValidator and abort the
+            // whole conversion (pre-merge review #9).
+            string folderLeaf = FolderNameValidator.Sanitize(
+                displayName, "Calendar " + calId[..Math.Min(8, calId.Length)]);
+
             result.Calendars.Add(new DiscoveredCalendarSource
             {
                 CalId                    = calId,
@@ -272,9 +280,9 @@ public static class MailProfileDiscovery
                 IsVisibleInThunderbird   = visible,
                 EventCount               = eventCount,
                 TaskCount                = taskCount,
-                DefaultCalendarFolderPath = new[] { "Calendars", displayName },
+                DefaultCalendarFolderPath = new[] { "Calendars", folderLeaf },
                 DefaultTaskFolderPath    = taskCount > 0
-                    ? new[] { "Tasks", displayName }
+                    ? new[] { "Tasks", folderLeaf }
                     : Array.Empty<string>(),
             });
         }

--- a/src/Mail2Pst.Core/Discovery/MailProfileDiscovery.cs
+++ b/src/Mail2Pst.Core/Discovery/MailProfileDiscovery.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Mail2Pst.Core.Calendar;
 using Mail2Pst.Core.Msf;
 
 namespace Mail2Pst.Core.Discovery;
@@ -138,12 +139,147 @@ public static class MailProfileDiscovery
 
         var addressBooks = DiscoverAddressBooks(prefsRoot ?? root).ToList();
 
+        var calendarResult = DiscoverCalendars(prefsRoot ?? root);
+        warnings.AddRange(calendarResult.Warnings);
+
         return new DiscoveryResult(root, layout, sources, warnings, skipped,
             new DiscoveryPairingSummary(paired, unpaired, orphan))
         {
             Accounts = accounts,
             AddressBooks = addressBooks,
+            Calendars = calendarResult.Calendars,
         };
+    }
+
+    /// <summary>
+    /// Discovers calendars for a Thunderbird profile directory.  Joins the prefs.js registry
+    /// (a hint for name/type/visibility) with actual per-cal_id row counts read from
+    /// <c>calendar-data/local.sqlite</c> and <c>calendar-data/cache.sqlite</c>.  Unregistered
+    /// cal_ids that have rows get a synthesized display name and a warning.  Skips
+    /// <c>deleted.sqlite</c>.
+    /// </summary>
+    public static CalendarDiscoveryResult DiscoverCalendars(string profileDir)
+    {
+        var result = new CalendarDiscoveryResult();
+
+        // Registry: cal_id -> entry (name, type, visibility). Missing file -> empty.
+        string prefsPath = Path.Combine(profileDir, "prefs.js");
+        var registry = CalendarRegistryReader.Read(prefsPath)
+            .ToDictionary(e => e.CalId, StringComparer.Ordinal);
+
+        // Read each store that exists; skip deleted.sqlite.
+        string calDataDir = Path.Combine(profileDir, "calendar-data");
+        string localPath  = Path.Combine(calDataDir, "local.sqlite");
+        string cachePath  = Path.Combine(calDataDir, "cache.sqlite");
+
+        var localData = new Dictionary<string, RawCalendarRead>(StringComparer.Ordinal);
+        var cacheData = new Dictionary<string, RawCalendarRead>(StringComparer.Ordinal);
+
+        var reader = new SqliteCalendarReader();
+
+        if (File.Exists(localPath))
+        {
+            CalendarReadResult localResult = reader.Read(localPath);
+            foreach (string w in localResult.Warnings)
+                result.Warnings.Add(new DiscoveryWarning("calendar-reader-warning", localPath, null, null, null, null, w));
+            foreach (RawCalendarRead cal in localResult.Calendars)
+                localData[cal.CalId] = cal;
+        }
+
+        if (File.Exists(cachePath))
+        {
+            CalendarReadResult cacheResult = reader.Read(cachePath);
+            foreach (string w in cacheResult.Warnings)
+                result.Warnings.Add(new DiscoveryWarning("calendar-reader-warning", cachePath, null, null, null, null, w));
+            foreach (RawCalendarRead cal in cacheResult.Calendars)
+                cacheData[cal.CalId] = cal;
+        }
+
+        // Union all cal_ids that actually have rows.
+        var allCalIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (string id in localData.Keys) allCalIds.Add(id);
+        foreach (string id in cacheData.Keys) allCalIds.Add(id);
+
+        foreach (string calId in allCalIds)
+        {
+            bool inLocal = localData.ContainsKey(calId);
+            bool inCache = cacheData.ContainsKey(calId);
+
+            // Both-stores rule: pick the store the registry expects; warn that the other is ignored.
+            string chosenKind;
+            string chosenPath;
+            RawCalendarRead chosenRead;
+
+            if (inLocal && inCache)
+            {
+                // type=="storage" -> local; anything else (caldav, ics, …) -> cache.
+                bool preferLocal = !registry.TryGetValue(calId, out CalendarRegistryEntry? reg)
+                    || string.Equals(reg.CalendarType, "storage", StringComparison.OrdinalIgnoreCase);
+                if (preferLocal)
+                {
+                    chosenKind = "local"; chosenPath = localPath; chosenRead = localData[calId];
+                    result.Warnings.Add(new DiscoveryWarning("calendar-both-stores-ignored", cachePath,
+                        null, null, null, null,
+                        $"Calendar {calId} found in both local and cache stores; cache store ignored."));
+                }
+                else
+                {
+                    chosenKind = "cache"; chosenPath = cachePath; chosenRead = cacheData[calId];
+                    result.Warnings.Add(new DiscoveryWarning("calendar-both-stores-ignored", localPath,
+                        null, null, null, null,
+                        $"Calendar {calId} found in both local and cache stores; local store ignored."));
+                }
+            }
+            else if (inLocal)
+            {
+                chosenKind = "local"; chosenPath = localPath; chosenRead = localData[calId];
+            }
+            else
+            {
+                chosenKind = "cache"; chosenPath = cachePath; chosenRead = cacheData[calId];
+            }
+
+            // Name / type / visibility from registry, or synthesize for unregistered cal_ids.
+            string displayName;
+            string calendarType;
+            bool visible;
+            if (registry.TryGetValue(calId, out CalendarRegistryEntry? entry))
+            {
+                displayName  = entry.DisplayName;
+                calendarType = entry.CalendarType;
+                visible      = entry.VisibleInThunderbird;
+            }
+            else
+            {
+                displayName  = "Calendar " + calId[..Math.Min(8, calId.Length)];
+                calendarType = "";
+                visible      = false;
+                result.Warnings.Add(new DiscoveryWarning("unregistered-calendar", chosenPath,
+                    null, null, null, null,
+                    $"Unregistered calendar {calId} imported from {chosenKind} store."));
+            }
+
+            int eventCount = chosenRead.EventGroups.Count;
+            int taskCount  = chosenRead.TodoGroups.Count;
+
+            result.Calendars.Add(new DiscoveredCalendarSource
+            {
+                CalId                    = calId,
+                DisplayName              = displayName,
+                StoreKind                = chosenKind,
+                StorePath                = chosenPath,
+                CalendarType             = calendarType,
+                IsVisibleInThunderbird   = visible,
+                EventCount               = eventCount,
+                TaskCount                = taskCount,
+                DefaultCalendarFolderPath = new[] { "Calendars", displayName },
+                DefaultTaskFolderPath    = taskCount > 0
+                    ? new[] { "Tasks", displayName }
+                    : Array.Empty<string>(),
+            });
+        }
+
+        return result;
     }
 
     public static IEnumerable<DiscoveredAddressBook> DiscoverAddressBooks(string profileDir)

--- a/src/Mail2Pst.Core/Mail2Pst.Core.csproj
+++ b/src/Mail2Pst.Core/Mail2Pst.Core.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="FolkerKinzel.VCards" Version="8.1.3" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="10.0.9" />
     <PackageReference Include="MimeKit" Version="4.17.0" />
   </ItemGroup>

--- a/src/Mail2Pst.Core/Mail2Pst.Core.csproj
+++ b/src/Mail2Pst.Core/Mail2Pst.Core.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="10.0.9" />
+    <PackageReference Include="Ical.Net" Version="5.2.2" />
     <PackageReference Include="MimeKit" Version="4.17.0" />
   </ItemGroup>
 </Project>

--- a/src/Mail2Pst.Core/Mapping/AppointmentMapping.cs
+++ b/src/Mail2Pst.Core/Mapping/AppointmentMapping.cs
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using Mail2Pst.Core.Config;
+
+namespace Mail2Pst.Core.Mapping;
+
+public class AppointmentMapping
+{
+    public CalendarSourceConfig Source { get; set; } = new();
+    public IReadOnlyList<string> TargetFolderPath { get; set; } = Array.Empty<string>();
+}

--- a/src/Mail2Pst.Core/Mapping/MappingEngine.cs
+++ b/src/Mail2Pst.Core/Mapping/MappingEngine.cs
@@ -80,6 +80,33 @@ public static class MappingEngine
                         $"Contact folder '{key}' collides with a mail folder of a different item type in output '{output.Name}'.");
             }
 
+            // Build task mappings (IncludeAppointments is PR5; only IncludeTasks wired here).
+            foreach (CalendarSourceConfig cal in output.Calendars ?? new List<CalendarSourceConfig>())
+            {
+                if (!cal.IncludeTasks)
+                    continue;
+                IReadOnlyList<string> target = cal.TaskFolderPath
+                    ?? new[] { "Tasks", cal.CalId };
+                plan.TaskMappings.Add(new TaskMapping
+                {
+                    Source = cal,
+                    TargetFolderPath = target,
+                });
+            }
+
+            // Plan-stage item-type collision check: a task folder path must not equal a mail or contact folder path.
+            var allNonTaskPathKeys = new HashSet<string>(
+                plan.SourceMappings.Select(m => FolderPathKey.Join(m.TargetFolderPath))
+                    .Concat(plan.ContactMappings.Select(m => FolderPathKey.Join(m.TargetFolderPath))),
+                StringComparer.OrdinalIgnoreCase);
+            foreach (TaskMapping tm in plan.TaskMappings)
+            {
+                string key = FolderPathKey.Join(tm.TargetFolderPath);
+                if (allNonTaskPathKeys.Contains(key))
+                    throw new ConfigValidationException(
+                        $"Task folder '{key}' collides with a mail or contact folder of a different item type in output '{output.Name}'.");
+            }
+
             plans.Add(plan);
         }
 

--- a/src/Mail2Pst.Core/Mapping/MappingEngine.cs
+++ b/src/Mail2Pst.Core/Mapping/MappingEngine.cs
@@ -80,7 +80,7 @@ public static class MappingEngine
                         $"Contact folder '{key}' collides with a mail folder of a different item type in output '{output.Name}'.");
             }
 
-            // Build task mappings (IncludeAppointments is PR5; only IncludeTasks wired here).
+            // Build task mappings.
             foreach (CalendarSourceConfig cal in output.Calendars ?? new List<CalendarSourceConfig>())
             {
                 if (!cal.IncludeTasks)
@@ -94,17 +94,45 @@ public static class MappingEngine
                 });
             }
 
-            // Plan-stage item-type collision check: a task folder path must not equal a mail or contact folder path.
-            var allNonTaskPathKeys = new HashSet<string>(
+            // Build appointment mappings.
+            foreach (CalendarSourceConfig cal in output.Calendars ?? new List<CalendarSourceConfig>())
+            {
+                if (!cal.IncludeAppointments)
+                    continue;
+                IReadOnlyList<string> target = cal.AppointmentFolderPath
+                    ?? new[] { "Calendars", cal.CalId };
+                plan.AppointmentMappings.Add(new AppointmentMapping
+                {
+                    Source = cal,
+                    TargetFolderPath = target,
+                });
+            }
+
+            // Plan-stage item-type collision check: task and appointment folder paths must not
+            // equal a mail, contact, task, or appointment folder path of a different item type.
+            // Build one unified key set covering mail + contacts, then check tasks and appointments
+            // against each other and against that set.
+            var mailAndContactKeys = new HashSet<string>(
                 plan.SourceMappings.Select(m => FolderPathKey.Join(m.TargetFolderPath))
                     .Concat(plan.ContactMappings.Select(m => FolderPathKey.Join(m.TargetFolderPath))),
                 StringComparer.OrdinalIgnoreCase);
+
+            var taskKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (TaskMapping tm in plan.TaskMappings)
             {
                 string key = FolderPathKey.Join(tm.TargetFolderPath);
-                if (allNonTaskPathKeys.Contains(key))
+                if (mailAndContactKeys.Contains(key))
                     throw new ConfigValidationException(
                         $"Task folder '{key}' collides with a mail or contact folder of a different item type in output '{output.Name}'.");
+                taskKeys.Add(key);
+            }
+
+            foreach (AppointmentMapping am in plan.AppointmentMappings)
+            {
+                string key = FolderPathKey.Join(am.TargetFolderPath);
+                if (mailAndContactKeys.Contains(key) || taskKeys.Contains(key))
+                    throw new ConfigValidationException(
+                        $"Appointment folder '{key}' collides with a mail, contact, or task folder of a different item type in output '{output.Name}'.");
             }
 
             plans.Add(plan);

--- a/src/Mail2Pst.Core/Mapping/PstOutputPlan.cs
+++ b/src/Mail2Pst.Core/Mapping/PstOutputPlan.cs
@@ -18,4 +18,5 @@ public class PstOutputPlan
     public List<SourceMapping> SourceMappings { get; set; } = new();
     public List<ContactMapping> ContactMappings { get; set; } = new();
     public List<TaskMapping> TaskMappings { get; set; } = new();
+    public List<AppointmentMapping> AppointmentMappings { get; set; } = new();
 }

--- a/src/Mail2Pst.Core/Mapping/PstOutputPlan.cs
+++ b/src/Mail2Pst.Core/Mapping/PstOutputPlan.cs
@@ -17,4 +17,5 @@ public class PstOutputPlan
 
     public List<SourceMapping> SourceMappings { get; set; } = new();
     public List<ContactMapping> ContactMappings { get; set; } = new();
+    public List<TaskMapping> TaskMappings { get; set; } = new();
 }

--- a/src/Mail2Pst.Core/Mapping/TaskMapping.cs
+++ b/src/Mail2Pst.Core/Mapping/TaskMapping.cs
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using Mail2Pst.Core.Config;
+
+namespace Mail2Pst.Core.Mapping;
+
+public class TaskMapping
+{
+    public CalendarSourceConfig Source { get; set; } = new();
+    public IReadOnlyList<string> TargetFolderPath { get; set; } = Array.Empty<string>();
+}

--- a/src/Mail2Pst.Core/Models/AppointmentAttendee.cs
+++ b/src/Mail2Pst.Core/Models/AppointmentAttendee.cs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Mail2Pst.Core.Models;
+
+// Recipient type for the MAPI recipient row: Required→To, Optional→Cc, Resource→Bcc.
+public enum AttendeeKind { Required, Optional, Resource }
+
+// Canonical MS-OXOCAL response/track-status values (used directly as the property int).
+public enum AttendeeResponse { None = 0, Organized = 1, Tentative = 2, Accepted = 3, Declined = 4, NotResponded = 5 }
+
+public sealed class AppointmentAttendee
+{
+    public string DisplayName { get; set; } = "";
+    public string Email { get; set; } = "";
+    public AttendeeKind Kind { get; set; } = AttendeeKind.Required;
+    public AttendeeResponse Response { get; set; } = AttendeeResponse.None;
+    public bool IsOrganizer { get; set; }
+}

--- a/src/Mail2Pst.Core/Models/AppointmentRecord.cs
+++ b/src/Mail2Pst.Core/Models/AppointmentRecord.cs
@@ -33,4 +33,11 @@ public sealed class AppointmentRecord
     public IReadOnlyList<AppointmentException> Exceptions { get; set; } = Array.Empty<AppointmentException>();
 
     public IReadOnlyList<CalendarAttachment> Attachments { get; set; } = Array.Empty<CalendarAttachment>();
+
+    /// <summary>
+    /// Raw 56-byte GlobalObjectId blob, hex-decoded from an Exchange-cached event id.
+    /// Null when the source id is a Mozilla UUID, CalDAV UID, or otherwise not a GOID
+    /// (Outlook generates a GOID on demand for non-Exchange items).
+    /// </summary>
+    public byte[]? GlobalObjectId { get; set; }
 }

--- a/src/Mail2Pst.Core/Models/AppointmentRecord.cs
+++ b/src/Mail2Pst.Core/Models/AppointmentRecord.cs
@@ -31,4 +31,6 @@ public sealed class AppointmentRecord
     public RecurrenceSpec? Recurrence { get; set; }
     public IReadOnlyList<RecurrenceInstanceId> DeletedOccurrences { get; set; } = Array.Empty<RecurrenceInstanceId>();
     public IReadOnlyList<AppointmentException> Exceptions { get; set; } = Array.Empty<AppointmentException>();
+
+    public IReadOnlyList<CalendarAttachment> Attachments { get; set; } = Array.Empty<CalendarAttachment>();
 }

--- a/src/Mail2Pst.Core/Models/AppointmentRecord.cs
+++ b/src/Mail2Pst.Core/Models/AppointmentRecord.cs
@@ -26,4 +26,9 @@ public sealed class AppointmentRecord
 
     public AppointmentAttendee? Organizer { get; set; }
     public IReadOnlyList<AppointmentAttendee> Attendees { get; set; } = Array.Empty<AppointmentAttendee>();
+
+    public string? OriginatingTimeZoneId { get; set; }   // canonical IANA/Olson id (event_start_tz)
+    public RecurrenceSpec? Recurrence { get; set; }
+    public IReadOnlyList<RecurrenceInstanceId> DeletedOccurrences { get; set; } = Array.Empty<RecurrenceInstanceId>();
+    public IReadOnlyList<AppointmentException> Exceptions { get; set; } = Array.Empty<AppointmentException>();
 }

--- a/src/Mail2Pst.Core/Models/AppointmentRecord.cs
+++ b/src/Mail2Pst.Core/Models/AppointmentRecord.cs
@@ -33,6 +33,7 @@ public sealed class AppointmentRecord
     public IReadOnlyList<AppointmentException> Exceptions { get; set; } = Array.Empty<AppointmentException>();
 
     public IReadOnlyList<CalendarAttachment> Attachments { get; set; } = Array.Empty<CalendarAttachment>();
+    public IReadOnlyList<string> Relations { get; set; } = Array.Empty<string>();
 
     /// <summary>
     /// Raw 56-byte GlobalObjectId blob, hex-decoded from an Exchange-cached event id.

--- a/src/Mail2Pst.Core/Models/AppointmentRecord.cs
+++ b/src/Mail2Pst.Core/Models/AppointmentRecord.cs
@@ -23,4 +23,7 @@ public sealed class AppointmentRecord
     public int ReminderMinutesBefore { get; set; }    // PidLidReminderDelta (appointments use a delta)
 
     public string SourceId { get; set; } = "";        // cal_events.id, for skip/warning messages
+
+    public AppointmentAttendee? Organizer { get; set; }
+    public IReadOnlyList<AppointmentAttendee> Attendees { get; set; } = Array.Empty<AppointmentAttendee>();
 }

--- a/src/Mail2Pst.Core/Models/AppointmentRecord.cs
+++ b/src/Mail2Pst.Core/Models/AppointmentRecord.cs
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+namespace Mail2Pst.Core.Models;
+
+public sealed class AppointmentRecord
+{
+    public string Subject { get; set; } = "";
+    public string? Body { get; set; }                 // plain text (DESCRIPTION)
+    public string? BodyHtml { get; set; }             // ALTREP HTML alternate, if present
+
+    public DateTime StartUtc { get; set; }            // event_start as UTC instant
+    public DateTime EndUtc { get; set; }              // event_end as UTC instant
+    public bool IsAllDay { get; set; }                // flags & 4
+    public TimeZoneInfo? TimeZone { get; set; }       // resolved display zone (null = floating/all-day)
+
+    public string? Location { get; set; }
+    public int BusyStatus { get; set; } = 2;          // 0=Free 1=Tentative 2=Busy 3=OOF (vendor BusyStatus enum)
+    public int Importance { get; set; } = 1;          // 0/1/2
+    public int Sensitivity { get; set; }              // 0 normal / 2 private / 3 confidential
+    public IReadOnlyList<string> Categories { get; set; } = Array.Empty<string>();
+
+    public bool ReminderSet { get; set; }
+    public int ReminderMinutesBefore { get; set; }    // PidLidReminderDelta (appointments use a delta)
+
+    public string SourceId { get; set; } = "";        // cal_events.id, for skip/warning messages
+}

--- a/src/Mail2Pst.Core/Models/AttachmentContent.cs
+++ b/src/Mail2Pst.Core/Models/AttachmentContent.cs
@@ -12,6 +12,7 @@ public sealed class AttachmentContent : IDisposable
     private readonly byte[]? _bytes;
     private readonly string? _tempPath;
     private readonly bool _lengthOnly;
+    private readonly bool _ownsFile;
     private bool _disposed;
 
     public long Length { get; }
@@ -19,11 +20,12 @@ public sealed class AttachmentContent : IDisposable
     internal bool IsTempFileBacked => _tempPath is not null;
     internal string? TempPath => _tempPath;
 
-    private AttachmentContent(byte[]? bytes, string? tempPath, long length, bool lengthOnly = false)
+    private AttachmentContent(byte[]? bytes, string? tempPath, long length, bool lengthOnly = false, bool ownsFile = true)
     {
         _bytes = bytes;
         _tempPath = tempPath;
         _lengthOnly = lengthOnly;
+        _ownsFile = ownsFile;
         Length = length;
     }
 
@@ -32,6 +34,12 @@ public sealed class AttachmentContent : IDisposable
 
     public static AttachmentContent FromTempFile(string path, long length) =>
         new(null, path, length);
+
+    /// <summary>A non-owning reference to an existing file. The file is read on demand but NEVER
+    /// deleted or mutated on <see cref="Dispose"/>. Use this for user's real calendar attachment
+    /// files — as opposed to <see cref="FromTempFile"/> which deletes on dispose.</summary>
+    public static AttachmentContent FromExistingFile(string path) =>
+        new(null, path, new FileInfo(path).Length, ownsFile: false);
 
     /// <summary>A scan measure-only attachment: carries the exact decoded <see cref="Length"/> but NO
     /// content. <see cref="OpenRead"/>/<see cref="ReadAllBytes"/> throw — it must never reach the writer.</summary>
@@ -77,7 +85,7 @@ public sealed class AttachmentContent : IDisposable
     {
         if (_disposed) return;
         _disposed = true;
-        if (_tempPath is not null)
+        if (_tempPath is not null && _ownsFile)
         {
             try { File.Delete(_tempPath); } catch (Exception) { }
         }

--- a/src/Mail2Pst.Core/Models/CalendarAttachment.cs
+++ b/src/Mail2Pst.Core/Models/CalendarAttachment.cs
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+namespace Mail2Pst.Core.Models;
+
+public enum CalendarAttachmentKind { InlineBytes, LocalFileByValue, LinkOnly }
+
+/// <summary>A classified calendar/task attachment. InlineBytes carries decoded bytes (embedded ByValue,
+/// NOT hidden); LocalFileByValue carries a validated in-root file path; LinkOnly carries a
+/// PreservedReference (remote URL or raw un-parseable ATTACH text) preserved in the body — never
+/// embedded, never fetched.</summary>
+public sealed record CalendarAttachment(
+    CalendarAttachmentKind Kind, string FileName, string MimeType,
+    byte[]? InlineData, string? LocalPath, string? PreservedReference);

--- a/src/Mail2Pst.Core/Models/RecurrenceSpec.cs
+++ b/src/Mail2Pst.Core/Models/RecurrenceSpec.cs
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+namespace Mail2Pst.Core.Models;
+
+public enum AppointmentRecurrenceFrequency { Daily, Weekly, Monthly, MonthlyNth, Yearly, YearlyNth }
+public enum RecurrenceEndKind { NoEnd, Count, Until }
+
+/// <summary>Original-occurrence identity. TimeZoneId is the canonical IANA/Olson id (or a tzone:// Windows id) verbatim from TB.</summary>
+public sealed record RecurrenceInstanceId(
+    DateTime OriginalStartUtc, DateTime OriginalStartLocal, string? TimeZoneId, bool IsDateOnly);
+
+[Flags]
+public enum AppointmentExceptionChangeFlags
+{
+    None = 0, Subject = 1, Location = 2, Body = 4, StartEnd = 8,
+    BusyStatus = 16, Reminder = 32, Sensitivity = 64, Categories = 128
+}
+
+public sealed class RecurrenceSpec
+{
+    public AppointmentRecurrenceFrequency Frequency { get; set; }
+    public int Interval { get; set; } = 1;     // in RecurrenceType natural units (years for yearly)
+    public DayOfWeek[] DaysOfWeek { get; set; } = Array.Empty<DayOfWeek>();
+    public int? DayOfMonth { get; set; }
+    public int? NthOccurrence { get; set; }     // 1..4, -1 = last
+    public int? Month { get; set; }
+    public RecurrenceEndKind EndKind { get; set; }
+    public int? Count { get; set; }
+    public DateTime? UntilUtc { get; set; }
+    public DateTime FirstStartUtc { get; set; }
+    public DateTime FirstStartLocal { get; set; }
+    public TimeZoneInfo? TimeZone { get; set; }        // for offset math only
+    public string? OriginatingTimeZoneId { get; set; } // canonical IANA/Olson id from event_start_tz
+    /// <summary>UTC start of the LAST occurrence (COUNT-th, or final occ ≤ UNTIL), computed by enumeration. Null only for NoEnd.</summary>
+    public DateTime? LastInstanceStartUtc { get; set; }
+    public string RawRRuleBody { get; set; } = "";     // RRULE body WITHOUT the "RRULE:" prefix
+}
+
+public sealed class AppointmentException
+{
+    public required RecurrenceInstanceId OriginalInstance { get; set; }
+    public DateTime? NewStartUtc { get; set; }
+    public DateTime? NewEndUtc { get; set; }
+    public string? Subject { get; set; }
+    public string? Location { get; set; }
+    public string? Body { get; set; }
+    public int? BusyStatus { get; set; }
+    public bool? ReminderSet { get; set; }
+    public int? ReminderMinutesBefore { get; set; }
+    public AppointmentExceptionChangeFlags ChangeFlags { get; set; }
+}

--- a/src/Mail2Pst.Core/Models/RecurrenceSpec.cs
+++ b/src/Mail2Pst.Core/Models/RecurrenceSpec.cs
@@ -3,7 +3,7 @@
 using System;
 namespace Mail2Pst.Core.Models;
 
-public enum AppointmentRecurrenceFrequency { Daily, Weekly, Monthly, MonthlyNth, Yearly, YearlyNth }
+public enum RecurrenceFrequency { Daily, Weekly, Monthly, MonthlyNth, Yearly, YearlyNth }
 public enum RecurrenceEndKind { NoEnd, Count, Until }
 
 /// <summary>Original-occurrence identity. TimeZoneId is the canonical IANA/Olson id (or a tzone:// Windows id) verbatim from TB.</summary>
@@ -19,7 +19,7 @@ public enum AppointmentExceptionChangeFlags
 
 public sealed class RecurrenceSpec
 {
-    public AppointmentRecurrenceFrequency Frequency { get; set; }
+    public RecurrenceFrequency Frequency { get; set; }
     public int Interval { get; set; } = 1;     // in RecurrenceType natural units (years for yearly)
     public DayOfWeek[] DaysOfWeek { get; set; } = Array.Empty<DayOfWeek>();
     public int? DayOfMonth { get; set; }

--- a/src/Mail2Pst.Core/Models/TaskRecord.cs
+++ b/src/Mail2Pst.Core/Models/TaskRecord.cs
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+namespace Mail2Pst.Core.Models;
+
+public enum TaskStatusKind
+{
+    NotStarted = 0,   // PidLidTaskStatus 0
+    InProgress = 1,   // 1
+    Complete   = 2,   // 2
+    Waiting    = 3,   // 3 (waiting on someone else)
+    Deferred   = 4,   // 4
+}
+
+public sealed class TaskRecord
+{
+    public string Subject { get; set; } = "";
+    public string? Body { get; set; }                     // plain text from DESCRIPTION
+    public TaskStatusKind Status { get; set; } = TaskStatusKind.NotStarted;
+    public int PercentComplete { get; set; }              // 0..100
+    public DateTimeOffset? StartDate { get; set; }        // todo_entry
+    public DateTimeOffset? DueDate { get; set; }          // todo_due
+    public DateTimeOffset? CompletedDate { get; set; }    // todo_completed
+    public int Importance { get; set; } = 1;              // PidTagImportance 0=low 1=normal 2=high
+    public int Sensitivity { get; set; }                  // PidTagSensitivity 0=normal 2=private 3=confidential
+    public IReadOnlyList<string> Categories { get; set; } = Array.Empty<string>();
+
+    // Reminder — ABSOLUTE for tasks (Task 0 ground-truth: PidLidReminderTime + PidLidReminderSignalTime,
+    // PidLidReminderDelta stays 0; the appointment-style minutes-before delta does NOT apply to tasks).
+    public bool ReminderSet { get; set; }
+    public DateTimeOffset? ReminderTime { get; set; }     // absolute reminder instant
+
+    public string SourceId { get; set; } = "";            // cal_todos.id, for skip/warning messages
+}

--- a/src/Mail2Pst.Core/Models/TaskRecord.cs
+++ b/src/Mail2Pst.Core/Models/TaskRecord.cs
@@ -33,4 +33,6 @@ public sealed class TaskRecord
 
     // Recurrence — null for non-recurring tasks.
     public RecurrenceSpec? Recurrence { get; set; }
+
+    public IReadOnlyList<CalendarAttachment> Attachments { get; set; } = Array.Empty<CalendarAttachment>();
 }

--- a/src/Mail2Pst.Core/Models/TaskRecord.cs
+++ b/src/Mail2Pst.Core/Models/TaskRecord.cs
@@ -30,4 +30,7 @@ public sealed class TaskRecord
     public DateTimeOffset? ReminderTime { get; set; }     // absolute reminder instant
 
     public string SourceId { get; set; } = "";            // cal_todos.id, for skip/warning messages
+
+    // Recurrence — null for non-recurring tasks.
+    public RecurrenceSpec? Recurrence { get; set; }
 }

--- a/src/Mail2Pst.Core/Models/TaskRecord.cs
+++ b/src/Mail2Pst.Core/Models/TaskRecord.cs
@@ -35,4 +35,5 @@ public sealed class TaskRecord
     public RecurrenceSpec? Recurrence { get; set; }
 
     public IReadOnlyList<CalendarAttachment> Attachments { get; set; } = Array.Empty<CalendarAttachment>();
+    public IReadOnlyList<string> Relations { get; set; } = Array.Empty<string>();
 }

--- a/src/Mail2Pst.Core/Progress/ConversionProgressEvent.cs
+++ b/src/Mail2Pst.Core/Progress/ConversionProgressEvent.cs
@@ -18,7 +18,11 @@ public sealed record ProgressEvent(
     long EstimatedOutputBytes = 0,
     int ContactsConverted = 0,
     int ContactsTotal = 0,
-    string Phase = "mail") : ConversionProgressEvent;
+    string Phase = "mail",
+    int AppointmentsConverted = 0,
+    int AppointmentsTotal = 0,
+    int TasksConverted = 0,
+    int TasksTotal = 0) : ConversionProgressEvent;
 
 public sealed record WarningEvent(
     string Source,

--- a/src/Mail2Pst.Core/Reporting/ConversionReport.cs
+++ b/src/Mail2Pst.Core/Reporting/ConversionReport.cs
@@ -196,6 +196,9 @@ public class ConversionReport
         return JsonSerializer.Serialize(new
         {
             converted = ConvertedCount,
+            contactsConverted = ContactsConverted,
+            contactsSkipped = ContactsSkipped,
+            contactWarnings = ContactWarningCount,
             appointmentsConverted = AppointmentsConverted,
             appointmentsSkipped = AppointmentsSkipped,
             appointmentWarnings = AppointmentWarningCount,

--- a/src/Mail2Pst.Core/Reporting/ConversionReport.cs
+++ b/src/Mail2Pst.Core/Reporting/ConversionReport.cs
@@ -19,6 +19,12 @@ public class ConversionReport
     private int _contactsConverted;
     private int _contactsSkipped;
     private int _contactWarningCount;
+    private int _appointmentsConverted;
+    private int _appointmentsSkipped;
+    private int _appointmentWarningCount;
+    private int _tasksConverted;
+    private int _tasksSkipped;
+    private int _taskWarningCount;
     private readonly List<SkippedMessage> _skipped = new();
     private readonly List<SkippedMessage> _warnings = new();
     private readonly List<string> _outputFiles = new();
@@ -35,6 +41,17 @@ public class ConversionReport
     public int ContactsConverted => Volatile.Read(ref _contactsConverted);
     public int ContactsSkipped => Volatile.Read(ref _contactsSkipped);
     public int ContactWarningCount => Volatile.Read(ref _contactWarningCount);
+
+    public int AppointmentsConverted => Volatile.Read(ref _appointmentsConverted);
+    public int AppointmentsSkipped => Volatile.Read(ref _appointmentsSkipped);
+    public int AppointmentWarningCount => Volatile.Read(ref _appointmentWarningCount);
+    public int TasksConverted => Volatile.Read(ref _tasksConverted);
+    public int TasksSkipped => Volatile.Read(ref _tasksSkipped);
+    public int TaskWarningCount => Volatile.Read(ref _taskWarningCount);
+
+    /// <summary>All written item types — the count PstOutputVerifier expects across all parts.</summary>
+    public int TotalWrittenItems =>
+        ConvertedCount + ContactsConverted + AppointmentsConverted + TasksConverted;
 
     // Cheap, lock-protected counts for the hot path (progress ticks) that don't
     // need to copy the whole list.
@@ -77,6 +94,29 @@ public class ConversionReport
     public void RecordContactWarning(string message)
     {
         Interlocked.Increment(ref _contactWarningCount);
+        AddWarning(message);
+    }
+
+    public void RecordAppointmentConverted() => Interlocked.Increment(ref _appointmentsConverted);
+    public void RecordAppointmentSkipped(string source, string error)
+    {
+        Interlocked.Increment(ref _appointmentsSkipped);
+        AddWarning($"Appointment skipped [{source}]: {error}");
+    }
+    public void RecordAppointmentWarning(string message)
+    {
+        Interlocked.Increment(ref _appointmentWarningCount);
+        AddWarning(message);
+    }
+    public void RecordTaskConverted() => Interlocked.Increment(ref _tasksConverted);
+    public void RecordTaskSkipped(string source, string error)
+    {
+        Interlocked.Increment(ref _tasksSkipped);
+        AddWarning($"Task skipped [{source}]: {error}");
+    }
+    public void RecordTaskWarning(string message)
+    {
+        Interlocked.Increment(ref _taskWarningCount);
         AddWarning(message);
     }
 
@@ -156,6 +196,12 @@ public class ConversionReport
         return JsonSerializer.Serialize(new
         {
             converted = ConvertedCount,
+            appointmentsConverted = AppointmentsConverted,
+            appointmentsSkipped = AppointmentsSkipped,
+            appointmentWarnings = AppointmentWarningCount,
+            tasksConverted = TasksConverted,
+            tasksSkipped = TasksSkipped,
+            taskWarnings = TaskWarningCount,
             skipped = skipped.Select(s => new { source = s.SourcePath, identifier = s.Identifier, reason = s.Reason }),
             warnings = warnings.Select(w => new { source = w.SourcePath, identifier = w.Identifier, reason = w.Reason }),
             enrichment = EnrichmentSummary,
@@ -173,6 +219,8 @@ public class ConversionReport
 
         var builder = new StringBuilder();
         builder.AppendLine($"Converted: {ConvertedCount}");
+        builder.AppendLine($"Appointments: {AppointmentsConverted}");
+        builder.AppendLine($"Tasks: {TasksConverted}");
         builder.AppendLine($"Skipped: {skipped.Length}");
 
         foreach (SkippedMessage skip in skipped)

--- a/src/Mail2Pst.Core/Storage/SqliteSnapshot.cs
+++ b/src/Mail2Pst.Core/Storage/SqliteSnapshot.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using Microsoft.Data.Sqlite;
 
-namespace Mail2Pst.Core.Contacts;
+namespace Mail2Pst.Core.Storage;
 
 /// <summary>
 /// Opens a Thunderbird SQLite address book for read. Tries a read-only connection on the

--- a/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
+++ b/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
@@ -55,21 +55,24 @@ public sealed class AppointmentWriter
         int importance  = a.Importance  is >= 0 and <= 2  ? a.Importance  : 1;
         int sensitivity = a.Sensitivity is 0 or 2 or 3   ? a.Sensitivity : 0;
 
-        // SetStartAndDuration writes PidLidAppointmentStartWhole / EndWhole + Clip + Common.
-        int durationMinutes = (int)Math.Max(0, Math.Round((a.EndUtc - a.StartUtc).TotalMinutes));
-        appt.SetStartAndDuration(a.StartUtc, durationMinutes);
-
-        // PidLidAppointmentSubType — set BEFORE timezone blob so Outlook reads all-day correctly.
-        appt.IsAllDayEvent = a.IsAllDay;
-
-        // Resolve a writable zone.
+        // Resolve and apply timezone BEFORE SetStartAndDuration.
+        // RecurringAppointment.StartDTUtc setter computes PidLidClipStart using this.OriginalTimeZone;
+        // if the zone is applied AFTER, ClipStart is computed in the host's local zone (wrong on any
+        // host whose local zone ≠ the event zone). SingleAppointment is unaffected (its ClipStart
+        // setter does not use OriginalTimeZone), so this reorder is safe for both paths.
         //   - Single appointments: null = floating/unresolved → skip SetOriginalTimeZone (no Win32 call).
         //   - Recurring appointments: MUST be non-null — SaveChanges() falls back to Win32
         //     TimeZoneInfo.Local when OriginalTimeZone is unset, breaking cross-platform builds.
         //     UTC is always a safe fallback for the blob's KeyName.
         TimeZoneInfo? zone = ResolveWindowsZone(a) ?? (a.Recurrence is null ? null : TimeZoneInfo.Utc);
         if (zone is not null)
-            appt.SetOriginalTimeZone(zone);
+            appt.SetOriginalTimeZone(zone);   // MUST precede SetStartAndDuration (RecurringAppointment ClipStart depends on the zone)
+
+        // SetStartAndDuration writes PidLidAppointmentStartWhole / EndWhole + Clip + Common.
+        int durationMinutes = (int)Math.Max(0, Math.Round((a.EndUtc - a.StartUtc).TotalMinutes));
+        appt.SetStartAndDuration(a.StartUtc, durationMinutes);
+
+        appt.IsAllDayEvent = a.IsAllDay;
 
         if (!string.IsNullOrEmpty(a.Location)) appt.Location = a.Location;
         appt.BusyStatus = (BusyStatus)busy;

--- a/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
+++ b/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Text;
 using Mail2Pst.Core.Models;
 using PSTFileFormat;
+// Alias disambiguates our model enum from PSTFileFormat.RecurrenceFrequency (the vendor blob type).
+using RecurrenceFrequency = Mail2Pst.Core.Models.RecurrenceFrequency;
 
 namespace Mail2Pst.Core.Writing;
 
@@ -164,12 +166,12 @@ public sealed class AppointmentWriter
     {
         ra.RecurrenceType = s.Frequency switch
         {
-            AppointmentRecurrenceFrequency.Daily      => RecurrenceType.EveryNDays,
-            AppointmentRecurrenceFrequency.Weekly     => RecurrenceType.EveryNWeeks,
-            AppointmentRecurrenceFrequency.Monthly    => RecurrenceType.EveryNMonths,
-            AppointmentRecurrenceFrequency.MonthlyNth => RecurrenceType.EveryNthDayOfEveryNMonths,
-            AppointmentRecurrenceFrequency.Yearly     => RecurrenceType.EveryNYears,
-            AppointmentRecurrenceFrequency.YearlyNth  => RecurrenceType.EveryNthDayOfEveryNYears,
+            RecurrenceFrequency.Daily      => RecurrenceType.EveryNDays,
+            RecurrenceFrequency.Weekly     => RecurrenceType.EveryNWeeks,
+            RecurrenceFrequency.Monthly    => RecurrenceType.EveryNMonths,
+            RecurrenceFrequency.MonthlyNth => RecurrenceType.EveryNthDayOfEveryNMonths,
+            RecurrenceFrequency.Yearly     => RecurrenceType.EveryNYears,
+            RecurrenceFrequency.YearlyNth  => RecurrenceType.EveryNthDayOfEveryNYears,
             _ => RecurrenceType.EveryNDays,
         };
 
@@ -180,9 +182,9 @@ public sealed class AppointmentWriter
         // Day: day-mask for weekly; OutlookDayOfWeek for nth-day patterns; day-of-month for others.
         ra.Day = s.Frequency switch
         {
-            AppointmentRecurrenceFrequency.Weekly =>
+            RecurrenceFrequency.Weekly =>
                 (int)ToMask(s.DaysOfWeek),
-            AppointmentRecurrenceFrequency.MonthlyNth or AppointmentRecurrenceFrequency.YearlyNth =>
+            RecurrenceFrequency.MonthlyNth or RecurrenceFrequency.YearlyNth =>
                 (int)ToOutlookDay(s.DaysOfWeek.Length > 0 ? s.DaysOfWeek[0] : DayOfWeek.Monday),
             // Day-of-month defaults to the LOCAL start day, not the UTC day: an all-day event anchored
             // to a positive-offset zone stores StartUtc as local-midnight-in-UTC (e.g. the prior day),
@@ -191,7 +193,7 @@ public sealed class AppointmentWriter
         };
 
         // DayOccurrenceNumber: only for Nth-day patterns (2nd Tuesday, Last Friday, etc.)
-        if (s.Frequency is AppointmentRecurrenceFrequency.MonthlyNth or AppointmentRecurrenceFrequency.YearlyNth)
+        if (s.Frequency is RecurrenceFrequency.MonthlyNth or RecurrenceFrequency.YearlyNth)
         {
             ra.DayOccurenceNumber = (s.NthOccurrence ?? 1) == -1
                 ? DayOccurenceNumber.Last

--- a/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
+++ b/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
@@ -391,7 +391,7 @@ public sealed class AppointmentWriter
     {
         // Compute appendix once (dedup against the original body text before any append).
         string? appendix = CalendarBodyAppendix.Format(a.Attachments,
-            System.Array.Empty<string>(),   // Task 5 supplies relation lines
+            a.Relations,
             existingText: a.Body ?? a.BodyHtml);
 
         string? plain = a.Body;

--- a/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
+++ b/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
@@ -154,13 +154,19 @@ public sealed class AppointmentWriter
 
         // asfMeeting = 0x1 (PidLidAppointmentStateFlags, PSETID_Appointment 0x8217)
         // The vendor Appointment.StateFlags setter takes int; there is no AppointmentStateFlags enum.
-        appt.StateFlags = 1;   // asfMeeting (0x1)
+        const int AsfMeeting = 0x1; // PidLidAppointmentStateFlags asfMeeting bit
+        appt.StateFlags = AsfMeeting;
 
         // PidLidResponseStatus = respOrganized(1) — PR6 organizer-copy default (Task 0 recipe).
         // Named prop registered in Task 2; PSETID_Appointment 0x8218.
-        PropertyID rs = file.NameToIDMap.ObtainIDFromName(
-            new PropertyName(PropertyLongID.PidLidResponseStatus, PropertySetGuid.PSETID_Appointment));
-        appt.PC.SetInt32Property(rs, (int)AttendeeResponse.Organized);
+        // Only written when a.Organizer is known: the organizer-copy response-status is
+        // meaningless (and misleading) when no organizer is present in the record.
+        if (a.Organizer is not null)
+        {
+            PropertyID rs = file.NameToIDMap.ObtainIDFromName(
+                new PropertyName(PropertyLongID.PidLidResponseStatus, PropertySetGuid.PSETID_Appointment));
+            appt.PC.SetInt32Property(rs, (int)AttendeeResponse.Organized);
+        }
 
         // Do NOT set PidLidFInvited (inconsistent in ground truth, not load-bearing) or
         // PidLidMeetingStatus/PidLidAppointmentReplyTime (absent in ground truth). GlobalObjectId → PR8.

--- a/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
+++ b/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Text;
 using Mail2Pst.Core.Models;
 using PSTFileFormat;
@@ -97,9 +98,72 @@ public sealed class AppointmentWriter
 
         // PidLidMeetingStatus is intentionally NOT set: absent in the Task 0 dump for plain appointments.
 
+        WriteAttendees(file, appt, a);   // recipients + organizer + meeting state (no-op when no attendees)
+
         appt.SaveChanges();
         folder.AddMessage(appt);
         // folder.SaveChanges() is the caller's responsibility (must be called before EndSavingChanges).
+    }
+
+    private static RecipientType MapRecipientType(AttendeeKind kind) => kind switch
+    {
+        AttendeeKind.Optional => RecipientType.Cc,
+        AttendeeKind.Resource => RecipientType.Bcc,
+        _ => RecipientType.To,
+    };
+
+    /// <summary>
+    /// Writes meeting attendees, organizer, and meeting-state props onto <paramref name="appt"/>.
+    /// Promotes the item to a meeting ONLY when <paramref name="a"/> has ≥1 attendee —
+    /// an organizer-only event is treated as a plain appointment (no recipient rows, no meeting state).
+    /// </summary>
+    private static void WriteAttendees(PSTFile file, SingleAppointment appt, AppointmentRecord a)
+    {
+        // PR6 promotes to a meeting ONLY when there is ≥1 non-organizer attendee. An organizer-only event
+        // (just an ORGANIZER line, no attendees) is a plain appointment — no recipient rows, no meeting state
+        // (avoids the hybrid "recipient table but not a meeting" state). The mapper guarantees every entry in
+        // a.Attendees has a non-empty Email; the organizer may be display-only (no email).
+        if (a.Attendees.Count == 0) return;
+
+        // Organizer → sender (mail precedent): name always, SMTP address only when present.
+        if (a.Organizer is { } org)
+        {
+            appt.SentRepresentingName = org.DisplayName;
+            if (!string.IsNullOrEmpty(org.Email))
+            {
+                appt.SentRepresentingAddressType = "SMTP";
+                appt.SentRepresentingEmailAddress = org.Email;
+            }
+        }
+
+        // Recipient rows — Task 0 CONFIRMED the organizer is a MeetingOrganizer-flagged To row
+        // (isOrganizer:true sets RecipientFlags.MeetingOrganizer) AND attendees are To/Cc/Bcc.
+        // AddRecipients also builds PidTagDisplayTo/Cc/Bcc automatically.
+        var recipients = new List<MessageRecipient>();
+
+        // Organizer recipient row ONLY when it has an email (a row with an empty address is invalid MAPI).
+        if (a.Organizer is { Email: { Length: > 0 } } orgWithEmail)
+            recipients.Add(new MessageRecipient(orgWithEmail.DisplayName, orgWithEmail.Email, isOrganizer: true,
+                RecipientType.To) { ResponseStatus = (int)AttendeeResponse.Organized });   // organizer copy = respOrganized; don't trust record.Response
+
+        foreach (var att in a.Attendees)   // each has a non-empty Email (mapper-enforced)
+            recipients.Add(new MessageRecipient(att.DisplayName, att.Email, isOrganizer: false,
+                MapRecipientType(att.Kind)) { ResponseStatus = (int)att.Response });
+
+        appt.AddRecipients(recipients);
+
+        // asfMeeting = 0x1 (PidLidAppointmentStateFlags, PSETID_Appointment 0x8217)
+        // The vendor Appointment.StateFlags setter takes int; there is no AppointmentStateFlags enum.
+        appt.StateFlags = 1;   // asfMeeting (0x1)
+
+        // PidLidResponseStatus = respOrganized(1) — PR6 organizer-copy default (Task 0 recipe).
+        // Named prop registered in Task 2; PSETID_Appointment 0x8218.
+        PropertyID rs = file.NameToIDMap.ObtainIDFromName(
+            new PropertyName(PropertyLongID.PidLidResponseStatus, PropertySetGuid.PSETID_Appointment));
+        appt.PC.SetInt32Property(rs, (int)AttendeeResponse.Organized);
+
+        // Do NOT set PidLidFInvited (inconsistent in ground truth, not load-bearing) or
+        // PidLidMeetingStatus/PidLidAppointmentReplyTime (absent in ground truth). GlobalObjectId → PR8.
     }
 
     // WriteBody rules (ground-truthed from PstWriter.WriteMessage pattern):

--- a/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
+++ b/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
@@ -101,6 +101,8 @@ public sealed class AppointmentWriter
 
         WriteAttendees(file, appt, a);   // recipients + organizer + meeting state (no-op when no attendees)
 
+        WriteAttachments(file, appt, a.Attachments);   // ByValue inline/local-file attachments + no-op for LinkOnly
+
         appt.SaveChanges();
         folder.AddMessage(appt);
         // folder.SaveChanges() is the caller's responsibility (must be called before EndSavingChanges).
@@ -382,19 +384,53 @@ public sealed class AppointmentWriter
     //   - If a.BodyHtml present → PidTagHtml (UTF-8 bytes) + PidTagNativeBody=3 + InternetCodepage=65001;
     //     AND ensure PidTagBody exists — derive it from HTML via PstWriter.HtmlToPlainText if a.Body is empty.
     //   - PstWriter.HtmlToPlainText is internal-static in the same assembly (Mail2Pst.Core); no HtmlBody.cs needed.
+    //   - LinkOnly attachments produce a body appendix (dedup-aware) appended to BOTH plain text and HTML.
     private static void WriteBody(Appointment appt, AppointmentRecord a)
     {
+        // Compute appendix once (dedup against the original body text before any append).
+        string? appendix = CalendarBodyAppendix.Format(a.Attachments,
+            System.Array.Empty<string>(),   // Task 5 supplies relation lines
+            existingText: a.Body ?? a.BodyHtml);
+
         string? plain = a.Body;
         if (!string.IsNullOrEmpty(a.BodyHtml))
         {
-            appt.PC.SetBytesProperty(PropertyID.PidTagHtml, Encoding.UTF8.GetBytes(a.BodyHtml));
+            // Append HTML-escaped block to the HTML body when there is a link-only appendix.
+            string htmlBody = appendix is null
+                ? a.BodyHtml
+                : a.BodyHtml + "\n<pre>" + HtmlEscape(appendix) + "</pre>";
+            appt.PC.SetBytesProperty(PropertyID.PidTagHtml, Encoding.UTF8.GetBytes(htmlBody));
             appt.PC.SetInt32Property(PropertyID.PidTagNativeBody, 3);
             // InternetCodepage=65001 already set unconditionally at the top of WriteAppointment.
             if (string.IsNullOrEmpty(plain))
                 plain = PstWriter.HtmlToPlainText(a.BodyHtml);
         }
+
+        // Append link-only references to the plain-text body.
+        if (appendix is not null)
+            plain = string.IsNullOrEmpty(plain) ? appendix : plain + "\n\n" + appendix;
+
         if (!string.IsNullOrEmpty(plain))
             appt.PC.SetStringProperty(PropertyID.PidTagBody, plain);
+    }
+
+    private static string HtmlEscape(string text) =>
+        text.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
+
+    private static void WriteAttachments(PSTFile file, Appointment appt, IReadOnlyList<CalendarAttachment> atts)
+    {
+        var writer = new AttachmentWriter();
+        foreach (CalendarAttachment att in atts)
+        {
+            // No IsInline: calendar attachments are VISIBLE ByValue attachments, never hidden CID resources.
+            if (att.Kind == CalendarAttachmentKind.InlineBytes && att.InlineData is not null)
+                writer.Write(file, appt, new AttachmentSpec(att.FileName, att.MimeType,
+                    AttachmentContent.FromBytes(att.InlineData)));
+            else if (att.Kind == CalendarAttachmentKind.LocalFileByValue && att.LocalPath is not null)
+                writer.Write(file, appt, new AttachmentSpec(att.FileName, att.MimeType,
+                    AttachmentContent.FromExistingFile(att.LocalPath)));   // NEVER FromTempFile — that deletes the source
+            // LinkOnly → body appendix only; no PST attachment row.
+        }
     }
 
     /// <summary>Writes Keywords (categories) MV-string if any are present.</summary>

--- a/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
+++ b/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
@@ -184,7 +184,10 @@ public sealed class AppointmentWriter
                 (int)ToMask(s.DaysOfWeek),
             AppointmentRecurrenceFrequency.MonthlyNth or AppointmentRecurrenceFrequency.YearlyNth =>
                 (int)ToOutlookDay(s.DaysOfWeek.Length > 0 ? s.DaysOfWeek[0] : DayOfWeek.Monday),
-            _ => s.DayOfMonth ?? s.FirstStartUtc.Day,
+            // Day-of-month defaults to the LOCAL start day, not the UTC day: an all-day event anchored
+            // to a positive-offset zone stores StartUtc as local-midnight-in-UTC (e.g. the prior day),
+            // so FirstStartUtc.Day would be off by one. FirstStartLocal == FirstStartUtc when no zone.
+            _ => s.DayOfMonth ?? s.FirstStartLocal.Day,
         };
 
         // DayOccurrenceNumber: only for Nth-day patterns (2nd Tuesday, Last Friday, etc.)

--- a/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
+++ b/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
@@ -11,17 +11,22 @@ namespace Mail2Pst.Core.Writing;
 
 /// <summary>
 /// Writes an <see cref="AppointmentRecord"/> as an IPM.Appointment item into an
-/// IPF.Appointment (CalendarFolder) via the vendored <see cref="SingleAppointment"/> substrate.
+/// IPF.Appointment (CalendarFolder) via the vendored <see cref="Appointment"/> substrate
+/// (<see cref="SingleAppointment"/> for non-recurring, <see cref="RecurringAppointment"/>
+/// for series masters).
 /// </summary>
 /// <remarks>
 /// MAPI recipe ground-truthed from a real Outlook appointment export (Task 0, 2026-06-30).
 /// Key decisions:
 /// <list type="bullet">
-///   <item>Timezone via <c>SetOriginalTimeZone(tz)</c> — only when <see cref="AppointmentRecord.TimeZone"/>
-///         is non-null; floating events (null tz) skip it entirely and make no Win32 registry calls.</item>
+///   <item>Timezone via <c>SetOriginalTimeZone(tz)</c> — only when a resolved zone is available;
+///         floating events (null tz) skip it for single appointments. Recurring appointments
+///         ALWAYS get a non-null zone (UTC fallback) so <c>RecurringAppointment.SaveChanges()</c>
+///         never hits the Win32 system-TZ fallback.</item>
 ///   <item>Reminder uses a MINUTES-BEFORE DELTA (<c>PidLidReminderDelta</c>) + derived signal time —
 ///         unlike tasks, which use an absolute reminder instant.</item>
 ///   <item><c>PidLidMeetingStatus</c> is intentionally NOT set: absent in the Task 0 dump for plain appointments.</item>
+///   <item>Common fields (body, categories, reminder, attendees) run for BOTH single and recurring paths.</item>
 /// </list>
 /// The caller must call <see cref="PSTFile.BeginSavingChanges"/> before this method
 /// (named-property allocation requires it) and <see cref="PSTFolder.SaveChanges"/> +
@@ -31,12 +36,17 @@ public sealed class AppointmentWriter
 {
     /// <summary>
     /// Writes one appointment into <paramref name="folder"/> inside <paramref name="file"/>.
+    /// Branches on <see cref="AppointmentRecord.Recurrence"/>: null → <see cref="SingleAppointment"/>;
+    /// non-null → <see cref="RecurringAppointment"/>.
     /// </summary>
     public void WriteAppointment(PSTFile file, PSTFolder folder, AppointmentRecord a)
     {
-        SingleAppointment appt = SingleAppointment.CreateNewSingleAppointment(file, folder.NodeID);
-        appt.InternetCodepage = 65001;  // override the 1255 Hebrew default (CreateNewSingleAppointment gotcha)
+        // Branch on recurrence: single vs. series master.
+        Appointment appt = a.Recurrence is null
+            ? SingleAppointment.CreateNewSingleAppointment(file, folder.NodeID)
+            : RecurringAppointment.CreateNewRecurringAppointment(file, folder.NodeID);
 
+        appt.InternetCodepage = 65001;  // override the 1255 Hebrew default (CreateNew* gotcha)
         appt.Subject = a.Subject;
 
         // Defensive normalization — AppointmentWriter must never emit invalid MAPI even if handed a
@@ -52,12 +62,14 @@ public sealed class AppointmentWriter
         // PidLidAppointmentSubType — set BEFORE timezone blob so Outlook reads all-day correctly.
         appt.IsAllDayEvent = a.IsAllDay;
 
-        // Timezone blob (PidLidAppointmentTimeZoneDefinitionStartDisplay):
-        //   - Timed events AND all-day events write the blob when a resolved zone is available.
-        //   - Floating/unresolved events (TimeZone == null) skip it entirely — NO Win32 registry
-        //     access is made on this path (critical for cross-platform correctness).
-        if (a.TimeZone is { } tz)
-            appt.SetOriginalTimeZone(tz);   // Appointment.SetOriginalTimeZone(TimeZoneInfo) single-arg overload
+        // Resolve a writable zone.
+        //   - Single appointments: null = floating/unresolved → skip SetOriginalTimeZone (no Win32 call).
+        //   - Recurring appointments: MUST be non-null — SaveChanges() falls back to Win32
+        //     TimeZoneInfo.Local when OriginalTimeZone is unset, breaking cross-platform builds.
+        //     UTC is always a safe fallback for the blob's KeyName.
+        TimeZoneInfo? zone = ResolveWindowsZone(a) ?? (a.Recurrence is null ? null : TimeZoneInfo.Utc);
+        if (zone is not null)
+            appt.SetOriginalTimeZone(zone);
 
         if (!string.IsNullOrEmpty(a.Location)) appt.Location = a.Location;
         appt.BusyStatus = (BusyStatus)busy;
@@ -71,32 +83,13 @@ public sealed class AppointmentWriter
         appt.PC.SetInt32Property(PropertyID.PidTagSensitivity, sensitivity);
 
         WriteBody(appt, a);
+        WriteCategories(file, appt, a);
+        WriteReminder(file, appt, a);
 
-        // Categories — reuse the mail / task "Keywords" MV-string path
-        if (a.Categories.Count > 0)
-        {
-            ushort kw = PropertyNameToIDMap.GetOrCreateStringNamedProperty(file, 2, "Keywords");
-            appt.PC.SetMultiStringProperty((PropertyID)kw, a.Categories);
-        }
-
-        // Reminder — appointments use a MINUTES-BEFORE DELTA (unlike tasks which use absolute time).
-        // PidLidReminderSet is written via the vendor IsReminderSet setter (PSETID_Common 0x8503).
-        // PidLidReminderDelta (0x8501) and PidLidReminderSignalTime (0x8560) via the named-prop path.
-        appt.IsReminderSet = a.ReminderSet;
-        if (a.ReminderSet)
-        {
-            PropertyID deltaId = file.NameToIDMap.ObtainIDFromName(
-                new PropertyName(PropertyLongID.PidLidReminderDelta, PropertySetGuid.PSETID_Common));
-            appt.PC.SetInt32Property(deltaId, a.ReminderMinutesBefore);
-
-            PropertyID signalId = file.NameToIDMap.ObtainIDFromName(
-                new PropertyName(PropertyLongID.PidLidReminderSignalTime, PropertySetGuid.PSETID_Common));
-            // Signal time = start − delta (UTC). This is the instant Outlook fires the reminder.
-            DateTime signalTime = a.StartUtc.AddMinutes(-a.ReminderMinutesBefore);
-            appt.PC.SetDateTimeProperty(signalId, signalTime);
-        }
-
-        // PidLidMeetingStatus is intentionally NOT set: absent in the Task 0 dump for plain appointments.
+        // Recurring-specific: apply recurrence pattern to the master.
+        // ApplyDeletions (Task 4) and ApplyExceptions (Task 5) extend this block.
+        if (appt is RecurringAppointment ra)
+            ApplyRecurrence(ra, a.Recurrence!, durationMinutes);
 
         WriteAttendees(file, appt, a);   // recipients + organizer + meeting state (no-op when no attendees)
 
@@ -104,6 +97,137 @@ public sealed class AppointmentWriter
         folder.AddMessage(appt);
         // folder.SaveChanges() is the caller's responsibility (must be called before EndSavingChanges).
     }
+
+    // -----------------------------------------------------------------------
+    // Recurrence helpers (Task 3)
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Resolves the Windows timezone for blob writing from <see cref="AppointmentRecord.OriginatingTimeZoneId"/>.
+    /// Deterministic and silent — the mapper (Task 2) already warned on unmappable zones.
+    ///
+    /// Resolution order:
+    /// <list type="number">
+    ///   <item><see cref="AppointmentRecord.OriginatingTimeZoneId"/> is null → return <see cref="AppointmentRecord.TimeZone"/> (may be null for floating events).</item>
+    ///   <item>Id starts with <c>tzone://Microsoft/</c> → strip prefix, use remainder as Windows id.</item>
+    ///   <item>Id equals "UTC" (case-insensitive) → <see cref="TimeZoneInfo.Utc"/>.</item>
+    ///   <item>IANA id → <see cref="TimeZoneInfo.TryConvertIanaIdToWindowsId"/> → <see cref="TimeZoneInfo.FindSystemTimeZoneById"/>.</item>
+    ///   <item>Already-Windows id → <see cref="TimeZoneInfo.FindSystemTimeZoneById"/>.</item>
+    ///   <item>Any failure → <see cref="TimeZoneInfo.Utc"/> (last-resort safety guard, no warning).</item>
+    /// </list>
+    /// </summary>
+    private static TimeZoneInfo? ResolveWindowsZone(AppointmentRecord a)
+    {
+        if (a.OriginatingTimeZoneId is null)
+            return a.TimeZone;  // null = floating or unresolved → caller decides (recurring gets UTC fallback)
+
+        string id = a.OriginatingTimeZoneId;
+
+        // Strip tzone://Microsoft/ prefix → use remainder as Windows zone id
+        const string TzonePrefix = "tzone://Microsoft/";
+        if (id.StartsWith(TzonePrefix, StringComparison.Ordinal))
+            id = id.Substring(TzonePrefix.Length);
+
+        // UTC sentinel (case-insensitive to catch both "UTC" and "Utc" from Thunderbird)
+        if (string.Equals(id, "UTC", StringComparison.OrdinalIgnoreCase))
+            return TimeZoneInfo.Utc;
+
+        // Try IANA → Windows id first (.NET 6+ TryConvertIanaIdToWindowsId works cross-platform via ICU)
+        if (TimeZoneInfo.TryConvertIanaIdToWindowsId(id, out string? winId) && winId is not null)
+        {
+            try { return TimeZoneInfo.FindSystemTimeZoneById(winId); }
+            catch { /* fall through */ }
+        }
+
+        // Try directly as a Windows/system id (also handles already-Windows ids from tzone:// prefix)
+        try { return TimeZoneInfo.FindSystemTimeZoneById(id); }
+        catch { /* fall through */ }
+
+        // Any failure → UTC fallback (no warning — mapper already warned)
+        return TimeZoneInfo.Utc;
+    }
+
+    /// <summary>
+    /// Applies the recurrence pattern to the series master.
+    /// Field mapping is ground-truthed against the Task 0 vendor blob tests
+    /// (<see cref="Vendor.RecurringAppointmentBlobTests"/>).
+    /// </summary>
+    private static void ApplyRecurrence(RecurringAppointment ra, RecurrenceSpec s, int durationMinutes)
+    {
+        ra.RecurrenceType = s.Frequency switch
+        {
+            AppointmentRecurrenceFrequency.Daily      => RecurrenceType.EveryNDays,
+            AppointmentRecurrenceFrequency.Weekly     => RecurrenceType.EveryNWeeks,
+            AppointmentRecurrenceFrequency.Monthly    => RecurrenceType.EveryNMonths,
+            AppointmentRecurrenceFrequency.MonthlyNth => RecurrenceType.EveryNthDayOfEveryNMonths,
+            AppointmentRecurrenceFrequency.Yearly     => RecurrenceType.EveryNYears,
+            AppointmentRecurrenceFrequency.YearlyNth  => RecurrenceType.EveryNthDayOfEveryNYears,
+            _ => RecurrenceType.EveryNDays,
+        };
+
+        // Period: natural units (days, weeks, months, or years depending on frequency).
+        // Vendored setter scales to the internal blob unit automatically.
+        ra.Period = Math.Max(1, s.Interval);
+
+        // Day: day-mask for weekly; OutlookDayOfWeek for nth-day patterns; day-of-month for others.
+        ra.Day = s.Frequency switch
+        {
+            AppointmentRecurrenceFrequency.Weekly =>
+                (int)ToMask(s.DaysOfWeek),
+            AppointmentRecurrenceFrequency.MonthlyNth or AppointmentRecurrenceFrequency.YearlyNth =>
+                (int)ToOutlookDay(s.DaysOfWeek.Length > 0 ? s.DaysOfWeek[0] : DayOfWeek.Monday),
+            _ => s.DayOfMonth ?? s.FirstStartUtc.Day,
+        };
+
+        // DayOccurrenceNumber: only for Nth-day patterns (2nd Tuesday, Last Friday, etc.)
+        if (s.Frequency is AppointmentRecurrenceFrequency.MonthlyNth or AppointmentRecurrenceFrequency.YearlyNth)
+        {
+            ra.DayOccurenceNumber = (s.NthOccurrence ?? 1) == -1
+                ? DayOccurenceNumber.Last
+                : (DayOccurenceNumber)Math.Clamp(s.NthOccurrence ?? 1, 1, 4);
+        }
+
+        // End-of-series: Count / Until → EndAfterNumberOfOccurrences + LastInstanceStartDate;
+        //               NoEnd → sentinel year 4500.
+        if ((s.EndKind is RecurrenceEndKind.Count or RecurrenceEndKind.Until)
+            && s.LastInstanceStartUtc is { } last)
+        {
+            ra.EndAfterNumberOfOccurences = (s.EndKind == RecurrenceEndKind.Count);
+            ra.LastInstanceStartDate = last;
+        }
+        else // NoEnd
+        {
+            ra.EndAfterNumberOfOccurences = false;
+            ra.LastInstanceStartDate = new DateTime(4500, 8, 31, 0, 0, 0, DateTimeKind.Utc);
+        }
+
+        // Note: yearly Month is NOT set here — YearlyRecurrencePatternStructure has no Month field;
+        // Outlook derives it from the start date via FirstDateTime. s.Month is for cardinality checks only.
+    }
+
+    /// <summary>Converts a <see cref="DayOfWeek"/> array to a bitfield mask for weekly recurrence.</summary>
+    /// <remarks>
+    /// Maps DayOfWeek enum values to <see cref="DaysOfWeekFlags"/> bit positions:
+    /// Sunday(0)→0x01, Monday(1)→0x02, …, Saturday(6)→0x40 — both enums share the same layout.
+    /// </remarks>
+    private static DaysOfWeekFlags ToMask(DayOfWeek[] days)
+    {
+        DaysOfWeekFlags m = 0;
+        foreach (var d in days)
+            m |= (DaysOfWeekFlags)(1u << (int)d);
+        return m;
+    }
+
+    /// <summary>
+    /// Converts a single <see cref="DayOfWeek"/> to the corresponding <see cref="OutlookDayOfWeek"/>
+    /// value for Nth-day patterns (e.g., "2nd Tuesday").
+    /// </summary>
+    private static OutlookDayOfWeek ToOutlookDay(DayOfWeek d)
+        => (OutlookDayOfWeek)(1u << (int)d);
+
+    // -----------------------------------------------------------------------
+    // Shared helpers (common fields — run for BOTH single and recurring paths)
+    // -----------------------------------------------------------------------
 
     private static RecipientType MapRecipientType(AttendeeKind kind) => kind switch
     {
@@ -116,10 +240,11 @@ public sealed class AppointmentWriter
     /// Writes meeting attendees, organizer, and meeting-state props onto <paramref name="appt"/>.
     /// Promotes the item to a meeting ONLY when <paramref name="a"/> has ≥1 attendee —
     /// an organizer-only event is treated as a plain appointment (no recipient rows, no meeting state).
+    /// Works for both <see cref="SingleAppointment"/> and <see cref="RecurringAppointment"/>.
     /// </summary>
-    private static void WriteAttendees(PSTFile file, SingleAppointment appt, AppointmentRecord a)
+    private static void WriteAttendees(PSTFile file, Appointment appt, AppointmentRecord a)
     {
-        // PR6 promotes to a meeting ONLY when there is ≥1 non-organizer attendee. An organizer-only event
+        // Promotes to a meeting ONLY when there is ≥1 non-organizer attendee. An organizer-only event
         // (just an ORGANIZER line, no attendees) is a plain appointment — no recipient rows, no meeting state
         // (avoids the hybrid "recipient table but not a meeting" state). The mapper guarantees every entry in
         // a.Attendees has a non-empty Email; the organizer may be display-only (no email).
@@ -144,7 +269,7 @@ public sealed class AppointmentWriter
         // Organizer recipient row ONLY when it has an email (a row with an empty address is invalid MAPI).
         if (a.Organizer is { Email: { Length: > 0 } } orgWithEmail)
             recipients.Add(new MessageRecipient(orgWithEmail.DisplayName, orgWithEmail.Email, isOrganizer: true,
-                RecipientType.To) { ResponseStatus = (int)AttendeeResponse.Organized });   // organizer copy = respOrganized; don't trust record.Response
+                RecipientType.To) { ResponseStatus = (int)AttendeeResponse.Organized });   // organizer copy = respOrganized
 
         foreach (var att in a.Attendees)   // each has a non-empty Email (mapper-enforced)
             recipients.Add(new MessageRecipient(att.DisplayName, att.Email, isOrganizer: false,
@@ -153,23 +278,17 @@ public sealed class AppointmentWriter
         appt.AddRecipients(recipients);
 
         // asfMeeting = 0x1 (PidLidAppointmentStateFlags, PSETID_Appointment 0x8217)
-        // The vendor Appointment.StateFlags setter takes int; there is no AppointmentStateFlags enum.
-        const int AsfMeeting = 0x1; // PidLidAppointmentStateFlags asfMeeting bit
+        const int AsfMeeting = 0x1;
         appt.StateFlags = AsfMeeting;
 
         // PidLidResponseStatus = respOrganized(1) — PR6 organizer-copy default (Task 0 recipe).
-        // Named prop registered in Task 2; PSETID_Appointment 0x8218.
-        // Only written when a.Organizer is known: the organizer-copy response-status is
-        // meaningless (and misleading) when no organizer is present in the record.
+        // Only written when a.Organizer is known.
         if (a.Organizer is not null)
         {
             PropertyID rs = file.NameToIDMap.ObtainIDFromName(
                 new PropertyName(PropertyLongID.PidLidResponseStatus, PropertySetGuid.PSETID_Appointment));
             appt.PC.SetInt32Property(rs, (int)AttendeeResponse.Organized);
         }
-
-        // Do NOT set PidLidFInvited (inconsistent in ground truth, not load-bearing) or
-        // PidLidMeetingStatus/PidLidAppointmentReplyTime (absent in ground truth). GlobalObjectId → PR8.
     }
 
     // WriteBody rules (ground-truthed from PstWriter.WriteMessage pattern):
@@ -177,7 +296,7 @@ public sealed class AppointmentWriter
     //   - If a.BodyHtml present → PidTagHtml (UTF-8 bytes) + PidTagNativeBody=3 + InternetCodepage=65001;
     //     AND ensure PidTagBody exists — derive it from HTML via PstWriter.HtmlToPlainText if a.Body is empty.
     //   - PstWriter.HtmlToPlainText is internal-static in the same assembly (Mail2Pst.Core); no HtmlBody.cs needed.
-    private static void WriteBody(SingleAppointment appt, AppointmentRecord a)
+    private static void WriteBody(Appointment appt, AppointmentRecord a)
     {
         string? plain = a.Body;
         if (!string.IsNullOrEmpty(a.BodyHtml))
@@ -190,5 +309,36 @@ public sealed class AppointmentWriter
         }
         if (!string.IsNullOrEmpty(plain))
             appt.PC.SetStringProperty(PropertyID.PidTagBody, plain);
+    }
+
+    /// <summary>Writes Keywords (categories) MV-string if any are present.</summary>
+    private static void WriteCategories(PSTFile file, Appointment appt, AppointmentRecord a)
+    {
+        if (a.Categories.Count > 0)
+        {
+            ushort kw = PropertyNameToIDMap.GetOrCreateStringNamedProperty(file, 2, "Keywords");
+            appt.PC.SetMultiStringProperty((PropertyID)kw, a.Categories);
+        }
+    }
+
+    /// <summary>
+    /// Writes reminder props (PidLidReminderSet, PidLidReminderDelta, PidLidReminderSignalTime)
+    /// if <see cref="AppointmentRecord.ReminderSet"/> is true.
+    /// Appointments use a MINUTES-BEFORE DELTA (unlike tasks, which use an absolute time).
+    /// </summary>
+    private static void WriteReminder(PSTFile file, Appointment appt, AppointmentRecord a)
+    {
+        appt.IsReminderSet = a.ReminderSet;
+        if (!a.ReminderSet) return;
+
+        PropertyID deltaId = file.NameToIDMap.ObtainIDFromName(
+            new PropertyName(PropertyLongID.PidLidReminderDelta, PropertySetGuid.PSETID_Common));
+        appt.PC.SetInt32Property(deltaId, a.ReminderMinutesBefore);
+
+        PropertyID signalId = file.NameToIDMap.ObtainIDFromName(
+            new PropertyName(PropertyLongID.PidLidReminderSignalTime, PropertySetGuid.PSETID_Common));
+        // Signal time = start − delta (UTC). This is the instant Outlook fires the reminder.
+        DateTime signalTime = a.StartUtc.AddMinutes(-a.ReminderMinutesBefore);
+        appt.PC.SetDateTimeProperty(signalId, signalTime);
     }
 }

--- a/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
+++ b/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
@@ -103,6 +103,8 @@ public sealed class AppointmentWriter
 
         WriteAttachments(file, appt, a.Attachments);   // ByValue inline/local-file attachments + no-op for LinkOnly
 
+        WriteGlobalObjectId(file, appt, a);
+
         appt.SaveChanges();
         folder.AddMessage(appt);
         // folder.SaveChanges() is the caller's responsibility (must be called before EndSavingChanges).
@@ -431,6 +433,33 @@ public sealed class AppointmentWriter
                     AttachmentContent.FromExistingFile(att.LocalPath)));   // NEVER FromTempFile — that deletes the source
             // LinkOnly → body appendix only; no PST attachment row.
         }
+    }
+
+    /// <summary>
+    /// Writes <c>PidLidGlobalObjectId</c> (PSETID_Meeting LID 0x0003) and
+    /// <c>PidLidCleanGlobalObjectId</c> (PSETID_Meeting LID 0x0023) when
+    /// <see cref="AppointmentRecord.GlobalObjectId"/> is non-null.
+    ///
+    /// These are byte-exact blobs derived by <see cref="Calendar.GlobalObjectIdCodec"/> from the
+    /// Exchange-cached source event id. CleanGlobalObjectId = GlobalObjectId with exception-date
+    /// bytes [16..20) zeroed (they are already zero for non-exception occurrences).
+    /// No-op when GlobalObjectId is null (Mozilla UUID / CalDAV events — Outlook generates on demand).
+    /// </summary>
+    private static void WriteGlobalObjectId(PSTFile file, Appointment appt, AppointmentRecord a)
+    {
+        if (a.GlobalObjectId is null) return;
+
+        // Derive CleanGlobalObjectId: clone, zero exception-date bytes [16..20).
+        byte[] clean = (byte[])a.GlobalObjectId.Clone();
+        for (int i = 16; i < 20; i++) clean[i] = 0;
+
+        PropertyID goidPropId = file.NameToIDMap.ObtainIDFromName(
+            new PropertyName(PropertyLongID.PidLidGlobalObjectId, PropertySetGuid.PSETID_Meeting));
+        appt.PC.SetBytesProperty(goidPropId, a.GlobalObjectId);
+
+        PropertyID cleanPropId = file.NameToIDMap.ObtainIDFromName(
+            new PropertyName(PropertyLongID.PidLidCleanGlobalObjectId, PropertySetGuid.PSETID_Meeting));
+        appt.PC.SetBytesProperty(cleanPropId, clean);
     }
 
     /// <summary>Writes Keywords (categories) MV-string if any are present.</summary>

--- a/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
+++ b/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
@@ -90,9 +90,12 @@ public sealed class AppointmentWriter
         WriteReminder(file, appt, a);
 
         // Recurring-specific: apply recurrence pattern to the master.
-        // ApplyDeletions (Task 4) and ApplyExceptions (Task 5) extend this block.
+        // ApplyExceptions (Task 5) extends this block.
         if (appt is RecurringAppointment ra)
+        {
             ApplyRecurrence(ra, a.Recurrence!, durationMinutes);
+            ApplyDeletions(ra, a, out _);   // populates ra.DeletedInstanceDates; Task 5 will capture the out set
+        }
 
         WriteAttendees(file, appt, a);   // recipients + organizer + meeting state (no-op when no attendees)
 
@@ -206,6 +209,36 @@ public sealed class AppointmentWriter
 
         // Note: yearly Month is NOT set here — YearlyRecurrencePatternStructure has no Month field;
         // Outlook derives it from the start date via FirstDateTime. s.Month is for cardinality checks only.
+    }
+
+    // -----------------------------------------------------------------------
+    // Deletion helpers (Task 4)
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Populates <see cref="RecurringAppointment.DeletedInstanceDates"/> from
+    /// <see cref="AppointmentRecord.DeletedOccurrences"/> (EXDATE lines).
+    /// De-duplicates via <paramref name="deletedDates"/>: Task 5 passes the same set to
+    /// <c>ApplyExceptions</c> so an EXDATE and an override on the same day don't create two entries.
+    /// </summary>
+    private static void ApplyDeletions(RecurringAppointment ra, AppointmentRecord a,
+        out HashSet<DateTime> deletedDates)
+    {
+        deletedDates = new HashSet<DateTime>();
+        foreach (var d in a.DeletedOccurrences)
+            AddDeletedDate(ra, deletedDates, d.OriginalStartLocal.Date);
+    }
+
+    /// <summary>
+    /// Adds a single zone-local day-start to <see cref="RecurringAppointment.DeletedInstanceDates"/>,
+    /// guarded by <paramref name="seen"/> to prevent duplicates.
+    /// The date is stored with <see cref="DateTimeKind.Unspecified"/> so the vendored serializer
+    /// writes it verbatim as a zone-local wall-clock value (confirmed Task 0).
+    /// </summary>
+    private static void AddDeletedDate(RecurringAppointment ra, HashSet<DateTime> seen, DateTime localDate)
+    {
+        DateTime key = DateTime.SpecifyKind(localDate, DateTimeKind.Unspecified);
+        if (seen.Add(key)) ra.DeletedInstanceDates.Add(key);
     }
 
     /// <summary>Converts a <see cref="DayOfWeek"/> array to a bitfield mask for weekly recurrence.</summary>

--- a/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
+++ b/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Text;
+using Mail2Pst.Core.Models;
+using PSTFileFormat;
+
+namespace Mail2Pst.Core.Writing;
+
+/// <summary>
+/// Writes an <see cref="AppointmentRecord"/> as an IPM.Appointment item into an
+/// IPF.Appointment (CalendarFolder) via the vendored <see cref="SingleAppointment"/> substrate.
+/// </summary>
+/// <remarks>
+/// MAPI recipe ground-truthed from a real Outlook appointment export (Task 0, 2026-06-30).
+/// Key decisions:
+/// <list type="bullet">
+///   <item>Timezone via <c>SetOriginalTimeZone(tz)</c> — only when <see cref="AppointmentRecord.TimeZone"/>
+///         is non-null; floating events (null tz) skip it entirely and make no Win32 registry calls.</item>
+///   <item>Reminder uses a MINUTES-BEFORE DELTA (<c>PidLidReminderDelta</c>) + derived signal time —
+///         unlike tasks, which use an absolute reminder instant.</item>
+///   <item><c>PidLidMeetingStatus</c> is intentionally NOT set: absent in the Task 0 dump for plain appointments.</item>
+/// </list>
+/// The caller must call <see cref="PSTFile.BeginSavingChanges"/> before this method
+/// (named-property allocation requires it) and <see cref="PSTFolder.SaveChanges"/> +
+/// <see cref="PSTFile.EndSavingChanges"/> after.
+/// </remarks>
+public sealed class AppointmentWriter
+{
+    /// <summary>
+    /// Writes one appointment into <paramref name="folder"/> inside <paramref name="file"/>.
+    /// </summary>
+    public void WriteAppointment(PSTFile file, PSTFolder folder, AppointmentRecord a)
+    {
+        SingleAppointment appt = SingleAppointment.CreateNewSingleAppointment(file, folder.NodeID);
+        appt.InternetCodepage = 65001;  // override the 1255 Hebrew default (CreateNewSingleAppointment gotcha)
+
+        appt.Subject = a.Subject;
+
+        // Defensive normalization — AppointmentWriter must never emit invalid MAPI even if handed a
+        // bad AppointmentRecord (it is called directly in tests / future pipelines, not only via the mapper).
+        int busy        = a.BusyStatus  is >= 0 and <= 3  ? a.BusyStatus  : 2;   // default Busy
+        int importance  = a.Importance  is >= 0 and <= 2  ? a.Importance  : 1;
+        int sensitivity = a.Sensitivity is 0 or 2 or 3   ? a.Sensitivity : 0;
+
+        // SetStartAndDuration writes PidLidAppointmentStartWhole / EndWhole + Clip + Common.
+        int durationMinutes = (int)Math.Max(0, Math.Round((a.EndUtc - a.StartUtc).TotalMinutes));
+        appt.SetStartAndDuration(a.StartUtc, durationMinutes);
+
+        // PidLidAppointmentSubType — set BEFORE timezone blob so Outlook reads all-day correctly.
+        appt.IsAllDayEvent = a.IsAllDay;
+
+        // Timezone blob (PidLidAppointmentTimeZoneDefinitionStartDisplay):
+        //   - Timed events AND all-day events write the blob when a resolved zone is available.
+        //   - Floating/unresolved events (TimeZone == null) skip it entirely — NO Win32 registry
+        //     access is made on this path (critical for cross-platform correctness).
+        if (a.TimeZone is { } tz)
+            appt.SetOriginalTimeZone(tz);   // Appointment.SetOriginalTimeZone(TimeZoneInfo) single-arg overload
+
+        if (!string.IsNullOrEmpty(a.Location)) appt.Location = a.Location;
+        appt.BusyStatus = (BusyStatus)busy;
+
+        // PidLidPrivate (PSETID_Common 0x8506): coupled to Sensitivity==2 only.
+        // Confidential (3) intentionally does NOT set it — matches Outlook ground truth (Task 0 dump).
+        appt.IsPrivate = sensitivity == 2;
+
+        // Static-tag props (same pattern as TaskWriter)
+        appt.PC.SetInt32Property(PropertyID.PidTagImportance, importance);
+        appt.PC.SetInt32Property(PropertyID.PidTagSensitivity, sensitivity);
+
+        WriteBody(appt, a);
+
+        // Categories — reuse the mail / task "Keywords" MV-string path
+        if (a.Categories.Count > 0)
+        {
+            ushort kw = PropertyNameToIDMap.GetOrCreateStringNamedProperty(file, 2, "Keywords");
+            appt.PC.SetMultiStringProperty((PropertyID)kw, a.Categories);
+        }
+
+        // Reminder — appointments use a MINUTES-BEFORE DELTA (unlike tasks which use absolute time).
+        // PidLidReminderSet is written via the vendor IsReminderSet setter (PSETID_Common 0x8503).
+        // PidLidReminderDelta (0x8501) and PidLidReminderSignalTime (0x8560) via the named-prop path.
+        appt.IsReminderSet = a.ReminderSet;
+        if (a.ReminderSet)
+        {
+            PropertyID deltaId = file.NameToIDMap.ObtainIDFromName(
+                new PropertyName(PropertyLongID.PidLidReminderDelta, PropertySetGuid.PSETID_Common));
+            appt.PC.SetInt32Property(deltaId, a.ReminderMinutesBefore);
+
+            PropertyID signalId = file.NameToIDMap.ObtainIDFromName(
+                new PropertyName(PropertyLongID.PidLidReminderSignalTime, PropertySetGuid.PSETID_Common));
+            // Signal time = start − delta (UTC). This is the instant Outlook fires the reminder.
+            DateTime signalTime = a.StartUtc.AddMinutes(-a.ReminderMinutesBefore);
+            appt.PC.SetDateTimeProperty(signalId, signalTime);
+        }
+
+        // PidLidMeetingStatus is intentionally NOT set: absent in the Task 0 dump for plain appointments.
+
+        appt.SaveChanges();
+        folder.AddMessage(appt);
+        // folder.SaveChanges() is the caller's responsibility (must be called before EndSavingChanges).
+    }
+
+    // WriteBody rules (ground-truthed from PstWriter.WriteMessage pattern):
+    //   - If a.Body present → PidTagBody (plain text).
+    //   - If a.BodyHtml present → PidTagHtml (UTF-8 bytes) + PidTagNativeBody=3 + InternetCodepage=65001;
+    //     AND ensure PidTagBody exists — derive it from HTML via PstWriter.HtmlToPlainText if a.Body is empty.
+    //   - PstWriter.HtmlToPlainText is internal-static in the same assembly (Mail2Pst.Core); no HtmlBody.cs needed.
+    private static void WriteBody(SingleAppointment appt, AppointmentRecord a)
+    {
+        string? plain = a.Body;
+        if (!string.IsNullOrEmpty(a.BodyHtml))
+        {
+            appt.PC.SetBytesProperty(PropertyID.PidTagHtml, Encoding.UTF8.GetBytes(a.BodyHtml));
+            appt.PC.SetInt32Property(PropertyID.PidTagNativeBody, 3);
+            appt.InternetCodepage = 65001;
+            if (string.IsNullOrEmpty(plain))
+                plain = PstWriter.HtmlToPlainText(a.BodyHtml);
+        }
+        if (!string.IsNullOrEmpty(plain))
+            appt.PC.SetStringProperty(PropertyID.PidTagBody, plain);
+    }
+}

--- a/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
+++ b/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
@@ -149,8 +149,10 @@ public sealed class AppointmentWriter
         try { return TimeZoneInfo.FindSystemTimeZoneById(id); }
         catch { /* fall through */ }
 
-        // Any failure → UTC fallback (no warning — mapper already warned)
-        return TimeZoneInfo.Utc;
+        // Any failure → prefer the zone the mapper already resolved (e.g. the machine-local zone
+        // anchored to a floating all-day event) so the recurrence/tz blob matches StartWhole;
+        // UTC only as a last resort. (No warning — mapper already warned for a bogus id.)
+        return a.TimeZone ?? TimeZoneInfo.Utc;
     }
 
     /// <summary>

--- a/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
+++ b/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
@@ -114,7 +114,7 @@ public sealed class AppointmentWriter
         {
             appt.PC.SetBytesProperty(PropertyID.PidTagHtml, Encoding.UTF8.GetBytes(a.BodyHtml));
             appt.PC.SetInt32Property(PropertyID.PidTagNativeBody, 3);
-            appt.InternetCodepage = 65001;
+            // InternetCodepage=65001 already set unconditionally at the top of WriteAppointment.
             if (string.IsNullOrEmpty(plain))
                 plain = PstWriter.HtmlToPlainText(a.BodyHtml);
         }

--- a/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
+++ b/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
@@ -67,6 +67,15 @@ public sealed class AppointmentWriter
         //     TimeZoneInfo.Local when OriginalTimeZone is unset, breaking cross-platform builds.
         //     UTC is always a safe fallback for the blob's KeyName.
         TimeZoneInfo? zone = ResolveWindowsZone(a) ?? (a.Recurrence is null ? null : TimeZoneInfo.Utc);
+        // Recurring appointments write the legacy PidLidTimeZoneStruct via TimeZoneStructure.FromTimeZoneInfo,
+        // which THROWS on a zone with >1 DST rule (real Windows/IANA zones such as "Eastern Standard Time"
+        // carry historical rules). Collapse to a single-rule static zone — keeping the FIRST rule, the same
+        // rule the vendor's GetFirstRule/FromTimeZoneInfo select for a natively single-rule zone — so the
+        // blob stays consistent and a 0/1-rule zone (UTC / Asia-Bangkok, owner-validated) is returned
+        // UNCHANGED (byte-identical). Single appointments never touch the throwing path (they use the
+        // tolerant TimeZoneDefinitionStructure overload with an explicit effective rule), so leave them be.
+        if (zone is not null && a.Recurrence is not null)
+            zone = ToStaticSingleRuleZone(zone);
         if (zone is not null)
             appt.SetOriginalTimeZone(zone);   // MUST precede SetStartAndDuration (RecurringAppointment ClipStart depends on the zone)
 
@@ -159,6 +168,29 @@ public sealed class AppointmentWriter
         // anchored to a floating all-day event) so the recurrence/tz blob matches StartWhole;
         // UTC only as a last resort. (No warning — mapper already warned for a bogus id.)
         return a.TimeZone ?? TimeZoneInfo.Utc;
+    }
+
+    /// <summary>
+    /// Collapses a timezone that carries multiple DST adjustment rules into an equivalent single-rule
+    /// static zone, keeping only the FIRST rule — the same rule the vendor's <c>GetFirstRule</c> /
+    /// <c>TimeZoneStructure.FromTimeZoneInfo</c> select for a natively single-rule zone. Zones with 0 or 1
+    /// rules are returned UNCHANGED, so their serialized timezone blobs stay byte-identical to the pre-fix
+    /// output (preserving the owner-validated UTC / Asia-Bangkok recurrence path).
+    ///
+    /// Required for the recurring path: <see cref="RecurringAppointment.SetOriginalTimeZone(TimeZoneInfo, TimeZoneInfo, int)"/>
+    /// writes the legacy <c>PidLidTimeZoneStruct</c> via <see cref="TimeZoneStructure.FromTimeZoneInfo"/>,
+    /// which throws <see cref="ArgumentException"/> on a zone with &gt;1 rule — aborting the whole
+    /// conversion (pre-merge review #1).
+    /// </summary>
+    private static TimeZoneInfo ToStaticSingleRuleZone(TimeZoneInfo zone)
+    {
+        TimeZoneInfo.AdjustmentRule[] rules = zone.GetAdjustmentRules();
+        if (rules.Length <= 1)
+            return zone;   // already static (0 or 1 rule) — unchanged, preserves byte-identity
+
+        return TimeZoneInfo.CreateCustomTimeZone(
+            zone.Id, zone.BaseUtcOffset, zone.DisplayName, zone.StandardName, zone.DaylightName,
+            new[] { rules[0] });
     }
 
     /// <summary>

--- a/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
+++ b/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
@@ -488,9 +488,8 @@ public sealed class AppointmentWriter
     {
         if (a.GlobalObjectId is null) return;
 
-        // Derive CleanGlobalObjectId: clone, zero exception-date bytes [16..20).
-        byte[] clean = (byte[])a.GlobalObjectId.Clone();
-        for (int i = 16; i < 20; i++) clean[i] = 0;
+        // CleanGlobalObjectId = GlobalObjectId with exception-date bytes [16..20) zeroed (shared codec).
+        byte[] clean = Calendar.GlobalObjectIdCodec.ToCleanGlobalObjectId(a.GlobalObjectId);
 
         PropertyID goidPropId = file.NameToIDMap.ObtainIDFromName(
             new PropertyName(PropertyLongID.PidLidGlobalObjectId, PropertySetGuid.PSETID_Meeting));

--- a/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
+++ b/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
@@ -89,12 +89,12 @@ public sealed class AppointmentWriter
         WriteCategories(file, appt, a);
         WriteReminder(file, appt, a);
 
-        // Recurring-specific: apply recurrence pattern to the master.
-        // ApplyExceptions (Task 5) extends this block.
+        // Recurring-specific: apply recurrence pattern, deletions, and overrides to the master.
         if (appt is RecurringAppointment ra)
         {
             ApplyRecurrence(ra, a.Recurrence!, durationMinutes);
-            ApplyDeletions(ra, a, out _);   // populates ra.DeletedInstanceDates; Task 5 will capture the out set
+            ApplyDeletions(ra, a, out var deletedDates);
+            ApplyExceptions(ra, a, durationMinutes, (BusyStatus)busy, zone ?? TimeZoneInfo.Utc, deletedDates);
         }
 
         WriteAttendees(file, appt, a);   // recipients + organizer + meeting state (no-op when no attendees)
@@ -239,6 +239,49 @@ public sealed class AppointmentWriter
     {
         DateTime key = DateTime.SpecifyKind(localDate, DateTimeKind.Unspecified);
         if (seen.Add(key)) ra.DeletedInstanceDates.Add(key);
+    }
+
+    // -----------------------------------------------------------------------
+    // Exception helpers (Task 5)
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// For each <see cref="AppointmentException"/> in <see cref="AppointmentRecord.Exceptions"/>:
+    /// (a) writes a <c>method=5</c> embedded-message attachment via
+    ///     <see cref="RecurringAppointment.AddModifiedInstanceAttachment"/>,
+    /// (b) adds an <see cref="ExceptionInfoStructure"/> to the blob's <c>ExceptionList</c>, and
+    /// (c) adds the original occurrence's zone-local date to the shared deleted-dates set
+    ///     (count-equality invariant:
+    ///     <c>ExceptionList.Count == ModifiedInstanceDates.Count</c>;
+    ///     <c>ModifiedInstanceDates.Count ≤ DeletedInstanceDates.Count</c>).
+    /// PR7a encodes Subject / StartEnd / Location / BusyStatus changes only; other changed fields
+    /// are warned at MAP time (Task 2 <c>ToException</c>) and silently ignored here.
+    /// </summary>
+    private static void ApplyExceptions(RecurringAppointment ra, AppointmentRecord master,
+        int masterDurationMinutes, BusyStatus masterBusy, TimeZoneInfo zone, HashSet<DateTime> deletedDates)
+    {
+        foreach (var ex in master.Exceptions)
+        {
+            DateTime origStartUtc = ex.OriginalInstance.OriginalStartUtc;
+            DateTime newStartUtc = ex.NewStartUtc ?? origStartUtc;
+            DateTime newEndUtc   = ex.NewEndUtc   ?? newStartUtc.AddMinutes(masterDurationMinutes);
+            int newDuration = (int)Math.Max(0, Math.Round((newEndUtc - newStartUtc).TotalMinutes));
+            BusyStatus busy = ex.BusyStatus is { } bs ? (BusyStatus)bs : masterBusy;
+
+            ra.AddModifiedInstanceAttachment(origStartUtc, masterDurationMinutes, newStartUtc, newDuration,
+                ex.Subject ?? master.Subject, ex.Location ?? "", busy, 0, MessagePriority.Normal, zone);
+
+            var info = new ExceptionInfoStructure();
+            info.SetOriginalStartDTUtc(origStartUtc, zone);
+            info.SetStartAndDuration(newStartUtc, newDuration, zone);
+            if (ex.ChangeFlags.HasFlag(AppointmentExceptionChangeFlags.Subject))  { info.HasModifiedSubject  = true; info.Subject  = ex.Subject  ?? master.Subject; }
+            if (ex.ChangeFlags.HasFlag(AppointmentExceptionChangeFlags.Location)) { info.HasModifiedLocation = true; info.Location = ex.Location ?? ""; }
+            if (ex.ChangeFlags.HasFlag(AppointmentExceptionChangeFlags.BusyStatus)) { info.HasModifiedBusyStatus = true; info.BusyStatus = busy; }
+            ra.ExceptionList.Add(info);
+
+            // Original date must also be a deleted instance (count-equality; de-dups shared set vs EXDATE).
+            AddDeletedDate(ra, deletedDates, TimeZoneInfo.ConvertTimeFromUtc(origStartUtc, zone).Date);
+        }
     }
 
     /// <summary>Converts a <see cref="DayOfWeek"/> array to a bitfield mask for weekly recurrence.</summary>

--- a/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
+++ b/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
@@ -242,6 +242,10 @@ public sealed class AppointmentWriter
             && s.LastInstanceStartUtc is { } last)
         {
             ra.EndAfterNumberOfOccurences = (s.EndKind == RecurrenceEndKind.Count);
+            // For a COUNT series, write the RRULE COUNT verbatim (not the date-span heuristic, which
+            // overcounts period-skipping patterns like BYMONTHDAY=31). UNTIL keeps the heuristic path.
+            if (s.EndKind == RecurrenceEndKind.Count)
+                ra.OccurrenceCount = s.Count;
             ra.LastInstanceStartDate = last;
         }
         else // NoEnd

--- a/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
+++ b/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
@@ -218,8 +218,11 @@ public sealed class AppointmentWriter
         // Day: day-mask for weekly; OutlookDayOfWeek for nth-day patterns; day-of-month for others.
         ra.Day = s.Frequency switch
         {
+            // Empty weekly day-mask → fall back to the DTSTART weekday (matches TaskRecurrenceBlob);
+            // a zero mask is an invalid weekly pattern. The mapper normally fills this, but the writer
+            // is called directly too, so guard here.
             RecurrenceFrequency.Weekly =>
-                (int)ToMask(s.DaysOfWeek),
+                (int)(ToMask(s.DaysOfWeek) is { } m && m != 0 ? m : ToMask(new[] { s.FirstStartLocal.DayOfWeek })),
             RecurrenceFrequency.MonthlyNth or RecurrenceFrequency.YearlyNth =>
                 (int)ToOutlookDay(s.DaysOfWeek.Length > 0 ? s.DaysOfWeek[0] : DayOfWeek.Monday),
             // Day-of-month defaults to the LOCAL start day, not the UTC day: an all-day event anchored
@@ -525,6 +528,10 @@ public sealed class AppointmentWriter
         PropertyID signalId = file.NameToIDMap.ObtainIDFromName(
             new PropertyName(PropertyLongID.PidLidReminderSignalTime, PropertySetGuid.PSETID_Common));
         // Signal time = start − delta (UTC). This is the instant Outlook fires the reminder.
+        // A past-dated signal is written verbatim (not suppressed): the reminder is a faithful property
+        // of the source event, and the past instant is correct. NOTE: Outlook shows overdue reminders
+        // when a PST carrying past signals is *imported* into the default mailbox (not when merely opened
+        // as a data file) — a one-time dismiss-all is the expected user action, by design.
         DateTime signalTime = a.StartUtc.AddMinutes(-a.ReminderMinutesBefore);
         appt.PC.SetDateTimeProperty(signalId, signalTime);
     }

--- a/src/Mail2Pst.Core/Writing/AttachmentWriter.cs
+++ b/src/Mail2Pst.Core/Writing/AttachmentWriter.cs
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using System.Threading;
+using Mail2Pst.Core.Models;
+using PSTFileFormat;
+
+namespace Mail2Pst.Core.Writing;
+
+public sealed record AttachmentSpec(
+    string FileName, string MimeType, AttachmentContent Content,
+    string? ContentId = null, string? ContentLocation = null,
+    bool IsInline = false, bool IsContactPhoto = false);
+
+/// <summary>Shared by-value attachment writer for mail, contacts, and calendar. Extracted from
+/// PstWriter.WriteAttachment (streaming/PERMUTE path) + ContactWriter.WriteContactPhoto —
+/// behavior-preserving.</summary>
+public sealed class AttachmentWriter
+{
+    private const int ATT_MHTML_REF = 4;                 // MS-OXCMSG PidTagAttachFlags
+    private readonly long _streamingThresholdBytes;
+    private readonly bool _streamingDisabled;
+
+    public AttachmentWriter() : this(16L * 1024 * 1024,
+        Environment.GetEnvironmentVariable("MAIL2PST_DISABLE_ATTACHMENT_STREAMING") == "1") { }
+
+    public AttachmentWriter(long streamingThresholdBytes, bool streamingDisabled)
+    {
+        _streamingThresholdBytes = streamingThresholdBytes;
+        _streamingDisabled = streamingDisabled;
+    }
+
+    public void Write(PSTFile file, MessageObject owner, AttachmentSpec spec, CancellationToken ct = default)
+    {
+        owner.CreateSubnodeBTreeIfNotExist();
+        AttachmentObject att = AttachmentObject.CreateNewAttachmentObject(file, owner.SubnodeBTree);
+
+        att.PC.SetStringProperty(PropertyID.PidTagAttachLongFilename, spec.FileName);
+        att.PC.SetStringProperty(PropertyID.PidTagAttachFilename, spec.FileName);
+        att.PC.SetStringProperty(PropertyID.PidTagDisplayName, spec.FileName);
+        att.PC.SetStringProperty(PropertyID.PidTagAttachExtension, Path.GetExtension(spec.FileName));
+        att.PC.SetStringProperty(PropertyID.PidTagAttachMimeTag, spec.MimeType);
+        att.PC.SetInt32Property(PropertyID.PidTagAttachMethod, (int)AttachMethod.ByValue);
+
+        // >2 GB guard so PidTagAttachSize's (int) cast below can never overflow. Mail already
+        // pre-flights this in PstWriter's measure phase (skips the message); this is the shared-writer
+        // backstop for calendar/contact callers that have no such preflight.
+        if (spec.Content.Length > int.MaxValue)
+            throw new AttachmentTooLargeException(spec.FileName, spec.Content.Length);
+
+        bool canStream = spec.Content.Length >= _streamingThresholdBytes
+            && file.Header.bCryptMethod == bCryptMethodName.NDB_CRYPT_PERMUTE
+            && !_streamingDisabled;
+        if (canStream)
+        {
+            using Stream s = spec.Content.OpenRead();
+            att.PC.SetExternalProperty(PropertyID.PidTagAttachData, PropertyTypeName.PtypBinary,
+                s, spec.Content.Length, ct);
+        }
+        else
+        {
+            att.PC.SetBytesProperty(PropertyID.PidTagAttachData, spec.Content.ReadAllBytes());
+        }
+        att.PC.SetInt32Property(PropertyID.PidTagAttachSize, (int)spec.Content.Length);
+
+        if (!string.IsNullOrEmpty(spec.ContentId))
+            att.PC.SetStringProperty(PropertyID.PidTagAttachContentId, spec.ContentId);
+        if (!string.IsNullOrEmpty(spec.ContentLocation))
+            att.PC.SetStringProperty(PropertyID.PidTagAttachContentLocation, spec.ContentLocation);
+
+        if (spec.IsInline)
+        {
+            att.PC.SetInt32Property(PropertyID.PidTagAttachFlags, ATT_MHTML_REF);
+            att.PC.SetBooleanProperty(PropertyID.PidTagAttachmentHidden, true);
+        }
+        if (spec.IsContactPhoto)
+        {
+            att.PC.SetBooleanProperty(PropertyID.PidTagAttachmentContactPhoto, true);
+            att.PC.SetBooleanProperty(PropertyID.PidTagAttachmentHidden, false);
+        }
+
+        att.SaveChanges(owner.SubnodeBTree);
+        owner.AddAttachment(att);
+    }
+}

--- a/src/Mail2Pst.Core/Writing/AttachmentWriter.cs
+++ b/src/Mail2Pst.Core/Writing/AttachmentWriter.cs
@@ -24,7 +24,7 @@ public sealed class AttachmentWriter
     private readonly bool _streamingDisabled;
 
     public AttachmentWriter() : this(16L * 1024 * 1024,
-        Environment.GetEnvironmentVariable("MAIL2PST_DISABLE_ATTACHMENT_STREAMING") == "1") { }
+        Environment.GetEnvironmentVariable("MAIL2PST_NO_ATTACH_STREAM") is { Length: > 0 }) { }
 
     public AttachmentWriter(long streamingThresholdBytes, bool streamingDisabled)
     {

--- a/src/Mail2Pst.Core/Writing/CalendarBodyAppendix.cs
+++ b/src/Mail2Pst.Core/Writing/CalendarBodyAppendix.cs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System.Collections.Generic;
+using Mail2Pst.Core.Models;
+
+namespace Mail2Pst.Core.Writing;
+
+/// <summary>Builds ONE deterministic, human-visible body appendix (link-only attachments + preserved
+/// relation lines), so there is a single append format. Dedup: a link already present in the existing
+/// body text is not re-appended.</summary>
+internal static class CalendarBodyAppendix
+{
+    public static string? Format(
+        IReadOnlyList<CalendarAttachment> attachments,
+        IReadOnlyList<string> relationLines,
+        string? existingText = null)
+    {
+        var lines = new List<string>();
+        foreach (var a in attachments)
+            if (a.Kind == CalendarAttachmentKind.LinkOnly && a.PreservedReference is not null
+                && (existingText is null || !existingText.Contains(a.PreservedReference)))
+                // "reference" not "link": PreservedReference may be a remote URL OR raw un-parseable ATTACH text.
+                lines.Add($"[Attachment reference (not embedded): {a.FileName} — {a.PreservedReference}]");
+        foreach (var r in relationLines)
+            if (existingText is null || !existingText.Contains(r))
+                lines.Add($"[Thunderbird relation not natively converted: {r}]");
+        return lines.Count == 0 ? null : string.Join("\n", lines);
+    }
+}

--- a/src/Mail2Pst.Core/Writing/ContactWriter.cs
+++ b/src/Mail2Pst.Core/Writing/ContactWriter.cs
@@ -62,21 +62,8 @@ public class ContactWriter
         string ext = ExtFromMediaType(mime);
         string name = "ContactPicture" + ext;
 
-        // EXACT mirror of PstWriter.WriteAttachment's create/persist shape:
-        msg.CreateSubnodeBTreeIfNotExist();
-        AttachmentObject att = AttachmentObject.CreateNewAttachmentObject(file, msg.SubnodeBTree);
-        att.PC.SetStringProperty(PropertyID.PidTagAttachLongFilename, name);
-        att.PC.SetStringProperty(PropertyID.PidTagAttachFilename, name);
-        att.PC.SetStringProperty(PropertyID.PidTagDisplayName, name);
-        att.PC.SetStringProperty(PropertyID.PidTagAttachExtension, ext);
-        att.PC.SetStringProperty(PropertyID.PidTagAttachMimeTag, mime);
-        att.PC.SetInt32Property(PropertyID.PidTagAttachMethod, (int)AttachMethod.ByValue);
-        att.PC.SetBytesProperty(PropertyID.PidTagAttachData, photo.Bytes);
-        att.PC.SetInt32Property(PropertyID.PidTagAttachSize, photo.Bytes.Length);
-        att.PC.SetBooleanProperty(PropertyID.PidTagAttachmentContactPhoto, true);
-        att.PC.SetBooleanProperty(PropertyID.PidTagAttachmentHidden, false);
-        att.SaveChanges(msg.SubnodeBTree);   // REQUIRED — flushes the attachment to the subnode B-tree
-        msg.AddAttachment(att);              // sets MSGFLAG_HASATTACH automatically — leave it (contacts aren't mail)
+        new AttachmentWriter().Write(file, msg, new AttachmentSpec(
+            name, mime, AttachmentContent.FromBytes(photo.Bytes), IsContactPhoto: true));
 
         PropertyID hasPic = file.NameToIDMap.ObtainIDFromName(
             new PropertyName((PropertyLongID)0x8015, PropertySetGuid.PSETID_Address)); // PidLidHasPicture

--- a/src/Mail2Pst.Core/Writing/PlannedAppointment.cs
+++ b/src/Mail2Pst.Core/Writing/PlannedAppointment.cs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using Mail2Pst.Core.Models;
+
+namespace Mail2Pst.Core.Writing;
+
+/// <summary>
+/// Pairs an <see cref="AppointmentRecord"/> with the PST folder path it should be written into.
+/// Consumed by the calendar write phase (analogous to <see cref="PlannedTask"/>).
+/// </summary>
+public sealed class PlannedAppointment
+{
+    public AppointmentRecord Appointment { get; set; } = new();
+    public IReadOnlyList<string> TargetFolderPath { get; set; } = Array.Empty<string>();
+}

--- a/src/Mail2Pst.Core/Writing/PlannedTask.cs
+++ b/src/Mail2Pst.Core/Writing/PlannedTask.cs
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using Mail2Pst.Core.Models;
+
+namespace Mail2Pst.Core.Writing;
+
+public class PlannedTask
+{
+    public TaskRecord Task { get; set; } = new();
+    public IReadOnlyList<string> TargetFolderPath { get; set; } = Array.Empty<string>();
+}

--- a/src/Mail2Pst.Core/Writing/PstPartManager.cs
+++ b/src/Mail2Pst.Core/Writing/PstPartManager.cs
@@ -12,6 +12,9 @@ using PSTFileFormat;
 
 namespace Mail2Pst.Core.Writing;
 
+/// <summary>One folder to pre-create, with the leaf container class it must carry.</summary>
+internal readonly record struct FolderToPrecreate(IReadOnlyList<string> Path, FolderItemTypeName Type);
+
 /// <summary>
 /// Owns the output-PST part lifecycle for a single WritePlan call: the current PSTFile
 /// handle, part numbering, rename-on-first-split, the per-part folder cache, the per-part
@@ -61,19 +64,15 @@ internal sealed class PstPartManager
     public bool CheckpointDue => _messagesSinceCheck >= _checkIntervalMessages;
 
     /// <summary>
-    /// Opens the first (un-suffixed) part, begins saving, and pre-creates the given folders
-    /// (the IncludeEmptyFolders set). Call exactly once, before the message loop.
+    /// Opens the first (un-suffixed) part, begins saving, and pre-creates the given folders with their
+    /// correct leaf item types (the IncludeEmptyFolders set + every contact/calendar/task target folder,
+    /// so an empty source still appears as an empty typed folder). Call exactly once, before the loop.
+    /// Validates the inventory FIRST, so a bad request throws before any PST file is created on disk.
     /// </summary>
-    public void Begin(IReadOnlyList<IReadOnlyList<string>> foldersToPrecreate) =>
-        Begin(foldersToPrecreate, Array.Empty<IReadOnlyList<string>>());
-
-    /// <summary>
-    /// Opens the first (un-suffixed) part, begins saving, and pre-creates the given mail and
-    /// contact folders with their correct item types. Call exactly once, before the message loop.
-    /// </summary>
-    public void Begin(IReadOnlyList<IReadOnlyList<string>> mailFolders,
-                      IReadOnlyList<IReadOnlyList<string>> contactFolders)
+    public void Begin(IReadOnlyList<FolderToPrecreate> foldersToPrecreate)
     {
+        ValidateFolderInventory(foldersToPrecreate);   // fail before touching the filesystem
+
         _currentPath = StartNewFile(_groupName, null, _outputDirectory);
         _outputFiles.Add(_currentPath);
         // Outlook2007RTM is load-bearing: it matches the compatibility mode CreateEmptyStore writes
@@ -81,10 +80,25 @@ internal sealed class PstPartManager
         // mismatch here corrupts the AMap marker; the IndependentValidationTests gate would catch it.
         _file = new PSTFile(_currentPath, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
         _file.BeginSavingChanges();
-        foreach (IReadOnlyList<string> path in mailFolders)
-            GetOrCreateFolder(path, FolderItemTypeName.Note);
-        foreach (IReadOnlyList<string> path in contactFolders)
-            GetOrCreateFolder(path, FolderItemTypeName.Contact);
+        foreach (FolderToPrecreate folder in foldersToPrecreate)
+            GetOrCreateFolder(folder.Path, folder.Type);   // GuardLeafClass is the second line of defense
+    }
+
+    // Pre-flight: reject an empty path or the same path requested as two different item types BEFORE any
+    // file is created, so a bad inventory never leaves a partial PST on disk.
+    private static void ValidateFolderInventory(IReadOnlyList<FolderToPrecreate> folders)
+    {
+        var seen = new Dictionary<string, FolderItemTypeName>(StringComparer.Ordinal);
+        foreach (FolderToPrecreate folder in folders)
+        {
+            if (folder.Path is null || folder.Path.Count == 0)
+                throw new ConfigValidationException("Folder path cannot be empty.");
+            string key = FolderPathKey.Join(folder.Path);
+            if (seen.TryGetValue(key, out FolderItemTypeName existing) && existing != folder.Type)
+                throw new ConfigValidationException(
+                    $"Folder '{string.Join("/", folder.Path)}' is requested as both {existing} and {folder.Type}.");
+            seen[key] = folder.Type;
+        }
     }
 
     public bool ShouldSplitBefore(long messageSize) =>

--- a/src/Mail2Pst.Core/Writing/PstPartManager.cs
+++ b/src/Mail2Pst.Core/Writing/PstPartManager.cs
@@ -32,6 +32,7 @@ internal sealed class PstPartManager
     private readonly Action<PSTFile, PSTFolder, MailMessage> _writeMessage;
     private readonly Action<PSTFile, PSTFolder, ContactRecord> _writeContact;
     private readonly Action<PSTFile, PSTFolder, TaskRecord> _writeTask;
+    private readonly Action<PSTFile, PSTFolder, AppointmentRecord> _writeAppointment;
     private readonly long _emptyStoreSize;
 
     private readonly List<string> _outputFiles = new();
@@ -48,7 +49,8 @@ internal sealed class PstPartManager
         long maxSizeBytes, int checkIntervalMessages,
         Action<PSTFile, PSTFolder, MailMessage> writeMessage,
         Action<PSTFile, PSTFolder, ContactRecord> writeContact,
-        Action<PSTFile, PSTFolder, TaskRecord>? writeTask = null)
+        Action<PSTFile, PSTFolder, TaskRecord>? writeTask = null,
+        Action<PSTFile, PSTFolder, AppointmentRecord>? writeAppointment = null)
     {
         _groupName = groupName;
         _outputDirectory = outputDirectory;
@@ -57,6 +59,7 @@ internal sealed class PstPartManager
         _writeMessage = writeMessage;
         _writeContact = writeContact;
         _writeTask = writeTask ?? ((_, _, _) => { });
+        _writeAppointment = writeAppointment ?? ((_, _, _) => { });
         // From-scratch creation (PSTFile.CreateEmptyStore) seeds every part; the template
         // copy is retired. The initial on-disk size is the constant empty-store size.
         _emptyStoreSize = PSTFile.EmptyStoreSizeBytes;
@@ -134,6 +137,13 @@ internal sealed class PstPartManager
     {
         PSTFolder folder = GetOrCreateFolder(path, FolderItemTypeName.Task);
         _writeTask(_file!, folder, task);
+        _dirtyFolders.Add(folder);
+    }
+
+    public void WriteAppointment(IReadOnlyList<string> path, AppointmentRecord appt)
+    {
+        PSTFolder folder = GetOrCreateFolder(path, FolderItemTypeName.Appointment);
+        _writeAppointment(_file!, folder, appt);
         _dirtyFolders.Add(folder);
     }
 

--- a/src/Mail2Pst.Core/Writing/PstPartManager.cs
+++ b/src/Mail2Pst.Core/Writing/PstPartManager.cs
@@ -31,6 +31,7 @@ internal sealed class PstPartManager
     private readonly int _checkIntervalMessages;
     private readonly Action<PSTFile, PSTFolder, MailMessage> _writeMessage;
     private readonly Action<PSTFile, PSTFolder, ContactRecord> _writeContact;
+    private readonly Action<PSTFile, PSTFolder, TaskRecord> _writeTask;
     private readonly long _emptyStoreSize;
 
     private readonly List<string> _outputFiles = new();
@@ -46,7 +47,8 @@ internal sealed class PstPartManager
     public PstPartManager(string groupName, string outputDirectory,
         long maxSizeBytes, int checkIntervalMessages,
         Action<PSTFile, PSTFolder, MailMessage> writeMessage,
-        Action<PSTFile, PSTFolder, ContactRecord> writeContact)
+        Action<PSTFile, PSTFolder, ContactRecord> writeContact,
+        Action<PSTFile, PSTFolder, TaskRecord>? writeTask = null)
     {
         _groupName = groupName;
         _outputDirectory = outputDirectory;
@@ -54,6 +56,7 @@ internal sealed class PstPartManager
         _checkIntervalMessages = checkIntervalMessages;
         _writeMessage = writeMessage;
         _writeContact = writeContact;
+        _writeTask = writeTask ?? ((_, _, _) => { });
         // From-scratch creation (PSTFile.CreateEmptyStore) seeds every part; the template
         // copy is retired. The initial on-disk size is the constant empty-store size.
         _emptyStoreSize = PSTFile.EmptyStoreSizeBytes;
@@ -124,6 +127,13 @@ internal sealed class PstPartManager
     {
         PSTFolder folder = GetOrCreateFolder(path, FolderItemTypeName.Contact);
         _writeContact(_file!, folder, contact);
+        _dirtyFolders.Add(folder);
+    }
+
+    public void WriteTask(IReadOnlyList<string> path, TaskRecord task)
+    {
+        PSTFolder folder = GetOrCreateFolder(path, FolderItemTypeName.Task);
+        _writeTask(_file!, folder, task);
         _dirtyFolders.Add(folder);
     }
 

--- a/src/Mail2Pst.Core/Writing/PstWriter.cs
+++ b/src/Mail2Pst.Core/Writing/PstWriter.cs
@@ -467,12 +467,39 @@ public class PstWriter
     // A contact is far smaller than a mail message; add photo bytes when present.
     private static long EstimateContactSize(ContactRecord c) => 2048 + (c.Photo?.Bytes.Length ?? 0);
 
-    // A task is small; body is plain text (UTF-16 in PST → 2 bytes/char).
-    private static long EstimateTaskSize(TaskRecord t) => 2048 + (t.Body?.Length ?? 0) * 2;
+    // A task is small; body is plain text (UTF-16 in PST → 2 bytes/char) + attachment bytes.
+    internal static long EstimateTaskSize(TaskRecord t) =>
+        2048 + (t.Body?.Length ?? 0) * 2 + EstimateAttachmentsSize(t.Attachments);
 
-    // An appointment: fixed overhead + plain body (UTF-16, 2 bytes/char) + HTML body (2× char count — conservative upper bound for split sizing, not UTF-8).
-    private static long EstimateAppointmentSize(AppointmentRecord a) =>
-        2048 + (a.Body?.Length ?? 0) * 2 + (a.BodyHtml?.Length ?? 0) * 2;
+    // An appointment: fixed overhead + plain body (UTF-16, 2 bytes/char) + HTML body (2× char count —
+    // conservative upper bound for split sizing, not UTF-8) + attachment bytes.
+    internal static long EstimateAppointmentSize(AppointmentRecord a) =>
+        2048 + (a.Body?.Length ?? 0) * 2 + (a.BodyHtml?.Length ?? 0) * 2 + EstimateAttachmentsSize(a.Attachments);
+
+    // Attachment bytes for split sizing: inline decoded bytes, or the local-file length for ByValue
+    // (LinkOnly carries no PST attachment row — its reference lives in the body, already counted).
+    // A local file that cannot be stat'd contributes only per-attachment overhead (estimate only).
+    private static long EstimateAttachmentsSize(IReadOnlyList<CalendarAttachment> atts)
+    {
+        long size = 0;
+        foreach (CalendarAttachment att in atts)
+        {
+            switch (att.Kind)
+            {
+                case CalendarAttachmentKind.InlineBytes:
+                    size += (att.InlineData?.Length ?? 0) + PerAttachmentOverheadBytes;
+                    break;
+                case CalendarAttachmentKind.LocalFileByValue:
+                    long len = 0;
+                    try { if (att.LocalPath is not null) len = new FileInfo(att.LocalPath).Length; }
+                    catch { /* estimate only — an unreadable file contributes overhead only */ }
+                    size += len + PerAttachmentOverheadBytes;
+                    break;
+                // LinkOnly → no PST attachment row.
+            }
+        }
+        return size;
+    }
 
     private static string GetPlainTextBody(MailMessage message)
     {

--- a/src/Mail2Pst.Core/Writing/PstWriter.cs
+++ b/src/Mail2Pst.Core/Writing/PstWriter.cs
@@ -77,10 +77,21 @@ public class PstWriter
 
     public List<string> WritePlan(PstOutputPlan plan, IEnumerable<PlannedMessage> messages, string outputDirectory, ConversionReport report, int totalMessages = -1, Action<ConversionProgressEvent>? onProgress = null, CancellationToken cancellationToken = default, DurableMemoryObserver? memoryObserver = null)
         => WritePlan(plan, messages, Array.Empty<PlannedContact>(), Array.Empty<IReadOnlyList<string>>(),
+                     Array.Empty<PlannedTask>(), Array.Empty<IReadOnlyList<string>>(),
                      outputDirectory, report, totalMessages, onProgress, cancellationToken, memoryObserver);
 
     public List<string> WritePlan(PstOutputPlan plan, IEnumerable<PlannedMessage> messages,
         IReadOnlyList<PlannedContact> contacts, IReadOnlyList<IReadOnlyList<string>> contactFolders,
+        string outputDirectory, ConversionReport report, int totalMessages = -1,
+        Action<ConversionProgressEvent>? onProgress = null, CancellationToken cancellationToken = default,
+        DurableMemoryObserver? memoryObserver = null)
+        => WritePlan(plan, messages, contacts, contactFolders,
+                     Array.Empty<PlannedTask>(), Array.Empty<IReadOnlyList<string>>(),
+                     outputDirectory, report, totalMessages, onProgress, cancellationToken, memoryObserver);
+
+    public List<string> WritePlan(PstOutputPlan plan, IEnumerable<PlannedMessage> messages,
+        IReadOnlyList<PlannedContact> contacts, IReadOnlyList<IReadOnlyList<string>> contactFolders,
+        IReadOnlyList<PlannedTask> tasks, IReadOnlyList<IReadOnlyList<string>> taskFolders,
         string outputDirectory, ConversionReport report, int totalMessages = -1,
         Action<ConversionProgressEvent>? onProgress = null, CancellationToken cancellationToken = default,
         DurableMemoryObserver? memoryObserver = null)
@@ -90,10 +101,12 @@ public class PstWriter
         _activeCancellationToken = cancellationToken;
 
         var contactWriter = new ContactWriter();
+        var taskWriter = new TaskWriter();
         var partManager = new PstPartManager(
             plan.Name, outputDirectory, plan.MaxSizeBytes, _checkIntervalMessages,
             writeMessage: (file, folder, message) => WriteMessageCore(file, folder, message),
-            writeContact: (file, folder, contact) => contactWriter.WriteContact(file, folder, contact));
+            writeContact: (file, folder, contact) => contactWriter.WriteContact(file, folder, contact),
+            writeTask: (file, folder, task) => taskWriter.WriteTask(file, folder, task));
         var throttler = new ProgressThrottler(onProgress, totalMessages);
 
         // Producer thread parses MIME (CPU-bound); this consumer writes PST (I/O-bound).
@@ -140,6 +153,8 @@ public class PstWriter
                     precreate.Add(new FolderToPrecreate(m.TargetFolderPath, FolderItemTypeName.Note));
             foreach (IReadOnlyList<string> contactFolder in contactFolders)
                 precreate.Add(new FolderToPrecreate(contactFolder, FolderItemTypeName.Contact));
+            foreach (IReadOnlyList<string> taskFolder in taskFolders)
+                precreate.Add(new FolderToPrecreate(taskFolder, FolderItemTypeName.Task));
             partManager.Begin(precreate);
 
             // Phase 1: mail. Phase 2: contacts — BOTH inside this try and the same open-store
@@ -148,6 +163,8 @@ public class PstWriter
                 WriteMailPhase(queue, partManager, throttler, report, cancellationToken, memoryObserver);
 
             WriteContactPhase(partManager, contacts, totalMessages, estimatedOutputBytes, report, onProgress, cancellationToken);
+
+            WriteTaskPhase(partManager, tasks, totalMessages, estimatedOutputBytes, report, onProgress, cancellationToken);
 
             partManager.Finish();
             throttler.Emit(report, currentSource, currentFolder, estimatedOutputBytes);
@@ -317,8 +334,52 @@ public class PstWriter
         }
     }
 
+    // Task phase: runs after the contact phase inside the SAME open-store lifecycle, reusing the
+    // part manager's split/checkpoint machinery. Task folders are pre-created in Begin so an
+    // empty calendar still yields an IPF.Task folder. Emits additive task progress (Phase="tasks").
+    private void WriteTaskPhase(PstPartManager partManager, IReadOnlyList<PlannedTask> tasks,
+        int mailTotal, long mailEstimatedOutputBytes, ConversionReport report, Action<ConversionProgressEvent>? onProgress,
+        CancellationToken cancellationToken)
+    {
+        int tasksTotal = tasks.Count;
+        foreach (PlannedTask planned in tasks)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            long size = EstimateTaskSize(planned.Task);
+            if (partManager.ShouldSplitBefore(size)) partManager.FlushAndSplit();
+            try
+            {
+                partManager.WriteTask(planned.TargetFolderPath, planned.Task);
+                report.RecordTaskConverted();
+            }
+            catch (ConfigValidationException) { throw; } // collision = fatal
+            partManager.OnWritten(size);
+            // Additive task progress: mail Converted/Total stay as-is (phase="tasks").
+            onProgress?.Invoke(new ProgressEvent(
+                Converted: report.ConvertedCount,
+                TotalMessages: mailTotal,
+                Warnings: report.WarningCount,
+                Skipped: report.SkippedCount,
+                CurrentSource: planned.Task.SourceId,
+                CurrentFolder: FolderPathDisplay.Join(planned.TargetFolderPath),
+                EstimatedOutputBytes: mailEstimatedOutputBytes,
+                TasksConverted: report.TasksConverted,
+                TasksTotal: tasksTotal,
+                Phase: "tasks"));
+            if (partManager.CheckpointDue)
+            {
+                partManager.Flush();
+                partManager.TrySplitOrResumeAfterFlush();
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+    }
+
     // A contact is far smaller than a mail message; add photo bytes when present.
     private static long EstimateContactSize(ContactRecord c) => 2048 + (c.Photo?.Bytes.Length ?? 0);
+
+    // A task is small; body is plain text (UTF-16 in PST → 2 bytes/char).
+    private static long EstimateTaskSize(TaskRecord t) => 2048 + (t.Body?.Length ?? 0) * 2;
 
     private static string GetPlainTextBody(MailMessage message)
     {

--- a/src/Mail2Pst.Core/Writing/PstWriter.cs
+++ b/src/Mail2Pst.Core/Writing/PstWriter.cs
@@ -371,12 +371,24 @@ public class PstWriter
             cancellationToken.ThrowIfCancellationRequested();
             long size = EstimateTaskSize(planned.Task);
             if (partManager.ShouldSplitBefore(size)) partManager.FlushAndSplit();
+            bool written = false;
             try
             {
                 partManager.WriteTask(planned.TargetFolderPath, planned.Task);
                 report.RecordTaskConverted();
+                written = true;
             }
             catch (ConfigValidationException) { throw; } // collision = fatal
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex) when (IsRecoverableWriteError(ex) || ex is IOException or UnauthorizedAccessException)
+            {
+                // A single bad attachment (oversized, or a file:// source locked/deleted between resolve
+                // and write) must not abort the phase and delete the in-progress part. The item is added
+                // to the folder only AFTER its attachments are written, so a failed write committed
+                // nothing — skipping keeps the store consistent (mirrors the mail phase).
+                report.RecordTaskSkipped(planned.Task.SourceId, ex.Message);
+            }
+            if (!written) continue;
             partManager.OnWritten(size);
             // Additive task progress: mail Converted/Total stay as-is (phase="tasks").
             onProgress?.Invoke(new ProgressEvent(
@@ -412,12 +424,24 @@ public class PstWriter
             cancellationToken.ThrowIfCancellationRequested();
             long size = EstimateAppointmentSize(planned.Appointment);
             if (partManager.ShouldSplitBefore(size)) partManager.FlushAndSplit();
+            bool written = false;
             try
             {
                 partManager.WriteAppointment(planned.TargetFolderPath, planned.Appointment);
                 report.RecordAppointmentConverted();
+                written = true;
             }
             catch (ConfigValidationException) { throw; } // collision = fatal
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex) when (IsRecoverableWriteError(ex) || ex is IOException or UnauthorizedAccessException)
+            {
+                // A single bad attachment (oversized, or a file:// source locked/deleted between resolve
+                // and write) must not abort the phase and delete the in-progress part. The item is added
+                // to the folder only AFTER its attachments are written, so a failed write committed
+                // nothing — skipping keeps the store consistent (mirrors the mail phase).
+                report.RecordAppointmentSkipped(planned.Appointment.SourceId, ex.Message);
+            }
+            if (!written) continue;
             partManager.OnWritten(size);
             // Additive appointment progress: mail Converted/Total stay as-is (phase="appointments").
             onProgress?.Invoke(new ProgressEvent(

--- a/src/Mail2Pst.Core/Writing/PstWriter.cs
+++ b/src/Mail2Pst.Core/Writing/PstWriter.cs
@@ -78,6 +78,7 @@ public class PstWriter
     public List<string> WritePlan(PstOutputPlan plan, IEnumerable<PlannedMessage> messages, string outputDirectory, ConversionReport report, int totalMessages = -1, Action<ConversionProgressEvent>? onProgress = null, CancellationToken cancellationToken = default, DurableMemoryObserver? memoryObserver = null)
         => WritePlan(plan, messages, Array.Empty<PlannedContact>(), Array.Empty<IReadOnlyList<string>>(),
                      Array.Empty<PlannedTask>(), Array.Empty<IReadOnlyList<string>>(),
+                     Array.Empty<PlannedAppointment>(), Array.Empty<IReadOnlyList<string>>(),
                      outputDirectory, report, totalMessages, onProgress, cancellationToken, memoryObserver);
 
     public List<string> WritePlan(PstOutputPlan plan, IEnumerable<PlannedMessage> messages,
@@ -87,11 +88,24 @@ public class PstWriter
         DurableMemoryObserver? memoryObserver = null)
         => WritePlan(plan, messages, contacts, contactFolders,
                      Array.Empty<PlannedTask>(), Array.Empty<IReadOnlyList<string>>(),
+                     Array.Empty<PlannedAppointment>(), Array.Empty<IReadOnlyList<string>>(),
                      outputDirectory, report, totalMessages, onProgress, cancellationToken, memoryObserver);
 
     public List<string> WritePlan(PstOutputPlan plan, IEnumerable<PlannedMessage> messages,
         IReadOnlyList<PlannedContact> contacts, IReadOnlyList<IReadOnlyList<string>> contactFolders,
         IReadOnlyList<PlannedTask> tasks, IReadOnlyList<IReadOnlyList<string>> taskFolders,
+        string outputDirectory, ConversionReport report, int totalMessages = -1,
+        Action<ConversionProgressEvent>? onProgress = null, CancellationToken cancellationToken = default,
+        DurableMemoryObserver? memoryObserver = null)
+        => WritePlan(plan, messages, contacts, contactFolders,
+                     tasks, taskFolders,
+                     Array.Empty<PlannedAppointment>(), Array.Empty<IReadOnlyList<string>>(),
+                     outputDirectory, report, totalMessages, onProgress, cancellationToken, memoryObserver);
+
+    public List<string> WritePlan(PstOutputPlan plan, IEnumerable<PlannedMessage> messages,
+        IReadOnlyList<PlannedContact> contacts, IReadOnlyList<IReadOnlyList<string>> contactFolders,
+        IReadOnlyList<PlannedTask> tasks, IReadOnlyList<IReadOnlyList<string>> taskFolders,
+        IReadOnlyList<PlannedAppointment> appointments, IReadOnlyList<IReadOnlyList<string>> appointmentFolders,
         string outputDirectory, ConversionReport report, int totalMessages = -1,
         Action<ConversionProgressEvent>? onProgress = null, CancellationToken cancellationToken = default,
         DurableMemoryObserver? memoryObserver = null)
@@ -102,11 +116,13 @@ public class PstWriter
 
         var contactWriter = new ContactWriter();
         var taskWriter = new TaskWriter();
+        var appointmentWriter = new AppointmentWriter();
         var partManager = new PstPartManager(
             plan.Name, outputDirectory, plan.MaxSizeBytes, _checkIntervalMessages,
             writeMessage: (file, folder, message) => WriteMessageCore(file, folder, message),
             writeContact: (file, folder, contact) => contactWriter.WriteContact(file, folder, contact),
-            writeTask: (file, folder, task) => taskWriter.WriteTask(file, folder, task));
+            writeTask: (file, folder, task) => taskWriter.WriteTask(file, folder, task),
+            writeAppointment: (file, folder, appt) => appointmentWriter.WriteAppointment(file, folder, appt));
         var throttler = new ProgressThrottler(onProgress, totalMessages);
 
         // Producer thread parses MIME (CPU-bound); this consumer writes PST (I/O-bound).
@@ -155,6 +171,8 @@ public class PstWriter
                 precreate.Add(new FolderToPrecreate(contactFolder, FolderItemTypeName.Contact));
             foreach (IReadOnlyList<string> taskFolder in taskFolders)
                 precreate.Add(new FolderToPrecreate(taskFolder, FolderItemTypeName.Task));
+            foreach (IReadOnlyList<string> appointmentFolder in appointmentFolders)
+                precreate.Add(new FolderToPrecreate(appointmentFolder, FolderItemTypeName.Appointment));
             partManager.Begin(precreate);
 
             // Phase 1: mail. Phase 2: contacts — BOTH inside this try and the same open-store
@@ -165,6 +183,8 @@ public class PstWriter
             WriteContactPhase(partManager, contacts, totalMessages, estimatedOutputBytes, report, onProgress, cancellationToken);
 
             WriteTaskPhase(partManager, tasks, totalMessages, estimatedOutputBytes, report, onProgress, cancellationToken);
+
+            WriteAppointmentPhase(partManager, appointments, totalMessages, estimatedOutputBytes, report, onProgress, cancellationToken);
 
             partManager.Finish();
             throttler.Emit(report, currentSource, currentFolder, estimatedOutputBytes);
@@ -375,11 +395,56 @@ public class PstWriter
         }
     }
 
+    // Appointment phase: runs after the task phase inside the SAME open-store lifecycle, reusing the
+    // part manager's split/checkpoint machinery. Appointment folders are pre-created in Begin so an
+    // empty calendar still yields an IPF.Appointment folder. Emits additive appointment progress (Phase="appointments").
+    private void WriteAppointmentPhase(PstPartManager partManager, IReadOnlyList<PlannedAppointment> appointments,
+        int mailTotal, long mailEstimatedOutputBytes, ConversionReport report, Action<ConversionProgressEvent>? onProgress,
+        CancellationToken cancellationToken)
+    {
+        int appointmentsTotal = appointments.Count;
+        foreach (PlannedAppointment planned in appointments)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            long size = EstimateAppointmentSize(planned.Appointment);
+            if (partManager.ShouldSplitBefore(size)) partManager.FlushAndSplit();
+            try
+            {
+                partManager.WriteAppointment(planned.TargetFolderPath, planned.Appointment);
+                report.RecordAppointmentConverted();
+            }
+            catch (ConfigValidationException) { throw; } // collision = fatal
+            partManager.OnWritten(size);
+            // Additive appointment progress: mail Converted/Total stay as-is (phase="appointments").
+            onProgress?.Invoke(new ProgressEvent(
+                Converted: report.ConvertedCount,
+                TotalMessages: mailTotal,
+                Warnings: report.WarningCount,
+                Skipped: report.SkippedCount,
+                CurrentSource: planned.Appointment.SourceId,
+                CurrentFolder: FolderPathDisplay.Join(planned.TargetFolderPath),
+                EstimatedOutputBytes: mailEstimatedOutputBytes,
+                AppointmentsConverted: report.AppointmentsConverted,
+                AppointmentsTotal: appointmentsTotal,
+                Phase: "appointments"));
+            if (partManager.CheckpointDue)
+            {
+                partManager.Flush();
+                partManager.TrySplitOrResumeAfterFlush();
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+    }
+
     // A contact is far smaller than a mail message; add photo bytes when present.
     private static long EstimateContactSize(ContactRecord c) => 2048 + (c.Photo?.Bytes.Length ?? 0);
 
     // A task is small; body is plain text (UTF-16 in PST → 2 bytes/char).
     private static long EstimateTaskSize(TaskRecord t) => 2048 + (t.Body?.Length ?? 0) * 2;
+
+    // An appointment: fixed overhead + plain body (UTF-16) + HTML body (UTF-8 bytes).
+    private static long EstimateAppointmentSize(AppointmentRecord a) =>
+        2048 + (a.Body?.Length ?? 0) * 2 + (a.BodyHtml?.Length ?? 0) * 2;
 
     private static string GetPlainTextBody(MailMessage message)
     {

--- a/src/Mail2Pst.Core/Writing/PstWriter.cs
+++ b/src/Mail2Pst.Core/Writing/PstWriter.cs
@@ -46,6 +46,9 @@ public class PstWriter
     // multi-output / parallel WritePlan work — concurrent WritePlan calls on one PstWriter would race this field.
     private CancellationToken _activeCancellationToken;
 
+    // built in WritePlan from the current streaming config
+    private AttachmentWriter _attachmentWriter = null!;
+
     // Number of successfully-written messages between on-disk size checks.
     private readonly int _checkIntervalMessages;
 
@@ -113,6 +116,7 @@ public class PstWriter
         // Pre-flight: if already cancelled, create nothing so DeletedFiles stays empty.
         cancellationToken.ThrowIfCancellationRequested();
         _activeCancellationToken = cancellationToken;
+        _attachmentWriter = new AttachmentWriter(StreamingThresholdBytes, _attachmentStreamingDisabled);
 
         var contactWriter = new ContactWriter();
         var taskWriter = new TaskWriter();
@@ -553,12 +557,10 @@ public class PstWriter
     // this flat constant under-counts the aggregate.
     private const long PerAttachmentOverheadBytes = 512;
 
-    // MAPI bit flags for PidTagMessageFlags (MS-OXCMSG) and the inline-attachment
-    // PidTagAttachFlags value (MS-OXCMSG ATT_MHTML_REF). Named here so the bit math
+    // MAPI bit flags for PidTagMessageFlags (MS-OXCMSG). Named here so the bit math
     // at the write sites reads intentionally instead of as raw hex.
     private const int MSGFLAG_READ = 0x0001;
     private const int MSGFLAG_HASATTACH = 0x0010;
-    private const int ATT_MHTML_REF = 4;
 
     internal static long EstimateMessageSize(MailMessage message)
     {
@@ -739,57 +741,10 @@ public class PstWriter
 
     private void WriteAttachment(PSTFile file, Note note, MailAttachment a)
     {
-        note.CreateSubnodeBTreeIfNotExist();
-        AttachmentObject attachment = AttachmentObject.CreateNewAttachmentObject(file, note.SubnodeBTree);
-
-        attachment.PC.SetStringProperty(PropertyID.PidTagAttachLongFilename, a.FileName);
-        attachment.PC.SetStringProperty(PropertyID.PidTagAttachFilename, a.FileName);
-        attachment.PC.SetStringProperty(PropertyID.PidTagDisplayName, a.FileName);
-        attachment.PC.SetStringProperty(PropertyID.PidTagAttachExtension, Path.GetExtension(a.FileName));
-        attachment.PC.SetStringProperty(PropertyID.PidTagAttachMimeTag, a.MimeType);
-        attachment.PC.SetInt32Property(PropertyID.PidTagAttachMethod, (int)AttachMethod.ByValue);
-        // [M1] Only large attachments stream; small/medium keep the proven byte[] path (zero memory
-        // benefit below tens of MB). [A9] streaming requires NDB_CRYPT_PERMUTE. [L4] kill-switch.
-        bool canStream = a.Content.Length >= StreamingThresholdBytes
-            && file.Header.bCryptMethod == bCryptMethodName.NDB_CRYPT_PERMUTE
-            && !_attachmentStreamingDisabled;
-        if (canStream)
-        {
-            using Stream attachStream = a.Content.OpenRead();   // [R2:H2] closed before finally deletes the temp file
-            attachment.PC.SetExternalProperty(PropertyID.PidTagAttachData, PropertyTypeName.PtypBinary,
-                attachStream, a.Content.Length, _activeCancellationToken);
-        }
-        else
-        {
-            attachment.PC.SetBytesProperty(PropertyID.PidTagAttachData, a.Content.ReadAllBytes());   // small/medium or non-PERMUTE
-        }
-        attachment.PC.SetInt32Property(PropertyID.PidTagAttachSize, (int)a.Content.Length);
-
-        if (!string.IsNullOrEmpty(a.ContentId))
-        {
-            attachment.PC.SetStringProperty(PropertyID.PidTagAttachContentId, a.ContentId);
-        }
-
-        if (!string.IsNullOrEmpty(a.ContentLocation))
-        {
-            attachment.PC.SetStringProperty(PropertyID.PidTagAttachContentLocation, a.ContentLocation);
-        }
-
-        if (a.IsInline)
-        {
-            attachment.PC.SetInt32Property(PropertyID.PidTagAttachFlags, ATT_MHTML_REF);
-            // Hide inline (CID) images from the attachment list so Outlook does
-            // not render a paperclip for body-embedded images.
-            attachment.PC.SetBooleanProperty(PropertyID.PidTagAttachmentHidden, true);
-        }
-
-        // attachment.PC's property writes above only update the in-memory
-        // property context; SaveChanges(note.SubnodeBTree) flushes it to the
-        // attachment's data tree and updates the entry this subnode occupies
-        // in the note's subnode B-tree (Subnode.SaveChanges(SubnodeBTree)),
-        // so the attachment's properties survive a reopen of the PST.
-        attachment.SaveChanges(note.SubnodeBTree);
-        note.AddAttachment(attachment);
+        _attachmentWriter.Write(file, note, new AttachmentSpec(
+            a.FileName, a.MimeType, a.Content,
+            ContentId: a.ContentId, ContentLocation: a.ContentLocation,
+            IsInline: a.IsInline), _activeCancellationToken);
     }
 
     // Windows FILETIME epoch is 1601-01-01. DateTime.ToFileTimeUtc() throws

--- a/src/Mail2Pst.Core/Writing/PstWriter.cs
+++ b/src/Mail2Pst.Core/Writing/PstWriter.cs
@@ -442,7 +442,7 @@ public class PstWriter
     // A task is small; body is plain text (UTF-16 in PST → 2 bytes/char).
     private static long EstimateTaskSize(TaskRecord t) => 2048 + (t.Body?.Length ?? 0) * 2;
 
-    // An appointment: fixed overhead + plain body (UTF-16) + HTML body (UTF-8 bytes).
+    // An appointment: fixed overhead + plain body (UTF-16, 2 bytes/char) + HTML body (2× char count — conservative upper bound for split sizing, not UTF-8).
     private static long EstimateAppointmentSize(AppointmentRecord a) =>
         2048 + (a.Body?.Length ?? 0) * 2 + (a.BodyHtml?.Length ?? 0) * 2;
 

--- a/src/Mail2Pst.Core/Writing/PstWriter.cs
+++ b/src/Mail2Pst.Core/Writing/PstWriter.cs
@@ -132,16 +132,15 @@ public class PstWriter
         ExceptionDispatchInfo? faultCapture = null;
         try
         {
-            // Pre-create a folder for every mapped source when IncludeEmptyFolders, so an
-            // empty source still appears as an empty folder (part 1 only — see spec inv. 6).
-            // Both branches yield IReadOnlyList<string>[] at runtime (.ToArray() / Array.Empty),
-            // giving the conditional a clean common type that satisfies IReadOnlyList<IReadOnlyList<string>>.
-            IReadOnlyList<IReadOnlyList<string>> emptyFolders = plan.IncludeEmptyFolders
-                ? plan.SourceMappings.Select(m => m.TargetFolderPath).ToArray()
-                : Array.Empty<IReadOnlyList<string>>();
-            // Two-arg Begin pre-creates contact folders too, so an EMPTY address book still
-            // gets its IPF.Contact folder.
-            partManager.Begin(emptyFolders, contactFolders);
+            // Pre-create all folders via the typed inventory so every source type gets the
+            // correct leaf container class and an empty source still appears as an empty folder.
+            var precreate = new List<FolderToPrecreate>();
+            if (plan.IncludeEmptyFolders)
+                foreach (var m in plan.SourceMappings)
+                    precreate.Add(new FolderToPrecreate(m.TargetFolderPath, FolderItemTypeName.Note));
+            foreach (IReadOnlyList<string> contactFolder in contactFolders)
+                precreate.Add(new FolderToPrecreate(contactFolder, FolderItemTypeName.Contact));
+            partManager.Begin(precreate);
 
             // Phase 1: mail. Phase 2: contacts — BOTH inside this try and the same open-store
             // lifecycle, so cancel/fatal cleanup (below) covers contacts as well.

--- a/src/Mail2Pst.Core/Writing/TaskRecurrenceBlob.cs
+++ b/src/Mail2Pst.Core/Writing/TaskRecurrenceBlob.cs
@@ -125,8 +125,13 @@ internal static class TaskRecurrenceBlob
             structure.EndType = isCount
                 ? PSTFileFormat.RecurrenceEndType.EndAfterNOccurrences
                 : PSTFileFormat.RecurrenceEndType.EndAfterDate;
-            structure.OccurrenceCount = (uint)CalendarHelper.CalculateNumberOfOccurences(
-                spec.FirstStartUtc, last, recType, period, dayForCount);
+            // For a COUNT series, OccurrenceCount is the RRULE COUNT itself — NOT a date-span heuristic,
+            // which overcounts period-skipping patterns (e.g. BYMONTHDAY=31 skips 30-day months). The
+            // heuristic is retained only for the end-by-date (UNTIL) branch, where it matches Outlook.
+            structure.OccurrenceCount = isCount
+                ? (uint)Math.Max(1, spec.Count ?? 1)   // must not be 0 (Outlook 2003 recurrence-window guard)
+                : (uint)CalendarHelper.CalculateNumberOfOccurences(
+                    spec.FirstStartUtc, last, recType, period, dayForCount);
             structure.LastInstanceStartDate = last;
         }
         else // NoEnd

--- a/src/Mail2Pst.Core/Writing/TaskRecurrenceBlob.cs
+++ b/src/Mail2Pst.Core/Writing/TaskRecurrenceBlob.cs
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using Mail2Pst.Core.Models;
+using PSTFileFormat;
+// Alias disambiguates our model enum from PSTFileFormat.RecurrenceFrequency (the vendor blob type).
+using RecurrenceFrequency = Mail2Pst.Core.Models.RecurrenceFrequency;
+
+namespace Mail2Pst.Core.Writing;
+
+/// <summary>
+/// Builds the bare MS-OXOCAL RecurrencePattern bytes for <c>PidLidTaskRecurrence</c>
+/// (0x8116, PSETID_Task) from a <see cref="RecurrenceSpec"/>.
+/// </summary>
+/// <remarks>
+/// Tasks carry only the RecurrencePattern prefix — no AppointmentRecurrencePattern tail
+/// (no time offsets, no exception list).  The serialiser is the same vendored
+/// <see cref="AppointmentRecurrencePatternStructure"/> used by <see cref="AppointmentWriter"/>;
+/// the difference is that we call
+/// <see cref="AppointmentRecurrencePatternStructure.GetRecurrencePatternBytes"/>
+/// instead of <see cref="AppointmentRecurrencePatternStructure.GetBytes"/>.
+/// Byte-gated against real Outlook task ground-truth oracles (PR7b, 2026-07-01).
+/// </remarks>
+internal static class TaskRecurrenceBlob
+{
+    /// <summary>Serialises <paramref name="spec"/> to bare MS-OXOCAL RecurrencePattern bytes.</summary>
+    internal static byte[] Build(RecurrenceSpec spec, TimeZoneInfo zone)
+        => BuildStructure(spec, zone).GetRecurrencePatternBytes();
+
+    private static AppointmentRecurrencePatternStructure BuildStructure(RecurrenceSpec spec, TimeZoneInfo zone)
+    {
+        // Map our model enum → vendored PSTFileFormat.RecurrenceType (mirrors AppointmentWriter.ApplyRecurrence).
+        PSTFileFormat.RecurrenceType recType = spec.Frequency switch
+        {
+            RecurrenceFrequency.Daily      => PSTFileFormat.RecurrenceType.EveryNDays,
+            RecurrenceFrequency.Weekly     => PSTFileFormat.RecurrenceType.EveryNWeeks,
+            RecurrenceFrequency.Monthly    => PSTFileFormat.RecurrenceType.EveryNMonths,
+            RecurrenceFrequency.MonthlyNth => PSTFileFormat.RecurrenceType.EveryNthDayOfEveryNMonths,
+            RecurrenceFrequency.Yearly     => PSTFileFormat.RecurrenceType.EveryNYears,
+            RecurrenceFrequency.YearlyNth  => PSTFileFormat.RecurrenceType.EveryNthDayOfEveryNYears,
+            _                              => PSTFileFormat.RecurrenceType.EveryNDays,
+        };
+
+        var freq    = RecurrenceTypeHelper.GetRecurrenceFrequency(recType);
+        var patType = RecurrenceTypeHelper.GetPatternType(recType);
+        int period  = Math.Max(1, spec.Interval);
+
+        AppointmentRecurrencePatternStructure structure;
+        int dayForCount; // passed to CalendarHelper.CalculateNumberOfOccurences as 'day'
+
+        switch (freq)
+        {
+            case PSTFileFormat.RecurrenceFrequency.Weekly:
+            {
+                // Guard: default to the DTSTART weekday if DaysOfWeek is empty.
+                var mask = ToDaysMask(spec.DaysOfWeek);
+                if (mask == 0) mask = ToDaysMask(new[] { spec.FirstStartLocal.DayOfWeek });
+                var w = new WeeklyRecurrencePatternStructure { DaysOfWeek = mask };
+                dayForCount = (int)mask;
+                structure   = w;
+                break;
+            }
+            case PSTFileFormat.RecurrenceFrequency.Monthly:
+            {
+                var m = new MonthlyRecurrencePatternStructure();
+                if (patType == PSTFileFormat.PatternType.Month)
+                {
+                    m.DayOfMonth = (uint)(spec.DayOfMonth ?? spec.FirstStartLocal.Day);
+                    dayForCount  = (int)m.DayOfMonth;
+                }
+                else // MonthNth
+                {
+                    m.DayOfWeek          = ToOutlookDay(spec.DaysOfWeek.Length > 0 ? spec.DaysOfWeek[0] : DayOfWeek.Monday);
+                    m.DayOccurenceNumber = ToOccurrenceNumber(spec.NthOccurrence);
+                    dayForCount          = (int)m.DayOfWeek;
+                }
+                structure = m;
+                break;
+            }
+            case PSTFileFormat.RecurrenceFrequency.Yearly:
+            {
+                var y = new YearlyRecurrencePatternStructure();
+                if (patType == PSTFileFormat.PatternType.Month)
+                {
+                    y.DayOfMonth = (uint)(spec.DayOfMonth ?? spec.FirstStartLocal.Day);
+                    dayForCount  = (int)y.DayOfMonth;
+                }
+                else // MonthNth
+                {
+                    y.DayOfWeek          = ToOutlookDay(spec.DaysOfWeek.Length > 0 ? spec.DaysOfWeek[0] : DayOfWeek.Monday);
+                    y.DayOccurenceNumber = ToOccurrenceNumber(spec.NthOccurrence);
+                    dayForCount          = (int)y.DayOfWeek;
+                }
+                structure = y;
+                break;
+            }
+            default: // Daily
+            {
+                structure   = new DailyRecurrencePatternStructure();
+                dayForCount = 0;
+                break;
+            }
+        }
+
+        structure.PatternType = patType;
+        structure.PeriodInRecurrenceTypeUnits = period;
+
+        // SetStartAndDuration sets StartDate (the private backing field) via StartDTZone.
+        // duration=0: tasks have no appointment duration; StartTimeOffset/EndTimeOffset are
+        // NOT part of the bare RecurrencePattern emitted by GetRecurrencePatternBytes().
+        structure.SetStartAndDuration(spec.FirstStartUtc, 0, zone);
+
+        // FirstDateTime: days-within-period offset from Jan 1, 1601 epoch.
+        // Must use zone-local start (not UTC) — same convention as RecurringAppointment.GetRecurrencePattern.
+        DateTime startDTZone = TimeZoneInfo.ConvertTimeFromUtc(spec.FirstStartUtc, zone);
+        structure.FirstDateTimeInDays = AppointmentRecurrencePatternStructure.CalculateFirstDateTimeInDays(
+            freq, patType, period, startDTZone);
+
+        // EndType + OccurrenceCount + EndDate (LastInstanceStartDate).
+        if ((spec.EndKind is RecurrenceEndKind.Count or RecurrenceEndKind.Until)
+            && spec.LastInstanceStartUtc is { } last)
+        {
+            bool isCount = (spec.EndKind == RecurrenceEndKind.Count);
+            structure.EndType = isCount
+                ? PSTFileFormat.RecurrenceEndType.EndAfterNOccurrences
+                : PSTFileFormat.RecurrenceEndType.EndAfterDate;
+            structure.OccurrenceCount = (uint)CalendarHelper.CalculateNumberOfOccurences(
+                spec.FirstStartUtc, last, recType, period, dayForCount);
+            structure.LastInstanceStartDate = last;
+        }
+        else // NoEnd
+        {
+            structure.EndType         = PSTFileFormat.RecurrenceEndType.NeverEnd;
+            structure.OccurrenceCount = 10; // no-end sentinel per MS-OXOCAL + Outlook GT
+            structure.LastInstanceStartDate = new DateTime(4500, 8, 31, 0, 0, 0, DateTimeKind.Utc);
+        }
+
+        // Tasks never carry deleted/modified exceptions in PidLidTaskRecurrence.
+        // DeletedInstanceDates and ModifiedInstanceDates remain empty (default).
+        return structure;
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers (mirrors AppointmentWriter.ToMask / ToOutlookDay)
+    // -----------------------------------------------------------------------
+
+    private static DaysOfWeekFlags ToDaysMask(DayOfWeek[] days)
+    {
+        DaysOfWeekFlags m = 0;
+        foreach (var d in days) m |= (DaysOfWeekFlags)(1u << (int)d);
+        return m;
+    }
+
+    private static OutlookDayOfWeek ToOutlookDay(DayOfWeek d)
+        => (OutlookDayOfWeek)(1u << (int)d);
+
+    private static DayOccurenceNumber ToOccurrenceNumber(int? n) => (n ?? 1) switch
+    {
+        -1 => DayOccurenceNumber.Last,
+        2  => DayOccurenceNumber.Second,
+        3  => DayOccurenceNumber.Third,
+        4  => DayOccurenceNumber.Fourth,
+        _  => DayOccurenceNumber.First,
+    };
+}

--- a/src/Mail2Pst.Core/Writing/TaskWriter.cs
+++ b/src/Mail2Pst.Core/Writing/TaskWriter.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #nullable enable
 using System;
+using System.Collections.Generic;
 using Mail2Pst.Core.Models;
 using PSTFileFormat;
 
@@ -22,9 +23,16 @@ public class TaskWriter
         if (status == TaskStatusKind.Complete && percent < 100) percent = 100;
         bool reminderSet = t.ReminderSet && t.ReminderTime is not null;
 
+        // Body with optional link-only attachment appendix (tasks are plain-text only; no HTML body).
+        string? appendix = CalendarBodyAppendix.Format(t.Attachments,
+            System.Array.Empty<string>(),   // Task 5 supplies relation lines
+            existingText: t.Body);
+        string? effectiveBody = appendix is null ? t.Body
+            : string.IsNullOrEmpty(t.Body) ? appendix : t.Body + "\n\n" + appendix;
+
         // Static-tag props
         SetIf(msg, PropertyID.PidTagSubject, t.Subject);
-        SetIf(msg, PropertyID.PidTagBody, t.Body);
+        SetIf(msg, PropertyID.PidTagBody, effectiveBody);
         msg.PC.SetInt32Property(PropertyID.PidTagImportance, t.Importance);
         msg.PC.SetInt32Property(PropertyID.PidTagSensitivity, t.Sensitivity);
 
@@ -77,6 +85,8 @@ public class TaskWriter
             SetNamedBool(file, msg, PropertyLongID.PidLidTaskFRecurring, PropertySetGuid.PSETID_Task, true);
         }
 
+        WriteAttachments(file, msg, t.Attachments);   // ByValue inline/local-file attachments + no-op for LinkOnly
+
         msg.SaveChanges();
         folder.AddMessage(msg);
     }
@@ -84,6 +94,22 @@ public class TaskWriter
     // -----------------------------------------------------------------------
     // Helpers (mirror ContactWriter pattern)
     // -----------------------------------------------------------------------
+
+    private static void WriteAttachments(PSTFile file, TaskMessage msg, IReadOnlyList<CalendarAttachment> atts)
+    {
+        var writer = new AttachmentWriter();
+        foreach (CalendarAttachment att in atts)
+        {
+            // No IsInline: task attachments are VISIBLE ByValue attachments, never hidden CID resources.
+            if (att.Kind == CalendarAttachmentKind.InlineBytes && att.InlineData is not null)
+                writer.Write(file, msg, new AttachmentSpec(att.FileName, att.MimeType,
+                    AttachmentContent.FromBytes(att.InlineData)));
+            else if (att.Kind == CalendarAttachmentKind.LocalFileByValue && att.LocalPath is not null)
+                writer.Write(file, msg, new AttachmentSpec(att.FileName, att.MimeType,
+                    AttachmentContent.FromExistingFile(att.LocalPath)));   // NEVER FromTempFile — that deletes the source
+            // LinkOnly → body appendix only; no PST attachment row.
+        }
+    }
 
     private static void SetIf(TaskMessage msg, PropertyID id, string? value)
     {

--- a/src/Mail2Pst.Core/Writing/TaskWriter.cs
+++ b/src/Mail2Pst.Core/Writing/TaskWriter.cs
@@ -29,7 +29,8 @@ public class TaskWriter
         msg.PC.SetInt32Property(PropertyID.PidTagSensitivity, t.Sensitivity);
 
         // Private flag (Task 0 batch 2): a Private task sets BOTH PidTagSensitivity=2 AND
-        // PidLidPrivate=true (PSETID_Common 0x8506).
+        // PidLidPrivate=true (PSETID_Common 0x8506). PidLidPrivate is coupled to Sensitivity==2 only;
+        // CONFIDENTIAL (3) intentionally does NOT set it — this matches Outlook ground truth.
         SetNamedBool(file, msg, PropertyLongID.PidLidPrivate, PropertySetGuid.PSETID_Common, t.Sensitivity == 2);
 
         // Task named props (PSETID_Task unless noted)
@@ -39,6 +40,8 @@ public class TaskWriter
         SetNamedInt(file, msg, PropertyLongID.PidLidTaskOwnership, PropertySetGuid.PSETID_Task, 0);  // 0 = not assigned
         SetNamedInt(file, msg, PropertyLongID.PidLidTaskMode,      PropertySetGuid.PSETID_Common, 0); // 0 = not assigned
 
+        // Intentional seam: start/due are written date-only (UTC midnight via SetNamedDateOnly) while
+        // reminders (below) are written as absolute instants — this matches Outlook ground truth.
         if (t.StartDate is { } sd)
             SetNamedDateOnly(file, msg, PropertyLongID.PidLidTaskStartDate, PropertySetGuid.PSETID_Task, sd);
         if (t.DueDate is { } dd)

--- a/src/Mail2Pst.Core/Writing/TaskWriter.cs
+++ b/src/Mail2Pst.Core/Writing/TaskWriter.cs
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using Mail2Pst.Core.Models;
+using PSTFileFormat;
+
+namespace Mail2Pst.Core.Writing;
+
+/// <summary>Writes a <see cref="TaskRecord"/> as an IPM.Task item into an IPF.Task folder.</summary>
+public class TaskWriter
+{
+    public void WriteTask(PSTFile file, PSTFolder folder, TaskRecord t)
+    {
+        TaskMessage msg = TaskMessage.CreateNewTask(file, folder.NodeID);
+
+        // Defensive invariants — TaskWriter must never emit invalid MAPI even if handed a bad
+        // TaskRecord (it is called directly in tests / future pipelines, not only via CalendarTaskMapper).
+        int percent = Math.Clamp(t.PercentComplete, 0, 100);
+        TaskStatusKind status = t.Status;
+        if (percent == 100) status = TaskStatusKind.Complete;
+        if (status == TaskStatusKind.Complete && percent < 100) percent = 100;
+        bool reminderSet = t.ReminderSet && t.ReminderTime is not null;
+
+        // Static-tag props
+        SetIf(msg, PropertyID.PidTagSubject, t.Subject);
+        SetIf(msg, PropertyID.PidTagBody, t.Body);
+        msg.PC.SetInt32Property(PropertyID.PidTagImportance, t.Importance);
+        msg.PC.SetInt32Property(PropertyID.PidTagSensitivity, t.Sensitivity);
+
+        // Private flag (Task 0 batch 2): a Private task sets BOTH PidTagSensitivity=2 AND
+        // PidLidPrivate=true (PSETID_Common 0x8506).
+        SetNamedBool(file, msg, PropertyLongID.PidLidPrivate, PropertySetGuid.PSETID_Common, t.Sensitivity == 2);
+
+        // Task named props (PSETID_Task unless noted)
+        SetNamedInt(file, msg, PropertyLongID.PidLidTaskStatus,    PropertySetGuid.PSETID_Task, (int)status);
+        SetNamedDouble(file, msg, PropertyLongID.PidLidPercentComplete, PropertySetGuid.PSETID_Task, percent / 100.0);
+        SetNamedBool(file, msg, PropertyLongID.PidLidTaskComplete, PropertySetGuid.PSETID_Task, status == TaskStatusKind.Complete);
+        SetNamedInt(file, msg, PropertyLongID.PidLidTaskOwnership, PropertySetGuid.PSETID_Task, 0);  // 0 = not assigned
+        SetNamedInt(file, msg, PropertyLongID.PidLidTaskMode,      PropertySetGuid.PSETID_Common, 0); // 0 = not assigned
+
+        if (t.StartDate is { } sd)
+            SetNamedDateOnly(file, msg, PropertyLongID.PidLidTaskStartDate, PropertySetGuid.PSETID_Task, sd);
+        if (t.DueDate is { } dd)
+            SetNamedDateOnly(file, msg, PropertyLongID.PidLidTaskDueDate, PropertySetGuid.PSETID_Task, dd);
+        if (t.CompletedDate is { } cd)
+            SetNamedDate(file, msg, PropertyLongID.PidLidTaskDateCompleted, PropertySetGuid.PSETID_Task, cd); // instant
+
+        // Reminder — tasks use an ABSOLUTE time (Task 0 ground-truth): ReminderTime + ReminderSignalTime,
+        // PidLidReminderDelta stays 0. The appointment-style minutes-before delta does NOT apply to tasks.
+        // Never write ReminderSet=true without a ReminderTime (the `reminderSet` guard above enforces this).
+        SetNamedBool(file, msg, PropertyLongID.PidLidReminderSet, PropertySetGuid.PSETID_Common, reminderSet);
+        if (reminderSet && t.ReminderTime is { } rt)
+        {
+            SetNamedDate(file, msg, PropertyLongID.PidLidReminderTime,       PropertySetGuid.PSETID_Common, rt);
+            SetNamedDate(file, msg, PropertyLongID.PidLidReminderSignalTime, PropertySetGuid.PSETID_Common, rt);
+            SetNamedInt(file, msg, PropertyLongID.PidLidReminderDelta,       PropertySetGuid.PSETID_Common, 0);
+        }
+
+        // Categories (reuse the mail "Keywords" path — PstWriter.cs:603)
+        if (t.Categories.Count > 0)
+        {
+            ushort kw = PropertyNameToIDMap.GetOrCreateStringNamedProperty(file, 2, "Keywords");
+            msg.PC.SetMultiStringProperty((PropertyID)kw, t.Categories);
+        }
+
+        msg.SaveChanges();
+        folder.AddMessage(msg);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers (mirror ContactWriter pattern)
+    // -----------------------------------------------------------------------
+
+    private static void SetIf(TaskMessage msg, PropertyID id, string? value)
+    {
+        if (!string.IsNullOrEmpty(value))
+            msg.PC.SetStringProperty(id, value);
+    }
+
+    private static PropertyID Obtain(PSTFile file, PropertyLongID lid, Guid set)
+        => file.NameToIDMap.ObtainIDFromName(new PropertyName(lid, set));
+
+    private static void SetNamedInt(PSTFile file, TaskMessage msg, PropertyLongID lid, Guid set, int value)
+        => msg.PC.SetInt32Property(Obtain(file, lid, set), value);
+
+    private static void SetNamedBool(PSTFile file, TaskMessage msg, PropertyLongID lid, Guid set, bool value)
+        => msg.PC.SetBooleanProperty(Obtain(file, lid, set), value);
+
+    private static void SetNamedDate(PSTFile file, TaskMessage msg, PropertyLongID lid, Guid set, DateTimeOffset value)
+        => msg.PC.SetDateTimeProperty(Obtain(file, lid, set), value.UtcDateTime);
+
+    // Date-only fields (start/due): UTC midnight of the calendar day.
+    // Uses the DateTimeOffset's own Y/M/D so a non-UTC zone (e.g. +07:00) keeps its date.
+    private static void SetNamedDateOnly(PSTFile file, TaskMessage msg, PropertyLongID lid, Guid set, DateTimeOffset value)
+        => msg.PC.SetDateTimeProperty(Obtain(file, lid, set),
+               new DateTime(value.Year, value.Month, value.Day, 0, 0, 0, DateTimeKind.Utc));
+
+    // PidLidPercentComplete is PtypFloating64 — write as IEEE-754 bytes via SetExternalProperty.
+    private static void SetNamedDouble(PSTFile file, TaskMessage msg, PropertyLongID lid, Guid set, double value)
+        => msg.PC.SetExternalProperty(Obtain(file, lid, set), PropertyTypeName.PtypFloating64, BitConverter.GetBytes(value));
+}

--- a/src/Mail2Pst.Core/Writing/TaskWriter.cs
+++ b/src/Mail2Pst.Core/Writing/TaskWriter.cs
@@ -4,6 +4,8 @@
 using System;
 using Mail2Pst.Core.Models;
 using PSTFileFormat;
+// Alias disambiguates our model enum from PSTFileFormat.RecurrenceFrequency (the vendor blob type).
+using RecurrenceFrequency = Mail2Pst.Core.Models.RecurrenceFrequency;
 
 namespace Mail2Pst.Core.Writing;
 
@@ -67,6 +69,16 @@ public class TaskWriter
             msg.PC.SetMultiStringProperty((PropertyID)kw, t.Categories);
         }
 
+        // Recurrence — only PidLidTaskRecurrence (the bare pattern) + PidLidTaskFRecurring=true.
+        // Non-recurring tasks write neither prop (absent is equivalent to FRecurring=false per GT).
+        if (t.Recurrence is { } rec)
+        {
+            var zone = rec.TimeZone ?? TimeZoneInfo.Utc;   // deterministic; mapper passes UTC. NEVER TimeZoneInfo.Local.
+            SetNamedBytes(file, msg, PropertyLongID.PidLidTaskRecurrence,  PropertySetGuid.PSETID_Task,
+                TaskRecurrenceBlob.Build(rec, zone));
+            SetNamedBool(file, msg, PropertyLongID.PidLidTaskFRecurring, PropertySetGuid.PSETID_Task, true);
+        }
+
         msg.SaveChanges();
         folder.AddMessage(msg);
     }
@@ -89,6 +101,9 @@ public class TaskWriter
 
     private static void SetNamedBool(PSTFile file, TaskMessage msg, PropertyLongID lid, Guid set, bool value)
         => msg.PC.SetBooleanProperty(Obtain(file, lid, set), value);
+
+    private static void SetNamedBytes(PSTFile file, TaskMessage msg, PropertyLongID lid, Guid set, byte[] value)
+        => msg.PC.SetBytesProperty(Obtain(file, lid, set), value);
 
     private static void SetNamedDate(PSTFile file, TaskMessage msg, PropertyLongID lid, Guid set, DateTimeOffset value)
         => msg.PC.SetDateTimeProperty(Obtain(file, lid, set), value.UtcDateTime);

--- a/src/Mail2Pst.Core/Writing/TaskWriter.cs
+++ b/src/Mail2Pst.Core/Writing/TaskWriter.cs
@@ -25,7 +25,7 @@ public class TaskWriter
 
         // Body with optional link-only attachment appendix (tasks are plain-text only; no HTML body).
         string? appendix = CalendarBodyAppendix.Format(t.Attachments,
-            System.Array.Empty<string>(),   // Task 5 supplies relation lines
+            t.Relations,
             existingText: t.Body);
         string? effectiveBody = appendix is null ? t.Body
             : string.IsNullOrEmpty(t.Body) ? appendix : t.Body + "\n\n" + appendix;

--- a/src/Mail2Pst.Core/Writing/TaskWriter.cs
+++ b/src/Mail2Pst.Core/Writing/TaskWriter.cs
@@ -4,8 +4,6 @@
 using System;
 using Mail2Pst.Core.Models;
 using PSTFileFormat;
-// Alias disambiguates our model enum from PSTFileFormat.RecurrenceFrequency (the vendor blob type).
-using RecurrenceFrequency = Mail2Pst.Core.Models.RecurrenceFrequency;
 
 namespace Mail2Pst.Core.Writing;
 

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarAttachmentResolverTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarAttachmentResolverTests.cs
@@ -53,6 +53,39 @@ public class CalendarAttachmentResolverTests
         finally { Directory.Delete(root, true); File.Delete(outside); }
     }
 
+    [Fact] public void Sensitive_profile_file_is_never_embedded()
+    {
+        // A file:// ATTACH pointing at a Thunderbird credential/key file inside the export root must NOT
+        // be embedded (defense-in-depth against a crafted calendar exfiltrating secrets), even though it
+        // passes the in-root check. Degrades to link-only with a warning.
+        string root = Path.Combine(Path.GetTempPath(), $"root-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        string secret = Path.Combine(root, "logins.json");
+        File.WriteAllText(secret, "{\"secret\":true}");
+        try
+        {
+            var r = new CalendarAttachmentResolver(root);
+            var (atts, warns) = r.ResolveAll(new[] { Line($"ATTACH:{FileUri(secret)}") }, "evt");
+            Assert.Equal(CalendarAttachmentKind.LinkOnly, Assert.Single(atts).Kind);
+            Assert.Contains(warns, w => w.Contains("sensitive"));
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact] public void Oversized_inline_is_dropped_with_accurate_warning()
+    {
+        // maxEmbedBytes small so a 100-byte inline attachment exceeds it. Inline data has no external
+        // reference, so the warning must say it was DROPPED, not "preserved as link".
+        var r = new CalendarAttachmentResolver(exportRoot: null, maxEmbedBytes: 8);
+        string big = Convert.ToBase64String(new byte[100]);
+        var (atts, warns) = r.ResolveAll(new[] {
+            Line($"ATTACH;FILENAME=big.bin;VALUE=BINARY;ENCODING=BASE64;FMTTYPE=application/octet-stream:{big}") }, "evt");
+        var a = Assert.Single(atts);
+        Assert.Equal(CalendarAttachmentKind.LinkOnly, a.Kind);
+        Assert.Contains(warns, w => w.Contains("dropped"));
+        Assert.DoesNotContain(warns, w => w.Contains("preserved as link"));
+    }
+
     [Fact] public void Local_file_missing_is_link_only_with_warning()
     {
         string root = Path.Combine(Path.GetTempPath(), $"root-{Guid.NewGuid():N}");

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarAttachmentResolverTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarAttachmentResolverTests.cs
@@ -85,6 +85,62 @@ public class CalendarAttachmentResolverTests
         finally { Directory.Delete(root, true); }
     }
 
+    // --- size-guard tests ---
+
+    [Fact] public void Local_file_exceeding_maxEmbedBytes_is_link_only_with_too_large_warning()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"root-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        try
+        {
+            string f = Path.Combine(root, "big.bin");
+            File.WriteAllBytes(f, new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }); // 10 bytes
+            var r = new CalendarAttachmentResolver(root, maxEmbedBytes: 4);        // threshold = 4
+            var (atts, warns) = r.ResolveAll(new[] { Line($"ATTACH;FILENAME=big.bin:{FileUri(f)}") }, "evt");
+            Assert.Equal(CalendarAttachmentKind.LinkOnly, Assert.Single(atts).Kind);
+            Assert.Contains(warns, w => w.Contains("too large"));
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact] public void Inline_data_exceeding_maxEmbedBytes_is_link_only_with_too_large_warning()
+    {
+        // "hello" = 5 bytes when decoded; maxEmbedBytes = 4 forces LinkOnly
+        var r = new CalendarAttachmentResolver(exportRoot: null, maxEmbedBytes: 4);
+        var (atts, warns) = r.ResolveAll(new[] {
+            Line("ATTACH;FILENAME=big.txt;VALUE=BINARY;ENCODING=BASE64;FMTTYPE=text/plain:aGVsbG8=") }, "evt");
+        var a = Assert.Single(atts);
+        Assert.Equal(CalendarAttachmentKind.LinkOnly, a.Kind);
+        Assert.Contains(warns, w => w.Contains("too large"));
+    }
+
+    [Fact] public void Default_threshold_small_inline_still_classifies_as_inline_bytes()
+    {
+        // Regression: default maxEmbedBytes = int.MaxValue must not affect normal small data
+        var r = new CalendarAttachmentResolver(exportRoot: null);
+        var (atts, warns) = r.ResolveAll(new[] {
+            Line("ATTACH;FILENAME=hi.txt;VALUE=BINARY;ENCODING=BASE64;FMTTYPE=text/plain:aGk=") }, "evt");
+        var a = Assert.Single(atts);
+        Assert.Equal(CalendarAttachmentKind.InlineBytes, a.Kind);
+        Assert.Empty(warns);
+    }
+
+    [Fact] public void Default_threshold_small_local_file_still_classifies_as_by_value()
+    {
+        // Regression: default maxEmbedBytes = int.MaxValue must not affect normal small files
+        string root = Path.Combine(Path.GetTempPath(), $"root-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        try
+        {
+            string f = Path.Combine(root, "ok.bin");
+            File.WriteAllBytes(f, new byte[] { 9, 9 });
+            var r = new CalendarAttachmentResolver(root);
+            var (atts, _) = r.ResolveAll(new[] { Line($"ATTACH;FILENAME=ok.bin:{FileUri(f)}") }, "evt");
+            Assert.Equal(CalendarAttachmentKind.LocalFileByValue, Assert.Single(atts).Kind);
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
     [SkippableFact]   // symlink creation needs privilege on Windows; skip if it throws
     public void Local_file_symlink_inside_root_is_rejected()
     {

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarAttachmentResolverTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarAttachmentResolverTests.cs
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.IO;
+using Mail2Pst.Core.Calendar;
+using Mail2Pst.Core.Models;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Calendar;
+
+public class CalendarAttachmentResolverTests
+{
+    private static RawSideText Line(string s) => new(s);
+
+    [Fact] public void Inline_data_uri_is_inline_bytes()
+    {
+        var r = new CalendarAttachmentResolver(exportRoot: null);
+        var (atts, warns) = r.ResolveAll(new[] {
+            Line("ATTACH;FILENAME=hi.txt;VALUE=BINARY;ENCODING=BASE64;FMTTYPE=text/plain:aGk=") }, "evt");
+        var a = Assert.Single(atts);
+        Assert.Equal(CalendarAttachmentKind.InlineBytes, a.Kind);
+        Assert.Equal("hi.txt", a.FileName);
+        Assert.Empty(warns);
+    }
+
+    [Fact] public void Remote_url_is_link_only_with_warning_never_fetched()
+    {
+        var r = new CalendarAttachmentResolver(exportRoot: null);
+        var (atts, warns) = r.ResolveAll(new[] {
+            Line("ATTACH;FILENAME=doc.pdf:https://drive.example.com/doc.pdf") }, "evt");
+        var a = Assert.Single(atts);
+        Assert.Equal(CalendarAttachmentKind.LinkOnly, a.Kind);
+        Assert.Equal("https://drive.example.com/doc.pdf", a.PreservedReference);
+        Assert.Contains(warns, w => w.Contains("preserved as link") && w.Contains("not fetched"));
+    }
+
+    // Build file: URIs with new Uri(path).AbsoluteUri (correct across Windows/Linux, spaces, drive letters).
+    private static string FileUri(string path) => new Uri(path).AbsoluteUri;
+
+    [Fact] public void Local_file_outside_root_is_link_only_with_warning()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"root-{Guid.NewGuid():N}");
+        string outside = Path.Combine(Path.GetTempPath(), $"outside-{Guid.NewGuid():N}.bin");
+        Directory.CreateDirectory(root);
+        File.WriteAllBytes(outside, new byte[] { 1 });
+        try
+        {
+            var r = new CalendarAttachmentResolver(root);
+            var (atts, warns) = r.ResolveAll(new[] { Line($"ATTACH;FILENAME=x.bin:{FileUri(outside)}") }, "evt");
+            Assert.Equal(CalendarAttachmentKind.LinkOnly, Assert.Single(atts).Kind);
+            Assert.Contains(warns, w => w.Contains("outside export root"));
+        }
+        finally { Directory.Delete(root, true); File.Delete(outside); }
+    }
+
+    [Fact] public void Local_file_missing_is_link_only_with_warning()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"root-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        try
+        {
+            var r = new CalendarAttachmentResolver(root);
+            string missing = Path.Combine(root, "gone.bin");
+            var (atts, warns) = r.ResolveAll(new[] { Line($"ATTACH;FILENAME=gone.bin:{FileUri(missing)}") }, "evt");
+            Assert.Equal(CalendarAttachmentKind.LinkOnly, Assert.Single(atts).Kind);
+            Assert.Contains(warns, w => w.Contains("missing") || w.Contains("unreadable"));
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact] public void Local_file_inside_root_is_by_value()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"root-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        try
+        {
+            string f = Path.Combine(root, "ok.bin");
+            File.WriteAllBytes(f, new byte[] { 9, 9 });
+            var r = new CalendarAttachmentResolver(root);
+            var (atts, _) = r.ResolveAll(new[] { Line($"ATTACH;FILENAME=ok.bin:{FileUri(f)}") }, "evt");
+            var a = Assert.Single(atts);
+            Assert.Equal(CalendarAttachmentKind.LocalFileByValue, a.Kind);
+            Assert.Equal(Path.GetFullPath(f), a.LocalPath);
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [SkippableFact]   // symlink creation needs privilege on Windows; skip if it throws
+    public void Local_file_symlink_inside_root_is_rejected()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"root-{Guid.NewGuid():N}");
+        string target = Path.Combine(Path.GetTempPath(), $"target-{Guid.NewGuid():N}.bin");
+        Directory.CreateDirectory(root);
+        File.WriteAllBytes(target, new byte[] { 5 });
+        string link = Path.Combine(root, "link.bin");
+        try { File.CreateSymbolicLink(link, target); }
+        catch (Exception ex) { Directory.Delete(root, true); File.Delete(target); throw new SkipException(ex.Message); }
+        try
+        {
+            var r = new CalendarAttachmentResolver(root);
+            var (atts, warns) = r.ResolveAll(new[] { Line($"ATTACH;FILENAME=link.bin:{FileUri(link)}") }, "evt");
+            Assert.Equal(CalendarAttachmentKind.LinkOnly, Assert.Single(atts).Kind);
+            Assert.Contains(warns, w => w.Contains("symlink") || w.Contains("reparse"));
+        }
+        finally { Directory.Delete(root, true); File.Delete(target); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarAttachmentResolverTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarAttachmentResolverTests.cs
@@ -85,6 +85,45 @@ public class CalendarAttachmentResolverTests
         finally { Directory.Delete(root, true); }
     }
 
+    // --- filename fallback (no FILENAME param) ---
+    // Thunderbird's storage calendar keeps only the attachment URI (no FILENAME param),
+    // so an embedded local file must take its name from the URI basename — a generic
+    // extensionless "attachment" won't open cleanly from Outlook.
+
+    [Fact] public void Local_file_without_filename_param_uses_uri_basename()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"root-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        try
+        {
+            string f = Path.Combine(root, "pr8-note.txt");
+            File.WriteAllBytes(f, new byte[] { 9 });
+            var r = new CalendarAttachmentResolver(root);
+            var (atts, _) = r.ResolveAll(new[] { Line($"ATTACH;FMTTYPE=text/plain:{FileUri(f)}") }, "evt");
+            var a = Assert.Single(atts);
+            Assert.Equal(CalendarAttachmentKind.LocalFileByValue, a.Kind);
+            Assert.Equal("pr8-note.txt", a.FileName);
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact] public void Local_file_filename_param_wins_over_uri_basename()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"root-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        try
+        {
+            string f = Path.Combine(root, "on-disk.bin");
+            File.WriteAllBytes(f, new byte[] { 9 });
+            var r = new CalendarAttachmentResolver(root);
+            var (atts, _) = r.ResolveAll(new[] { Line($"ATTACH;FILENAME=custom.txt:{FileUri(f)}") }, "evt");
+            var a = Assert.Single(atts);
+            Assert.Equal(CalendarAttachmentKind.LocalFileByValue, a.Kind);
+            Assert.Equal("custom.txt", a.FileName);
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
     // --- size-guard tests ---
 
     [Fact] public void Local_file_exceeding_maxEmbedBytes_is_link_only_with_too_large_warning()

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperAttendeeTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperAttendeeTests.cs
@@ -1,0 +1,308 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Mail2Pst.Core.Calendar;
+using Mail2Pst.Core.Models;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Calendar;
+
+/// <summary>
+/// Tests for the attendee-mapping block in <see cref="CalendarEventMapper.Map"/>.
+/// All data is synthetic/reserved (example.com) — no real mail or PII.
+/// </summary>
+public class CalendarEventMapperAttendeeTests
+{
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static long MicrosFor(int year, int month, int day, int hour = 0, int minute = 0) =>
+        new DateTimeOffset(year, month, day, hour, minute, 0, TimeSpan.Zero).ToUnixTimeMilliseconds() * 1000L;
+
+    private static RawEventGroup GroupWithAttendees(IEnumerable<string> icalLines)
+    {
+        var ev = new RawEvent
+        {
+            Id           = "attendee-test@example.com",
+            Title        = "Meeting",
+            EventStart   = MicrosFor(2026, 8, 1, 10, 0),
+            EventStartTz = "UTC",
+            EventEnd     = MicrosFor(2026, 8, 1, 11, 0),
+            EventEndTz   = "UTC",
+            Flags        = 0,
+            Priority     = 5,
+        };
+        foreach (var line in icalLines)
+            ev.Attendees.Add(new RawSideText(line));
+
+        return new RawEventGroup { Master = ev };
+    }
+
+    // -----------------------------------------------------------------------
+    // Happy-path: organizer + required/optional attendees
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void OrganizerPlusRequiredPlusOptional_MapsCorrectly()
+    {
+        var group = GroupWithAttendees([
+            "ORGANIZER;CN=Boss:mailto:boss@example.com",
+            "ATTENDEE;CN=Alice;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED:mailto:alice@example.com",
+            "ATTENDEE;CN=Bob;ROLE=OPT-PARTICIPANT;PARTSTAT=TENTATIVE:mailto:bob@example.com",
+        ]);
+
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.NotNull(appt!.Organizer);
+        Assert.Equal("boss@example.com", appt.Organizer!.Email);
+        Assert.Equal("Boss", appt.Organizer.DisplayName);
+        Assert.True(appt.Organizer.IsOrganizer);
+        Assert.Equal(AttendeeResponse.Organized, appt.Organizer.Response);
+        Assert.Equal(AttendeeKind.Required, appt.Organizer.Kind);
+
+        Assert.Equal(2, appt.Attendees.Count);
+
+        var alice = appt.Attendees[0];
+        Assert.Equal("alice@example.com", alice.Email);
+        Assert.Equal("Alice", alice.DisplayName);
+        Assert.Equal(AttendeeKind.Required, alice.Kind);
+        Assert.Equal(AttendeeResponse.Accepted, alice.Response);
+        Assert.False(alice.IsOrganizer);
+
+        var bob = appt.Attendees[1];
+        Assert.Equal("bob@example.com", bob.Email);
+        Assert.Equal("Bob", bob.DisplayName);
+        Assert.Equal(AttendeeKind.Optional, bob.Kind);
+        Assert.Equal(AttendeeResponse.Tentative, bob.Response);
+        Assert.False(bob.IsOrganizer);
+
+        // Organizer must not appear in Attendees
+        Assert.DoesNotContain(appt.Attendees, a => a.Email == "boss@example.com");
+    }
+
+    // -----------------------------------------------------------------------
+    // ROLE=CHAIR → Required (CHAIR has no Outlook recipient type)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void RoleChair_MapsToRequired()
+    {
+        var group = GroupWithAttendees([
+            "ATTENDEE;CN=Chair;ROLE=CHAIR;PARTSTAT=ACCEPTED:mailto:chair@example.com",
+        ]);
+
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.Single(appt!.Attendees);
+        Assert.Equal(AttendeeKind.Required, appt.Attendees[0].Kind);
+    }
+
+    // -----------------------------------------------------------------------
+    // CUTYPE=ROOM → Resource (wins over ROLE)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void CuTypeRoom_MapsToResource()
+    {
+        var group = GroupWithAttendees([
+            "ATTENDEE;CN=Conference Room;CUTYPE=ROOM;ROLE=REQ-PARTICIPANT:mailto:room@example.com",
+        ]);
+
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.Single(appt!.Attendees);
+        Assert.Equal(AttendeeKind.Resource, appt.Attendees[0].Kind);
+    }
+
+    // -----------------------------------------------------------------------
+    // PARTSTAT mappings: DECLINED, NEEDS-ACTION, missing
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void PartStat_Declined_MapsToDeclined()
+    {
+        var group = GroupWithAttendees([
+            "ATTENDEE;CN=Decliner;ROLE=REQ-PARTICIPANT;PARTSTAT=DECLINED:mailto:decliner@example.com",
+        ]);
+
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.Single(appt!.Attendees);
+        Assert.Equal(AttendeeResponse.Declined, appt.Attendees[0].Response);
+    }
+
+    [Fact]
+    public void PartStat_NeedsAction_MapsToNotResponded()
+    {
+        var group = GroupWithAttendees([
+            "ATTENDEE;CN=Pending;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION:mailto:pending@example.com",
+        ]);
+
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.Single(appt!.Attendees);
+        Assert.Equal(AttendeeResponse.NotResponded, appt.Attendees[0].Response);
+    }
+
+    [Fact]
+    public void PartStat_Missing_MapsToNone()
+    {
+        var group = GroupWithAttendees([
+            "ATTENDEE;CN=NoStat;ROLE=REQ-PARTICIPANT:mailto:nostat@example.com",
+        ]);
+
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.Single(appt!.Attendees);
+        Assert.Equal(AttendeeResponse.None, appt.Attendees[0].Response);
+    }
+
+    // -----------------------------------------------------------------------
+    // No-email non-organizer → skipped + warning
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void NonOrganizerWithNoEmail_SkippedWithWarning()
+    {
+        var group = GroupWithAttendees([
+            "ATTENDEE;CN=Alice:",   // empty URI → parser returns null/empty email
+        ]);
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.Empty(appt!.Attendees);
+        Assert.Contains(warnings, w => w.Contains("no email") && w.Contains("skipped"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Only-mailto (no CN) → kept, DisplayName == email
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void AttendeeWithNoDisplayName_UsesEmailAsDisplayName()
+    {
+        var group = GroupWithAttendees([
+            "ATTENDEE;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED:mailto:noncn@example.com",
+        ]);
+
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.Single(appt!.Attendees);
+        Assert.Equal("noncn@example.com", appt.Attendees[0].DisplayName);
+        Assert.Equal("noncn@example.com", appt.Attendees[0].Email);
+    }
+
+    // -----------------------------------------------------------------------
+    // Organizer with no email → display-only; Email is empty string
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void OrganizerWithNoEmail_DisplayOnly_EmailEmpty()
+    {
+        var group = GroupWithAttendees([
+            "ORGANIZER;CN=Boss:",   // no mailto: address
+        ]);
+
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.NotNull(appt!.Organizer);
+        Assert.Equal("Boss", appt.Organizer!.DisplayName);
+        Assert.Equal("", appt.Organizer.Email);
+        Assert.True(appt.Organizer.IsOrganizer);
+    }
+
+    // -----------------------------------------------------------------------
+    // Case-insensitive dedup: two attendees with same email (different case)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void CaseInsensitiveDuplicate_OnlyFirstKept_WarnOnSecond()
+    {
+        var group = GroupWithAttendees([
+            "ATTENDEE;CN=Req1;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED:mailto:req1@example.com",
+            "ATTENDEE;CN=Req1Upper;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED:mailto:REQ1@example.com",
+        ]);
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.Single(appt!.Attendees);
+        Assert.Equal("req1@example.com", appt.Attendees[0].Email);
+        Assert.Contains(warnings, w => w.Contains("duplicate") && w.Contains("req1@example.com", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // -----------------------------------------------------------------------
+    // Organizer/attendee dedup: ATTENDEE row with same email as ORGANIZER → dropped
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void OrganizerDuplicate_AttendeeRowDropped()
+    {
+        var group = GroupWithAttendees([
+            "ORGANIZER;CN=Boss:mailto:boss@example.com",
+            "ATTENDEE;CN=Boss;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED:mailto:boss@example.com",
+        ]);
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.NotNull(appt!.Organizer);
+        Assert.Equal("boss@example.com", appt.Organizer!.Email);
+        Assert.Empty(appt.Attendees);   // boss must NOT be in Attendees
+        Assert.Contains(warnings, w => w.Contains("duplicate") && w.Contains("boss@example.com"));
+    }
+
+    // -----------------------------------------------------------------------
+    // No attendees rows → Organizer == null, Attendees empty
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void NoAttendeeRows_OrganizerNullAndAttendeesEmpty()
+    {
+        var group = GroupWithAttendees([]); // empty
+
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.Null(appt!.Organizer);
+        Assert.Empty(appt.Attendees);
+    }
+
+    // -----------------------------------------------------------------------
+    // Malformed line: forwards warning, mapping still returns a record
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void MalformedAttendeeLine_ForwardsWarning_NeverThrows()
+    {
+        // A truly garbage line that cannot be interpreted as an ATTENDEE/ORGANIZER.
+        // We provide at least one valid attendee too so we can confirm mapping proceeds.
+        var group = GroupWithAttendees([
+            "NOT_A_VALID_ICAL_LINE===###",
+            "ATTENDEE;CN=Valid;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED:mailto:valid@example.com",
+        ]);
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        // Must not throw and must return a record
+        Assert.NotNull(appt);
+        // The valid attendee may or may not survive depending on fallback path, but the
+        // mapper must never throw and must forward any parse warnings.
+        // Primary assertion: no exception + result is non-null (asserted above).
+        // Secondary: if warnings were generated by the parser they are forwarded.
+        // (We don't assert a specific warning text since it's parser-internal.)
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperAttendeeTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperAttendeeTests.cs
@@ -282,6 +282,59 @@ public class CalendarEventMapperAttendeeTests
     }
 
     // -----------------------------------------------------------------------
+    // Test gap 4a: bare ORGANIZER line (no CN, no email, no params) → Organizer == null
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void BareOrganizerLine_NoUsableData_OrganizerIsNull()
+    {
+        // "ORGANIZER:" with no CN and no email address is a degenerate line.
+        // The mapper must not throw; Organizer should be null (neither name nor email present).
+        var group = GroupWithAttendees([
+            "ORGANIZER:",  // bare — no value after the colon
+        ]);
+
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.Null(appt!.Organizer);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test gap 4c: CUTYPE=RESOURCE → Resource; ROLE=NON-PARTICIPANT → Optional
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void CuTypeResource_MapsToResource()
+    {
+        // CUTYPE=RESOURCE is the generic non-room resource; should map to AttendeeKind.Resource.
+        var group = GroupWithAttendees([
+            "ATTENDEE;CN=Projector;CUTYPE=RESOURCE;ROLE=REQ-PARTICIPANT:mailto:projector@example.com",
+        ]);
+
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.Single(appt!.Attendees);
+        Assert.Equal(AttendeeKind.Resource, appt.Attendees[0].Kind);
+    }
+
+    [Fact]
+    public void RoleNonParticipant_MapsToOptional()
+    {
+        // ROLE=NON-PARTICIPANT: observer/informational; maps to Optional (Cc row).
+        var group = GroupWithAttendees([
+            "ATTENDEE;CN=Observer;ROLE=NON-PARTICIPANT:mailto:observer@example.com",
+        ]);
+
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.Single(appt!.Attendees);
+        Assert.Equal(AttendeeKind.Optional, appt.Attendees[0].Kind);
+    }
+
+    // -----------------------------------------------------------------------
     // Malformed line: forwards warning, mapping still returns a record
     // -----------------------------------------------------------------------
 

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperGoidTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperGoidTests.cs
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Text;
+using Mail2Pst.Core.Calendar;
+using Mail2Pst.Core.Models;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Calendar;
+
+/// <summary>
+/// Tests that <see cref="CalendarEventMapper.Map"/> correctly wires <see cref="GlobalObjectIdCodec"/>
+/// to set <see cref="AppointmentRecord.GlobalObjectId"/> for Exchange-cached events.
+/// </summary>
+public class CalendarEventMapperGoidTests
+{
+    // A 112-char Exchange GOID hex string (bytes 16-19 already zero).
+    private const string ExchangeGoidHex =
+        "040000008200E00074C5B7101A82E00800000000B40F44F359B6DC01000000000000000010000000DC21992D2F90224BB5EE6F8189627094";
+
+    private static long MicrosFor(int year, int month, int day, int hour = 0, int minute = 0) =>
+        new DateTimeOffset(year, month, day, hour, minute, 0, TimeSpan.Zero).ToUnixTimeMilliseconds() * 1000L;
+
+    private static RawEventGroup SimpleGroup(string eventId)
+    {
+        var ev = new RawEvent
+        {
+            Id           = eventId,
+            Title        = "Test Event",
+            EventStart   = MicrosFor(2026, 8, 1, 10, 0),
+            EventStartTz = "UTC",
+            EventEnd     = MicrosFor(2026, 8, 1, 11, 0),
+            EventEndTz   = "UTC",
+            Flags        = 0,
+            Priority     = 5,
+        };
+        return new RawEventGroup { Master = ev };
+    }
+
+    [Fact]
+    public void Exchange_hex_event_id_sets_GlobalObjectId()
+    {
+        var group = SimpleGroup(ExchangeGoidHex);
+        var rec = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(rec);
+        Assert.NotNull(rec!.GlobalObjectId);
+        Assert.Equal(56, rec.GlobalObjectId!.Length);
+        Assert.Equal(Convert.FromHexString(ExchangeGoidHex), rec.GlobalObjectId);
+    }
+
+    [Fact]
+    public void Mozilla_uuid_event_id_does_not_set_GlobalObjectId()
+    {
+        var group = SimpleGroup("4ad842d0-1234-5678-9abc-def012345678");
+        var rec = CalendarEventMapper.Map(group, out var warns);
+
+        Assert.NotNull(rec);
+        Assert.Null(rec!.GlobalObjectId);
+        // No warning emitted for a non-Exchange id — it is normal, not an error.
+        Assert.DoesNotContain(warns, w => w.Contains("GlobalObjectId", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperOnlineMeetingTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperOnlineMeetingTests.cs
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Text;
+using Mail2Pst.Core.Calendar;
+using Mail2Pst.Core.Models;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Calendar;
+
+/// <summary>
+/// Tests for online-meeting join-URL preservation in <see cref="CalendarEventMapper.Map"/>.
+/// All data is synthetic/reserved (example.com, teams.example.com, meet.example.com) — no real mail or PII.
+/// </summary>
+public class CalendarEventMapperOnlineMeetingTests
+{
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static long MicrosFor(int year, int month, int day, int hour = 0, int minute = 0) =>
+        new DateTimeOffset(year, month, day, hour, minute, 0, TimeSpan.Zero).ToUnixTimeMilliseconds() * 1000L;
+
+    private static byte[] Utf8(string s) => Encoding.UTF8.GetBytes(s);
+
+    private static RawEventGroup SimpleGroup(Action<RawEvent>? configure = null)
+    {
+        var ev = new RawEvent
+        {
+            Id           = "online-meeting-test@example.com",
+            Title        = "Online Meeting",
+            EventStart   = MicrosFor(2026, 8, 1, 14, 0),
+            EventStartTz = "UTC",
+            EventEnd     = MicrosFor(2026, 8, 1, 15, 0),
+            EventEndTz   = "UTC",
+            Flags        = 0,
+            Priority     = 5,
+        };
+        configure?.Invoke(ev);
+        return new RawEventGroup { Master = ev };
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0;
+        int pos = 0;
+        while ((pos = haystack.IndexOf(needle, pos, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            pos += needle.Length;
+        }
+        return count;
+    }
+
+    // -----------------------------------------------------------------------
+    // Teams X-prop → Body contains URL
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Teams_join_url_is_ensured_in_body()
+    {
+        const string joinUrl = "https://teams.example.com/l/x";
+
+        var group = SimpleGroup(e =>
+        {
+            e.Properties.Add(new RawProperty("DESCRIPTION", Utf8("Meeting agenda."), null, null));
+            e.Properties.Add(new RawProperty("X-MICROSOFT-SKYPETEAMSMEETINGURL", Utf8(joinUrl), null, null));
+        });
+
+        var rec = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(rec);
+        Assert.Contains(joinUrl, rec!.Body ?? "");
+    }
+
+    // -----------------------------------------------------------------------
+    // Google Meet X-prop → Body contains URL
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Google_meet_join_url_is_ensured_in_body()
+    {
+        const string joinUrl = "https://meet.example.com/abc";
+
+        var group = SimpleGroup(e =>
+        {
+            e.Properties.Add(new RawProperty("DESCRIPTION", Utf8("Stand-up notes."), null, null));
+            e.Properties.Add(new RawProperty("X-GOOGLE-CONFERENCE", Utf8(joinUrl), null, null));
+        });
+
+        var rec = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(rec);
+        Assert.Contains(joinUrl, rec!.Body ?? "");
+    }
+
+    // -----------------------------------------------------------------------
+    // URL already in DESCRIPTION → not duplicated (appears exactly once)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Join_url_already_in_body_is_not_duplicated()
+    {
+        const string joinUrl = "https://teams.example.com/l/x";
+
+        var group = SimpleGroup(e =>
+        {
+            // DESCRIPTION already contains the join URL.
+            e.Properties.Add(new RawProperty("DESCRIPTION", Utf8($"Join: {joinUrl}"), null, null));
+            e.Properties.Add(new RawProperty("X-MICROSOFT-SKYPETEAMSMEETINGURL", Utf8(joinUrl), null, null));
+        });
+
+        var rec = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(rec);
+        Assert.Equal(1, CountOccurrences(rec!.Body ?? "", joinUrl));
+    }
+
+    // -----------------------------------------------------------------------
+    // No provider X-prop → Body identical to DESCRIPTION (no synthetic append)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Plain_appointment_body_unchanged_when_no_provider_xprop()
+    {
+        const string description = "Just a plain meeting with no online-meeting X-prop.";
+
+        var group = SimpleGroup(e =>
+        {
+            e.Properties.Add(new RawProperty("DESCRIPTION", Utf8(description), null, null));
+            // Intentionally no X-MICROSOFT-SKYPETEAMSMEETINGURL or X-GOOGLE-CONFERENCE.
+            // A URL in DESCRIPTION alone must NOT trigger an append.
+            e.Properties.Add(new RawProperty("LOCATION", Utf8("https://ordinary-url.example.com"), null, null));
+        });
+
+        var rec = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(rec);
+        Assert.Equal(description, rec!.Body);
+    }
+
+    // -----------------------------------------------------------------------
+    // Teams + BodyHtml (ALTREP) present → BodyHtml also contains URL
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Teams_join_url_is_ensured_in_html_body_too()
+    {
+        const string joinUrl = "https://teams.example.com/l/x";
+
+        // Build an ALTREP data URI with HTML that does NOT already contain the join URL.
+        var html    = "<p>Meeting notes.</p>";
+        var b64     = Convert.ToBase64String(Encoding.UTF8.GetBytes(html));
+        var dataUri = $"data:text/html;base64,{b64}";
+
+        var group = SimpleGroup(e =>
+        {
+            e.Properties.Add(new RawProperty("DESCRIPTION", Utf8("Meeting notes."), null, null));
+            e.Properties.Add(new RawProperty("X-MICROSOFT-SKYPETEAMSMEETINGURL", Utf8(joinUrl), null, null));
+            e.Parameters.Add(new RawParameter("DESCRIPTION", "ALTREP", dataUri, null, null));
+        });
+
+        var rec = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(rec);
+        Assert.Contains(joinUrl, rec!.BodyHtml ?? "");
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperRelationTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperRelationTests.cs
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Calendar;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Writing;
+using PSTFileFormat;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Calendar;
+
+/// <summary>
+/// TDD tests for cal_relations preservation:
+///   (a) mapper pure-unit — field set + warning emitted;
+///   (b) writer round-trip — PidTagBody contains the appendix line.
+/// All data is synthetic/reserved (example.com) — no real mail or PII.
+/// </summary>
+public class CalendarEventMapperRelationTests
+{
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static long MicrosFor(int year, int month, int day, int hour = 0, int minute = 0) =>
+        new DateTimeOffset(year, month, day, hour, minute, 0, TimeSpan.Zero).ToUnixTimeMilliseconds() * 1000L;
+
+    private static RawEventGroup SimpleGroup(Action<RawEvent>? configure = null)
+    {
+        var ev = new RawEvent
+        {
+            Id           = "relation-test-event@example.com",
+            Title        = "Meeting With Relations",
+            EventStart   = MicrosFor(2026, 8, 1, 14, 0),
+            EventStartTz = "UTC",
+            EventEnd     = MicrosFor(2026, 8, 1, 15, 0),
+            EventEndTz   = "UTC",
+            Flags        = 0,
+            Priority     = 5,
+        };
+        configure?.Invoke(ev);
+        return new RawEventGroup { Master = ev };
+    }
+
+    // -----------------------------------------------------------------------
+    // Mapper unit tests
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Relations_are_collected_with_warning()
+    {
+        var group = SimpleGroup(e =>
+            e.Relations.Add(new RawSideText("RELATED-TO;RELTYPE=PARENT:uid-123")));
+
+        var rec = CalendarEventMapper.Map(group, out var warns);
+
+        Assert.NotNull(rec);
+        Assert.Contains("RELATED-TO;RELTYPE=PARENT:uid-123", rec!.Relations);
+        Assert.Contains(warns, w => w.Contains("relation") && w.Contains("not natively converted"));
+    }
+
+    [Fact]
+    public void Empty_relations_produce_no_warnings()
+    {
+        var group = SimpleGroup(); // no relations
+
+        var rec = CalendarEventMapper.Map(group, out var warns);
+
+        Assert.NotNull(rec);
+        Assert.Empty(rec!.Relations);
+        Assert.DoesNotContain(warns, w => w.Contains("relation") && w.Contains("not natively converted"));
+    }
+
+    [Fact]
+    public void Multiple_relations_each_produce_a_warning()
+    {
+        var group = SimpleGroup(e =>
+        {
+            e.Relations.Add(new RawSideText("RELATED-TO;RELTYPE=PARENT:uid-A"));
+            e.Relations.Add(new RawSideText("RELATED-TO;RELTYPE=CHILD:uid-B"));
+        });
+
+        var rec = CalendarEventMapper.Map(group, out var warns);
+
+        Assert.NotNull(rec);
+        Assert.Equal(2, rec!.Relations.Count);
+        Assert.Equal(2, warns.Count(w => w.Contains("relation") && w.Contains("not natively converted")));
+    }
+
+    [Fact]
+    public void Whitespace_only_relation_lines_are_dropped()
+    {
+        var group = SimpleGroup(e =>
+        {
+            e.Relations.Add(new RawSideText("   "));
+            e.Relations.Add(new RawSideText("RELATED-TO:uid-real"));
+        });
+
+        var rec = CalendarEventMapper.Map(group, out var warns);
+
+        Assert.NotNull(rec);
+        Assert.Single(rec!.Relations);
+        Assert.Equal("RELATED-TO:uid-real", rec.Relations[0]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Writer round-trip
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Writer_body_contains_relation_appendix()
+    {
+        var start = new DateTime(2026, 8, 1, 14, 0, 0, DateTimeKind.Utc);
+        var end   = new DateTime(2026, 8, 1, 15, 0, 0, DateTimeKind.Utc);
+
+        var rec = new AppointmentRecord
+        {
+            Subject   = "Test Relation",
+            StartUtc  = start,
+            EndUtc    = end,
+            Relations = new[] { "RELATED-TO;RELTYPE=PARENT:uid-123" },
+        };
+
+        string path = Path.Combine(Path.GetTempPath(), $"m2p-rel-{Guid.NewGuid():N}.pst");
+        PSTFile? pst = null;
+        try
+        {
+            PSTFile.CreateEmptyStore(path);
+
+            try
+            {
+                pst = new PSTFile(path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+                pst.BeginSavingChanges();
+                PSTFolder folder = pst.TopOfPersonalFolders.CreateChildFolder(
+                    "Calendar", FolderItemTypeName.Appointment);
+                new AppointmentWriter().WriteAppointment(pst, folder, rec);
+                folder.SaveChanges();
+                pst.EndSavingChanges();
+            }
+            finally { pst?.CloseFile(); pst = null; }
+
+            try
+            {
+                pst = new PSTFile(path, FileAccess.Read, WriterCompatibilityMode.Outlook2007RTM);
+                PSTFolder found = pst.TopOfPersonalFolders.FindChildFolder("Calendar");
+                CalendarFolder cal = Assert.IsType<CalendarFolder>(found);
+                Appointment appt = cal.GetAppointment(0);
+                string body = appt.PC.GetStringProperty(PropertyID.PidTagBody) ?? "";
+
+                Assert.Contains("[Thunderbird relation not natively converted: RELATED-TO;RELTYPE=PARENT:uid-123]", body);
+            }
+            finally { pst?.CloseFile(); pst = null; }
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
@@ -175,8 +175,8 @@ public class CalendarEventMapperTests
 
         Assert.NotNull(appt);
         Assert.Null(appt.TimeZone);
-        // TimeZoneResolver emits "no TZ description" + mapper adds floating/unresolved warning
-        Assert.True(warnings.Count >= 1, "Expected at least one warning for no-TZ event");
+        // Exactly two warnings: resolver emits "no TZ description", mapper adds "floating/unresolved timezone"
+        Assert.Equal(2, warnings.Count);
         Assert.Contains("floating/unresolved timezone", string.Join(" ", warnings));
     }
 
@@ -232,6 +232,38 @@ public class CalendarEventMapperTests
         Assert.True(appt.IsAllDay);
         Assert.Equal(new DateTime(2026, 7, 15, 0, 0, 0, DateTimeKind.Utc), appt.StartUtc);
         Assert.Equal(new DateTime(2026, 7, 16, 0, 0, 0, DateTimeKind.Utc), appt.EndUtc);
+    }
+
+    [Fact]
+    public void AllDayEvent_NullEventStart_UsesSentinelDateAndWarns()
+    {
+        // All-day event where EventStart is null → must not use DateTime.UtcNow
+        // (non-deterministic). Should fall back to default(DateTime) and warn.
+        var group = SimpleGroup(e =>
+        {
+            e.Title        = "Sentinel Holiday";
+            e.Flags        = 4; // EVENT_ALLDAY
+            e.EventStart   = null;
+            e.EventStartTz = "UTC";
+            e.EventEnd     = null;
+            e.EventEndTz   = "UTC";
+        });
+
+        var appt1 = CalendarEventMapper.Map(group, out var warnings1);
+        var appt2 = CalendarEventMapper.Map(group, out var warnings2);
+
+        Assert.NotNull(appt1);
+        Assert.True(appt1.IsAllDay);
+
+        // Sentinel date — default(DateTime) round-tripped through UTC midnight
+        Assert.Equal(default(DateTime), appt1.StartUtc);
+
+        // Warning emitted for missing start
+        Assert.Contains(warnings1, w => w.Contains("missing start"));
+
+        // Deterministic: two calls produce identical output
+        Assert.Equal(appt1.StartUtc, appt2.StartUtc);
+        Assert.Equal(warnings1.Count, warnings2.Count);
     }
 
     // -----------------------------------------------------------------------

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
@@ -339,11 +339,48 @@ public class CalendarEventMapperTests
     }
 
     // -----------------------------------------------------------------------
-    // All-day event with unresolved timezone → TimeZone=Utc + warn
+    // Floating all-day event → anchored to LOCAL zone (local-midnight-in-UTC)
     // -----------------------------------------------------------------------
 
     [Fact]
-    public void AllDayEvent_UnresolvedTimezone_UsesUtcAndWarn()
+    public void AllDayEvent_FloatingTimezone_AnchorsToLocalMidnightInUtc()
+    {
+        // Regression (real Thunderbird all-day events are floating): a floating all-day event must
+        // anchor midnight to the machine LOCAL zone (local-midnight-in-UTC) and carry that zone —
+        // NOT UTC. Anchoring to UTC makes the event straddle two calendar days for any viewer east
+        // of UTC (e.g. a UTC+2 viewer sees a one-day event span both days).
+        var group = SimpleGroup(e =>
+        {
+            e.Title        = "Company Holiday";
+            e.Flags        = 8 | 4;                       // EVENT_ALLDAY | HAS_PROPERTIES
+            e.EventStart   = MicrosFor(2026, 7, 1, 0, 0); // floating wall-clock July 1 00:00
+            e.EventStartTz = "floating";
+            e.EventEnd     = MicrosFor(2026, 7, 2, 0, 0);
+            e.EventEndTz   = "floating";
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.True(appt!.IsAllDay);
+        Assert.Equal(TimeZoneInfo.Local, appt.TimeZone);
+
+        // local-midnight-in-UTC for July 1 / July 2 — deterministic on any machine (incl. UTC CI,
+        // where Local == UTC so this reduces to UTC midnight).
+        var expStart = TimeZoneInfo.ConvertTimeToUtc(new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Unspecified), TimeZoneInfo.Local);
+        var expEnd   = TimeZoneInfo.ConvertTimeToUtc(new DateTime(2026, 7, 2, 0, 0, 0, DateTimeKind.Unspecified), TimeZoneInfo.Local);
+        Assert.Equal(expStart, appt.StartUtc);
+        Assert.Equal(expEnd, appt.EndUtc);
+        // Genuine floating is normal → no warning.
+        Assert.Empty(warnings);
+    }
+
+    // -----------------------------------------------------------------------
+    // All-day event with unresolved (bogus) timezone → LOCAL anchor + resolver warn
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void AllDayEvent_UnresolvedTimezone_AnchorsToLocalAndWarns()
     {
         var startMicros = MicrosFor(2026, 7, 15, 0, 0);
         var endMicros   = MicrosFor(2026, 7, 16, 0, 0);
@@ -362,7 +399,9 @@ public class CalendarEventMapperTests
 
         Assert.NotNull(appt);
         Assert.True(appt.IsAllDay);
-        Assert.Equal(TimeZoneInfo.Utc, appt.TimeZone);
+        // Unresolvable zone → anchored to LOCAL (same policy as floating), never straddles days.
+        Assert.Equal(TimeZoneInfo.Local, appt.TimeZone);
+        // The resolver still surfaces the lost zone.
         Assert.True(warnings.Count > 0, "Expected a warning for unresolved timezone");
         Assert.Contains("unresolved", string.Join(" ", warnings), StringComparison.OrdinalIgnoreCase);
     }

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
@@ -266,6 +266,29 @@ public class CalendarEventMapperTests
         Assert.Equal(warnings1.Count, warnings2.Count);
     }
 
+    [Fact]
+    public void AllDayEvent_NoEndDate_EndUtcIsExactly24hAfterStartUtc()
+    {
+        // Non-DST zone (UTC): all-day with null end → EndUtc − StartUtc must equal exactly 24 h.
+        var startMicros = MicrosFor(2026, 7, 15, 0, 0);
+
+        var group = SimpleGroup(e =>
+        {
+            e.Title        = "Exact Day Event";
+            e.Flags        = 4; // EVENT_ALLDAY
+            e.EventStart   = startMicros;
+            e.EventStartTz = "UTC";
+            e.EventEnd     = null; // missing end → fallback to one-day boundary
+            e.EventEndTz   = "UTC";
+        });
+
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.True(appt.IsAllDay);
+        Assert.Equal(TimeSpan.FromHours(24), appt.EndUtc - appt.StartUtc);
+    }
+
     // -----------------------------------------------------------------------
     // All-day event with unresolved timezone → TimeZone=Utc + warn
     // -----------------------------------------------------------------------
@@ -377,16 +400,52 @@ public class CalendarEventMapperTests
     }
 
     [Fact]
-    public void BusyStatus_Default_Returns2()
+    public void BusyStatus_Default_TimedEvent_Returns2()
     {
         var group = SimpleGroup(e =>
         {
             e.IcalStatus = null;
+            // no TRANSP property; Flags=0 → timed event
+        });
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.Equal(2, appt.BusyStatus);
+    }
+
+    [Fact]
+    public void BusyStatus_AllDay_NoTransp_NoStatus_Returns0_Free()
+    {
+        // All-day event with no TRANSP and no TENTATIVE → Free (0), not Busy.
+        var group = SimpleGroup(e =>
+        {
+            e.Flags        = 4; // EVENT_ALLDAY
+            e.EventStartTz = "UTC";
+            e.IcalStatus   = null;
             // no TRANSP property
         });
         var appt = CalendarEventMapper.Map(group, out _);
 
         Assert.NotNull(appt);
+        Assert.True(appt.IsAllDay);
+        Assert.Equal(0, appt.BusyStatus);
+    }
+
+    [Fact]
+    public void BusyStatus_AllDay_OpaqueTransp_Returns2_Busy()
+    {
+        // All-day event WITH explicit TRANSP=OPAQUE → Busy (2); explicit wins over all-day default.
+        var group = SimpleGroup(e =>
+        {
+            e.Flags        = 4; // EVENT_ALLDAY
+            e.EventStartTz = "UTC";
+            e.IcalStatus   = null;
+            e.Properties.Add(new RawProperty("TRANSP", Utf8("OPAQUE"), null, null));
+        });
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.True(appt.IsAllDay);
         Assert.Equal(2, appt.BusyStatus);
     }
 

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
@@ -643,6 +643,59 @@ public class CalendarEventMapperTests
     }
 
     /// <summary>
+    /// Should-fix (SF-A): a malformed EXDATE value must be skipped (null), not coerced to
+    /// default(0001-01-01) which would feed the vendored serializer an invalid date; whitespace around a
+    /// valid value must be trimmed.
+    /// </summary>
+    [Fact]
+    public void ToInstanceId_malformed_returns_null_and_trims_whitespace()
+    {
+        Assert.Null(CalendarEventMapper.ToInstanceId("notadate", "UTC", isDateOnly: true));
+
+        var ok = CalendarEventMapper.ToInstanceId("  20260708  ", "UTC", isDateOnly: true);
+        Assert.NotNull(ok);
+        Assert.Equal(new DateTime(2026, 7, 8), ok!.OriginalStartLocal.Date);
+    }
+
+    /// <summary>
+    /// Should-fix (SF-A): an absolute alarm firing AT or AFTER the event start must be dropped with a
+    /// warning (not silently clamped to fire-at-start), matching the relative-trigger path.
+    /// </summary>
+    [Fact]
+    public void Alarm_AbsoluteAtOrAfterStart_NotConvertedAndWarnAndBodyPreserved()
+    {
+        // SimpleGroup starts 2026-07-10 14:00 UTC; absolute trigger at 15:00 UTC is after start.
+        var group = SimpleGroup(e => e.Alarms.Add(new RawSideText(
+            "BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER;VALUE=DATE-TIME:20260710T150000Z\r\nEND:VALARM")));
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.False(appt!.ReminderSet);
+        Assert.Equal(0, appt.ReminderMinutesBefore);
+        Assert.Contains(warnings, x => x.Contains("at/after"));
+        Assert.NotNull(appt.Body);
+        Assert.Contains("[Thunderbird alarm not converted:", appt.Body);
+    }
+
+    /// <summary>
+    /// Should-fix (SF-A): a VALARM that parses but yields no usable trigger (no TRIGGER line) must be
+    /// dropped with a warning, not silently ignored. (There is no TRIGGER text to preserve in the body.)
+    /// </summary>
+    [Fact]
+    public void Alarm_NoTrigger_NotConvertedAndWarned()
+    {
+        var group = SimpleGroup(e => e.Alarms.Add(new RawSideText(
+            "BEGIN:VALARM\r\nACTION:DISPLAY\r\nEND:VALARM")));
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.False(appt!.ReminderSet);
+        Assert.Contains(warnings, x => x.Contains("no usable trigger"));
+    }
+
+    /// <summary>
     /// Pre-merge review #6: a RELATED=END reminder must fire relative to the event END, not START.
     /// For the 60-min SimpleGroup event (14:00–15:00 UTC) with TRIGGER;RELATED=END:-PT15M the reminder
     /// fires at 14:45 = 45 min AFTER start, so PidLidReminderDelta (minutes-before-start) is -45 and the

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
@@ -197,7 +197,7 @@ public class CalendarEventMapperTests
         var group = SimpleGroup(e =>
         {
             e.Title        = "Company Holiday";
-            e.Flags        = 4; // EVENT_ALLDAY
+            e.Flags        = 8; // EVENT_ALLDAY
             e.EventStart   = startMicros;
             e.EventStartTz = "UTC";
             e.EventEnd     = endMicros;
@@ -214,6 +214,53 @@ public class CalendarEventMapperTests
     }
 
     [Fact]
+    public void EventWithPropertiesFlagButNotAllDayBit_IsTimedNotAllDay()
+    {
+        // Regression (real Thunderbird data): Mozilla flags bit 4 = HAS_PROPERTIES,
+        // bit 8 = EVENT_ALLDAY. Nearly every real event has HAS_PROPERTIES set
+        // (DESCRIPTION/LOCATION live in cal_properties), so a timed event routinely
+        // arrives with (flags & 4) != 0. All-day detection must key on bit 8 only —
+        // otherwise every event renders as all-day in Outlook.
+        var group = SimpleGroup(e =>
+        {
+            e.Title        = "Team Standup";
+            e.Flags        = 4 | 16 | 256; // HAS_PROPERTIES | HAS_RECURRENCE | HAS_ALARMS, NOT EVENT_ALLDAY
+            e.EventStart   = MicrosFor(2026, 7, 13, 9, 0);
+            e.EventStartTz = "UTC";
+            e.EventEnd     = MicrosFor(2026, 7, 13, 9, 15);
+            e.EventEndTz   = "UTC";
+        });
+
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.False(appt!.IsAllDay);
+        // Timed boundaries preserved (not snapped to midnight).
+        Assert.Equal(new DateTime(2026, 7, 13, 9, 0, 0, DateTimeKind.Utc), appt.StartUtc);
+        Assert.Equal(new DateTime(2026, 7, 13, 9, 15, 0, DateTimeKind.Utc), appt.EndUtc);
+    }
+
+    [Fact]
+    public void EventWithAllDayBitSet_IsAllDay()
+    {
+        // The genuine all-day flag is bit 8 (EVENT_ALLDAY), here OR'd with HAS_PROPERTIES.
+        var group = SimpleGroup(e =>
+        {
+            e.Title        = "Company Anniversary";
+            e.Flags        = 8 | 4; // EVENT_ALLDAY | HAS_PROPERTIES
+            e.EventStart   = MicrosFor(2026, 7, 15, 0, 0);
+            e.EventStartTz = "UTC";
+            e.EventEnd     = MicrosFor(2026, 7, 16, 0, 0);
+            e.EventEndTz   = "UTC";
+        });
+
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.True(appt!.IsAllDay);
+    }
+
+    [Fact]
     public void AllDayEvent_EndEqualStart_EndSetToOneDayLater()
     {
         var startMicros = MicrosFor(2026, 7, 15, 0, 0);
@@ -221,7 +268,7 @@ public class CalendarEventMapperTests
         var group = SimpleGroup(e =>
         {
             e.Title        = "Single Day Holiday";
-            e.Flags        = 4;
+            e.Flags        = 8;
             e.EventStart   = startMicros;
             e.EventStartTz = "UTC";
             e.EventEnd     = startMicros; // same as start
@@ -244,7 +291,7 @@ public class CalendarEventMapperTests
         var group = SimpleGroup(e =>
         {
             e.Title        = "Sentinel Holiday";
-            e.Flags        = 4; // EVENT_ALLDAY
+            e.Flags        = 8; // EVENT_ALLDAY
             e.EventStart   = null;
             e.EventStartTz = "UTC";
             e.EventEnd     = null;
@@ -277,7 +324,7 @@ public class CalendarEventMapperTests
         var group = SimpleGroup(e =>
         {
             e.Title        = "Exact Day Event";
-            e.Flags        = 4; // EVENT_ALLDAY
+            e.Flags        = 8; // EVENT_ALLDAY
             e.EventStart   = startMicros;
             e.EventStartTz = "UTC";
             e.EventEnd     = null; // missing end → fallback to one-day boundary
@@ -304,7 +351,7 @@ public class CalendarEventMapperTests
         var group = SimpleGroup(e =>
         {
             e.Title        = "Holiday";
-            e.Flags        = 4;
+            e.Flags        = 8;
             e.EventStart   = startMicros;
             e.EventStartTz = "Unknown/Bogus_Timezone_99";
             e.EventEnd     = endMicros;
@@ -421,7 +468,7 @@ public class CalendarEventMapperTests
         // All-day event with no TRANSP and no TENTATIVE → Free (0), not Busy.
         var group = SimpleGroup(e =>
         {
-            e.Flags        = 4; // EVENT_ALLDAY
+            e.Flags        = 8; // EVENT_ALLDAY
             e.EventStartTz = "UTC";
             e.IcalStatus   = null;
             // no TRANSP property
@@ -439,7 +486,7 @@ public class CalendarEventMapperTests
         // All-day event WITH explicit TRANSP=OPAQUE → Busy (2); explicit wins over all-day default.
         var group = SimpleGroup(e =>
         {
-            e.Flags        = 4; // EVENT_ALLDAY
+            e.Flags        = 8; // EVENT_ALLDAY
             e.EventStartTz = "UTC";
             e.IcalStatus   = null;
             e.Properties.Add(new RawProperty("TRANSP", Utf8("OPAQUE"), null, null));
@@ -643,7 +690,7 @@ public class CalendarEventMapperTests
         var group = SimpleGroup(e =>
         {
             e.Title        = "Weekly Review";
-            e.Flags        = 4; // EVENT_ALLDAY
+            e.Flags        = 8; // EVENT_ALLDAY
             e.EventStart   = MicrosFor(2026, 7, 13, 0, 0); // Monday 2026-07-13
             e.EventEnd     = MicrosFor(2026, 7, 14, 0, 0);
             e.EventStartTz = "UTC";

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
@@ -87,7 +87,7 @@ public class CalendarEventMapperTests
 
         Assert.NotNull(result);
         Assert.NotNull(result!.Recurrence);
-        Assert.Equal(AppointmentRecurrenceFrequency.Daily, result.Recurrence!.Frequency);
+        Assert.Equal(RecurrenceFrequency.Daily, result.Recurrence!.Frequency);
         Assert.Empty(warnings);
     }
 
@@ -684,7 +684,7 @@ public class CalendarEventMapperTests
 
         Assert.NotNull(appt);
         Assert.NotNull(appt!.Recurrence);
-        Assert.Equal(AppointmentRecurrenceFrequency.Daily, appt.Recurrence!.Frequency);
+        Assert.Equal(RecurrenceFrequency.Daily, appt.Recurrence!.Frequency);
         Assert.Equal("Europe/Copenhagen", appt.OriginatingTimeZoneId);
         Assert.Equal("Europe/Copenhagen", appt.Recurrence.OriginatingTimeZoneId);
     }
@@ -742,7 +742,7 @@ public class CalendarEventMapperTests
         Assert.NotNull(appt);
         Assert.True(appt!.IsAllDay);
         Assert.NotNull(appt.Recurrence);
-        Assert.Equal(AppointmentRecurrenceFrequency.Weekly, appt.Recurrence!.Frequency);
+        Assert.Equal(RecurrenceFrequency.Weekly, appt.Recurrence!.Frequency);
         Assert.Contains(DayOfWeek.Monday, appt.Recurrence.DaysOfWeek);
         Assert.Equal(RecurrenceEndKind.Count, appt.Recurrence.EndKind);
         Assert.Equal(4, appt.Recurrence.Count);
@@ -946,7 +946,7 @@ public class CalendarEventMapperTests
 
         Assert.NotNull(appt);
         Assert.NotNull(appt!.Recurrence);
-        Assert.Equal(AppointmentRecurrenceFrequency.Weekly, appt.Recurrence!.Frequency);
+        Assert.Equal(RecurrenceFrequency.Weekly, appt.Recurrence!.Frequency);
         // RFC 5545: bare FREQ=WEEKLY (no BYDAY) must recur on the DTSTART weekday (Monday here).
         Assert.Equal(new[] { DayOfWeek.Monday }, appt.Recurrence.DaysOfWeek);
         Assert.Empty(warnings);
@@ -976,7 +976,7 @@ public class CalendarEventMapperTests
 
         Assert.NotNull(appt);
         Assert.NotNull(appt!.Recurrence);
-        Assert.Equal(AppointmentRecurrenceFrequency.Yearly, appt.Recurrence!.Frequency);
+        Assert.Equal(RecurrenceFrequency.Yearly, appt.Recurrence!.Frequency);
         Assert.Empty(warnings);
     }
 
@@ -998,7 +998,7 @@ public class CalendarEventMapperTests
 
         Assert.NotNull(appt);
         Assert.NotNull(appt!.Recurrence);
-        Assert.Equal(AppointmentRecurrenceFrequency.Monthly, appt.Recurrence!.Frequency);
+        Assert.Equal(RecurrenceFrequency.Monthly, appt.Recurrence!.Frequency);
         Assert.Empty(warnings);
     }
 
@@ -1045,7 +1045,7 @@ public class CalendarEventMapperTests
 
         Assert.NotNull(appt);
         Assert.NotNull(appt!.Recurrence);
-        Assert.Equal(AppointmentRecurrenceFrequency.YearlyNth, appt.Recurrence!.Frequency);
+        Assert.Equal(RecurrenceFrequency.YearlyNth, appt.Recurrence!.Frequency);
         Assert.Equal(2, appt.Recurrence.NthOccurrence);
         Assert.Empty(warnings);
     }

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
@@ -1,0 +1,560 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Mail2Pst.Core.Calendar;
+using Mail2Pst.Core.Models;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Calendar;
+
+/// <summary>
+/// Unit tests for <see cref="CalendarEventMapper.Map"/>.
+/// All data is synthetic/reserved (example.com, example.org) — no real mail or PII.
+/// </summary>
+public class CalendarEventMapperTests
+{
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static long MicrosFor(int year, int month, int day, int hour = 0, int minute = 0) =>
+        new DateTimeOffset(year, month, day, hour, minute, 0, TimeSpan.Zero).ToUnixTimeMilliseconds() * 1000L;
+
+    private static byte[] Utf8(string s) => Encoding.UTF8.GetBytes(s);
+
+    private static RawEventGroup SimpleGroup(Action<RawEvent>? configure = null)
+    {
+        var ev = new RawEvent
+        {
+            Id          = "event-example-001@example.com",
+            Title       = "Example Event",
+            EventStart  = MicrosFor(2026, 7, 10, 14, 0),
+            EventStartTz = "UTC",
+            EventEnd    = MicrosFor(2026, 7, 10, 15, 0),
+            EventEndTz  = "UTC",
+            Flags       = 0,
+            Priority    = 5,
+            Privacy     = null,
+            IcalStatus  = null,
+        };
+        configure?.Invoke(ev);
+        return new RawEventGroup { Master = ev };
+    }
+
+    // -----------------------------------------------------------------------
+    // Group-skip rules
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void NullMaster_ReturnsNullWithOrphanWarning()
+    {
+        var group = new RawEventGroup(); // Master == null
+        var result = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.Null(result);
+        Assert.Single(warnings);
+        Assert.Contains("orphan event override (no master) skipped", warnings[0]);
+    }
+
+    [Fact]
+    public void GroupWithOverrides_ReturnsNullWithRecurringWarning()
+    {
+        var group = new RawEventGroup
+        {
+            Master    = new RawEvent { Id = "e1@example.com", Title = "Weekly Standup" },
+            Overrides = new List<RawEvent> { new RawEvent { Id = "e1@example.com" } }
+        };
+        var result = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.Null(result);
+        Assert.Single(warnings);
+        Assert.Contains("recurring event 'Weekly Standup' with exceptions deferred to PR7", warnings[0]);
+    }
+
+    [Fact]
+    public void MasterWithRecurrenceLine_ReturnsNullWithRecurringWarning()
+    {
+        var group = SimpleGroup(e =>
+        {
+            e.Title = "Daily Sync";
+            e.Recurrence.Add(new RawSideText("RRULE:FREQ=DAILY"));
+        });
+        var result = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.Null(result);
+        Assert.Single(warnings);
+        Assert.Contains("recurring event 'Daily Sync' deferred to PR7", warnings[0]);
+    }
+
+    [Fact]
+    public void MasterWithRecurrenceIdSet_ReturnsNullWithOverrideWarning()
+    {
+        var group = SimpleGroup(e =>
+        {
+            e.RecurrenceId = MicrosFor(2026, 7, 10);
+        });
+        var result = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.Null(result);
+        Assert.Single(warnings);
+        Assert.Contains("event override row deferred to PR7", warnings[0]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Flat timed event with resolved timezone
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void FlatTimedEvent_ResolvedTimezone_MapsFieldsCorrectly()
+    {
+        var startMicros = MicrosFor(2026, 7, 10, 12, 0);
+        var endMicros   = MicrosFor(2026, 7, 10, 13, 0);
+
+        var group = SimpleGroup(e =>
+        {
+            e.Id           = "flat-event-001@example.com";
+            e.Title        = "Team Meeting";
+            e.EventStart   = startMicros;
+            e.EventStartTz = "UTC";
+            e.EventEnd     = endMicros;
+            e.EventEndTz   = "UTC";
+            e.Flags        = 0;
+            e.Properties.Add(new RawProperty("DESCRIPTION", Utf8("Meeting agenda."), null, null));
+            e.Properties.Add(new RawProperty("LOCATION",    Utf8("Room 101"),         null, null));
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.Empty(warnings);
+        Assert.Equal("flat-event-001@example.com", appt.SourceId);
+        Assert.Equal("Team Meeting", appt.Subject);
+        Assert.Equal("Meeting agenda.", appt.Body);
+        Assert.Equal("Room 101", appt.Location);
+        Assert.False(appt.IsAllDay);
+        Assert.NotNull(appt.TimeZone);
+        Assert.Equal(TimeZoneInfo.Utc, appt.TimeZone);
+        Assert.Equal(new DateTime(2026, 7, 10, 12, 0, 0, DateTimeKind.Utc), appt.StartUtc);
+        Assert.Equal(new DateTime(2026, 7, 10, 13, 0, 0, DateTimeKind.Utc), appt.EndUtc);
+    }
+
+    // -----------------------------------------------------------------------
+    // Timed event with floating/unresolved timezone → TimeZone=null + warn
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void TimedEvent_FloatingTimezone_TimeZoneNullAndWarn()
+    {
+        var group = SimpleGroup(e =>
+        {
+            e.Title        = "Floating Meeting";
+            e.EventStartTz = ""; // floating
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.Null(appt.TimeZone);
+        Assert.Single(warnings);
+        Assert.Contains("floating/unresolved timezone", warnings[0]);
+    }
+
+    [Fact]
+    public void TimedEvent_NoTzDescription_TimeZoneNullAndWarn()
+    {
+        var group = SimpleGroup(e =>
+        {
+            e.Title        = "No-TZ Event";
+            e.EventStartTz = "(no TZ description)";
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.Null(appt.TimeZone);
+        // TimeZoneResolver emits "no TZ description" + mapper adds floating/unresolved warning
+        Assert.True(warnings.Count >= 1, "Expected at least one warning for no-TZ event");
+        Assert.Contains("floating/unresolved timezone", string.Join(" ", warnings));
+    }
+
+    // -----------------------------------------------------------------------
+    // All-day event with timezone
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void AllDayEvent_ResolvedTimezone_IsAllDayTrueAndMidnightBoundaries()
+    {
+        // 2026-07-15 as an all-day event in UTC
+        // UTC midnight = 2026-07-15T00:00:00Z
+        var startMicros = MicrosFor(2026, 7, 15, 0, 0);
+        var endMicros   = MicrosFor(2026, 7, 16, 0, 0);
+
+        var group = SimpleGroup(e =>
+        {
+            e.Title        = "Company Holiday";
+            e.Flags        = 4; // EVENT_ALLDAY
+            e.EventStart   = startMicros;
+            e.EventStartTz = "UTC";
+            e.EventEnd     = endMicros;
+            e.EventEndTz   = "UTC";
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.True(appt.IsAllDay);
+        Assert.NotNull(appt.TimeZone);
+        Assert.Equal(new DateTime(2026, 7, 15, 0, 0, 0, DateTimeKind.Utc), appt.StartUtc);
+        Assert.Equal(new DateTime(2026, 7, 16, 0, 0, 0, DateTimeKind.Utc), appt.EndUtc);
+    }
+
+    [Fact]
+    public void AllDayEvent_EndEqualStart_EndSetToOneDayLater()
+    {
+        var startMicros = MicrosFor(2026, 7, 15, 0, 0);
+
+        var group = SimpleGroup(e =>
+        {
+            e.Title        = "Single Day Holiday";
+            e.Flags        = 4;
+            e.EventStart   = startMicros;
+            e.EventStartTz = "UTC";
+            e.EventEnd     = startMicros; // same as start
+            e.EventEndTz   = "UTC";
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.True(appt.IsAllDay);
+        Assert.Equal(new DateTime(2026, 7, 15, 0, 0, 0, DateTimeKind.Utc), appt.StartUtc);
+        Assert.Equal(new DateTime(2026, 7, 16, 0, 0, 0, DateTimeKind.Utc), appt.EndUtc);
+    }
+
+    // -----------------------------------------------------------------------
+    // All-day event with unresolved timezone → TimeZone=Utc + warn
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void AllDayEvent_UnresolvedTimezone_UsesUtcAndWarn()
+    {
+        var startMicros = MicrosFor(2026, 7, 15, 0, 0);
+        var endMicros   = MicrosFor(2026, 7, 16, 0, 0);
+
+        var group = SimpleGroup(e =>
+        {
+            e.Title        = "Holiday";
+            e.Flags        = 4;
+            e.EventStart   = startMicros;
+            e.EventStartTz = "Unknown/Bogus_Timezone_99";
+            e.EventEnd     = endMicros;
+            e.EventEndTz   = "Unknown/Bogus_Timezone_99";
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.True(appt.IsAllDay);
+        Assert.Equal(TimeZoneInfo.Utc, appt.TimeZone);
+        Assert.True(warnings.Count > 0, "Expected a warning for unresolved timezone");
+        Assert.Contains("unresolved", string.Join(" ", warnings), StringComparison.OrdinalIgnoreCase);
+    }
+
+    // -----------------------------------------------------------------------
+    // EndUtc < StartUtc → warn + clamp
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void TimedEvent_EndPrecedesStart_ClampsEndToStart()
+    {
+        var startMicros = MicrosFor(2026, 7, 10, 14, 0);
+        var endMicros   = MicrosFor(2026, 7, 10, 13, 0); // before start
+
+        var group = SimpleGroup(e =>
+        {
+            e.Title      = "Bad Times Event";
+            e.EventStart = startMicros;
+            e.EventEnd   = endMicros;
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.Equal(appt.StartUtc, appt.EndUtc);
+        Assert.True(warnings.Count > 0);
+        Assert.Contains("end precedes start", warnings[0]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Zero-length event → warn (allowed)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void TimedEvent_ZeroLength_AllowedWithWarn()
+    {
+        var startMicros = MicrosFor(2026, 7, 10, 14, 0);
+
+        var group = SimpleGroup(e =>
+        {
+            e.Title      = "Zero Length";
+            e.EventStart = startMicros;
+            e.EventEnd   = startMicros; // same as start
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.Equal(appt.StartUtc, appt.EndUtc);
+        Assert.Single(warnings);
+        Assert.Contains("zero-length event", warnings[0]);
+    }
+
+    // -----------------------------------------------------------------------
+    // BusyStatus precedence
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void BusyStatus_Tentative_Returns1()
+    {
+        var group = SimpleGroup(e =>
+        {
+            e.IcalStatus = "TENTATIVE";
+            e.Properties.Add(new RawProperty("TRANSP", Utf8("OPAQUE"), null, null));
+        });
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.Equal(1, appt.BusyStatus);
+    }
+
+    [Fact]
+    public void BusyStatus_TranspTransparent_NoStatus_Returns0()
+    {
+        var group = SimpleGroup(e =>
+        {
+            e.IcalStatus = null;
+            e.Properties.Add(new RawProperty("TRANSP", Utf8("TRANSPARENT"), null, null));
+        });
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.Equal(0, appt.BusyStatus);
+    }
+
+    [Fact]
+    public void BusyStatus_Default_Returns2()
+    {
+        var group = SimpleGroup(e =>
+        {
+            e.IcalStatus = null;
+            // no TRANSP property
+        });
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.Equal(2, appt.BusyStatus);
+    }
+
+    // -----------------------------------------------------------------------
+    // Sensitivity / Privacy
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Privacy_Private_Sensitivity2()
+    {
+        var group = SimpleGroup(e => e.Privacy = "PRIVATE");
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.Equal(2, appt.Sensitivity);
+    }
+
+    // -----------------------------------------------------------------------
+    // ALTREP HTML body
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Altrep_DataUriPercentEncoded_SetsBodyHtml()
+    {
+        // data:text/html;charset=utf-8,<b>Hello</b>  (percent-encoded)
+        var htmlEncoded = Uri.EscapeDataString("<b>Hello</b>");
+        var dataUri = $"data:text/html;charset=utf-8,{htmlEncoded}";
+
+        var group = SimpleGroup(e =>
+        {
+            e.Parameters.Add(new RawParameter("DESCRIPTION", "ALTREP", dataUri, null, null));
+        });
+
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.Equal("<b>Hello</b>", appt.BodyHtml);
+    }
+
+    [Fact]
+    public void Altrep_DataUriBase64_SetsBodyHtml()
+    {
+        var html = "<p>Test</p>";
+        var b64  = Convert.ToBase64String(Encoding.UTF8.GetBytes(html));
+        var dataUri = $"data:text/html;base64,{b64}";
+
+        var group = SimpleGroup(e =>
+        {
+            e.Parameters.Add(new RawParameter("DESCRIPTION", "ALTREP", dataUri, null, null));
+        });
+
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.Equal("<p>Test</p>", appt.BodyHtml);
+    }
+
+    // -----------------------------------------------------------------------
+    // Categories
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Categories_EscapedComma_SplitCorrectly()
+    {
+        var group = SimpleGroup(e =>
+            e.Properties.Add(new RawProperty("CATEGORIES", Utf8(@"A\,B,C"), null, null)));
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.Equal(2, appt.Categories.Count);
+        Assert.Equal("A,B", appt.Categories[0]);
+        Assert.Equal("C",   appt.Categories[1]);
+    }
+
+    [Fact]
+    public void Categories_XMozPrefixed_Dropped()
+    {
+        var group = SimpleGroup(e =>
+            e.Properties.Add(new RawProperty("CATEGORIES", Utf8("Work,X-MOZ-SNOOZE-TIME,Home"), null, null)));
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.Equal(2, appt.Categories.Count);
+        Assert.Equal("Work", appt.Categories[0]);
+        Assert.Equal("Home", appt.Categories[1]);
+    }
+
+    // -----------------------------------------------------------------------
+    // VALARM -PT15M → ReminderSet + ReminderMinutesBefore=15
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Alarm_NegativeTrigger_SetsReminderMinutesBefore()
+    {
+        var group = SimpleGroup(e =>
+        {
+            e.Alarms.Add(new RawSideText(
+                "BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER:-PT15M\r\nEND:VALARM"));
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.True(appt.ReminderSet);
+        Assert.Equal(15, appt.ReminderMinutesBefore);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void Alarm_PositiveTrigger_NoReminderAndWarnAndBodyPreserved()
+    {
+        var group = SimpleGroup(e =>
+        {
+            e.Title = "Post-meeting note";
+            e.Alarms.Add(new RawSideText(
+                "BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER:PT15M\r\nEND:VALARM"));
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.False(appt.ReminderSet);
+        Assert.Equal(0, appt.ReminderMinutesBefore);
+        Assert.True(warnings.Count > 0);
+        Assert.Contains("reminder fires at/after", warnings[0]);
+        Assert.NotNull(appt.Body);
+        Assert.Contains("[Thunderbird alarm not converted:", appt.Body);
+        Assert.Contains("TRIGGER:PT15M", appt.Body);
+    }
+
+    // -----------------------------------------------------------------------
+    // Pending: recurring-event support (PR7)
+    // -----------------------------------------------------------------------
+
+    [Fact(Skip = "Recurring events land in PR7; tracked by this skipped test.")]
+    public void Recurring_event_is_written_with_recurrence_pattern() { /* TODO PR7 */ }
+
+    [Fact(Skip = "Recurring events land in PR7; tracked by this skipped test.")]
+    public void Recurring_event_with_exception_override_is_written_correctly() { /* TODO PR7 */ }
+}
+
+/// <summary>
+/// Unit tests for <see cref="IcalDataUri.TryDecode"/>.
+/// </summary>
+public class IcalDataUriTests
+{
+    [Fact]
+    public void TryDecode_Base64_DecodesCorrectly()
+    {
+        var b64    = Convert.ToBase64String(Encoding.UTF8.GetBytes("hello"));
+        var uri    = $"data:text/html;base64,{b64}";
+        var result = IcalDataUri.TryDecode(uri, out var mediaType, out var bytes);
+
+        Assert.True(result);
+        Assert.Equal("text/html", mediaType);
+        Assert.Equal("hello", Encoding.UTF8.GetString(bytes));
+    }
+
+    [Fact]
+    public void TryDecode_PercentEncoded_DecodesCorrectly()
+    {
+        var encoded = Uri.EscapeDataString("<b>Test</b>");
+        var uri     = $"data:text/html;charset=utf-8,{encoded}";
+        var result  = IcalDataUri.TryDecode(uri, out var mediaType, out var bytes);
+
+        Assert.True(result);
+        Assert.Equal("text/html", mediaType);
+        Assert.Equal("<b>Test</b>", Encoding.UTF8.GetString(bytes));
+    }
+
+    [Fact]
+    public void TryDecode_PlainTextNoBase64_DecodesAsUtf8()
+    {
+        var uri    = "data:text/plain,hello";
+        var result = IcalDataUri.TryDecode(uri, out var mediaType, out var bytes);
+
+        Assert.True(result);
+        Assert.Equal("text/plain", mediaType);
+        Assert.Equal("hello", Encoding.UTF8.GetString(bytes));
+    }
+
+    [Fact]
+    public void TryDecode_MalformedNoComma_ReturnsFalse()
+    {
+        var result = IcalDataUri.TryDecode("data:text/plain", out _, out _);
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void TryDecode_NonDataUri_ReturnsFalse()
+    {
+        var result = IcalDataUri.TryDecode("https://example.com/file.html", out _, out _);
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void TryDecode_InvalidBase64_ReturnsFalse()
+    {
+        var uri    = "data:text/html;base64,!!!not-valid-base64!!!";
+        var result = IcalDataUri.TryDecode(uri, out _, out _);
+        Assert.False(result);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
@@ -658,6 +658,66 @@ public class CalendarEventMapperTests
     }
 
     /// <summary>
+    /// Mutation-coverage (Stryker): a resolved-zone (non-floating) all-day event must anchor its start to
+    /// LOCAL midnight in that zone, not read the raw UTC instant's date. For an all-day event stored as
+    /// 2026-07-09 17:00 UTC with tz=Asia/Bangkok (= Jul 10 00:00 local), StartUtc must be Jul 9 17:00 UTC.
+    /// Kills the `allDayFloating ? rawUtc.Date : ConvertTimeFromUtc(...)` conditional mutations.
+    /// </summary>
+    [Fact]
+    public void AllDay_resolved_zone_anchors_start_to_local_midnight()
+    {
+        var group = SimpleGroup(e =>
+        {
+            e.Flags        = 8; // EVENT_ALLDAY
+            e.EventStart   = MicrosFor(2026, 7, 9, 17, 0);   // Jul 10 00:00 Asia/Bangkok (UTC+7)
+            e.EventStartTz = "Asia/Bangkok";
+            e.EventEnd     = MicrosFor(2026, 7, 10, 17, 0);  // next day
+            e.EventEndTz   = "Asia/Bangkok";
+        });
+
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.True(appt!.IsAllDay);
+        Assert.Equal(new DateTime(2026, 7, 9, 17, 0, 0, DateTimeKind.Utc), appt.StartUtc);
+    }
+
+    /// <summary>
+    /// Mutation-coverage (Stryker): an absolute alarm firing EXACTLY at the event start (delta 0) must be
+    /// dropped, pinning the `minutesBefore &gt; 0` boundary (kills the `&gt;= 0` mutation that would keep it).
+    /// </summary>
+    [Fact]
+    public void Alarm_AbsoluteExactlyAtStart_NotConverted()
+    {
+        // SimpleGroup starts 2026-07-10 14:00 UTC; trigger exactly at start.
+        var group = SimpleGroup(e => e.Alarms.Add(new RawSideText(
+            "BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER;VALUE=DATE-TIME:20260710T140000Z\r\nEND:VALARM")));
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.False(appt!.ReminderSet);
+        Assert.Contains(warnings, x => x.Contains("at/after"));
+    }
+
+    /// <summary>
+    /// Mutation-coverage (Stryker): a relative alarm with a ZERO offset (TRIGGER:PT0M, fires at start) must
+    /// be dropped, pinning the `offset &lt; TimeSpan.Zero` boundary (kills the `&lt;= Zero` mutation).
+    /// </summary>
+    [Fact]
+    public void Alarm_RelativeZeroOffset_NotConverted()
+    {
+        var group = SimpleGroup(e => e.Alarms.Add(new RawSideText(
+            "BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER:PT0M\r\nEND:VALARM")));
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.False(appt!.ReminderSet);
+        Assert.Contains(warnings, x => x.Contains("at/after"));
+    }
+
+    /// <summary>
     /// Should-fix (SF-A): an absolute alarm firing AT or AFTER the event start must be dropped with a
     /// warning (not silently clamped to fire-at-start), matching the relative-trigger path.
     /// </summary>

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
@@ -836,6 +836,136 @@ public class CalendarEventMapperTests
         // EXDATE is still tracked as a deleted occurrence.
         Assert.Single(appt.DeletedOccurrences);
     }
+
+    // -----------------------------------------------------------------------
+    // Yearly recurrence — offset-range guard (finding 1 follow-up tests)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Yearly_5th_byday_degrades_to_single_with_warning()
+    {
+        // BYDAY=5MO on a YEARLY rule — 5th Monday is unsupported (only 1..4 and -1 are valid).
+        // Must degrade to single occurrence and emit a warning; must NOT return null.
+        var group = SimpleGroup(e =>
+        {
+            e.EventStart   = MicrosFor(2026, 3, 1, 9, 0);
+            e.EventEnd     = MicrosFor(2026, 3, 1, 10, 0);
+            e.EventStartTz = "UTC";
+            e.EventEndTz   = "UTC";
+            e.Recurrence.Add(new RawSideText("RRULE:FREQ=YEARLY;BYDAY=5MO;BYMONTH=3"));
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.Null(appt!.Recurrence);
+        Assert.Contains(warnings, w => w.Contains("unrepresentable"));
+    }
+
+    [Fact]
+    public void Yearly_2nd_byday_maps_to_YearlyNth()
+    {
+        // BYDAY=2MO;BYMONTH=3 on YEARLY — second Monday in March, valid offset (2).
+        // Must map to YearlyNth with NthOccurrence=2.
+        var group = SimpleGroup(e =>
+        {
+            e.EventStart   = MicrosFor(2026, 3, 9, 9, 0); // second Monday in March 2026
+            e.EventEnd     = MicrosFor(2026, 3, 9, 10, 0);
+            e.EventStartTz = "UTC";
+            e.EventEndTz   = "UTC";
+            e.Recurrence.Add(new RawSideText("RRULE:FREQ=YEARLY;BYDAY=2MO;BYMONTH=3"));
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.NotNull(appt!.Recurrence);
+        Assert.Equal(AppointmentRecurrenceFrequency.YearlyNth, appt.Recurrence!.Frequency);
+        Assert.Equal(2, appt.Recurrence.NthOccurrence);
+        Assert.Empty(warnings);
+    }
+
+    // -----------------------------------------------------------------------
+    // Mapper-level timezone integration (finding 2)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Timezone_AsiaBangkok_PreservesIanaIdAndResolvesToUtcPlus7()
+    {
+        // Asia/Bangkok = UTC+7 (no DST). Must resolve without warning and set TimeZone.
+        var group = SimpleGroup(e =>
+        {
+            e.EventStartTz = "Asia/Bangkok";
+            e.EventEndTz   = "Asia/Bangkok";
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.Equal("Asia/Bangkok", appt!.OriginatingTimeZoneId);
+        Assert.NotNull(appt.TimeZone);
+        Assert.Equal(TimeSpan.FromHours(7), appt.TimeZone!.BaseUtcOffset);
+        // No timezone-resolution warning.
+        Assert.DoesNotContain(warnings, w => w.Contains("unresolved", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Timezone_TzoneMicrosoftUtc_ResolvesToUtcNoWarning()
+    {
+        // tzone://Microsoft/Utc is the canonical Thunderbird id for UTC.
+        // Must resolve to TimeZoneInfo.Utc with no warning.
+        var group = SimpleGroup(e =>
+        {
+            e.EventStartTz = "tzone://Microsoft/Utc";
+            e.EventEndTz   = "tzone://Microsoft/Utc";
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.NotNull(appt!.TimeZone);
+        Assert.Equal(TimeZoneInfo.Utc, appt.TimeZone);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void Timezone_Utc_ResolvesToUtcNoWarning()
+    {
+        // Plain "UTC" id must resolve to TimeZoneInfo.Utc with no warning.
+        var group = SimpleGroup(e =>
+        {
+            e.EventStartTz = "UTC";
+            e.EventEndTz   = "UTC";
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.NotNull(appt!.TimeZone);
+        Assert.Equal(TimeZoneInfo.Utc, appt.TimeZone);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void Timezone_Unresolvable_EmitsWarningAndPreservesOriginalId()
+    {
+        // "Mars/Phobos" is not a known timezone. The mapper must:
+        //   1. Add a warning naming the unresolved zone.
+        //   2. Preserve OriginatingTimeZoneId verbatim.
+        //   3. Fall back to appt.TimeZone = null (timed event with unresolvable tz → stored as UTC instant).
+        var group = SimpleGroup(e =>
+        {
+            e.EventStartTz = "Mars/Phobos";
+            e.EventEndTz   = "Mars/Phobos";
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.Equal("Mars/Phobos", appt!.OriginatingTimeZoneId);
+        Assert.Null(appt.TimeZone);
+        Assert.Contains(warnings, w => w.Contains("Mars/Phobos", StringComparison.OrdinalIgnoreCase));
+    }
 }
 
 /// <summary>

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
@@ -642,6 +642,30 @@ public class CalendarEventMapperTests
         Assert.Empty(warnings);
     }
 
+    /// <summary>
+    /// Pre-merge review #6: a RELATED=END reminder must fire relative to the event END, not START.
+    /// For the 60-min SimpleGroup event (14:00–15:00 UTC) with TRIGGER;RELATED=END:-PT15M the reminder
+    /// fires at 14:45 = 45 min AFTER start, so PidLidReminderDelta (minutes-before-start) is -45 and the
+    /// writer's signal time (Start − delta) lands on 14:45 = End−15. Before the fix the anchor was
+    /// ignored and the delta was 15, firing ~60 min early (15 min before START).
+    /// </summary>
+    [Fact]
+    public void Alarm_RelatedEnd_AnchorsReminderToEnd()
+    {
+        var group = SimpleGroup(e =>
+        {
+            e.Alarms.Add(new RawSideText(
+                "BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER;RELATED=END:-PT15M\r\nEND:VALARM"));
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.True(appt!.ReminderSet);
+        Assert.Equal(-45, appt.ReminderMinutesBefore);
+        Assert.Empty(warnings);
+    }
+
     [Fact]
     public void Alarm_PositiveTrigger_NoReminderAndWarnAndBodyPreserved()
     {

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
@@ -838,6 +838,35 @@ public class CalendarEventMapperTests
     }
 
     // -----------------------------------------------------------------------
+    // I1: bare FREQ=WEEKLY with no BYDAY must default to DTSTART weekday (RFC 5545)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Weekly_bare_rrule_no_byday_defaults_to_dtstart_weekday()
+    {
+        // RRULE:FREQ=WEEKLY with no BYDAY — must default DaysOfWeek to the DTSTART weekday
+        // per RFC 5545 §3.3.10.  2026-07-06 is a Monday.
+        var group = SimpleGroup(e =>
+        {
+            e.Title        = "Bare Weekly";
+            e.EventStart   = MicrosFor(2026, 7, 6, 14, 0); // Monday 2026-07-06
+            e.EventEnd     = MicrosFor(2026, 7, 6, 15, 0);
+            e.EventStartTz = "UTC";
+            e.EventEndTz   = "UTC";
+            e.Recurrence.Add(new RawSideText("RRULE:FREQ=WEEKLY"));
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.NotNull(appt!.Recurrence);
+        Assert.Equal(AppointmentRecurrenceFrequency.Weekly, appt.Recurrence!.Frequency);
+        // RFC 5545: bare FREQ=WEEKLY (no BYDAY) must recur on the DTSTART weekday (Monday here).
+        Assert.Equal(new[] { DayOfWeek.Monday }, appt.Recurrence.DaysOfWeek);
+        Assert.Empty(warnings);
+    }
+
+    // -----------------------------------------------------------------------
     // Yearly recurrence — offset-range guard (finding 1 follow-up tests)
     // -----------------------------------------------------------------------
 

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
@@ -953,6 +953,56 @@ public class CalendarEventMapperTests
     }
 
     // -----------------------------------------------------------------------
+    // Bare FREQ=YEARLY / FREQ=MONTHLY (no BY* parts) — recur on DTSTART, don't degrade
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Yearly_bare_rrule_maps_to_yearly_not_degraded()
+    {
+        // RRULE:FREQ=YEARLY with no BY* parts recurs on the DTSTART month + day-of-month
+        // (RFC 5545). It is representable (writer defaults day from DTSTART, Outlook derives
+        // the month from the start date) and must NOT degrade to a single occurrence.
+        var group = SimpleGroup(e =>
+        {
+            e.Title        = "Bare Yearly";
+            e.EventStart   = MicrosFor(2026, 7, 1, 9, 0);
+            e.EventEnd     = MicrosFor(2026, 7, 1, 10, 0);
+            e.EventStartTz = "UTC";
+            e.EventEndTz   = "UTC";
+            e.Recurrence.Add(new RawSideText("RRULE:FREQ=YEARLY"));
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.NotNull(appt!.Recurrence);
+        Assert.Equal(AppointmentRecurrenceFrequency.Yearly, appt.Recurrence!.Frequency);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void Monthly_bare_rrule_maps_to_monthly_not_degraded()
+    {
+        // RRULE:FREQ=MONTHLY with no BY* parts recurs on the DTSTART day-of-month (RFC 5545).
+        var group = SimpleGroup(e =>
+        {
+            e.Title        = "Bare Monthly";
+            e.EventStart   = MicrosFor(2026, 7, 15, 9, 0);
+            e.EventEnd     = MicrosFor(2026, 7, 15, 10, 0);
+            e.EventStartTz = "UTC";
+            e.EventEndTz   = "UTC";
+            e.Recurrence.Add(new RawSideText("RRULE:FREQ=MONTHLY"));
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.NotNull(appt!.Recurrence);
+        Assert.Equal(AppointmentRecurrenceFrequency.Monthly, appt.Recurrence!.Frequency);
+        Assert.Empty(warnings);
+    }
+
+    // -----------------------------------------------------------------------
     // Yearly recurrence — offset-range guard (finding 1 follow-up tests)
     // -----------------------------------------------------------------------
 

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
@@ -60,23 +60,24 @@ public class CalendarEventMapperTests
     }
 
     [Fact]
-    public void GroupWithOverrides_ReturnsNullWithRecurringWarning()
+    public void Overrides_without_rrule_write_single_with_warning()
     {
-        var group = new RawEventGroup
-        {
-            Master    = new RawEvent { Id = "e1@example.com", Title = "Weekly Standup" },
-            Overrides = new List<RawEvent> { new RawEvent { Id = "e1@example.com" } }
-        };
+        // Overrides present but no RRULE → degrades to single occurrence, warns overrides dropped.
+        var group = SimpleGroup(e => e.Title = "Weekly Standup");
+        group.Overrides.Add(new RawEvent { Id = "e1@example.com" });
+
         var result = CalendarEventMapper.Map(group, out var warnings);
 
-        Assert.Null(result);
+        Assert.NotNull(result);
+        Assert.Null(result!.Recurrence);
         Assert.Single(warnings);
-        Assert.Contains("recurring event 'Weekly Standup' with exceptions deferred to PR7", warnings[0]);
+        Assert.Contains("overrides dropped", warnings[0]);
     }
 
     [Fact]
-    public void MasterWithRecurrenceLine_ReturnsNullWithRecurringWarning()
+    public void MasterWithRecurrenceLine_MapsRecurrenceSpec()
     {
+        // RRULE:FREQ=DAILY — always mappable; result should have Recurrence set.
         var group = SimpleGroup(e =>
         {
             e.Title = "Daily Sync";
@@ -84,9 +85,10 @@ public class CalendarEventMapperTests
         });
         var result = CalendarEventMapper.Map(group, out var warnings);
 
-        Assert.Null(result);
-        Assert.Single(warnings);
-        Assert.Contains("recurring event 'Daily Sync' deferred to PR7", warnings[0]);
+        Assert.NotNull(result);
+        Assert.NotNull(result!.Recurrence);
+        Assert.Equal(AppointmentRecurrenceFrequency.Daily, result.Recurrence!.Frequency);
+        Assert.Empty(warnings);
     }
 
     [Fact]
@@ -100,7 +102,7 @@ public class CalendarEventMapperTests
 
         Assert.Null(result);
         Assert.Single(warnings);
-        Assert.Contains("event override row deferred to PR7", warnings[0]);
+        Assert.Contains("mis-grouped as master", warnings[0]);
     }
 
     // -----------------------------------------------------------------------
@@ -577,14 +579,263 @@ public class CalendarEventMapperTests
     }
 
     // -----------------------------------------------------------------------
-    // Pending: recurring-event support (PR7)
+    // Recurrence (PR7a Task 2)
     // -----------------------------------------------------------------------
 
-    [Fact(Skip = "Recurring events land in PR7; tracked by this skipped test.")]
-    public void Recurring_event_is_written_with_recurrence_pattern() { /* TODO PR7 */ }
+    [Fact]
+    public void Daily_rrule_maps_spec_and_iana_id()
+    {
+        // RRULE:FREQ=DAILY with IANA tz — spec must be non-null, IANA id must pass through.
+        var group = SimpleGroup(e =>
+        {
+            e.Title        = "Daily Standup";
+            e.EventStartTz = "Europe/Copenhagen";
+            e.EventEndTz   = "Europe/Copenhagen";
+            e.Recurrence.Add(new RawSideText("RRULE:FREQ=DAILY"));
+        });
 
-    [Fact(Skip = "Recurring events land in PR7; tracked by this skipped test.")]
-    public void Recurring_event_with_exception_override_is_written_correctly() { /* TODO PR7 */ }
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.NotNull(appt!.Recurrence);
+        Assert.Equal(AppointmentRecurrenceFrequency.Daily, appt.Recurrence!.Frequency);
+        Assert.Equal("Europe/Copenhagen", appt.OriginatingTimeZoneId);
+        Assert.Equal("Europe/Copenhagen", appt.Recurrence.OriginatingTimeZoneId);
+    }
+
+    [Fact]
+    public void Bysetpos_degrades_to_single_with_warning()
+    {
+        // BYSETPOS is not representable in RecurrenceSpec → degrade to single, never skip.
+        var group = SimpleGroup(e =>
+        {
+            e.Title = "Last Monday";
+            e.Recurrence.Add(new RawSideText("RRULE:FREQ=MONTHLY;BYDAY=MO;BYSETPOS=-1"));
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.Null(appt!.Recurrence);
+        Assert.Contains(warnings, w => w.Contains("BYSETPOS"));
+    }
+
+    [Fact]
+    public void Monthly_byday_without_offset_degrades()
+    {
+        // BYDAY without a numeric offset on a MONTHLY rule is unrepresentable → degrade.
+        var group = SimpleGroup(e =>
+        {
+            e.Recurrence.Add(new RawSideText("RRULE:FREQ=MONTHLY;BYDAY=MO"));
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.Null(appt!.Recurrence);
+        Assert.Contains(warnings, w => w.Contains("unrepresentable"));
+    }
+
+    [Fact]
+    public void AllDay_weekly_recurrence_maps_local_midnight()
+    {
+        // All-day weekly event (Mon) — spec frequency, BYDAY, and EndKind must be correct.
+        var group = SimpleGroup(e =>
+        {
+            e.Title        = "Weekly Review";
+            e.Flags        = 4; // EVENT_ALLDAY
+            e.EventStart   = MicrosFor(2026, 7, 14, 0, 0); // Monday
+            e.EventEnd     = MicrosFor(2026, 7, 15, 0, 0);
+            e.EventStartTz = "UTC";
+            e.EventEndTz   = "UTC";
+            e.Recurrence.Add(new RawSideText("RRULE:FREQ=WEEKLY;BYDAY=MO;COUNT=4"));
+        });
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.True(appt!.IsAllDay);
+        Assert.NotNull(appt.Recurrence);
+        Assert.Equal(AppointmentRecurrenceFrequency.Weekly, appt.Recurrence!.Frequency);
+        Assert.Contains(DayOfWeek.Monday, appt.Recurrence.DaysOfWeek);
+        Assert.Equal(RecurrenceEndKind.Count, appt.Recurrence.EndKind);
+        Assert.Equal(4, appt.Recurrence.Count);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void DateOnly_exdate_in_bangkok_converts_to_correct_utc()
+    {
+        // Bangkok = UTC+7; midnight July 6 Bangkok = 2026-07-05T17:00:00Z
+        var group = SimpleGroup(e =>
+        {
+            e.Recurrence.Add(new RawSideText("RRULE:FREQ=WEEKLY;BYDAY=MO"));
+            e.Recurrence.Add(new RawSideText("EXDATE;TZID=Asia/Bangkok;VALUE=DATE:20260706"));
+        });
+
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt);
+        Assert.NotNull(appt!.Recurrence);
+        var deleted = Assert.Single(appt.DeletedOccurrences);
+        Assert.True(deleted.IsDateOnly);
+        var expectedUtc = new DateTime(2026, 7, 5, 17, 0, 0, DateTimeKind.Utc);
+        Assert.Equal(expectedUtc, deleted.OriginalStartUtc);
+    }
+
+    [Fact]
+    public void Override_with_body_change_creates_exception_with_warning()
+    {
+        // An override with changed DESCRIPTION → exception in model + "changed Body not encoded" warning.
+        var overrideEv = new RawEvent
+        {
+            Id             = "event-example-001@example.com",
+            Title          = "Modified Occurrence",
+            RecurrenceId   = MicrosFor(2026, 7, 11, 14, 0),
+            RecurrenceIdTz = "UTC",
+            EventStart     = MicrosFor(2026, 7, 11, 15, 0),
+            EventEnd       = MicrosFor(2026, 7, 11, 16, 0),
+        };
+        overrideEv.Properties.Add(new RawProperty("DESCRIPTION", Utf8("Changed body text"), null, null));
+
+        var group = SimpleGroup(e =>
+        {
+            e.Recurrence.Add(new RawSideText("RRULE:FREQ=DAILY"));
+        });
+        group.Overrides.Add(overrideEv);
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        Assert.NotNull(appt!.Recurrence);
+        var ex = Assert.Single(appt.Exceptions);
+        Assert.True(ex.ChangeFlags.HasFlag(AppointmentExceptionChangeFlags.Body));
+        Assert.Contains(warnings, w => w.Contains("changed Body not encoded"));
+    }
+
+    [Fact]
+    public void Override_with_reminder_change_creates_exception_with_warning()
+    {
+        // An override with a VALARM → Reminder flag in exception + warning.
+        var overrideEv = new RawEvent
+        {
+            Id             = "event-example-001@example.com",
+            Title          = "Rescheduled",
+            RecurrenceId   = MicrosFor(2026, 7, 11, 14, 0),
+            RecurrenceIdTz = "UTC",
+            EventStart     = MicrosFor(2026, 7, 11, 14, 0),
+            EventEnd       = MicrosFor(2026, 7, 11, 15, 0),
+        };
+        overrideEv.Alarms.Add(new RawSideText("BEGIN:VALARM\r\nTRIGGER:-PT10M\r\nEND:VALARM"));
+
+        var group = SimpleGroup(e =>
+        {
+            e.Recurrence.Add(new RawSideText("RRULE:FREQ=DAILY"));
+        });
+        group.Overrides.Add(overrideEv);
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        var ex = Assert.Single(appt!.Exceptions);
+        Assert.True(ex.ChangeFlags.HasFlag(AppointmentExceptionChangeFlags.Reminder));
+        Assert.Contains(warnings, w => w.Contains("changed Reminder not encoded"));
+    }
+
+    [Fact]
+    public void Override_with_categories_creates_exception_with_warning()
+    {
+        // An override with CATEGORIES → Categories flag in exception + warning.
+        var overrideEv = new RawEvent
+        {
+            Id             = "event-example-001@example.com",
+            Title          = "Recategorized",
+            RecurrenceId   = MicrosFor(2026, 7, 11, 14, 0),
+            RecurrenceIdTz = "UTC",
+            EventStart     = MicrosFor(2026, 7, 11, 14, 0),
+            EventEnd       = MicrosFor(2026, 7, 11, 15, 0),
+        };
+        overrideEv.Properties.Add(new RawProperty("CATEGORIES", Utf8("Work"), null, null));
+
+        var group = SimpleGroup(e =>
+        {
+            e.Recurrence.Add(new RawSideText("RRULE:FREQ=DAILY"));
+        });
+        group.Overrides.Add(overrideEv);
+
+        var appt = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(appt);
+        var ex = Assert.Single(appt!.Exceptions);
+        Assert.True(ex.ChangeFlags.HasFlag(AppointmentExceptionChangeFlags.Categories));
+        Assert.Contains(warnings, w => w.Contains("changed Categories not encoded"));
+    }
+
+    [Fact]
+    public void ComputeLastInstanceUtc_Weekly_Count_Returns_Nth_Occurrence()
+    {
+        // WEEKLY MO+WE COUNT=6 from Wed 2026-07-01 14:00 UTC.
+        // Raw occurrences: 1-Jul, 6-Jul, 8-Jul, 13-Jul, 15-Jul, 20-Jul → 6th = Mon 20-Jul.
+        var group = SimpleGroup(e =>
+        {
+            e.EventStart   = MicrosFor(2026, 7, 1, 14, 0);
+            e.EventEnd     = MicrosFor(2026, 7, 1, 15, 0);
+            e.EventStartTz = "UTC";
+            e.EventEndTz   = "UTC";
+            e.Recurrence.Add(new RawSideText("RRULE:FREQ=WEEKLY;BYDAY=MO,WE;COUNT=6"));
+        });
+
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt?.Recurrence);
+        Assert.Equal(RecurrenceEndKind.Count, appt!.Recurrence!.EndKind);
+        Assert.Equal(6, appt.Recurrence.Count);
+        var expected = new DateTime(2026, 7, 20, 14, 0, 0, DateTimeKind.Utc);
+        Assert.Equal(expected, appt.Recurrence.LastInstanceStartUtc);
+    }
+
+    [Fact]
+    public void ComputeLastInstanceUtc_Weekly_Until_ReturnsUntilDirectly()
+    {
+        // Until-bounded rule: LastInstanceStartUtc must equal UntilUtc without enumeration.
+        var group = SimpleGroup(e =>
+        {
+            e.Recurrence.Add(new RawSideText("RRULE:FREQ=WEEKLY;BYDAY=MO;UNTIL=20260831T000000Z"));
+        });
+
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt?.Recurrence);
+        Assert.Equal(RecurrenceEndKind.Until, appt!.Recurrence!.EndKind);
+        Assert.NotNull(appt.Recurrence.UntilUtc);
+        // Must be the same value — returned directly, no enumeration.
+        Assert.Equal(appt.Recurrence.UntilUtc, appt.Recurrence.LastInstanceStartUtc);
+    }
+
+    [Fact]
+    public void ComputeLastInstanceUtc_CountWithExdate_CountNotReduced()
+    {
+        // EXDATE removes an instance from the visible set but does NOT reduce COUNT.
+        // Raw occurrences: Jul 6, Jul 13, Jul 20 → COUNT=3 → last = Jul 20 (EXDATE on Jul 13 ignored).
+        var group = SimpleGroup(e =>
+        {
+            e.EventStart   = MicrosFor(2026, 7, 6, 14, 0);   // Monday
+            e.EventEnd     = MicrosFor(2026, 7, 6, 15, 0);
+            e.EventStartTz = "UTC";
+            e.EventEndTz   = "UTC";
+            e.Recurrence.Add(new RawSideText("RRULE:FREQ=WEEKLY;BYDAY=MO;COUNT=3"));
+            e.Recurrence.Add(new RawSideText("EXDATE:20260713T140000Z")); // delete 2nd raw occurrence
+        });
+
+        var appt = CalendarEventMapper.Map(group, out _);
+
+        Assert.NotNull(appt?.Recurrence);
+        // 3rd raw occurrence is Jul 20 — not Jul 27 (which would wrongly count EXDATE as consuming one slot).
+        var expected = new DateTime(2026, 7, 20, 14, 0, 0, DateTimeKind.Utc);
+        Assert.Equal(expected, appt!.Recurrence!.LastInstanceStartUtc);
+        // EXDATE is still tracked as a deleted occurrence.
+        Assert.Single(appt.DeletedOccurrences);
+    }
 }
 
 /// <summary>

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
@@ -644,8 +644,8 @@ public class CalendarEventMapperTests
         {
             e.Title        = "Weekly Review";
             e.Flags        = 4; // EVENT_ALLDAY
-            e.EventStart   = MicrosFor(2026, 7, 14, 0, 0); // Monday
-            e.EventEnd     = MicrosFor(2026, 7, 15, 0, 0);
+            e.EventStart   = MicrosFor(2026, 7, 13, 0, 0); // Monday 2026-07-13
+            e.EventEnd     = MicrosFor(2026, 7, 14, 0, 0);
             e.EventStartTz = "UTC";
             e.EventEndTz   = "UTC";
             e.Recurrence.Add(new RawSideText("RRULE:FREQ=WEEKLY;BYDAY=MO;COUNT=4"));

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarRegistryReaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarRegistryReaderTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+﻿// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
 // SPDX-License-Identifier: GPL-3.0-or-later
 using System.Linq;
 using Mail2Pst.Core.Calendar;
@@ -9,7 +9,7 @@ namespace Mail2Pst.Core.Tests.Calendar;
 public class CalendarRegistryReaderTests
 {
     private const string Prefs = """
-        user_pref("calendar.registry.4ad842d0.name", "Ferie æøå");
+        user_pref("calendar.registry.4ad842d0.name", "Ferie \u00e6\u00f8\u00e5");
         user_pref("calendar.registry.4ad842d0.type", "storage");
         user_pref("calendar.registry.4ad842d0.uri", "moz-storage-calendar://");
         user_pref("calendar.registry.4ad842d0.calendar-main-in-composite", true);
@@ -25,7 +25,7 @@ public class CalendarRegistryReaderTests
         Assert.Equal(2, entries.Count);
 
         var home = entries.Single(e => e.CalId == "4ad842d0");
-        Assert.Equal("Ferie æøå", home.DisplayName);   // \uXXXX unescaped via PrefsJsEscape
+        Assert.Equal("Ferie \u00e6\u00f8\u00e5", home.DisplayName);   // \uXXXX unescaped via PrefsJsEscape
         Assert.Equal("storage", home.CalendarType);
         Assert.True(home.VisibleInThunderbird);
 

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarRegistryReaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarRegistryReaderTests.cs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Linq;
+using Mail2Pst.Core.Calendar;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Calendar;
+
+public class CalendarRegistryReaderTests
+{
+    private const string Prefs = """
+        user_pref("calendar.registry.4ad842d0.name", "Ferie æøå");
+        user_pref("calendar.registry.4ad842d0.type", "storage");
+        user_pref("calendar.registry.4ad842d0.uri", "moz-storage-calendar://");
+        user_pref("calendar.registry.4ad842d0.calendar-main-in-composite", true);
+        user_pref("calendar.registry.007f8267.name", "work@example.com");
+        user_pref("calendar.registry.007f8267.type", "caldav");
+        // user_pref("calendar.registry.ignored.name", "Commented");
+        """;
+
+    [Fact]
+    public void Parses_entries_with_unicode_names_and_default_visibility()
+    {
+        var entries = CalendarRegistryReader.ParseText(Prefs);
+        Assert.Equal(2, entries.Count);
+
+        var home = entries.Single(e => e.CalId == "4ad842d0");
+        Assert.Equal("Ferie æøå", home.DisplayName);   // \uXXXX unescaped via PrefsJsEscape
+        Assert.Equal("storage", home.CalendarType);
+        Assert.True(home.VisibleInThunderbird);
+
+        var work = entries.Single(e => e.CalId == "007f8267");
+        Assert.False(work.VisibleInThunderbird);        // no calendar-main-in-composite => default false
+    }
+
+    [Fact]
+    public void Commented_lines_are_ignored()
+        => Assert.DoesNotContain(CalendarRegistryReader.ParseText(Prefs), e => e.DisplayName == "Commented");
+}

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarTaskMapperRelationTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarTaskMapperRelationTests.cs
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Linq;
+using Mail2Pst.Core.Calendar;
+using Mail2Pst.Core.Models;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Calendar;
+
+/// <summary>
+/// TDD tests for cal_relations preservation in <see cref="CalendarTaskMapper.Map"/>.
+/// All data is synthetic/reserved (example.com) — no real mail or PII.
+/// </summary>
+public class CalendarTaskMapperRelationTests
+{
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static RawTodoGroup SimpleGroup(Action<RawTodo>? configure = null)
+    {
+        var todo = new RawTodo
+        {
+            Id           = "task-relation-test@example.com",
+            Title        = "Task With Relation",
+            IcalStatus   = "NEEDS-ACTION",
+            TodoComplete = 0,
+            Priority     = 5,
+        };
+        configure?.Invoke(todo);
+        return new RawTodoGroup { Master = todo };
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Relations_are_collected_with_warning()
+    {
+        var group = SimpleGroup(t =>
+            t.Relations.Add(new RawSideText("RELATED-TO;RELTYPE=PARENT:uid-123")));
+
+        var rec = CalendarTaskMapper.Map(group, out var warns);
+
+        Assert.NotNull(rec);
+        Assert.Contains("RELATED-TO;RELTYPE=PARENT:uid-123", rec!.Relations);
+        Assert.Contains(warns, w => w.Contains("relation") && w.Contains("not natively converted"));
+    }
+
+    [Fact]
+    public void Empty_relations_produce_no_warnings()
+    {
+        var group = SimpleGroup(); // no relations
+
+        var rec = CalendarTaskMapper.Map(group, out var warns);
+
+        Assert.NotNull(rec);
+        Assert.Empty(rec!.Relations);
+        Assert.DoesNotContain(warns, w => w.Contains("relation") && w.Contains("not natively converted"));
+    }
+
+    [Fact]
+    public void Multiple_relations_each_produce_a_warning()
+    {
+        var group = SimpleGroup(t =>
+        {
+            t.Relations.Add(new RawSideText("RELATED-TO;RELTYPE=PARENT:uid-A"));
+            t.Relations.Add(new RawSideText("RELATED-TO;RELTYPE=CHILD:uid-B"));
+        });
+
+        var rec = CalendarTaskMapper.Map(group, out var warns);
+
+        Assert.NotNull(rec);
+        Assert.Equal(2, rec!.Relations.Count);
+        Assert.Equal(2, warns.Count(w => w.Contains("relation") && w.Contains("not natively converted")));
+    }
+
+    [Fact]
+    public void Whitespace_only_relation_lines_are_dropped()
+    {
+        var group = SimpleGroup(t =>
+        {
+            t.Relations.Add(new RawSideText("   "));
+            t.Relations.Add(new RawSideText("RELATED-TO:uid-real"));
+        });
+
+        var rec = CalendarTaskMapper.Map(group, out var warns);
+
+        Assert.NotNull(rec);
+        Assert.Single(rec!.Relations);
+        Assert.Equal("RELATED-TO:uid-real", rec.Relations[0]);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarTaskMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarTaskMapperTests.cs
@@ -169,6 +169,73 @@ public class CalendarTaskMapperTests
     }
 
     // -----------------------------------------------------------------------
+    // PercentComplete fallback (cal_properties PERCENT-COMPLETE)
+    // -----------------------------------------------------------------------
+    // Thunderbird's storage calendar persists PERCENT-COMPLETE only as a
+    // cal_properties row (TEXT), leaving cal_todos.todo_complete NULL —
+    // observed on a real profile (ICS import, TB 140). The column, when
+    // populated, stays authoritative.
+
+    [Fact]
+    public void PercentComplete_FallsBackToProperty_WhenColumnIsNull()
+    {
+        var group = SimpleGroup(t =>
+        {
+            t.IcalStatus   = "IN-PROCESS";
+            t.TodoComplete = null;
+            t.Properties.Add(new RawProperty("PERCENT-COMPLETE", Utf8("50"), null, null));
+        });
+        var task = CalendarTaskMapper.Map(group, out _);
+
+        Assert.NotNull(task);
+        Assert.Equal(50, task.PercentComplete);
+    }
+
+    [Fact]
+    public void PercentComplete_ColumnWins_OverProperty()
+    {
+        var group = SimpleGroup(t =>
+        {
+            t.TodoComplete = 25;
+            t.Properties.Add(new RawProperty("PERCENT-COMPLETE", Utf8("75"), null, null));
+        });
+        var task = CalendarTaskMapper.Map(group, out _);
+
+        Assert.NotNull(task);
+        Assert.Equal(25, task.PercentComplete);
+    }
+
+    [Fact]
+    public void PercentComplete_PropertyOf100_ForcesStatusComplete()
+    {
+        var group = SimpleGroup(t =>
+        {
+            t.IcalStatus   = "IN-PROCESS";
+            t.TodoComplete = null;
+            t.Properties.Add(new RawProperty("PERCENT-COMPLETE", Utf8("100"), null, null));
+        });
+        var task = CalendarTaskMapper.Map(group, out _);
+
+        Assert.NotNull(task);
+        Assert.Equal(100, task.PercentComplete);
+        Assert.Equal(TaskStatusKind.Complete, task.Status);
+    }
+
+    [Fact]
+    public void PercentComplete_NonNumericProperty_IsIgnored()
+    {
+        var group = SimpleGroup(t =>
+        {
+            t.TodoComplete = null;
+            t.Properties.Add(new RawProperty("PERCENT-COMPLETE", Utf8("half"), null, null));
+        });
+        var task = CalendarTaskMapper.Map(group, out _);
+
+        Assert.NotNull(task);
+        Assert.Equal(0, task.PercentComplete);
+    }
+
+    // -----------------------------------------------------------------------
     // Status/percent invariants
     // -----------------------------------------------------------------------
 

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarTaskMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarTaskMapperTests.cs
@@ -252,6 +252,20 @@ public class CalendarTaskMapperTests
         Assert.Equal("Personal",    task.Categories[2]);
     }
 
+    [Fact]
+    public void Categories_DropsXMozPrefixedTokens()
+    {
+        // X-MOZ-* tokens are Mozilla-internal and must be stripped from CATEGORIES.
+        var group = SimpleGroup(t =>
+            t.Properties.Add(new RawProperty("CATEGORIES", Utf8("Work,X-MOZ-SNOOZE-TIME,Personal"), null, null)));
+        var task = CalendarTaskMapper.Map(group, out _);
+
+        Assert.NotNull(task);
+        Assert.Equal(2, task.Categories.Count);
+        Assert.Equal("Work",     task.Categories[0]);
+        Assert.Equal("Personal", task.Categories[1]);
+    }
+
     // -----------------------------------------------------------------------
     // Reminder — relative TRIGGER with RELATED=START
     // -----------------------------------------------------------------------
@@ -449,5 +463,36 @@ public class CalendarTaskMapperTests
         Assert.NotNull(task.ReminderTime);
         Assert.Equal(new DateTimeOffset(2026, 8, 1, 7, 0, 0, TimeSpan.Zero), task.ReminderTime!.Value);
         Assert.Empty(warnings);
+    }
+
+    // -----------------------------------------------------------------------
+    // Reminder — VALARM parse failure → no reminder + warning + body preserved
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Alarm_ParseFailure_NoReminderAndWarningAndBodyPreserved()
+    {
+        // A "VALARM block" without a BEGIN:VALARM/END:VALARM envelope is stored by
+        // Thunderbird as bare iCal text.  ICalTextParser.ParseAlarm wraps it in a
+        // VEVENT; because there is no nested VALARM component, Ical.Net produces
+        // evt.Alarms.Count == 0, which ParseAlarm maps to Fail (Value=null + warning).
+        // The raw TRIGGER line in the block must then be preserved in the task body.
+        var group = SimpleGroup(t =>
+        {
+            t.TodoEntry = MicrosFor(2026, 8, 1);
+            // Bare text: has a TRIGGER line but no BEGIN:VALARM wrapper.
+            t.Alarms.Add(new RawSideText(
+                "TRIGGER:-PT15M\r\nX-SYNTHETIC-PROPERTY:failsafe"));
+        });
+
+        var task = CalendarTaskMapper.Map(group, out var warnings);
+
+        Assert.NotNull(task);
+        Assert.False(task.ReminderSet);
+        Assert.Null(task.ReminderTime);
+        Assert.True(warnings.Count > 0, "Expected at least one warning for parse failure");
+        Assert.NotNull(task.Body);
+        Assert.Contains("[Thunderbird alarm not converted:", task.Body);
+        Assert.Contains("TRIGGER", task.Body);
     }
 }

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarTaskMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarTaskMapperTests.cs
@@ -57,8 +57,11 @@ public class CalendarTaskMapperTests
     }
 
     [Fact]
-    public void GroupWithOverrides_ReturnsNullWithRecurringWarning()
+    public void GroupWithOverrides_NoRrule_MapsMasterNormally()
     {
+        // Overrides with no RRULE in master — the override list is only relevant when
+        // there is also a recurrence rule. Without one, the master is a non-recurring task
+        // and the override rows are effectively orphaned; map the master as a plain task.
         var group = new RawTodoGroup
         {
             Master = new RawTodo { Id = "t1@example.com", Title = "Weekly Review" },
@@ -66,14 +69,15 @@ public class CalendarTaskMapperTests
         };
         var result = CalendarTaskMapper.Map(group, out var warnings);
 
-        Assert.Null(result);
-        Assert.Single(warnings);
-        Assert.Contains("recurring task 'Weekly Review' with exceptions deferred to PR7", warnings[0]);
+        Assert.NotNull(result);
+        Assert.Empty(warnings);
+        Assert.Equal("Weekly Review", result.Subject);
     }
 
     [Fact]
-    public void MasterWithRecurrenceLine_ReturnsNullWithRecurringWarning()
+    public void MasterWithRecurrenceLine_NoDates_DegradesWith_NoDueDateWarning()
     {
+        // RRULE present but no anchor date → degrade to single non-recurring task + warning.
         var group = SimpleGroup(t =>
         {
             t.Title = "Recurring Task";
@@ -81,14 +85,16 @@ public class CalendarTaskMapperTests
         });
         var result = CalendarTaskMapper.Map(group, out var warnings);
 
-        Assert.Null(result);
+        Assert.NotNull(result);
         Assert.Single(warnings);
-        Assert.Contains("recurring task 'Recurring Task' deferred to PR7", warnings[0]);
+        Assert.Contains("no due/start date to anchor recurrence", warnings[0]);
+        Assert.Null(result.Recurrence);
     }
 
     [Fact]
-    public void MasterWithRecurrenceIdSet_ReturnsNullWithOverrideWarning()
+    public void MasterWithRecurrenceIdSet_ReturnsNullWithMisgroupedWarning()
     {
+        // A task with RecurrenceId is an override row that got mis-grouped as a master; skip it.
         var group = SimpleGroup(t =>
         {
             t.RecurrenceId = MicrosFor(2026, 7, 7);
@@ -97,7 +103,7 @@ public class CalendarTaskMapperTests
 
         Assert.Null(result);
         Assert.Single(warnings);
-        Assert.Contains("task override row deferred to PR7", warnings[0]);
+        Assert.Contains("task override row mis-grouped as master; skipped", warnings[0]);
     }
 
     // -----------------------------------------------------------------------
@@ -497,14 +503,217 @@ public class CalendarTaskMapperTests
     }
 
     // -----------------------------------------------------------------------
-    // Pending: recurring-task support (PR7)
-    // These skipped tests are placeholders that track the work deferred to PR7.
-    // Remove the Skip attribute and implement when the recurrence writer lands.
+    // Recurring task support (PR7)
     // -----------------------------------------------------------------------
 
-    [Fact(Skip = "Recurring tasks land in PR7 (recurrence + exceptions); tracked by this skipped test.")]
-    public void Recurring_task_is_written_with_recurrence_pattern() { /* TODO PR7 */ }
+    [Fact]
+    public void Recurring_task_is_written_with_recurrence_pattern()
+    {
+        // Basic recurring task with a weekly RRULE and a DueDate anchor.
+        // 2026-07-13 is a Monday — consistent with the BYDAY=MO rule.
+        var group = SimpleGroup(t =>
+        {
+            t.Title   = "Weekly Standup";
+            t.TodoDue = MicrosFor(2026, 7, 13); // Monday
+            t.Recurrence.Add(new RawSideText("RRULE:FREQ=WEEKLY;BYDAY=MO;COUNT=5"));
+        });
 
-    [Fact(Skip = "Recurring tasks land in PR7 (recurrence + exceptions); tracked by this skipped test.")]
-    public void Recurring_task_with_exception_override_is_written_correctly() { /* TODO PR7 */ }
+        var task = CalendarTaskMapper.Map(group, out var warnings);
+
+        Assert.NotNull(task);
+        Assert.Empty(warnings);
+        Assert.NotNull(task.Recurrence);
+        Assert.Equal(RecurrenceFrequency.Weekly, task.Recurrence!.Frequency);
+        Assert.Equal(RecurrenceEndKind.Count, task.Recurrence.EndKind);
+        Assert.Equal(5, task.Recurrence.Count);
+    }
+
+    [Fact]
+    public void Recurring_task_with_exception_override_is_written_correctly()
+    {
+        // A recurring task whose series has an override row (exception) should degrade to
+        // a single non-recurring task with a warning — NOT return null.
+        var overrideTodo = new RawTodo
+        {
+            Id    = "task-override-001@example.com",
+            Title = "Weekly Review",
+        };
+        var group = new RawTodoGroup
+        {
+            Master = new RawTodo
+            {
+                Id    = "task-master-001@example.com",
+                Title = "Weekly Review",
+                TodoDue = MicrosFor(2026, 7, 13),
+            },
+            Overrides = new List<RawTodo> { overrideTodo },
+        };
+        group.Master.Recurrence.Add(new RawSideText("RRULE:FREQ=WEEKLY;COUNT=5"));
+
+        var task = CalendarTaskMapper.Map(group, out var warnings);
+
+        // Task is returned (NOT null) — it degrades to single non-recurring
+        Assert.NotNull(task);
+        Assert.Single(warnings);
+        Assert.Contains("deletions/exceptions not supported", warnings[0]);
+        Assert.Null(task.Recurrence);
+    }
+
+    [Fact]
+    public void Weekly_task_with_due_anchor_maps_recurrence()
+    {
+        // RRULE anchored on DueDate (preferred over StartDate).
+        // 2026-07-13 is a Monday — consistent with BYDAY=MO.
+        var group = SimpleGroup(t =>
+        {
+            t.Title      = "Monday Task";
+            t.TodoEntry  = MicrosFor(2026, 7, 6);   // start (Sunday)
+            t.TodoDue    = MicrosFor(2026, 7, 13);  // due (Monday) — anchor
+            t.Recurrence.Add(new RawSideText("RRULE:FREQ=WEEKLY;BYDAY=MO;COUNT=5"));
+        });
+
+        var task = CalendarTaskMapper.Map(group, out var warnings);
+
+        Assert.NotNull(task);
+        Assert.Empty(warnings);
+        Assert.NotNull(task.Recurrence);
+        Assert.Equal(RecurrenceFrequency.Weekly, task.Recurrence!.Frequency);
+        Assert.Equal(5, task.Recurrence.Count);
+        Assert.Equal(RecurrenceEndKind.Count, task.Recurrence.EndKind);
+        // Anchor is UTC-midnight of the DueDate (2026-07-13)
+        Assert.Equal(new DateTime(2026, 7, 13, 0, 0, 0, DateTimeKind.Utc), task.Recurrence.FirstStartUtc);
+    }
+
+    [Fact]
+    public void No_due_falls_back_to_start_anchor()
+    {
+        // When there is no DueDate, StartDate is used as the anchor.
+        var group = SimpleGroup(t =>
+        {
+            t.Title     = "Daily Habit";
+            t.TodoEntry = MicrosFor(2026, 7, 14); // start only
+            // No TodoDue
+            t.Recurrence.Add(new RawSideText("RRULE:FREQ=DAILY;COUNT=3"));
+        });
+
+        var task = CalendarTaskMapper.Map(group, out var warnings);
+
+        Assert.NotNull(task);
+        Assert.Empty(warnings);
+        Assert.NotNull(task.Recurrence);
+        Assert.Equal(RecurrenceFrequency.Daily, task.Recurrence!.Frequency);
+        Assert.Equal(new DateTime(2026, 7, 14, 0, 0, 0, DateTimeKind.Utc), task.Recurrence.FirstStartUtc);
+    }
+
+    [Fact]
+    public void No_due_no_start_degrades_with_warning()
+    {
+        // Neither DueDate nor StartDate — cannot anchor the recurrence; degrade to single task.
+        var group = SimpleGroup(t =>
+        {
+            t.Title = "Undated Recurring";
+            t.Recurrence.Add(new RawSideText("RRULE:FREQ=WEEKLY;COUNT=3"));
+            // No TodoEntry, no TodoDue
+        });
+
+        var task = CalendarTaskMapper.Map(group, out var warnings);
+
+        // Task is still returned (non-null) — just without Recurrence
+        Assert.NotNull(task);
+        Assert.Single(warnings);
+        Assert.Contains("no due/start date to anchor recurrence", warnings[0]);
+        Assert.Null(task.Recurrence);
+    }
+
+    [Fact]
+    public void Exdate_present_degrades_to_single_task_with_warning()
+    {
+        // An EXDATE line means the series has deleted occurrences — not representable;
+        // degrade to a single non-recurring task with a warning, task is NOT null.
+        var group = SimpleGroup(t =>
+        {
+            t.Title   = "Skipped Monday";
+            t.TodoDue = MicrosFor(2026, 7, 13); // Monday
+            t.Recurrence.Add(new RawSideText("RRULE:FREQ=WEEKLY;BYDAY=MO;COUNT=5"));
+            t.Recurrence.Add(new RawSideText("EXDATE:20260720T000000Z"));
+        });
+
+        var task = CalendarTaskMapper.Map(group, out var warnings);
+
+        Assert.NotNull(task);
+        Assert.Single(warnings);
+        Assert.Contains("deletions/exceptions not supported", warnings[0]);
+        Assert.Null(task.Recurrence);
+    }
+
+    [Fact]
+    public void Override_rows_degrade_to_single_task_with_warning()
+    {
+        // group.Overrides.Count > 0 with RRULE present → degrade, task still returned (NOT null).
+        var group = new RawTodoGroup
+        {
+            Master = new RawTodo
+            {
+                Id      = "master-002@example.com",
+                Title   = "Weekly Sync",
+                TodoDue = MicrosFor(2026, 7, 13),
+            },
+            Overrides = new List<RawTodo>
+            {
+                new RawTodo { Id = "override-002@example.com", Title = "Weekly Sync" }
+            },
+        };
+        group.Master.Recurrence.Add(new RawSideText("RRULE:FREQ=WEEKLY;COUNT=5"));
+
+        var task = CalendarTaskMapper.Map(group, out var warnings);
+
+        Assert.NotNull(task);
+        Assert.Single(warnings);
+        Assert.Contains("deletions/exceptions not supported", warnings[0]);
+        Assert.Null(task.Recurrence);
+    }
+
+    [Fact]
+    public void Bysetpos_degrades_with_warning()
+    {
+        // BYSETPOS (e.g. "last Monday of month") is not representable — degrade.
+        var group = SimpleGroup(t =>
+        {
+            t.Title   = "Last Monday";
+            t.TodoDue = MicrosFor(2026, 7, 27); // last Monday of July 2026
+            t.Recurrence.Add(new RawSideText("RRULE:FREQ=MONTHLY;BYDAY=MO;BYSETPOS=-1"));
+        });
+
+        var task = CalendarTaskMapper.Map(group, out var warnings);
+
+        Assert.NotNull(task);
+        Assert.Single(warnings);
+        Assert.Contains("BYSETPOS", warnings[0]);
+        Assert.Null(task.Recurrence);
+    }
+
+    [Fact]
+    public void Completed_recurring_task_degrades_if_unsupported()
+    {
+        // A completed recurring task triggers Outlook live-regeneration when written.
+        // The converter cannot author that lifecycle, so degrade to a single completed task.
+        var group = SimpleGroup(t =>
+        {
+            t.Title        = "Done Series";
+            t.IcalStatus   = "COMPLETED";
+            t.TodoComplete = 100;
+            t.TodoDue      = MicrosFor(2026, 7, 13);
+            t.Recurrence.Add(new RawSideText("RRULE:FREQ=WEEKLY;COUNT=5"));
+        });
+
+        var task = CalendarTaskMapper.Map(group, out var warnings);
+
+        Assert.NotNull(task);
+        Assert.Single(warnings);
+        Assert.Contains("completed recurring tasks not supported", warnings[0]);
+        Assert.Null(task.Recurrence);
+        // Task is still complete
+        Assert.Equal(TaskStatusKind.Complete, task.Status);
+        Assert.Equal(100, task.PercentComplete);
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarTaskMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarTaskMapperTests.cs
@@ -716,4 +716,31 @@ public class CalendarTaskMapperTests
         Assert.Equal(TaskStatusKind.Complete, task.Status);
         Assert.Equal(100, task.PercentComplete);
     }
+
+    // -----------------------------------------------------------------------
+    // I1: RRULE present but body is malformed — must warn, not silently drop
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Recurring_task_with_unparseable_rrule_degrades_with_warning()
+    {
+        // RRULE:FREQ=WEEKLY;BYDAY=ZZ — "ZZ" is not a valid BYDAY weekday abbreviation; Ical.Net's
+        // RecurrencePattern constructor throws, causing ICalTextParser.ParseRecurrence to return
+        // (Value=null, Warnings=[...]).  RecurrenceMapping.FromIcal collapses this to (null,null).
+        // With hasRrule==true the task mapper must emit "RRULE could not be parsed" — not silently
+        // produce a non-recurring task with zero warnings.
+        var group = SimpleGroup(t =>
+        {
+            t.Title   = "Bad RRULE Task";
+            t.TodoDue = MicrosFor(2026, 7, 13);
+            t.Recurrence.Add(new RawSideText("RRULE:FREQ=WEEKLY;BYDAY=ZZ"));
+        });
+
+        var task = CalendarTaskMapper.Map(group, out var warnings);
+
+        Assert.NotNull(task);                              // task is returned, not null
+        Assert.Null(task.Recurrence);                     // degraded — no recurrence pattern
+        Assert.Single(warnings);                          // exactly one warning
+        Assert.Contains("could not be parsed", warnings[0]); // the parse-failure warning
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarTaskMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarTaskMapperTests.cs
@@ -495,4 +495,16 @@ public class CalendarTaskMapperTests
         Assert.Contains("[Thunderbird alarm not converted:", task.Body);
         Assert.Contains("TRIGGER", task.Body);
     }
+
+    // -----------------------------------------------------------------------
+    // Pending: recurring-task support (PR7)
+    // These skipped tests are placeholders that track the work deferred to PR7.
+    // Remove the Skip attribute and implement when the recurrence writer lands.
+    // -----------------------------------------------------------------------
+
+    [Fact(Skip = "Recurring tasks land in PR7 (recurrence + exceptions); tracked by this skipped test.")]
+    public void Recurring_task_is_written_with_recurrence_pattern() { /* TODO PR7 */ }
+
+    [Fact(Skip = "Recurring tasks land in PR7 (recurrence + exceptions); tracked by this skipped test.")]
+    public void Recurring_task_with_exception_override_is_written_correctly() { /* TODO PR7 */ }
 }

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarTaskMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarTaskMapperTests.cs
@@ -1,0 +1,453 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Mail2Pst.Core.Calendar;
+using Mail2Pst.Core.Models;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Calendar;
+
+/// <summary>
+/// Unit tests for <see cref="CalendarTaskMapper.Map"/>.
+/// All data is synthetic/reserved (example.com, example.org) — no real mail or PII.
+/// </summary>
+public class CalendarTaskMapperTests
+{
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /// <summary>Returns PRTime microseconds for a UTC date.</summary>
+    private static long MicrosFor(int year, int month, int day, int hour = 0, int minute = 0) =>
+        new DateTimeOffset(year, month, day, hour, minute, 0, TimeSpan.Zero).ToUnixTimeMilliseconds() * 1000L;
+
+    private static byte[] Utf8(string s) => Encoding.UTF8.GetBytes(s);
+
+    private static RawTodoGroup SimpleGroup(Action<RawTodo>? configure = null)
+    {
+        var todo = new RawTodo
+        {
+            Id       = "task-example-001@example.com",
+            Title    = "Example Task",
+            IcalStatus  = "NEEDS-ACTION",
+            TodoComplete = 0,
+            Priority = 5,
+            Privacy  = null,
+        };
+        configure?.Invoke(todo);
+        return new RawTodoGroup { Master = todo };
+    }
+
+    // -----------------------------------------------------------------------
+    // Group-skip rules
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void NullMaster_ReturnsNullWithOrphanWarning()
+    {
+        var group = new RawTodoGroup(); // Master == null
+        var result = CalendarTaskMapper.Map(group, out var warnings);
+
+        Assert.Null(result);
+        Assert.Single(warnings);
+        Assert.Contains("orphan task override (no master) skipped", warnings[0]);
+    }
+
+    [Fact]
+    public void GroupWithOverrides_ReturnsNullWithRecurringWarning()
+    {
+        var group = new RawTodoGroup
+        {
+            Master = new RawTodo { Id = "t1@example.com", Title = "Weekly Review" },
+            Overrides = new List<RawTodo> { new RawTodo { Id = "t1@example.com", Title = "Weekly Review" } }
+        };
+        var result = CalendarTaskMapper.Map(group, out var warnings);
+
+        Assert.Null(result);
+        Assert.Single(warnings);
+        Assert.Contains("recurring task 'Weekly Review' with exceptions deferred to PR7", warnings[0]);
+    }
+
+    [Fact]
+    public void MasterWithRecurrenceLine_ReturnsNullWithRecurringWarning()
+    {
+        var group = SimpleGroup(t =>
+        {
+            t.Title = "Recurring Task";
+            t.Recurrence.Add(new RawSideText("RRULE:FREQ=WEEKLY;BYDAY=MO"));
+        });
+        var result = CalendarTaskMapper.Map(group, out var warnings);
+
+        Assert.Null(result);
+        Assert.Single(warnings);
+        Assert.Contains("recurring task 'Recurring Task' deferred to PR7", warnings[0]);
+    }
+
+    [Fact]
+    public void MasterWithRecurrenceIdSet_ReturnsNullWithOverrideWarning()
+    {
+        var group = SimpleGroup(t =>
+        {
+            t.RecurrenceId = MicrosFor(2026, 7, 7);
+        });
+        var result = CalendarTaskMapper.Map(group, out var warnings);
+
+        Assert.Null(result);
+        Assert.Single(warnings);
+        Assert.Contains("task override row deferred to PR7", warnings[0]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Flat non-recurring master → populated TaskRecord
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void FlatMaster_MapsBasicFieldsToTaskRecord()
+    {
+        var group = SimpleGroup(t =>
+        {
+            t.Title       = "Buy groceries";
+            t.Id          = "groceries-123@example.org";
+            t.IcalStatus  = "NEEDS-ACTION";
+            t.TodoComplete = 0;
+            t.Priority    = 5;
+            t.Privacy     = null;
+            t.TodoEntry   = MicrosFor(2026, 7, 1);
+            t.TodoDue     = MicrosFor(2026, 7, 5);
+            t.Properties.Add(new RawProperty("DESCRIPTION", Utf8("Pick up milk and bread."), null, null));
+            t.Properties.Add(new RawProperty("CATEGORIES",  Utf8("Shopping,Home"),            null, null));
+        });
+
+        var task = CalendarTaskMapper.Map(group, out var warnings);
+
+        Assert.NotNull(task);
+        Assert.Empty(warnings);
+        Assert.Equal("groceries-123@example.org", task.SourceId);
+        Assert.Equal("Buy groceries", task.Subject);
+        Assert.Equal("Pick up milk and bread.", task.Body);
+        Assert.Equal(new[] { "Shopping", "Home" }, task.Categories);
+        Assert.Equal(TaskStatusKind.NotStarted, task.Status);
+        Assert.Equal(0, task.PercentComplete);
+        Assert.Equal(1, task.Importance);   // priority 5 → normal
+        Assert.Equal(0, task.Sensitivity);  // null/PUBLIC → 0
+        Assert.NotNull(task.StartDate);
+        Assert.NotNull(task.DueDate);
+        Assert.Null(task.CompletedDate);
+        Assert.False(task.ReminderSet);
+    }
+
+    // -----------------------------------------------------------------------
+    // Status mapping
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("COMPLETED",   TaskStatusKind.Complete,    100)]
+    [InlineData("IN-PROCESS",  TaskStatusKind.InProgress,   50)]
+    [InlineData("CANCELLED",   TaskStatusKind.Deferred,      0)]
+    [InlineData("NEEDS-ACTION",TaskStatusKind.NotStarted,    0)]
+    [InlineData(null,          TaskStatusKind.NotStarted,    0)]
+    public void StatusMapping_MatchesIcalStatus(string? icalStatus, TaskStatusKind expected, int percent)
+    {
+        var group = SimpleGroup(t =>
+        {
+            t.IcalStatus  = icalStatus;
+            t.TodoComplete = percent;
+        });
+        var task = CalendarTaskMapper.Map(group, out _);
+
+        Assert.NotNull(task);
+        Assert.Equal(expected, task.Status);
+    }
+
+    // -----------------------------------------------------------------------
+    // Status/percent invariants
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void PercentComplete100_ForcesStatusComplete()
+    {
+        var group = SimpleGroup(t =>
+        {
+            t.IcalStatus   = "NEEDS-ACTION"; // would be NotStarted
+            t.TodoComplete = 100;
+        });
+        var task = CalendarTaskMapper.Map(group, out _);
+
+        Assert.NotNull(task);
+        Assert.Equal(TaskStatusKind.Complete, task.Status);
+        Assert.Equal(100, task.PercentComplete);
+    }
+
+    [Fact]
+    public void StatusComplete_WithLowPercent_ForcesPercent100()
+    {
+        var group = SimpleGroup(t =>
+        {
+            t.IcalStatus   = "COMPLETED";
+            t.TodoComplete = 0; // inconsistent — should be forced to 100
+        });
+        var task = CalendarTaskMapper.Map(group, out _);
+
+        Assert.NotNull(task);
+        Assert.Equal(TaskStatusKind.Complete, task.Status);
+        Assert.Equal(100, task.PercentComplete);
+    }
+
+    // -----------------------------------------------------------------------
+    // Importance mapping
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(1, 2)]  // high
+    [InlineData(4, 2)]  // high
+    [InlineData(5, 1)]  // normal
+    [InlineData(null, 1)] // normal (null)
+    [InlineData(6, 0)]  // low
+    [InlineData(9, 0)]  // low
+    public void Importance_MapsFromPriority(int? priority, int expected)
+    {
+        var group = SimpleGroup(t => t.Priority = priority);
+        var task = CalendarTaskMapper.Map(group, out _);
+
+        Assert.NotNull(task);
+        Assert.Equal(expected, task.Importance);
+    }
+
+    // -----------------------------------------------------------------------
+    // Sensitivity mapping
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("PRIVATE",      2)]
+    [InlineData("CONFIDENTIAL", 3)]
+    [InlineData("PUBLIC",       0)]
+    [InlineData(null,           0)]
+    public void Sensitivity_MapsFromPrivacy(string? privacy, int expected)
+    {
+        var group = SimpleGroup(t => t.Privacy = privacy);
+        var task = CalendarTaskMapper.Map(group, out _);
+
+        Assert.NotNull(task);
+        Assert.Equal(expected, task.Sensitivity);
+    }
+
+    // -----------------------------------------------------------------------
+    // Categories — unescaped-comma split + unescape \,
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Categories_SplitOnUnescapedCommas()
+    {
+        var group = SimpleGroup(t =>
+            t.Properties.Add(new RawProperty("CATEGORIES", Utf8(@"Work,Home\,Office,Personal"), null, null)));
+        var task = CalendarTaskMapper.Map(group, out _);
+
+        Assert.NotNull(task);
+        Assert.Equal(3, task.Categories.Count);
+        Assert.Equal("Work",        task.Categories[0]);
+        Assert.Equal("Home,Office", task.Categories[1]); // \, → ,
+        Assert.Equal("Personal",    task.Categories[2]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Reminder — relative TRIGGER with RELATED=START
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Alarm_RelatedStart_NegativeOffset_SetsReminderBeforeStartDate()
+    {
+        var startMicros = MicrosFor(2026, 8, 1, 10, 0);
+        var group = SimpleGroup(t =>
+        {
+            t.TodoEntry = startMicros;
+            t.TodoDue   = MicrosFor(2026, 8, 5, 10, 0);
+            t.Alarms.Add(new RawSideText(
+                "BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER;RELATED=START:-PT15M\r\nEND:VALARM"));
+        });
+
+        var task = CalendarTaskMapper.Map(group, out var warnings);
+
+        Assert.NotNull(task);
+        Assert.True(task.ReminderSet);
+        Assert.NotNull(task.ReminderTime);
+
+        var expectedStart = PrTime.FromMicros(startMicros)!.Value;
+        var expectedReminder = expectedStart.AddMinutes(-15);
+        Assert.Equal(expectedReminder, task.ReminderTime!.Value);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void Alarm_RelatedEnd_NegativeOffset_SetsReminderBeforeDueDate()
+    {
+        var dueMicros = MicrosFor(2026, 8, 5, 10, 0);
+        var group = SimpleGroup(t =>
+        {
+            t.TodoEntry = MicrosFor(2026, 8, 1, 10, 0);
+            t.TodoDue   = dueMicros;
+            t.Alarms.Add(new RawSideText(
+                "BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER;RELATED=END:-PT30M\r\nEND:VALARM"));
+        });
+
+        var task = CalendarTaskMapper.Map(group, out var warnings);
+
+        Assert.NotNull(task);
+        Assert.True(task.ReminderSet);
+        var expectedDue = PrTime.FromMicros(dueMicros)!.Value;
+        Assert.Equal(expectedDue.AddMinutes(-30), task.ReminderTime!.Value);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void Alarm_NoExplicitRelated_DefaultsToStart_SetsReminderBeforeStartDate()
+    {
+        // Ical.Net defaults RELATED to START when not specified in the TRIGGER line.
+        // So "TRIGGER:-PT1H" (no RELATED=) anchors on StartDate.
+        var startMicros = MicrosFor(2026, 9, 10, 9, 0);
+        var group = SimpleGroup(t =>
+        {
+            t.TodoEntry = startMicros; // StartDate — Ical.Net default anchor
+            t.Alarms.Add(new RawSideText(
+                "BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER:-PT1H\r\nEND:VALARM"));
+        });
+
+        var task = CalendarTaskMapper.Map(group, out _);
+
+        Assert.NotNull(task);
+        Assert.True(task.ReminderSet);
+        var expectedStart = PrTime.FromMicros(startMicros)!.Value;
+        Assert.Equal(expectedStart.AddHours(-1), task.ReminderTime!.Value);
+    }
+
+    // -----------------------------------------------------------------------
+    // Reminder — positive/zero trigger → no reminder + warning + body preserved
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Alarm_PositiveTrigger_NoReminderSetAndWarningAndBodyPreserved()
+    {
+        // Ical.Net defaults RELATED to START; so we need a StartDate for anchoring.
+        // Positive offset (fires after anchor) → skip reminder + warn + preserve raw trigger.
+        var group = SimpleGroup(t =>
+        {
+            t.Title     = "Example Task";
+            t.TodoEntry = MicrosFor(2026, 8, 1);
+            t.TodoDue   = MicrosFor(2026, 8, 5);
+            t.Alarms.Add(new RawSideText(
+                "BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER:PT15M\r\nEND:VALARM"));
+        });
+
+        var task = CalendarTaskMapper.Map(group, out var warnings);
+
+        Assert.NotNull(task);
+        Assert.False(task.ReminderSet);
+        Assert.Null(task.ReminderTime);
+
+        // Warning issued
+        Assert.Single(warnings);
+        Assert.Contains("reminder fires at/after the anchor", warnings[0]);
+
+        // Raw trigger preserved in body
+        Assert.NotNull(task.Body);
+        Assert.Contains("[Thunderbird alarm not converted:", task.Body);
+        Assert.Contains("TRIGGER:PT15M", task.Body);
+    }
+
+    [Fact]
+    public void Alarm_ZeroTrigger_NoReminderSetAndWarning()
+    {
+        // Zero offset = fires exactly at anchor (START by Ical.Net default).
+        var group = SimpleGroup(t =>
+        {
+            t.TodoEntry = MicrosFor(2026, 8, 1);
+            t.TodoDue   = MicrosFor(2026, 8, 5);
+            t.Alarms.Add(new RawSideText(
+                "BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER:PT0S\r\nEND:VALARM"));
+        });
+
+        var task = CalendarTaskMapper.Map(group, out var warnings);
+
+        Assert.NotNull(task);
+        Assert.False(task.ReminderSet);
+        Assert.Single(warnings);
+        Assert.Contains("reminder fires at/after the anchor", warnings[0]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Reminder — alarm with no anchor date
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Alarm_NoAnchorDate_WarnAndPreserveBody()
+    {
+        var group = SimpleGroup(t =>
+        {
+            // No TodoEntry, no TodoDue — default (null) anchor
+            t.Alarms.Add(new RawSideText(
+                "BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER:-PT15M\r\nEND:VALARM"));
+        });
+
+        var task = CalendarTaskMapper.Map(group, out var warnings);
+
+        Assert.NotNull(task);
+        Assert.False(task.ReminderSet);
+        Assert.Single(warnings);
+        Assert.Contains("alarm has no anchor date", warnings[0]);
+        Assert.NotNull(task.Body);
+        Assert.Contains("[Thunderbird alarm not converted:", task.Body);
+    }
+
+    // -----------------------------------------------------------------------
+    // Multiple alarms → warning + only first converted
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void MultipleAlarms_WarnsAndConvertsFirst()
+    {
+        var startMicros = MicrosFor(2026, 8, 1, 10, 0);
+        var group = SimpleGroup(t =>
+        {
+            t.TodoEntry = startMicros;
+            t.Alarms.Add(new RawSideText(
+                "BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER;RELATED=START:-PT15M\r\nEND:VALARM"));
+            t.Alarms.Add(new RawSideText(
+                "BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER;RELATED=START:-PT5M\r\nEND:VALARM"));
+        });
+
+        var task = CalendarTaskMapper.Map(group, out var warnings);
+
+        Assert.NotNull(task);
+        Assert.True(task.ReminderSet);
+        Assert.Single(warnings);
+        Assert.Contains("multiple Thunderbird alarms", warnings[0]);
+        // First alarm (-PT15M) is used
+        var expectedStart = PrTime.FromMicros(startMicros)!.Value;
+        Assert.Equal(expectedStart.AddMinutes(-15), task.ReminderTime!.Value);
+    }
+
+    // -----------------------------------------------------------------------
+    // Absolute trigger
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Alarm_AbsoluteTrigger_SetsReminderToAbsoluteUtc()
+    {
+        var group = SimpleGroup(t =>
+        {
+            t.TodoDue = MicrosFor(2026, 8, 5);
+            t.Alarms.Add(new RawSideText(
+                "BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER;VALUE=DATE-TIME:20260801T070000Z\r\nEND:VALARM"));
+        });
+
+        var task = CalendarTaskMapper.Map(group, out var warnings);
+
+        Assert.NotNull(task);
+        Assert.True(task.ReminderSet);
+        Assert.NotNull(task.ReminderTime);
+        Assert.Equal(new DateTimeOffset(2026, 8, 1, 7, 0, 0, TimeSpan.Zero), task.ReminderTime!.Value);
+        Assert.Empty(warnings);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Calendar/GlobalObjectIdCodecTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/GlobalObjectIdCodecTests.cs
@@ -33,7 +33,7 @@ public class GlobalObjectIdCodecTests
     public void Mozilla_uuid_is_not_a_goid()   => Assert.False(GlobalObjectIdCodec.TryDecode("4ad842d0-1234-5678-9abc-def012345678", out _, out _));
 
     [Fact]
-    public void Caldav_email_uid_is_not_a_goid() => Assert.False(GlobalObjectIdCodec.TryDecode("abc123@google.com", out _, out _));
+    public void Caldav_email_uid_is_not_a_goid() => Assert.False(GlobalObjectIdCodec.TryDecode("abc123@example.com", out _, out _));
 
     [Fact]
     public void Null_or_empty_is_not_a_goid()   => Assert.False(GlobalObjectIdCodec.TryDecode(null, out _, out _));

--- a/tests/Mail2Pst.Core.Tests/Calendar/GlobalObjectIdCodecTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/GlobalObjectIdCodecTests.cs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using Mail2Pst.Core.Calendar;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Calendar;
+
+/// <summary>
+/// Unit tests for <see cref="GlobalObjectIdCodec"/>.
+/// All data is synthetic (Exchange GOID format verified from real Outlook dump, Task 0).
+/// </summary>
+public class GlobalObjectIdCodecTests
+{
+    // A real-looking Exchange GOID hex string (112 chars = 56 bytes).
+    // Prefix: 040000008200E00074C5B7101A82E008 (EDK byte-array class id, bytes 0-15).
+    // Bytes 16-19 (exception-date): 00000000 (already zero in this sample).
+    private const string GoidHex =
+        "040000008200E00074C5B7101A82E00800000000B40F44F359B6DC01000000000000000010000000DC21992D2F90224BB5EE6F8189627094";
+
+    [Fact]
+    public void Exchange_hex_id_decodes_to_56_byte_goid()
+    {
+        Assert.True(GlobalObjectIdCodec.TryDecode(GoidHex, out var goid, out var clean));
+        Assert.Equal(56, goid.Length);
+        Assert.Equal(Convert.FromHexString(GoidHex), goid);
+        // CleanGlobalObjectId zeroes the exception-date bytes [16..20]; identical here (already zero).
+        Assert.Equal(0, clean[16]); Assert.Equal(0, clean[17]); Assert.Equal(0, clean[18]); Assert.Equal(0, clean[19]);
+    }
+
+    [Fact]
+    public void Mozilla_uuid_is_not_a_goid()   => Assert.False(GlobalObjectIdCodec.TryDecode("4ad842d0-1234-5678-9abc-def012345678", out _, out _));
+
+    [Fact]
+    public void Caldav_email_uid_is_not_a_goid() => Assert.False(GlobalObjectIdCodec.TryDecode("abc123@google.com", out _, out _));
+
+    [Fact]
+    public void Null_or_empty_is_not_a_goid()   => Assert.False(GlobalObjectIdCodec.TryDecode(null, out _, out _));
+
+    [Fact]
+    public void Clean_zeroes_only_the_exception_date_bytes()
+    {
+        // Synthetic GOID with NON-ZERO date bytes [16..20] proves the clean transform (the real sample is
+        // already zero there, so it can't). Bytes 0..15 = EDK prefix; force 16..19 = AA BB CC DD.
+        byte[] goid = Convert.FromHexString("040000008200E00074C5B7101A82E008" + "AABBCCDD"
+            + "74D8B6378F09DD01000000000000000010000000DC21992D2F90224BB5EE6F8189627094");
+        string hex = Convert.ToHexString(goid);
+        Assert.True(GlobalObjectIdCodec.TryDecode(hex, out var full, out var clean));
+        Assert.Equal(goid, full);                                   // full = verbatim
+        for (int i = 16; i < 20; i++) Assert.Equal(0, clean[i]);    // date bytes zeroed
+        for (int i = 0; i < 16; i++)  Assert.Equal(full[i], clean[i]);   // prefix untouched
+        for (int i = 20; i < 56; i++) Assert.Equal(full[i], clean[i]);   // everything after untouched
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Calendar/IcalNetAvailableTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/IcalNetAvailableTests.cs
@@ -1,0 +1,17 @@
+using System.Linq;
+using Ical.Net;
+using IcalCalendar = Ical.Net.Calendar;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Calendar;
+
+public class IcalNetAvailableTests
+{
+    [Fact]
+    public void IcalNet_loads_a_minimal_vevent()
+    {
+        var cal = IcalCalendar.Load("BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//x//x//EN\r\n" +
+            "BEGIN:VEVENT\r\nUID:1\r\nSUMMARY:Hi\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+        Assert.Equal("Hi", cal.Events.Single().Summary);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Calendar/IcalParseSupportTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/IcalParseSupportTests.cs
@@ -63,4 +63,16 @@ public class IcalParseSupportTests
         Assert.Contains("END:VEVENT", ics);
         Assert.Contains("END:VCALENDAR", ics);
     }
+
+    [Fact]
+    public void Unfold_joins_three_continuation_lines()
+        // A value folded across three lines — all three segments join with no separator.
+        => Assert.Equal("DESCRIPTION:abcdef",
+            IcalParseSupport.UnfoldIcalLines("DESCRIPTION:ab\r\n cd\r\n ef"));
+
+    [Fact]
+    public void Unfold_handles_fold_at_value_start()
+        // Fold immediately after the colon: value starts on the continuation line.
+        => Assert.Equal("DESCRIPTION:value",
+            IcalParseSupport.UnfoldIcalLines("DESCRIPTION:\r\n value"));
 }

--- a/tests/Mail2Pst.Core.Tests/Calendar/IcalParseSupportTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/IcalParseSupportTests.cs
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using Mail2Pst.Core.Calendar;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Calendar;
+
+public class IcalParseSupportTests
+{
+    [Fact]
+    public void Unfold_joins_continuation_lines()
+        => Assert.Equal("ATTENDEE:mailto:folded@example.com",
+            IcalParseSupport.UnfoldIcalLines("ATTENDEE:mailto:\r\n folded@example.com"));
+
+    [Fact]
+    public void WrapVevent_embeds_body_in_a_loadable_calendar()
+    {
+        var ics = IcalParseSupport.WrapVevent("SUMMARY:Hi");
+        Assert.Contains("BEGIN:VEVENT", ics);
+        Assert.Contains("DTSTART:", ics);
+        Assert.Contains("SUMMARY:Hi", ics);
+        Assert.Equal("Hi", Ical.Net.Calendar.Load(ics).Events[0].Summary);
+    }
+
+    [Fact]
+    public void ParseResult_fail_carries_warning_and_null_value()
+    {
+        var r = ParseResult<string>.Fail("bad");
+        Assert.Null(r.Value);
+        Assert.Single(r.Warnings);
+    }
+
+    [Fact]
+    public void ParseResult_ok_carries_value_and_no_warnings()
+    {
+        var r = ParseResult<string>.Ok("hello");
+        Assert.Equal("hello", r.Value);
+        Assert.Empty(r.Warnings);
+    }
+
+    [Fact]
+    public void Unfold_handles_tab_continuation()
+        // RFC-5545: the leading whitespace (fold marker) is stripped; "long" + "text" join directly.
+        => Assert.Equal("DESCRIPTION:longtext here",
+            IcalParseSupport.UnfoldIcalLines("DESCRIPTION:long\r\n\ttext here"));
+
+    [Fact]
+    public void Unfold_normalises_bare_cr_line_endings()
+        => Assert.Equal("A:1\r\nB:2",
+            IcalParseSupport.UnfoldIcalLines("A:1\rB:2"));
+
+    [Fact]
+    public void Unfold_normalises_bare_lf_line_endings()
+        => Assert.Equal("A:1\r\nB:2",
+            IcalParseSupport.UnfoldIcalLines("A:1\nB:2"));
+
+    [Fact]
+    public void WrapVevent_includes_required_calendar_structure()
+    {
+        var ics = IcalParseSupport.WrapVevent("SUMMARY:Test");
+        Assert.StartsWith("BEGIN:VCALENDAR", ics);
+        Assert.Contains("VERSION:2.0", ics);
+        Assert.Contains("END:VEVENT", ics);
+        Assert.Contains("END:VCALENDAR", ics);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Calendar/ParseAlarmTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/ParseAlarmTests.cs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using Mail2Pst.Core.Calendar;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Calendar;
+
+public class ParseAlarmTests
+{
+    [Fact]
+    public void Before_start_relative_15m()
+    {
+        var a = ICalTextParser.ParseAlarm("BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER:-PT15M\r\nEND:VALARM").Value!;
+        Assert.Equal("DISPLAY", a.Action);
+        Assert.Equal(TimeSpan.FromMinutes(-15), a.RelativeOffset);
+    }
+
+    [Theory]
+    [InlineData("-P1D")]
+    [InlineData("-PT7H")]
+    [InlineData("PT9H")]
+    public void Various_relative_triggers_parse(string trig)
+        => Assert.NotNull(ICalTextParser.ParseAlarm($"BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER:{trig}\r\nEND:VALARM").Value!.RelativeOffset);
+
+    [Fact]
+    public void Related_end_is_preserved()
+    {
+        var a = ICalTextParser.ParseAlarm("BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER;RELATED=END:-PT15M\r\nEND:VALARM").Value!;
+        Assert.Equal("END", a.Related);
+    }
+
+    [Fact]
+    public void Absolute_trigger_sets_utc()
+    {
+        var a = ICalTextParser.ParseAlarm("BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER;VALUE=DATE-TIME:20260701T070000Z\r\nEND:VALARM").Value!;
+        Assert.NotNull(a.AbsoluteTimeUtc);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Calendar/ParseAlarmTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/ParseAlarmTests.cs
@@ -36,4 +36,12 @@ public class ParseAlarmTests
         var a = ICalTextParser.ParseAlarm("BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER;VALUE=DATE-TIME:20260701T070000Z\r\nEND:VALARM").Value!;
         Assert.NotNull(a.AbsoluteTimeUtc);
     }
+
+    [Fact]
+    public void Description_is_preserved()
+    {
+        var a = ICalTextParser.ParseAlarm(
+            "BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER:-PT15M\r\nDESCRIPTION:Reminder text\r\nEND:VALARM").Value!;
+        Assert.Equal("Reminder text", a.Description);
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Calendar/ParseAttachmentTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/ParseAttachmentTests.cs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Text;
+using Mail2Pst.Core.Calendar;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Calendar;
+
+public class ParseAttachmentTests
+{
+    [Fact]
+    public void Remote_uri_is_a_link()
+    {
+        var a = ICalTextParser.ParseAttachment("ATTACH;FILENAME=\"r.txt\";FMTTYPE=text/plain:https://example.com/r").Value!;
+        Assert.Equal("https://example.com/r", a.Uri);
+        Assert.Null(a.InlineData);
+        Assert.Equal("r.txt", a.FileName);
+    }
+
+    [Fact]
+    public void Inline_base64_binary_is_decoded()
+    {
+        var a = ICalTextParser.ParseAttachment("ATTACH;ENCODING=BASE64;VALUE=BINARY;FMTTYPE=text/plain:aGk=").Value!;
+        Assert.Null(a.Uri);
+        Assert.Equal("hi", Encoding.UTF8.GetString(a.InlineData!));
+    }
+
+    [Fact]
+    public void Data_uri_is_decoded_to_inline()
+    {
+        var a = ICalTextParser.ParseAttachment("ATTACH;FILENAME=\"n.txt\":data:text/plain;base64,aGk=").Value!;
+        Assert.Null(a.Uri);
+        Assert.Equal("hi", Encoding.UTF8.GetString(a.InlineData!));
+        Assert.Equal("n.txt", a.FileName);
+    }
+
+    [Fact]
+    public void Malformed_attach_null_value_implies_warning_no_throw()
+    {
+        var r = ICalTextParser.ParseAttachment("ATTACH;:::"); // must not throw
+        if (r.Value is null) Assert.NotEmpty(r.Warnings);    // contract: a failed parse carries a warning
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Calendar/ParseAttachmentTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/ParseAttachmentTests.cs
@@ -32,12 +32,22 @@ public class ParseAttachmentTests
         Assert.Null(a.Uri);
         Assert.Equal("hi", Encoding.UTF8.GetString(a.InlineData!));
         Assert.Equal("n.txt", a.FileName);
+        Assert.Equal("text/plain", a.FormatType);
     }
 
     [Fact]
-    public void Malformed_attach_null_value_implies_warning_no_throw()
+    public void Data_uri_without_base64_is_decoded_as_utf8()
+    {
+        var a = ICalTextParser.ParseAttachment("ATTACH:data:text/plain,hello").Value!;
+        Assert.Null(a.Uri);
+        Assert.Equal("hello", Encoding.UTF8.GetString(a.InlineData!));
+    }
+
+    [Fact]
+    public void Malformed_attach_returns_null_value_and_warning()
     {
         var r = ICalTextParser.ParseAttachment("ATTACH;:::"); // must not throw
-        if (r.Value is null) Assert.NotEmpty(r.Warnings);    // contract: a failed parse carries a warning
+        Assert.Null(r.Value);
+        Assert.NotEmpty(r.Warnings);
     }
 }

--- a/tests/Mail2Pst.Core.Tests/Calendar/ParseAttendeesTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/ParseAttendeesTests.cs
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Linq;
+using Mail2Pst.Core.Calendar;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Calendar;
+
+public class ParseAttendeesTests
+{
+    [Fact]
+    public void Attendee_and_organizer_with_cutype_and_roles()
+    {
+        var r = ICalTextParser.ParseAttendees(new[]{
+            "ATTENDEE;CN=Alice;PARTSTAT=ACCEPTED;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:alice@example.com",
+            "ATTENDEE;ROLE=OPT-PARTICIPANT;CUTYPE=ROOM:mailto:room1@example.com",
+            "ORGANIZER;CN=Boss:mailto:boss@example.com"});
+        var list = r.Value!;
+        var a = list.Single(x => x.Email == "alice@example.com");
+        Assert.Equal("Alice", a.CommonName); Assert.Equal("ACCEPTED", a.ParticipationStatus);
+        Assert.Equal("REQ-PARTICIPANT", a.Role); Assert.Equal("INDIVIDUAL", a.CuType);
+        Assert.Equal("ROOM", list.Single(x => x.Email=="room1@example.com").CuType);
+        Assert.Contains(list, x => x.IsOrganizer && x.Email == "boss@example.com");
+    }
+
+    [Fact]
+    public void Malformed_attendee_line_returns_non_null_list_no_throw()
+        => Assert.NotNull(ICalTextParser.ParseAttendees(new[]{"ATTENDEE;:::garbage"}).Value); // contract: Value is empty-or-partial, never null
+}

--- a/tests/Mail2Pst.Core.Tests/Calendar/ParseRecurrenceTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/ParseRecurrenceTests.cs
@@ -70,4 +70,12 @@ public class ParseRecurrenceTests
     [Fact]
     public void Malformed_rrule_returns_warning_not_throw()
         => Assert.NotEmpty(ICalTextParser.ParseRecurrence(new[]{"RRULE:FREQ=GARBAGE;;;"}).Warnings);
+
+    [Fact]
+    public void ParseRecurrence_surfaces_bysetpos()
+    {
+        var r = ICalTextParser.ParseRecurrence(new[] { "RRULE:FREQ=MONTHLY;BYDAY=MO;BYSETPOS=-1" });
+        Assert.NotNull(r.Value);
+        Assert.Equal(new[] { -1 }, r.Value!.BySetPosition);
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Calendar/ParseRecurrenceTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/ParseRecurrenceTests.cs
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Linq;
+using Mail2Pst.Core.Calendar;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Calendar;
+
+public class ParseRecurrenceTests
+{
+    [Fact]
+    public void Weekly_byday_interval_count_with_structured_exdate()
+    {
+        var r = ICalTextParser.ParseRecurrence(new[] {
+            "RRULE:FREQ=WEEKLY;BYDAY=MO,WE;INTERVAL=2;COUNT=10",
+            "EXDATE;TZID=(no TZ description);VALUE=DATE:20250516" });
+        Assert.Empty(r.Warnings);
+        var v = r.Value!;
+        Assert.Equal(ParsedFrequency.Weekly, v.Frequency);
+        Assert.Equal(2, v.Interval);
+        Assert.Equal(10, v.Count);
+        Assert.Contains(v.ByDay, d => d.DayOfWeek == System.DayOfWeek.Monday);
+        var ex = Assert.Single(v.ExDates);
+        Assert.Equal("(no TZ description)", ex.TzId);
+        Assert.True(ex.IsDateOnly);
+        Assert.Equal("20250516", ex.Values.Single());
+    }
+
+    [Theory]
+    [InlineData("RRULE:FREQ=MONTHLY;BYDAY=2MO;COUNT=5", ParsedFrequency.Monthly)]
+    [InlineData("RRULE:FREQ=YEARLY;BYMONTH=5;BYMONTHDAY=23", ParsedFrequency.Yearly)]
+    [InlineData("RRULE:FREQ=WEEKLY;UNTIL=20261231T235959Z", ParsedFrequency.Weekly)]
+    public void Parses_frequency_variants(string rrule, ParsedFrequency expected)
+        => Assert.Equal(expected, ICalTextParser.ParseRecurrence(new[]{rrule}).Value!.Frequency);
+
+    [Fact]
+    public void Monthly_byday_keeps_offset()
+    {
+        var v = ICalTextParser.ParseRecurrence(new[]{"RRULE:FREQ=MONTHLY;BYDAY=2MO;COUNT=5"}).Value!;
+        Assert.Equal(2, v.ByDay.Single().Offset);
+    }
+
+    [Fact]
+    public void Rdate_is_structured()
+    {
+        var v = ICalTextParser.ParseRecurrence(new[]{
+            "RRULE:FREQ=WEEKLY",
+            "RDATE;TZID=Europe/Copenhagen:20260701T090000,20260708T090000"}).Value!;
+        var rd = Assert.Single(v.RDates);
+        Assert.Equal("Europe/Copenhagen", rd.TzId);
+        Assert.Equal(2, rd.Values.Count);
+    }
+
+    [Fact]
+    public void No_rrule_line_returns_null_value_no_warning()
+    {
+        var r = ICalTextParser.ParseRecurrence(new[]{"EXDATE:20260706"});
+        Assert.Null(r.Value);
+        Assert.Empty(r.Warnings);
+    }
+
+    [Fact]
+    public void Malformed_rrule_returns_warning_not_throw()
+        => Assert.NotEmpty(ICalTextParser.ParseRecurrence(new[]{"RRULE:FREQ=GARBAGE;;;"}).Warnings);
+}

--- a/tests/Mail2Pst.Core.Tests/Calendar/ParseRecurrenceTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/ParseRecurrenceTests.cs
@@ -27,6 +27,7 @@ public class ParseRecurrenceTests
     }
 
     [Theory]
+    [InlineData("RRULE:FREQ=DAILY", ParsedFrequency.Daily)]
     [InlineData("RRULE:FREQ=MONTHLY;BYDAY=2MO;COUNT=5", ParsedFrequency.Monthly)]
     [InlineData("RRULE:FREQ=YEARLY;BYMONTH=5;BYMONTHDAY=23", ParsedFrequency.Yearly)]
     [InlineData("RRULE:FREQ=WEEKLY;UNTIL=20261231T235959Z", ParsedFrequency.Weekly)]
@@ -57,6 +58,13 @@ public class ParseRecurrenceTests
         var r = ICalTextParser.ParseRecurrence(new[]{"EXDATE:20260706"});
         Assert.Null(r.Value);
         Assert.Empty(r.Warnings);
+    }
+
+    [Fact]
+    public void Weekly_byday_plain_has_null_offset()
+    {
+        var v = ICalTextParser.ParseRecurrence(new[]{"RRULE:FREQ=WEEKLY;BYDAY=MO"}).Value!;
+        Assert.Null(v.ByDay.Single().Offset);
     }
 
     [Fact]

--- a/tests/Mail2Pst.Core.Tests/Calendar/ParseRecurrenceTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/ParseRecurrenceTests.cs
@@ -26,6 +26,35 @@ public class ParseRecurrenceTests
         Assert.Equal("20250516", ex.Values.Single());
     }
 
+    [Fact]
+    public void Rrule_with_trailing_crlf_parses_successfully()
+    {
+        // Real Thunderbird cal_recurrence stores each property with a trailing CRLF line
+        // terminator. The final token (WKST=SU) must not carry the "\r\n" into Ical.Net,
+        // which rejects "SU\r\n" as an invalid day-of-week indicator.
+        var r = ICalTextParser.ParseRecurrence(new[] {
+            "RRULE:FREQ=WEEKLY;BYDAY=MO;UNTIL=20260901T120000Z;WKST=SU\r\n" });
+        Assert.Empty(r.Warnings);
+        var v = r.Value!;
+        Assert.Equal(ParsedFrequency.Weekly, v.Frequency);
+        Assert.Equal(System.DayOfWeek.Monday, v.ByDay.Single().DayOfWeek);
+        Assert.NotNull(v.UntilUtc);
+    }
+
+    [Fact]
+    public void Exdate_with_trailing_crlf_value_is_clean()
+    {
+        // The trailing CRLF must be stripped from the EXDATE value, or the downstream
+        // date parse (yyyyMMddTHHmmss) fails and the deletion is silently lost.
+        var r = ICalTextParser.ParseRecurrence(new[] {
+            "RRULE:FREQ=WEEKLY;BYDAY=MO\r\n",
+            "EXDATE;TZID=Europe/Copenhagen:20260706T140000\r\n" });
+        Assert.Empty(r.Warnings);
+        var ex = Assert.Single(r.Value!.ExDates);
+        Assert.Equal("Europe/Copenhagen", ex.TzId);
+        Assert.Equal("20260706T140000", ex.Values.Single());
+    }
+
     [Theory]
     [InlineData("RRULE:FREQ=DAILY", ParsedFrequency.Daily)]
     [InlineData("RRULE:FREQ=MONTHLY;BYDAY=2MO;COUNT=5", ParsedFrequency.Monthly)]

--- a/tests/Mail2Pst.Core.Tests/Calendar/PrTimeTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/PrTimeTests.cs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using Mail2Pst.Core.Calendar;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Calendar;
+
+public class PrTimeTests
+{
+    [Fact]
+    public void Converts_microseconds_since_epoch_to_utc()
+        => Assert.Equal(new DateTimeOffset(2026, 6, 30, 9, 0, 0, TimeSpan.Zero),
+                        PrTime.FromMicros(1782810000000000L));
+
+    [Fact]
+    public void Null_passes_through() => Assert.Null(PrTime.FromMicros(null));
+}

--- a/tests/Mail2Pst.Core.Tests/Calendar/PrTimeTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/PrTimeTests.cs
@@ -15,4 +15,28 @@ public class PrTimeTests
 
     [Fact]
     public void Null_passes_through() => Assert.Null(PrTime.FromMicros(null));
+
+    /// <summary>
+    /// Should-fix (SF-E): PRTime is microseconds — sub-millisecond precision must be preserved
+    /// (the old `micros / 1000` truncated it). 1234 µs = 12,340 ticks past the epoch.
+    /// </summary>
+    [Fact]
+    public void Preserves_sub_millisecond_precision()
+    {
+        var r = PrTime.FromMicros(1234L);
+        Assert.NotNull(r);
+        Assert.Equal(12_340L, (r!.Value - DateTimeOffset.UnixEpoch).Ticks);
+    }
+
+    /// <summary>
+    /// Should-fix (SF-E): pre-1970 (negative) micros must not mis-round toward zero.
+    /// -1234 µs = -12,340 ticks (the old truncating division gave -10,000).
+    /// </summary>
+    [Fact]
+    public void Pre_epoch_negative_micros_do_not_misround()
+    {
+        var r = PrTime.FromMicros(-1234L);
+        Assert.NotNull(r);
+        Assert.Equal(-12_340L, (r!.Value - DateTimeOffset.UnixEpoch).Ticks);
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Calendar/RecurrenceMappingTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/RecurrenceMappingTests.cs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using Mail2Pst.Core.Calendar;
+using Mail2Pst.Core.Models;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Calendar;
+
+public class RecurrenceMappingTests
+{
+    [Fact]
+    public void FromIcal_weekly_count_maps_spec()
+    {
+        var (spec, reason) = RecurrenceMapping.FromIcal(
+            new[] { "RRULE:FREQ=WEEKLY;BYDAY=MO;COUNT=5" },
+            new DateTime(2026, 7, 6, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 7, 6, 0, 0, 0), null, "UTC");
+        Assert.Null(reason);
+        Assert.NotNull(spec);
+        Assert.Equal(RecurrenceFrequency.Weekly, spec!.Frequency);
+        Assert.Equal(RecurrenceEndKind.Count, spec.EndKind);
+        Assert.Equal(5, spec.Count);
+    }
+
+    [Fact]
+    public void FromIcal_bysetpos_degrades()
+    {
+        var (spec, reason) = RecurrenceMapping.FromIcal(
+            new[] { "RRULE:FREQ=MONTHLY;BYDAY=MO;BYSETPOS=-1" },
+            new DateTime(2026, 7, 6, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 7, 6, 0, 0, 0), null, "UTC");
+        Assert.Null(spec);
+        Assert.Contains("BYSETPOS", reason);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Calendar/RecurrenceMappingTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/RecurrenceMappingTests.cs
@@ -51,6 +51,27 @@ public class RecurrenceMappingTests
         Assert.Contains("BYMONTHDAY", reason);
     }
 
+    /// <summary>
+    /// Mutation-coverage (Stryker): pins the exact valid BYMONTHDAY boundaries. Both 1 and 31 must MAP
+    /// (they are in range). This kills the surviving `&lt;1`→`&lt;=1`, `&gt;31`→`&gt;=31`, and
+    /// `&gt;31`→`&lt;31` boundary mutations — each would wrongly degrade day 1 or day 31. (Out-of-range
+    /// values like 32/0 are rejected by the iCal parser upstream, so they never reach this guard.)
+    /// </summary>
+    [Theory]
+    [InlineData(1)]    // first of month — must map, not degrade
+    [InlineData(31)]   // 31st — upper boundary, must map
+    public void FromIcal_valid_bymonthday_boundaries_map(int day)
+    {
+        var (spec, reason) = RecurrenceMapping.FromIcal(
+            new[] { $"RRULE:FREQ=MONTHLY;BYMONTHDAY={day};COUNT=3" },
+            new DateTime(2026, 7, 15, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 7, 15, 0, 0, 0), null, "UTC");
+
+        Assert.NotNull(spec);
+        Assert.Null(reason);
+        Assert.Equal(day, spec!.DayOfMonth);
+    }
+
     /// <summary>Pre-merge review #4: negative BYMONTHDAY on a yearly rule degrades too.</summary>
     [Fact]
     public void FromIcal_negative_bymonthday_yearly_degrades()

--- a/tests/Mail2Pst.Core.Tests/Calendar/RecurrenceMappingTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/RecurrenceMappingTests.cs
@@ -34,4 +34,32 @@ public class RecurrenceMappingTests
         Assert.Null(spec);
         Assert.Contains("BYSETPOS", reason);
     }
+
+    /// <summary>
+    /// Pre-merge review #4: a negative BYMONTHDAY (-1 = last day of month; emitted by Google Calendar)
+    /// is not representable as a fixed day-of-month — <c>(uint)(-1)</c> would corrupt the recurrence
+    /// blob. It must degrade to a single occurrence + warning, not silently map.
+    /// </summary>
+    [Fact]
+    public void FromIcal_negative_bymonthday_monthly_degrades()
+    {
+        var (spec, reason) = RecurrenceMapping.FromIcal(
+            new[] { "RRULE:FREQ=MONTHLY;BYMONTHDAY=-1;COUNT=3" },
+            new DateTime(2026, 7, 31, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 7, 31, 0, 0, 0), null, "UTC");
+        Assert.Null(spec);
+        Assert.Contains("BYMONTHDAY", reason);
+    }
+
+    /// <summary>Pre-merge review #4: negative BYMONTHDAY on a yearly rule degrades too.</summary>
+    [Fact]
+    public void FromIcal_negative_bymonthday_yearly_degrades()
+    {
+        var (spec, reason) = RecurrenceMapping.FromIcal(
+            new[] { "RRULE:FREQ=YEARLY;BYMONTH=12;BYMONTHDAY=-1;COUNT=3" },
+            new DateTime(2026, 12, 31, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 12, 31, 0, 0, 0), null, "UTC");
+        Assert.Null(spec);
+        Assert.Contains("BYMONTHDAY", reason);
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Calendar/RecurrenceSpecTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/RecurrenceSpecTests.cs
@@ -1,0 +1,19 @@
+using System; using Mail2Pst.Core.Models; using Xunit;
+namespace Mail2Pst.Core.Tests.Calendar;
+public class RecurrenceSpecTests
+{
+    [Fact] public void Defaults_have_no_recurrence_and_no_tzid()
+    {
+        var a = new AppointmentRecord();
+        Assert.Null(a.Recurrence); Assert.Empty(a.DeletedOccurrences); Assert.Empty(a.Exceptions);
+        Assert.Null(a.OriginatingTimeZoneId);
+    }
+    [Fact] public void InstanceId_carries_iana_id_local_and_utc()
+    {
+        var id = new RecurrenceInstanceId(
+            new DateTime(2026,7,8,1,0,0,DateTimeKind.Utc),
+            new DateTime(2026,7,8,8,0,0,DateTimeKind.Unspecified), "Asia/Bangkok", false);
+        Assert.Equal("Asia/Bangkok", id.TimeZoneId);
+        Assert.Equal(8, id.OriginalStartLocal.Hour);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Calendar/SqliteCalendarReaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/SqliteCalendarReaderTests.cs
@@ -69,4 +69,46 @@ public class SqliteCalendarReaderTests
         }
         finally { File.Delete(path); }
     }
+
+    [Fact]
+    public void Properties_stored_as_text_or_integer_are_read_not_dropped()
+    {
+        // Real Thunderbird stores cal_properties.value as TEXT (DESCRIPTION/LOCATION/CATEGORIES/…)
+        // or INTEGER (e.g. PERCENT-COMPLETE), NOT BLOB. A hard (byte[]) cast throws and the
+        // whole-table catch drops EVERY property for EVERY event. The reader must handle text/int.
+        string path = Path.Combine(Path.GetTempPath(), $"cal-props-{System.Guid.NewGuid():N}.sqlite");
+        try
+        {
+            using (var c = new SqliteConnection($"Data Source={path}"))
+            {
+                c.Open();
+                void X(string sql){ using var cmd=c.CreateCommand(); cmd.CommandText=sql; cmd.ExecuteNonQuery(); }
+                X("CREATE TABLE cal_events (cal_id TEXT,id TEXT,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,event_start INTEGER,event_end INTEGER,event_start_tz TEXT,event_end_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,time_created INTEGER,last_modified INTEGER);");
+                X("CREATE TABLE cal_todos (cal_id TEXT,id TEXT,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,todo_entry INTEGER,todo_due INTEGER,todo_completed INTEGER,todo_complete INTEGER,todo_entry_tz TEXT,todo_due_tz TEXT,todo_completed_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,time_created INTEGER,last_modified INTEGER);");
+                X("CREATE TABLE cal_recurrence (item_id TEXT,cal_id TEXT,icalString TEXT);");
+                X("CREATE TABLE cal_attendees (item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT,icalString TEXT);");
+                X("CREATE TABLE cal_alarms (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+                X("CREATE TABLE cal_attachments (item_id TEXT,cal_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+                X("CREATE TABLE cal_relations (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+                X("CREATE TABLE cal_properties (item_id TEXT,key TEXT,value BLOB,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT);");
+                X("CREATE TABLE cal_parameters (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,key1 TEXT,key2 TEXT,value TEXT);");
+                X("INSERT INTO cal_events (cal_id,id,title,flags,event_start,event_end,event_start_tz,recurrence_id) VALUES ('CAL','E1','Ev',0,1782810000000000,1782811800000000,'UTC',NULL);");
+                X("INSERT INTO cal_properties (item_id,key,value,cal_id) VALUES ('E1','DESCRIPTION','Test','CAL');"); // TEXT
+                X("INSERT INTO cal_properties (item_id,key,value,cal_id) VALUES ('E1','LOCATION','Room 5','CAL');");  // TEXT
+                X("INSERT INTO cal_properties (item_id,key,value,cal_id) VALUES ('E1','SEQUENCE',2,'CAL');");         // INTEGER
+            }
+
+            var res = new SqliteCalendarReader().Read(path);
+
+            Assert.DoesNotContain(res.Warnings, w => w.Contains("cal_properties"));
+            var props = Assert.Single(res.Calendars.Single().EventGroups).Master!.Properties;
+            string? Val(string key) => props.Where(p => p.Key == key)
+                .Select(p => p.Value is { } b ? System.Text.Encoding.UTF8.GetString(b) : null)
+                .FirstOrDefault();
+            Assert.Equal("Test",   Val("DESCRIPTION"));
+            Assert.Equal("Room 5", Val("LOCATION"));
+            Assert.Equal("2",      Val("SEQUENCE"));
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Calendar/SqliteCalendarReaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/SqliteCalendarReaderTests.cs
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.IO;
+using System.Linq;
+using Microsoft.Data.Sqlite;
+using Mail2Pst.Core.Calendar;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Calendar;
+
+public class SqliteCalendarReaderTests
+{
+    private static string MakeStore()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"cal-{System.Guid.NewGuid():N}.sqlite");
+        using var c = new SqliteConnection($"Data Source={path}"); c.Open();
+        void X(string sql){ using var cmd=c.CreateCommand(); cmd.CommandText=sql; cmd.ExecuteNonQuery(); }
+        X("CREATE TABLE cal_events (cal_id TEXT,id TEXT,time_created INTEGER,last_modified INTEGER,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,event_start INTEGER,event_end INTEGER,event_stamp INTEGER,event_start_tz TEXT,event_end_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,alarm_last_ack INTEGER,offline_journal INTEGER);");
+        X("CREATE TABLE cal_todos (cal_id TEXT,id TEXT,time_created INTEGER,last_modified INTEGER,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,todo_entry INTEGER,todo_due INTEGER,todo_completed INTEGER,todo_complete INTEGER,todo_entry_tz TEXT,todo_due_tz TEXT,todo_completed_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,alarm_last_ack INTEGER,todo_stamp INTEGER,offline_journal INTEGER);");
+        X("CREATE TABLE cal_recurrence (item_id TEXT,cal_id TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_attendees (item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_alarms (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_attachments (item_id TEXT,cal_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_relations (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_properties (item_id TEXT,key TEXT,value BLOB,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT);");
+        X("CREATE TABLE cal_parameters (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,key1 TEXT,key2 TEXT,value TEXT);");
+        // CAL / E1: master + override
+        X("INSERT INTO cal_events (cal_id,id,title,flags,event_start,event_end,event_start_tz,recurrence_id) VALUES ('CAL','E1','Standup',0,1782810000000000,1782811800000000,'Europe/Copenhagen',NULL);");
+        X("INSERT INTO cal_events (cal_id,id,title,flags,event_start,event_end,event_start_tz,recurrence_id) VALUES ('CAL','E1','Standup moved',0,1782896400000000,1782898200000000,'Europe/Copenhagen',1782896400000000);");
+        X("INSERT INTO cal_recurrence (item_id,cal_id,icalString) VALUES ('E1','CAL','RRULE:FREQ=DAILY');");
+        X("INSERT INTO cal_attendees (item_id,cal_id,icalString) VALUES ('E1','CAL','ATTENDEE;CN=A:mailto:a@example.com');");
+        X("INSERT INTO cal_attendees (item_id,cal_id,icalString) VALUES ('E1','CAL','ATTENDEE;CN=B:mailto:b@example.com');");
+        X("INSERT INTO cal_alarms (cal_id,item_id,icalString) VALUES ('CAL','E1','BEGIN:VALARM\nTRIGGER:-PT15M\nEND:VALARM');");
+        X("INSERT INTO cal_alarms (cal_id,item_id,icalString) VALUES ('CAL','E1','BEGIN:VALARM\nTRIGGER:-PT5M\nEND:VALARM');");
+        X("INSERT INTO cal_properties (item_id,key,value,cal_id) VALUES ('E1','DESCRIPTION',CAST('d' AS BLOB),'CAL');");
+        X("INSERT INTO cal_properties (item_id,key,value,cal_id) VALUES ('E1','LOCATION',CAST('room' AS BLOB),'CAL');");
+        X("INSERT INTO cal_todos (cal_id,id,title,flags,todo_entry,todo_due,todo_complete,recurrence_id) VALUES ('CAL','T1','Report',0,1782810000000000,1782820000000000,0,NULL);");
+        // CAL2 reuses id='E1' with its OWN single attendee (cross-attach guard)
+        X("INSERT INTO cal_events (cal_id,id,title,flags,event_start,event_start_tz,recurrence_id) VALUES ('CAL2','E1','Other',0,1782810000000000,'UTC',NULL);");
+        X("INSERT INTO cal_attendees (item_id,cal_id,icalString) VALUES ('E1','CAL2','ATTENDEE;CN=Z:mailto:z@example.com');");
+        return path;
+    }
+
+    [Fact]
+    public void Groups_events_and_todos_attaches_side_tables_without_cartesian_or_cross_attach()
+    {
+        string path = MakeStore();
+        try
+        {
+            CalendarReadResult res = new SqliteCalendarReader().Read(path);
+            RawCalendarRead cal = res.Calendars.Single(c => c.CalId == "CAL");
+
+            RawEventGroup grp = Assert.Single(cal.EventGroups);
+            Assert.NotNull(grp.Master);
+            Assert.Equal("Standup", grp.Master!.Title);
+            Assert.Single(grp.Overrides);                          // exactly one override
+            Assert.Equal(2, grp.Master.Attendees.Count);           // NOT 4/8 — no cartesian blow-up
+            Assert.Equal(2, grp.Master.Alarms.Count);
+            Assert.Equal(2, grp.Master.Properties.Count);
+            Assert.Equal("RRULE:FREQ=DAILY", Assert.Single(grp.Master.Recurrence).IcalString);
+
+            RawTodoGroup tg = Assert.Single(cal.TodoGroups);
+            Assert.Equal("Report", tg.Master!.Title);
+
+            // CAL2's E1 must carry ONLY its own single attendee — no cross-calendar bleed.
+            RawEventGroup other = Assert.Single(res.Calendars.Single(c => c.CalId == "CAL2").EventGroups);
+            Assert.Single(other.Master!.Attendees);
+        }
+        finally { File.Delete(path); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Calendar/SqliteCalendarReaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/SqliteCalendarReaderTests.cs
@@ -25,7 +25,7 @@ public class SqliteCalendarReaderTests
         X("CREATE TABLE cal_properties (item_id TEXT,key TEXT,value BLOB,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT);");
         X("CREATE TABLE cal_parameters (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,key1 TEXT,key2 TEXT,value TEXT);");
         // CAL / E1: master + override
-        X("INSERT INTO cal_events (cal_id,id,title,flags,event_start,event_end,event_start_tz,recurrence_id) VALUES ('CAL','E1','Standup',0,1782810000000000,1782811800000000,'Europe/Copenhagen',NULL);");
+        X("INSERT INTO cal_events (cal_id,id,title,flags,privacy,event_start,event_end,event_start_tz,recurrence_id) VALUES ('CAL','E1','Standup',0,'PRIVATE',1782810000000000,1782811800000000,'Europe/Copenhagen',NULL);");
         X("INSERT INTO cal_events (cal_id,id,title,flags,event_start,event_end,event_start_tz,recurrence_id) VALUES ('CAL','E1','Standup moved',0,1782896400000000,1782898200000000,'Europe/Copenhagen',1782896400000000);");
         X("INSERT INTO cal_recurrence (item_id,cal_id,icalString) VALUES ('E1','CAL','RRULE:FREQ=DAILY');");
         X("INSERT INTO cal_attendees (item_id,cal_id,icalString) VALUES ('E1','CAL','ATTENDEE;CN=A:mailto:a@example.com');");
@@ -53,6 +53,7 @@ public class SqliteCalendarReaderTests
             RawEventGroup grp = Assert.Single(cal.EventGroups);
             Assert.NotNull(grp.Master);
             Assert.Equal("Standup", grp.Master!.Title);
+            Assert.Equal("PRIVATE", grp.Master!.Privacy);          // iCal CLASS field round-trips as string
             Assert.Single(grp.Overrides);                          // exactly one override
             Assert.Equal(2, grp.Master.Attendees.Count);           // NOT 4/8 — no cartesian blow-up
             Assert.Equal(2, grp.Master.Alarms.Count);

--- a/tests/Mail2Pst.Core.Tests/Calendar/TimeZoneResolverTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/TimeZoneResolverTests.cs
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using Mail2Pst.Core.Calendar;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Calendar;
+
+public class TimeZoneResolverTests
+{
+    [Theory]
+    [InlineData("Europe/Copenhagen", "Europe/Copenhagen")]
+    [InlineData("Asia/Bangkok", "Asia/Bangkok")]
+    [InlineData("UTC", "UTC")]
+    public void Resolves_olson_and_utc(string input, string expectedId)
+    {
+        var r = TimeZoneResolver.Resolve(input);
+        Assert.False(r.IsFloating);
+        Assert.Equal(expectedId, r.Zone!.Id);
+        Assert.Equal(expectedId, r.ResolvedId);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("floating")]
+    public void Floating_is_floating_no_warning(string input)
+    {
+        var r = TimeZoneResolver.Resolve(input);
+        Assert.True(r.IsFloating);
+        Assert.Null(r.Warning);
+    }
+
+    [Fact]
+    public void No_tz_description_inline_is_floating_with_warning()
+    {
+        var r = TimeZoneResolver.Resolve("BEGIN:VTIMEZONE\r\nTZID:(no TZ description)\r\nEND:VTIMEZONE\r\n");
+        Assert.True(r.IsFloating);
+        Assert.NotNull(r.Warning);
+    }
+
+    [Fact]
+    public void Microsoft_utc_maps_to_utc()
+    {
+        var r = TimeZoneResolver.Resolve("BEGIN:VTIMEZONE\r\nTZID:tzone://Microsoft/Utc\r\nEND:VTIMEZONE\r\n");
+        Assert.Equal(TimeZoneInfo.Utc.Id, r.Zone!.Id);
+    }
+
+    [Fact]
+    public void Unresolvable_id_yields_warning_and_preserves_id_not_throw()
+    {
+        var r = TimeZoneResolver.Resolve("Mars/Phobos");
+        Assert.Null(r.Zone);
+        Assert.NotNull(r.Warning);
+        Assert.Equal("Mars/Phobos", r.ResolvedId);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Calendar/TimeZoneResolverTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/TimeZoneResolverTests.cs
@@ -24,7 +24,7 @@ public class TimeZoneResolverTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("floating")]
-    public void Floating_is_floating_no_warning(string input)
+    public void Floating_is_floating_no_warning(string? input)
     {
         var r = TimeZoneResolver.Resolve(input);
         Assert.True(r.IsFloating);
@@ -42,8 +42,31 @@ public class TimeZoneResolverTests
     [Fact]
     public void Microsoft_utc_maps_to_utc()
     {
-        var r = TimeZoneResolver.Resolve("BEGIN:VTIMEZONE\r\nTZID:tzone://Microsoft/Utc\r\nEND:VTIMEZONE\r\n");
+        const string block = "BEGIN:VTIMEZONE\r\nTZID:tzone://Microsoft/Utc\r\nEND:VTIMEZONE\r\n";
+        var r = TimeZoneResolver.Resolve(block);
         Assert.Equal(TimeZoneInfo.Utc.Id, r.Zone!.Id);
+        // OriginalId must be the full inline block, not the extracted TZID.
+        Assert.StartsWith("BEGIN:VTIMEZONE", r.OriginalId);
+    }
+
+    [Fact]
+    public void No_tz_description_raw_is_floating_with_warning()
+    {
+        // Raw "(no TZ description)" string — not wrapped in a VTIMEZONE block.
+        var r = TimeZoneResolver.Resolve("(no TZ description)");
+        Assert.True(r.IsFloating);
+        Assert.NotNull(r.Warning);
+    }
+
+    [Fact]
+    public void Unresolvable_microsoft_tz_in_vtimezone_yields_warning_and_preserves_name()
+    {
+        const string block = "BEGIN:VTIMEZONE\r\nTZID:tzone://Microsoft/Made-Up-Zone\r\nEND:VTIMEZONE\r\n";
+        var r = TimeZoneResolver.Resolve(block);
+        Assert.Null(r.Zone);
+        Assert.NotNull(r.Warning);
+        // The stripped name after "tzone://Microsoft/" must be preserved in ResolvedId.
+        Assert.Equal("Made-Up-Zone", r.ResolvedId);
     }
 
     [Fact]

--- a/tests/Mail2Pst.Core.Tests/Cli/DiscoverCommandE2ETests.cs
+++ b/tests/Mail2Pst.Core.Tests/Cli/DiscoverCommandE2ETests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Data.Sqlite;
 using Xunit;
 
 namespace Mail2Pst.Core.Tests.Cli;
@@ -113,5 +114,66 @@ public class DiscoverCommandE2ETests
             Assert.Equal(1, root.GetProperty("pairing").GetProperty("pairedMsfCount").GetInt32());
         }
         finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void Discover_Profile_EmitsCalendarsArray()
+    {
+        // Build a minimal Thunderbird profile: Mail/LocalFolders triggers "thunderbird-profile"
+        // layout which calls DiscoverCalendars. A prefs.js registry entry + a local.sqlite row
+        // produce one DiscoveredCalendarSource. The test asserts it surfaces in the emitted JSON.
+        string profile = Path.Combine(Path.GetTempPath(), "m2p-cal-e2e-" + Guid.NewGuid());
+        Directory.CreateDirectory(Path.Combine(profile, "Mail", "Local Folders"));
+        Directory.CreateDirectory(Path.Combine(profile, "calendar-data"));
+        try
+        {
+            File.WriteAllText(Path.Combine(profile, "prefs.js"),
+                "user_pref(\"calendar.registry.CAL1.name\", \"Work\");\n" +
+                "user_pref(\"calendar.registry.CAL1.type\", \"storage\");\n" +
+                "user_pref(\"calendar.registry.CAL1.calendar-main-in-composite\", true);\n",
+                new UTF8Encoding(false));
+
+            MakeCalStore(Path.Combine(profile, "calendar-data", "local.sqlite"), "CAL1", addEvent: true);
+
+            (int exit, string stdout, string stderr) = RunCli($"discover --input \"{profile}\"");
+            Assert.True(exit == 0, $"expected exit 0, got {exit}. stderr: {stderr}");
+
+            using JsonDocument doc = JsonDocument.Parse(stdout);
+            JsonElement root = doc.RootElement;
+            Assert.Equal("discovery", root.GetProperty("type").GetString());
+            Assert.Equal(1, root.GetProperty("schemaVersion").GetInt32());
+
+            JsonElement calendars = root.GetProperty("calendars");
+            Assert.Equal(1, calendars.GetArrayLength());
+            JsonElement cal = calendars.EnumerateArray().Single();
+            Assert.Equal("CAL1", cal.GetProperty("calId").GetString());
+            Assert.Equal("Work", cal.GetProperty("displayName").GetString());
+        }
+        finally
+        {
+            // Clear SQLite connection pool so the file lock is released on Windows before cleanup.
+            SqliteConnection.ClearAllPools();
+            Directory.Delete(profile, true);
+        }
+    }
+
+    // Minimal cal store (mirrors DiscoverCalendarsTests.MakeCalStore).
+    private static void MakeCalStore(string path, string calId, bool addEvent = true)
+    {
+        using var conn = new SqliteConnection($"Data Source={path}");
+        conn.Open();
+        void X(string sql) { using var cmd = conn.CreateCommand(); cmd.CommandText = sql; cmd.ExecuteNonQuery(); }
+        X("CREATE TABLE cal_events (cal_id TEXT,id TEXT,time_created INTEGER,last_modified INTEGER,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,event_start INTEGER,event_end INTEGER,event_stamp INTEGER,event_start_tz TEXT,event_end_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,alarm_last_ack INTEGER,offline_journal INTEGER);");
+        X("CREATE TABLE cal_todos (cal_id TEXT,id TEXT,time_created INTEGER,last_modified INTEGER,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,todo_entry INTEGER,todo_due INTEGER,todo_completed INTEGER,todo_complete INTEGER,todo_entry_tz TEXT,todo_due_tz TEXT,todo_completed_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,alarm_last_ack INTEGER,todo_stamp INTEGER,offline_journal INTEGER);");
+        X("CREATE TABLE cal_recurrence (item_id TEXT,cal_id TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_attendees (item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_alarms (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_attachments (item_id TEXT,cal_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_relations (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_properties (item_id TEXT,key TEXT,value BLOB,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT);");
+        X("CREATE TABLE cal_parameters (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,key1 TEXT,key2 TEXT,value TEXT);");
+        if (addEvent)
+            X($"INSERT INTO cal_events (cal_id,id,title,flags,event_start,event_end,recurrence_id) " +
+              $"VALUES ('{calId}','ev1','Test Event',0,1782810000000000,1782811800000000,NULL);");
     }
 }

--- a/tests/Mail2Pst.Core.Tests/Config/ConfigValidatorAppointmentTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Config/ConfigValidatorAppointmentTests.cs
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Collections.Generic;
+using Mail2Pst.Core.Config;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Config;
+
+public class ConfigValidatorAppointmentTests
+{
+    [Fact]
+    public void Validate_IncludeAppointmentsTrue_Validates()
+    {
+        // PR5: IncludeAppointments is now supported — must NOT throw.
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    Sources = new List<SourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "local.sqlite",
+                            CalId = "home",
+                            IncludeAppointments = true,
+                            AppointmentFolderPath = new[] { "Calendars", "Home" },
+                        },
+                    },
+                },
+            },
+        };
+        ConfigValidator.Validate(config); // must not throw
+    }
+
+    [Fact]
+    public void Validate_AppointmentsOnlyGroup_IsLegal()
+    {
+        // A group that contributes only appointments (no mail, no contacts, no tasks).
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Calendars",
+                    Sources = new List<SourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "local.sqlite",
+                            CalId = "home",
+                            IncludeAppointments = true,
+                            AppointmentFolderPath = new[] { "Calendars", "Home" },
+                        },
+                    },
+                },
+            },
+        };
+        ConfigValidator.Validate(config); // must not throw
+    }
+
+    [Fact]
+    public void Validate_IncludeAppointmentsTrueNullCalIdNoAppointmentFolder_Throws()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    Sources = new List<SourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "local.sqlite",
+                            CalId = "",                   // empty = "all calendars in store"
+                            IncludeTasks = false,         // appointments only
+                            IncludeAppointments = true,
+                            AppointmentFolderPath = null, // no explicit path → can't build default
+                        },
+                    },
+                },
+            },
+        };
+        Assert.Throws<ConfigValidationException>(() => ConfigValidator.Validate(config));
+    }
+
+    [Fact]
+    public void Validate_IncludeAppointmentsTrueNullCalIdWithExplicitAppointmentFolder_DoesNotThrow()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    Sources = new List<SourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "local.sqlite",
+                            CalId = "",                                           // all calendars
+                            IncludeTasks = false,                                 // appointments only
+                            IncludeAppointments = true,
+                            AppointmentFolderPath = new[] { "Calendars", "All" }, // explicit path
+                        },
+                    },
+                },
+            },
+        };
+        ConfigValidator.Validate(config); // must not throw
+    }
+
+    [Fact]
+    public void Validate_EmptyElementInAppointmentFolderPath_Throws()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    Sources = new List<SourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "local.sqlite",
+                            CalId = "home",
+                            IncludeAppointments = true,
+                            AppointmentFolderPath = new[] { "Calendars", "" }, // empty segment
+                        },
+                    },
+                },
+            },
+        };
+        Assert.Throws<ConfigValidationException>(() => ConfigValidator.Validate(config));
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Config/ConfigValidatorTaskTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Config/ConfigValidatorTaskTests.cs
@@ -63,8 +63,9 @@ public class ConfigValidatorTaskTests
     }
 
     [Fact]
-    public void Validate_IncludeAppointmentsTrue_Throws()
+    public void Validate_IncludeAppointmentsTrueWithTasksTrue_Validates()
     {
+        // PR5: IncludeAppointments is now supported — both flags true on the same calendar is legal.
         var config = new ConversionConfig
         {
             Outputs = new List<OutputGroupConfig>
@@ -80,6 +81,7 @@ public class ConfigValidatorTaskTests
                             StorePath = "local.sqlite",
                             CalId = "home",
                             IncludeAppointments = true,
+                            AppointmentFolderPath = new[] { "Calendars", "Home" },
                             IncludeTasks = true,
                             TaskFolderPath = new[] { "Tasks", "Home" },
                         },
@@ -87,7 +89,7 @@ public class ConfigValidatorTaskTests
                 },
             },
         };
-        Assert.Throws<ConfigValidationException>(() => ConfigValidator.Validate(config));
+        ConfigValidator.Validate(config); // must not throw
     }
 
     [Fact]

--- a/tests/Mail2Pst.Core.Tests/Config/ConfigValidatorTaskTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Config/ConfigValidatorTaskTests.cs
@@ -1,0 +1,219 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Collections.Generic;
+using Mail2Pst.Core.Config;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Config;
+
+public class ConfigValidatorTaskTests
+{
+    [Fact]
+    public void Validate_CalendarOnlyOutput_IsLegal()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Tasks",
+                    Sources = new List<SourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "local.sqlite",
+                            CalId = "home",
+                            IncludeTasks = true,
+                            TaskFolderPath = new[] { "Tasks", "Home" },
+                        },
+                    },
+                },
+            },
+        };
+        ConfigValidator.Validate(config); // must not throw
+    }
+
+    [Fact]
+    public void Validate_EmptyStorePath_Throws()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    Sources = new List<SourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "",
+                            CalId = "home",
+                            IncludeTasks = true,
+                            TaskFolderPath = new[] { "Tasks", "Home" },
+                        },
+                    },
+                },
+            },
+        };
+        Assert.Throws<ConfigValidationException>(() => ConfigValidator.Validate(config));
+    }
+
+    [Fact]
+    public void Validate_IncludeAppointmentsTrue_Throws()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    Sources = new List<SourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "local.sqlite",
+                            CalId = "home",
+                            IncludeAppointments = true,
+                            IncludeTasks = true,
+                            TaskFolderPath = new[] { "Tasks", "Home" },
+                        },
+                    },
+                },
+            },
+        };
+        Assert.Throws<ConfigValidationException>(() => ConfigValidator.Validate(config));
+    }
+
+    [Fact]
+    public void Validate_BothFlagsFalse_Throws()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    Sources = new List<SourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "local.sqlite",
+                            CalId = "home",
+                            IncludeAppointments = false,
+                            IncludeTasks = false,
+                        },
+                    },
+                },
+            },
+        };
+        Assert.Throws<ConfigValidationException>(() => ConfigValidator.Validate(config));
+    }
+
+    [Fact]
+    public void Validate_IncludeTasksTrueNullCalIdNoTaskFolder_Throws()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    Sources = new List<SourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "local.sqlite",
+                            CalId = "",           // empty = "all calendars in store"
+                            IncludeTasks = true,
+                            TaskFolderPath = null, // no explicit path → can't build default
+                        },
+                    },
+                },
+            },
+        };
+        Assert.Throws<ConfigValidationException>(() => ConfigValidator.Validate(config));
+    }
+
+    [Fact]
+    public void Validate_IncludeTasksTrueNullCalIdWithExplicitTaskFolder_DoesNotThrow()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    Sources = new List<SourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "local.sqlite",
+                            CalId = "",                                    // all calendars
+                            IncludeTasks = true,
+                            TaskFolderPath = new[] { "Tasks", "All" },    // explicit path provided
+                        },
+                    },
+                },
+            },
+        };
+        ConfigValidator.Validate(config); // must not throw
+    }
+
+    [Fact]
+    public void Validate_EmptyElementInTaskFolderPath_Throws()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    Sources = new List<SourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "local.sqlite",
+                            CalId = "home",
+                            IncludeTasks = true,
+                            TaskFolderPath = new[] { "Tasks", "" },   // empty segment
+                        },
+                    },
+                },
+            },
+        };
+        Assert.Throws<ConfigValidationException>(() => ConfigValidator.Validate(config));
+    }
+
+    [Fact]
+    public void Validate_EmptyGroupWithNoSourcesContactsOrCalendars_Throws()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Empty",
+                    Sources = new List<SourceConfig>(),
+                    Contacts = new List<ContactSourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>(),
+                },
+            },
+        };
+        Assert.Throws<ConfigValidationException>(() => ConfigValidator.Validate(config));
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Contacts/ContactPropertyMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Contacts/ContactPropertyMapperTests.cs
@@ -37,6 +37,49 @@ public class ContactPropertyMapperTests
         Assert.Equal("card-1", c.SourceCardId);
     }
 
+    /// <summary>
+    /// Mutation-coverage (Stryker): the contact birthday parser (BirthYear/Month/Day) was entirely
+    /// uncovered. Valid dates must map; the month 1..12 and day 1..31 range guards must reject out-of-range.
+    /// </summary>
+    [Theory]
+    [InlineData("1990", "1", "1", 1990, 1, 1)]     // lower boundaries valid
+    [InlineData("1990", "12", "31", 1990, 12, 31)] // upper boundaries valid
+    public void Map_Birthday_valid_date(string y, string m, string d, int ey, int em, int ed)
+    {
+        var c = new ContactPropertyMapper().Map(new Dictionary<string, string>
+            { ["BirthYear"] = y, ["BirthMonth"] = m, ["BirthDay"] = d }, null);
+        Assert.NotNull(c.Birthday);
+        Assert.Equal(ey, c.Birthday!.Value.Year);
+        Assert.Equal(em, c.Birthday.Value.Month);
+        Assert.Equal(ed, c.Birthday.Value.Day);
+    }
+
+    [Theory]
+    [InlineData("1990", "13", "15")]  // month out of range
+    [InlineData("1990", "0", "15")]   // month out of range
+    [InlineData("1990", "6", "32")]   // day out of range
+    public void Map_Birthday_out_of_range_is_null(string y, string m, string d)
+    {
+        var c = new ContactPropertyMapper().Map(new Dictionary<string, string>
+            { ["BirthYear"] = y, ["BirthMonth"] = m, ["BirthDay"] = d }, null);
+        Assert.Null(c.Birthday);
+    }
+
+    /// <summary>
+    /// Mutation-coverage: a missing/zero year with a valid month+day must fall back to the 1604 sentinel
+    /// (Outlook's date-only birthday convention), not be dropped.
+    /// </summary>
+    [Fact]
+    public void Map_Birthday_missing_year_uses_sentinel()
+    {
+        var c = new ContactPropertyMapper().Map(new Dictionary<string, string>
+            { ["BirthMonth"] = "6", ["BirthDay"] = "15" }, null);
+        Assert.NotNull(c.Birthday);
+        Assert.Equal(1604, c.Birthday!.Value.Year);
+        Assert.Equal(6, c.Birthday.Value.Month);
+        Assert.Equal(15, c.Birthday.Value.Day);
+    }
+
     [Fact]
     public void Map_EmptyEmail_NotAddedToList()
     {

--- a/tests/Mail2Pst.Core.Tests/ConversionRunnerAppointmentTests.cs
+++ b/tests/Mail2Pst.Core.Tests/ConversionRunnerAppointmentTests.cs
@@ -6,6 +6,8 @@ using System.IO;
 using System.Linq;
 using Mail2Pst.Core;
 using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Reporting;
+using Microsoft.Data.Sqlite;
 using Xunit;
 
 namespace Mail2Pst.Core.Tests;
@@ -107,4 +109,106 @@ public class ConversionRunnerAppointmentTests
             Directory.Delete(dir, true);
         }
     }
+
+    /// <summary>
+    /// A degraded recurrence (BYSETPOS — cannot be mapped to RecurrenceSpec) must still count
+    /// as a converted appointment, not a skipped one.  Degrade = single occurrence + warning.
+    /// </summary>
+    [Fact]
+    public void Degraded_recurrence_counts_converted_not_skipped()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), $"m2p-runappt-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        string dbPath = MakeCalStore();
+        try
+        {
+            var report = RunConvertWith(dbPath, "test-cal", dir);
+
+            // One event in the store → must be counted as converted.
+            Assert.Equal(1, report.AppointmentsConverted);
+
+            // A warning about BYSETPOS must be present.
+            Assert.Contains(report.Warnings, w =>
+                w.Reason.Contains("BYSETPOS", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Creates a minimal Thunderbird calendar SQLite with one MONTHLY/BYSETPOS event.
+    /// All data is synthetic (example.com) — no real mail/PII.
+    /// </summary>
+    private static string MakeCalStore()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"cal-bysetpos-{Guid.NewGuid():N}.sqlite");
+        using var conn = new SqliteConnection($"Data Source={path}");
+        conn.Open();
+
+        void X(string sql)
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = sql;
+            cmd.ExecuteNonQuery();
+        }
+
+        // Schema (matches SqliteCalendarReader expectations).
+        X("CREATE TABLE cal_events (cal_id TEXT,id TEXT,time_created INTEGER,last_modified INTEGER,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,event_start INTEGER,event_end INTEGER,event_stamp INTEGER,event_start_tz TEXT,event_end_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,alarm_last_ack INTEGER,offline_journal INTEGER);");
+        X("CREATE TABLE cal_todos (cal_id TEXT,id TEXT,time_created INTEGER,last_modified INTEGER,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,todo_entry INTEGER,todo_due INTEGER,todo_completed INTEGER,todo_complete INTEGER,todo_entry_tz TEXT,todo_due_tz TEXT,todo_completed_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,alarm_last_ack INTEGER,todo_stamp INTEGER,offline_journal INTEGER);");
+        X("CREATE TABLE cal_recurrence (item_id TEXT,cal_id TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_attendees (item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_alarms (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_attachments (item_id TEXT,cal_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_relations (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_properties (item_id TEXT,key TEXT,value BLOB,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT);");
+        X("CREATE TABLE cal_parameters (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,key1 TEXT,key2 TEXT,value TEXT);");
+
+        // One event: MONTHLY BYSETPOS=-1 (last Monday of month) — triggers degrade path.
+        long start = MicrosFor(2026, 7, 6, 14, 0);   // Monday 2026-07-06 14:00 UTC
+        long end   = MicrosFor(2026, 7, 6, 15, 0);
+        X($"INSERT INTO cal_events (cal_id,id,title,flags,event_start,event_end,event_start_tz) " +
+          $"VALUES ('test-cal','bysetpos-01@example.com','Last Monday',0,{start},{end},'UTC');");
+        X("INSERT INTO cal_recurrence (item_id,cal_id,icalString) " +
+          "VALUES ('bysetpos-01@example.com','test-cal','RRULE:FREQ=MONTHLY;BYDAY=MO;BYSETPOS=-1');");
+
+        return path;
+    }
+
+    private static ConversionReport RunConvertWith(string dbPath, string calId, string outputDir)
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name    = "Out",
+                    Sources = new List<SourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath             = dbPath,
+                            CalId                 = calId,
+                            IncludeAppointments   = true,
+                            IncludeTasks          = false,
+                            AppointmentFolderPath = new[] { "Calendars", "TestCal" },
+                        },
+                    },
+                },
+            },
+        };
+        return new ConversionRunner().Run(config, outputDir);
+    }
+
+    private static long MicrosFor(int year, int month, int day, int hour = 0, int minute = 0) =>
+        new DateTimeOffset(year, month, day, hour, minute, 0, TimeSpan.Zero)
+            .ToUnixTimeMilliseconds() * 1000L;
 }

--- a/tests/Mail2Pst.Core.Tests/ConversionRunnerAppointmentTests.cs
+++ b/tests/Mail2Pst.Core.Tests/ConversionRunnerAppointmentTests.cs
@@ -127,6 +127,9 @@ public class ConversionRunnerAppointmentTests
             // One event in the store → must be counted as converted.
             Assert.Equal(1, report.AppointmentsConverted);
 
+            // Degraded is not skipped.
+            Assert.Equal(0, report.AppointmentsSkipped);
+
             // A warning about BYSETPOS must be present.
             Assert.Contains(report.Warnings, w =>
                 w.Reason.Contains("BYSETPOS", StringComparison.OrdinalIgnoreCase));

--- a/tests/Mail2Pst.Core.Tests/ConversionRunnerAppointmentTests.cs
+++ b/tests/Mail2Pst.Core.Tests/ConversionRunnerAppointmentTests.cs
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core;
+using Mail2Pst.Core.Config;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests;
+
+public class ConversionRunnerAppointmentTests
+{
+    /// <summary>
+    /// When skipAppointments is true, the runner must ignore plan.AppointmentMappings entirely,
+    /// produce zero AppointmentsConverted, and emit "appointments disabled by --no-appointments"
+    /// exactly once even when multiple output groups carry appointment mappings.
+    /// </summary>
+    [Fact]
+    public void Run_SkipAppointments_ZeroAppointmentsAndWarningEmittedOnce()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), $"m2p-runappt-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            // Config with IncludeAppointments=true and no real SQLite file.
+            // With skipAppointments=true the runner must never open the store.
+            var config = new ConversionConfig
+            {
+                Outputs = new List<OutputGroupConfig>
+                {
+                    new()
+                    {
+                        Name = "Out",
+                        Sources = new List<SourceConfig>(),
+                        Calendars = new List<CalendarSourceConfig>
+                        {
+                            new()
+                            {
+                                StorePath = Path.Combine(dir, "local.sqlite"), // does not exist
+                                CalId = "cal-guid-1",
+                                IncludeAppointments = true,
+                                IncludeTasks = false,
+                                AppointmentFolderPath = new[] { "Calendars", "MyCalendar" },
+                            },
+                        },
+                    },
+                },
+            };
+
+            var report = new ConversionRunner().Run(config, dir, skipAppointments: true);
+
+            Assert.Equal(0, report.AppointmentsConverted);
+
+            int warnCount = report.Warnings.Count(w =>
+                w.Reason.Contains("appointments disabled by --no-appointments", StringComparison.Ordinal));
+            Assert.Equal(1, warnCount);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    /// <summary>
+    /// When the appointment store path does not exist, the runner records a warning
+    /// and does not throw.
+    /// </summary>
+    [Fact]
+    public void Run_NonExistentStorePath_RecordsWarningAndDoesNotThrow()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), $"m2p-runappt-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var config = new ConversionConfig
+            {
+                Outputs = new List<OutputGroupConfig>
+                {
+                    new()
+                    {
+                        Name = "Out",
+                        Sources = new List<SourceConfig>(),
+                        Calendars = new List<CalendarSourceConfig>
+                        {
+                            new()
+                            {
+                                StorePath = Path.Combine(dir, "missing.sqlite"), // does not exist
+                                CalId = "cal-guid-1",
+                                IncludeAppointments = true,
+                                IncludeTasks = false,
+                                AppointmentFolderPath = new[] { "Calendars", "MyCalendar" },
+                            },
+                        },
+                    },
+                },
+            };
+
+            var report = new ConversionRunner().Run(config, dir);
+
+            Assert.Equal(0, report.AppointmentsConverted);
+            Assert.True(report.AppointmentWarningCount > 0);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/ConversionRunnerCalendarAttachmentTests.cs
+++ b/tests/Mail2Pst.Core.Tests/ConversionRunnerCalendarAttachmentTests.cs
@@ -92,6 +92,69 @@ public class ConversionRunnerCalendarAttachmentTests
     }
 
     // -----------------------------------------------------------------------
+    // Pre-merge review #3: one bad item must not abort the whole conversion.
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// A single event whose data throws inside the mapper (here: an out-of-range event_start that
+    /// overflows during date construction) must be recorded as a skip, NOT abort the entire run —
+    /// a good event in the same calendar must still convert. Before the fix the uncaught exception
+    /// escaped ConversionRunner.Run and aborted mail/contacts/all calendars.
+    /// </summary>
+    [Fact]
+    public void Event_that_throws_in_mapper_is_skipped_not_fatal_and_good_event_survives()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), $"m2p-runbad-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        string dbPath = MakeCalStoreWithBadAndGoodEvent();
+        try
+        {
+            // Must not throw.
+            var report = RunConvertWith(dbPath, "test-cal", dir);
+
+            // The good event converted; the bad one was skipped (not fatal).
+            Assert.Equal(1, report.AppointmentsConverted);
+            Assert.True(report.AppointmentsSkipped >= 1,
+                $"Expected the bad event to be recorded as skipped but got {report.AppointmentsSkipped}");
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    /// <summary>
+    /// A store with one event carrying an out-of-range (overflowing) start plus one normal event.
+    /// The bad event is ordered first to prove the good one is still reached after containment.
+    /// </summary>
+    private static string MakeCalStoreWithBadAndGoodEvent()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"cal-badgood-{Guid.NewGuid():N}.sqlite");
+        using var conn = new SqliteConnection($"Data Source={path}");
+        conn.Open();
+        CreateCalSchema(conn);
+
+        void X(string sql)
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = sql;
+            cmd.ExecuteNonQuery();
+        }
+
+        // Bad event: all-day (flags=8) with an absurd event_start that overflows date construction.
+        X($"INSERT INTO cal_events (cal_id,id,title,flags,event_start,event_end,event_start_tz) " +
+          $"VALUES ('test-cal','bad-01@example.com','Bad Event',8,{long.MaxValue},{long.MaxValue},'UTC');");
+        // Good event: a normal timed event.
+        long start = MicrosFor(2026, 7, 8, 9, 0);
+        long end   = MicrosFor(2026, 7, 8, 10, 0);
+        X($"INSERT INTO cal_events (cal_id,id,title,flags,event_start,event_end,event_start_tz) " +
+          $"VALUES ('test-cal','good-01@example.com','Good Event',0,{start},{end},'UTC');");
+
+        return path;
+    }
+
+    // -----------------------------------------------------------------------
     // Helpers — synthetic SQLite stores (no real mail/PII, all example.com).
     // -----------------------------------------------------------------------
 

--- a/tests/Mail2Pst.Core.Tests/ConversionRunnerCalendarAttachmentTests.cs
+++ b/tests/Mail2Pst.Core.Tests/ConversionRunnerCalendarAttachmentTests.cs
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core;
+using Mail2Pst.Core.Calendar;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Reporting;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests;
+
+public class ConversionRunnerCalendarAttachmentTests
+{
+    // -----------------------------------------------------------------------
+    // Internal-seam unit test — assert record.Attachments directly.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Resolve_sets_inline_attachment_on_record()
+    {
+        var rec = new AppointmentRecord { Subject = "s" };
+        var warns = new List<string>();
+        ConversionRunner.ApplyCalendarAttachments(
+            rec, new[] { new RawSideText("ATTACH;FILENAME=hi.txt;VALUE=BINARY;ENCODING=BASE64;FMTTYPE=text/plain:aGk=") },
+            new CalendarAttachmentResolver(exportRoot: null), warns.Add);
+        var a = Assert.Single(rec.Attachments);
+        Assert.Equal(CalendarAttachmentKind.InlineBytes, a.Kind);
+        Assert.Empty(warns);
+    }
+
+    // -----------------------------------------------------------------------
+    // Full-run warning plumbing — via ConversionRunner.Run over synthetic store.
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// An event with a remote-URL ATTACH must produce at least one appointment warning
+    /// containing "remote URL preserved as link, not fetched".
+    /// </summary>
+    [Fact]
+    public void Event_with_remote_url_attach_records_appointment_warning()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), $"m2p-runattach-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        string dbPath = MakeCalStoreWithRemoteAttach();
+        try
+        {
+            var report = RunConvertWith(dbPath, "test-cal", dir);
+
+            Assert.Equal(1, report.AppointmentsConverted);
+            Assert.True(report.AppointmentWarningCount >= 1,
+                $"Expected at least one appointment warning but got {report.AppointmentWarningCount}");
+            Assert.Contains(report.Warnings, w =>
+                w.Reason.Contains("remote URL preserved as link, not fetched", StringComparison.Ordinal));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    /// <summary>
+    /// An event with an inline (base64-encoded) ATTACH must count as converted
+    /// and produce no attachment-related warning.
+    /// </summary>
+    [Fact]
+    public void Event_with_inline_attach_counts_converted_no_attachment_warning()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), $"m2p-runattach-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        string dbPath = MakeCalStoreWithInlineAttach();
+        try
+        {
+            var report = RunConvertWith(dbPath, "test-cal", dir);
+
+            Assert.Equal(1, report.AppointmentsConverted);
+            // Inline attach must not produce a "preserved as link" or "not fetched" warning.
+            Assert.DoesNotContain(report.Warnings, w =>
+                w.Reason.Contains("preserved as link", StringComparison.Ordinal) ||
+                w.Reason.Contains("not fetched", StringComparison.Ordinal));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers — synthetic SQLite stores (no real mail/PII, all example.com).
+    // -----------------------------------------------------------------------
+
+    private static void CreateCalSchema(SqliteConnection conn)
+    {
+        void X(string sql)
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = sql;
+            cmd.ExecuteNonQuery();
+        }
+
+        X("CREATE TABLE cal_events (cal_id TEXT,id TEXT,time_created INTEGER,last_modified INTEGER,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,event_start INTEGER,event_end INTEGER,event_stamp INTEGER,event_start_tz TEXT,event_end_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,alarm_last_ack INTEGER,offline_journal INTEGER);");
+        X("CREATE TABLE cal_todos (cal_id TEXT,id TEXT,time_created INTEGER,last_modified INTEGER,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,todo_entry INTEGER,todo_due INTEGER,todo_completed INTEGER,todo_complete INTEGER,todo_entry_tz TEXT,todo_due_tz TEXT,todo_completed_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,alarm_last_ack INTEGER,todo_stamp INTEGER,offline_journal INTEGER);");
+        X("CREATE TABLE cal_recurrence (item_id TEXT,cal_id TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_attendees (item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_alarms (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_attachments (item_id TEXT,cal_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_relations (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_properties (item_id TEXT,key TEXT,value BLOB,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT);");
+        X("CREATE TABLE cal_parameters (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,key1 TEXT,key2 TEXT,value TEXT);");
+    }
+
+    /// <summary>
+    /// A minimal Thunderbird calendar store with one event that has a remote-URL attachment.
+    /// </summary>
+    private static string MakeCalStoreWithRemoteAttach()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"cal-remoteatt-{Guid.NewGuid():N}.sqlite");
+        using var conn = new SqliteConnection($"Data Source={path}");
+        conn.Open();
+        CreateCalSchema(conn);
+
+        void X(string sql)
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = sql;
+            cmd.ExecuteNonQuery();
+        }
+
+        long start = MicrosFor(2026, 7, 6, 14, 0);
+        long end   = MicrosFor(2026, 7, 6, 15, 0);
+        X($"INSERT INTO cal_events (cal_id,id,title,flags,event_start,event_end,event_start_tz) " +
+          $"VALUES ('test-cal','remoteatt-01@example.com','Remote Attach Event',0,{start},{end},'UTC');");
+        // Remote URL attachment.
+        X("INSERT INTO cal_attachments (item_id,cal_id,recurrence_id,recurrence_id_tz,icalString) " +
+          "VALUES ('remoteatt-01@example.com','test-cal',NULL,NULL," +
+          "'ATTACH;FILENAME=doc.pdf:https://drive.example.com/doc.pdf');");
+
+        return path;
+    }
+
+    /// <summary>
+    /// A minimal Thunderbird calendar store with one event that has a base64-inline attachment.
+    /// </summary>
+    private static string MakeCalStoreWithInlineAttach()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"cal-inlineatt-{Guid.NewGuid():N}.sqlite");
+        using var conn = new SqliteConnection($"Data Source={path}");
+        conn.Open();
+        CreateCalSchema(conn);
+
+        void X(string sql)
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = sql;
+            cmd.ExecuteNonQuery();
+        }
+
+        long start = MicrosFor(2026, 7, 7, 10, 0);
+        long end   = MicrosFor(2026, 7, 7, 11, 0);
+        X($"INSERT INTO cal_events (cal_id,id,title,flags,event_start,event_end,event_start_tz) " +
+          $"VALUES ('test-cal','inlineatt-01@example.com','Inline Attach Event',0,{start},{end},'UTC');");
+        // Inline base64 attachment — "hi" encoded as aGk=.
+        X("INSERT INTO cal_attachments (item_id,cal_id,recurrence_id,recurrence_id_tz,icalString) " +
+          "VALUES ('inlineatt-01@example.com','test-cal',NULL,NULL," +
+          "'ATTACH;FILENAME=hi.txt;VALUE=BINARY;ENCODING=BASE64;FMTTYPE=text/plain:aGk=');");
+
+        return path;
+    }
+
+    private static ConversionReport RunConvertWith(string dbPath, string calId, string outputDir)
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name    = "Out",
+                    Sources = new List<SourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath             = dbPath,
+                            CalId                 = calId,
+                            IncludeAppointments   = true,
+                            IncludeTasks          = false,
+                            AppointmentFolderPath = new[] { "Calendars", "TestCal" },
+                        },
+                    },
+                },
+            },
+        };
+        return new ConversionRunner().Run(config, outputDir);
+    }
+
+    private static long MicrosFor(int year, int month, int day, int hour = 0, int minute = 0) =>
+        new DateTimeOffset(year, month, day, hour, minute, 0, TimeSpan.Zero)
+            .ToUnixTimeMilliseconds() * 1000L;
+}

--- a/tests/Mail2Pst.Core.Tests/ConversionRunnerCalendarRootTests.cs
+++ b/tests/Mail2Pst.Core.Tests/ConversionRunnerCalendarRootTests.cs
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.IO;
+using Mail2Pst.Core.Config;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests;
+
+public class ConversionRunnerCalendarRootTests
+{
+    [Fact]
+    public void Explicit_profile_path_is_used()
+    {
+        string prof = Path.Combine(Path.GetTempPath(), "prof");
+        var cfg = new ConversionConfig { ProfilePath = prof };
+        var src = new CalendarSourceConfig { StorePath = Path.Combine("other", "calendar-data", "local.sqlite") };
+        Assert.Equal(prof, ConversionRunner.ResolveCalendarAttachmentRoot(src, cfg));
+    }
+
+    [Fact]
+    public void Store_under_calendar_data_yields_profile_root()
+    {
+        string prof = Path.Combine(Path.GetTempPath(), "prof");
+        var cfg = new ConversionConfig();  // no ProfilePath
+        var src = new CalendarSourceConfig { StorePath = Path.Combine(prof, "calendar-data", "local.sqlite") };
+        Assert.Equal(prof, ConversionRunner.ResolveCalendarAttachmentRoot(src, cfg));
+    }
+
+    [Fact]
+    public void Unexpected_store_shape_yields_null_root()
+    {
+        var cfg = new ConversionConfig();
+        var src = new CalendarSourceConfig { StorePath = Path.Combine(Path.GetTempPath(), "weird.sqlite") };
+        Assert.Null(ConversionRunner.ResolveCalendarAttachmentRoot(src, cfg));  // → file attachments become link-only
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/ConversionRunnerTaskTests.cs
+++ b/tests/Mail2Pst.Core.Tests/ConversionRunnerTaskTests.cs
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core;
+using Mail2Pst.Core.Config;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests;
+
+public class ConversionRunnerTaskTests
+{
+    /// <summary>
+    /// When skipTasks is true, the runner must ignore plan.TaskMappings entirely,
+    /// produce zero TasksConverted, and emit the "tasks disabled by --no-tasks"
+    /// warning exactly once (even with multiple output groups that each carry task mappings).
+    /// </summary>
+    [Fact]
+    public void Run_SkipTasks_ZeroTasksAndWarningEmittedOnce()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), $"m2p-runtask-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            // Config with a valid calendar source (passes ConfigValidator) but NO real SQLite file.
+            // With skipTasks=true the runner must never open the store.
+            var config = new ConversionConfig
+            {
+                Outputs = new List<OutputGroupConfig>
+                {
+                    new()
+                    {
+                        Name = "Out",
+                        Sources = new List<SourceConfig>(),
+                        Calendars = new List<CalendarSourceConfig>
+                        {
+                            new()
+                            {
+                                StorePath = Path.Combine(dir, "local.sqlite"), // does not exist
+                                CalId = "cal-guid-1",
+                                IncludeTasks = true,
+                                TaskFolderPath = new[] { "Tasks", "MyTasks" },
+                            },
+                        },
+                    },
+                },
+            };
+
+            var report = new ConversionRunner().Run(config, dir, skipTasks: true);
+
+            Assert.Equal(0, report.TasksConverted);
+
+            int warnCount = report.Warnings.Count(w =>
+                w.Reason.Contains("tasks disabled by --no-tasks", StringComparison.Ordinal));
+            Assert.Equal(1, warnCount);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/ConversionRunnerTaskTests.cs
+++ b/tests/Mail2Pst.Core.Tests/ConversionRunnerTaskTests.cs
@@ -6,6 +6,8 @@ using System.IO;
 using System.Linq;
 using Mail2Pst.Core;
 using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Reporting;
+using Microsoft.Data.Sqlite;
 using Xunit;
 
 namespace Mail2Pst.Core.Tests;
@@ -61,4 +63,109 @@ public class ConversionRunnerTaskTests
             Directory.Delete(dir, true);
         }
     }
+
+    /// <summary>
+    /// A recurring todo with an unrepresentable RRULE (BYSETPOS) must degrade gracefully:
+    /// the task is still written and reported as converted (not skipped), with a warning.
+    /// End-to-end through ConversionRunner (mapper → writer → report).
+    /// </summary>
+    [Fact]
+    public void Unsupported_recurring_todo_is_written_as_one_task_and_reported_converted_not_skipped()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), $"m2p-runtask-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        string dbPath = MakeTaskStore();
+        try
+        {
+            var report = RunConvertWith(dbPath, "test-cal", dir);
+
+            // One todo with an unrepresentable recurrence → must count as converted, not skipped.
+            Assert.Equal(1, report.TasksConverted);
+            Assert.Equal(0, report.TasksSkipped);
+
+            // A recurrence-degrade warning must be present (BYSETPOS or similar).
+            Assert.True(report.TaskWarningCount >= 1,
+                $"Expected at least one task warning but got {report.TaskWarningCount}");
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Creates a minimal Thunderbird calendar SQLite with one todo using an unrepresentable
+    /// RRULE (MONTHLY/BYSETPOS=-1 — "last Monday of month").
+    /// All data is synthetic (example.com) — no real mail/PII.
+    /// </summary>
+    private static string MakeTaskStore()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"task-bysetpos-{Guid.NewGuid():N}.sqlite");
+        using var conn = new SqliteConnection($"Data Source={path}");
+        conn.Open();
+
+        void X(string sql)
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = sql;
+            cmd.ExecuteNonQuery();
+        }
+
+        // Schema matching SqliteCalendarReader expectations.
+        X("CREATE TABLE cal_events (cal_id TEXT,id TEXT,time_created INTEGER,last_modified INTEGER,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,event_start INTEGER,event_end INTEGER,event_stamp INTEGER,event_start_tz TEXT,event_end_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,alarm_last_ack INTEGER,offline_journal INTEGER);");
+        X("CREATE TABLE cal_todos (cal_id TEXT,id TEXT,time_created INTEGER,last_modified INTEGER,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,todo_entry INTEGER,todo_due INTEGER,todo_completed INTEGER,todo_complete INTEGER,todo_entry_tz TEXT,todo_due_tz TEXT,todo_completed_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,alarm_last_ack INTEGER,todo_stamp INTEGER,offline_journal INTEGER);");
+        X("CREATE TABLE cal_recurrence (item_id TEXT,cal_id TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_attendees (item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_alarms (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_attachments (item_id TEXT,cal_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_relations (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_properties (item_id TEXT,key TEXT,value BLOB,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT);");
+        X("CREATE TABLE cal_parameters (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,key1 TEXT,key2 TEXT,value TEXT);");
+
+        // One todo: MONTHLY BYSETPOS=-1 (last Monday of month) — triggers degrade path.
+        // Due 2026-07-31 (UTC midnight) — provides an anchor for RecurrenceMapping.
+        long due = MicrosFor(2026, 7, 31);
+        X($"INSERT INTO cal_todos (cal_id,id,title,flags,todo_due) " +
+          $"VALUES ('test-cal','bysetpos-todo-01@example.com','Monthly Task',0,{due});");
+        X("INSERT INTO cal_recurrence (item_id,cal_id,icalString) " +
+          "VALUES ('bysetpos-todo-01@example.com','test-cal','RRULE:FREQ=MONTHLY;BYDAY=MO;BYSETPOS=-1');");
+
+        return path;
+    }
+
+    private static ConversionReport RunConvertWith(string dbPath, string calId, string outputDir)
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name    = "Out",
+                    Sources = new List<SourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath           = dbPath,
+                            CalId               = calId,
+                            IncludeTasks        = true,
+                            IncludeAppointments = false,
+                            TaskFolderPath      = new[] { "Tasks", "TestTasks" },
+                        },
+                    },
+                },
+            },
+        };
+        return new ConversionRunner().Run(config, outputDir);
+    }
+
+    private static long MicrosFor(int year, int month, int day) =>
+        new DateTimeOffset(year, month, day, 0, 0, 0, TimeSpan.Zero)
+            .ToUnixTimeMilliseconds() * 1000L;
 }

--- a/tests/Mail2Pst.Core.Tests/Discovery/ConfigFromDiscoveryAppointmentTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Discovery/ConfigFromDiscoveryAppointmentTests.cs
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Discovery;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Discovery;
+
+public class ConfigFromDiscoveryAppointmentTests
+{
+    private static DiscoveryResult SampleEventOnly(int eventCount = 3) => new(
+        Root: "/data/tb/profile",
+        Layout: "thunderbird-profile",
+        Sources: new[]
+        {
+            new DiscoveredSource("/p/Inbox", "mbox", new[] { "Local Folders", "Inbox" }, "Inbox", 10, "/p/Inbox.msf"),
+        },
+        Warnings: Array.Empty<DiscoveryWarning>(),
+        Skipped: Array.Empty<DiscoverySkipped>(),
+        Pairing: new DiscoveryPairingSummary(1, 0, 0))
+    {
+        Calendars = new List<DiscoveredCalendarSource>
+        {
+            new()
+            {
+                CalId = "cal-guid-1",
+                DisplayName = "Personal",
+                StoreKind = "local",
+                StorePath = "/p/local.sqlite",
+                CalendarType = "calendar",
+                IsVisibleInThunderbird = true,
+                EventCount = eventCount,
+                TaskCount = 0,
+                DefaultCalendarFolderPath = new[] { "Calendars", "Personal" },
+                DefaultTaskFolderPath = Array.Empty<string>(),
+            },
+        },
+    };
+
+    private static DiscoveryResult SampleBothEventsAndTasks() => new(
+        Root: "/data/tb/profile",
+        Layout: "thunderbird-profile",
+        Sources: new[]
+        {
+            new DiscoveredSource("/p/Inbox", "mbox", new[] { "Local Folders", "Inbox" }, "Inbox", 10, "/p/Inbox.msf"),
+        },
+        Warnings: Array.Empty<DiscoveryWarning>(),
+        Skipped: Array.Empty<DiscoverySkipped>(),
+        Pairing: new DiscoveryPairingSummary(1, 0, 0))
+    {
+        Calendars = new List<DiscoveredCalendarSource>
+        {
+            new()
+            {
+                CalId = "cal-guid-2",
+                DisplayName = "Work",
+                StoreKind = "local",
+                StorePath = "/p/local.sqlite",
+                CalendarType = "both",
+                IsVisibleInThunderbird = true,
+                EventCount = 5,
+                TaskCount = 3,
+                DefaultCalendarFolderPath = new[] { "Calendars", "Work" },
+                DefaultTaskFolderPath = new[] { "Tasks", "Work" },
+            },
+        },
+    };
+
+    [Fact]
+    public void Build_IncludeAppointments_SynthesizesCalendarSource()
+    {
+        ConversionConfig config = ConfigFromDiscovery.Build(SampleEventOnly(), includeAppointments: true);
+        Assert.Contains(config.Outputs.SelectMany(o => o.Calendars), c => c.StorePath == "/p/local.sqlite");
+    }
+
+    [Fact]
+    public void Build_IncludeAppointments_FlagsAndFolderPathMatchDefault()
+    {
+        ConversionConfig config = ConfigFromDiscovery.Build(SampleEventOnly(), includeAppointments: true);
+        var cal = config.Outputs.SelectMany(o => o.Calendars).Single(c => c.StorePath == "/p/local.sqlite");
+        Assert.True(cal.IncludeAppointments);
+        Assert.Equal(new[] { "Calendars", "Personal" }, cal.AppointmentFolderPath);
+    }
+
+    [Fact]
+    public void Build_NoAppointments_OmitsCalendarSources()
+    {
+        // SampleEventOnly has EventCount=3, TaskCount=0; with includeAppointments=false
+        // and includeTasks=true (default), no condition is met → nothing synthesized.
+        ConversionConfig config = ConfigFromDiscovery.Build(SampleEventOnly(), includeAppointments: false);
+        Assert.Empty(config.Outputs.SelectMany(o => o.Calendars));
+    }
+
+    [Fact]
+    public void Build_BothEventsAndTasks_ProducesOneConfigCarryingBoth()
+    {
+        ConversionConfig config = ConfigFromDiscovery.Build(
+            SampleBothEventsAndTasks(), includeAppointments: true, includeTasks: true);
+
+        var cals = config.Outputs.SelectMany(o => o.Calendars).ToList();
+        Assert.Single(cals);
+
+        var cal = cals[0];
+        Assert.True(cal.IncludeAppointments);
+        Assert.True(cal.IncludeTasks);
+        Assert.Equal(new[] { "Calendars", "Work" }, cal.AppointmentFolderPath);
+        Assert.Equal(new[] { "Tasks", "Work" }, cal.TaskFolderPath);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Discovery/ConfigFromDiscoveryTaskTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Discovery/ConfigFromDiscoveryTaskTests.cs
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Discovery;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Discovery;
+
+public class ConfigFromDiscoveryTaskTests
+{
+    private static DiscoveryResult Sample(int taskCount = 2) => new(
+        Root: "/data/tb/profile",
+        Layout: "thunderbird-profile",
+        Sources: new[]
+        {
+            new DiscoveredSource("/p/Inbox", "mbox", new[] { "Local Folders", "Inbox" }, "Inbox", 10, "/p/Inbox.msf"),
+        },
+        Warnings: Array.Empty<DiscoveryWarning>(),
+        Skipped: Array.Empty<DiscoverySkipped>(),
+        Pairing: new DiscoveryPairingSummary(1, 0, 0))
+    {
+        Calendars = new List<DiscoveredCalendarSource>
+        {
+            new()
+            {
+                CalId = "cal-guid-1",
+                DisplayName = "Personal Tasks",
+                StoreKind = "local",
+                StorePath = "/p/local.sqlite",
+                CalendarType = "task",
+                IsVisibleInThunderbird = true,
+                EventCount = 0,
+                TaskCount = taskCount,
+                DefaultCalendarFolderPath = Array.Empty<string>(),
+                DefaultTaskFolderPath = new[] { "Tasks", "Personal Tasks" },
+            },
+        },
+    };
+
+    [Fact]
+    public void Build_IncludeTasks_SynthesizesCalendarSource()
+    {
+        ConversionConfig config = ConfigFromDiscovery.Build(Sample(), includeTasks: true);
+        Assert.Contains(config.Outputs.SelectMany(o => o.Calendars), c => c.StorePath == "/p/local.sqlite");
+    }
+
+    [Fact]
+    public void Build_IncludeTasks_TaskFolderPathMatchesDefault()
+    {
+        ConversionConfig config = ConfigFromDiscovery.Build(Sample(), includeTasks: true);
+        var cal = config.Outputs.SelectMany(o => o.Calendars).Single(c => c.StorePath == "/p/local.sqlite");
+        Assert.Equal(new[] { "Tasks", "Personal Tasks" }, cal.TaskFolderPath);
+    }
+
+    [Fact]
+    public void Build_NoTasks_OmitsCalendarSources()
+    {
+        ConversionConfig config = ConfigFromDiscovery.Build(Sample(), includeTasks: false);
+        Assert.Empty(config.Outputs.SelectMany(o => o.Calendars));
+    }
+
+    [Fact]
+    public void Build_CalendarTaskCountZero_NotSynthesized()
+    {
+        ConversionConfig config = ConfigFromDiscovery.Build(Sample(taskCount: 0), includeTasks: true);
+        Assert.Empty(config.Outputs.SelectMany(o => o.Calendars));
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Discovery/DiscoverCalendarsTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Discovery/DiscoverCalendarsTests.cs
@@ -77,6 +77,37 @@ public class DiscoverCalendarsTests
         finally { Directory.Delete(profile, true); }
     }
 
+    /// <summary>
+    /// Pre-merge review #9: a calendar whose Thunderbird name contains a folder-invalid character
+    /// (e.g. "Home / Work") must still yield a VALID synthesized folder path. Before the fix the raw
+    /// name flowed into ["Calendars", name] and ConfigValidator hard-failed, aborting the ENTIRE
+    /// conversion (mail + all other calendars). DisplayName keeps the real name; the folder leaf is sanitized.
+    /// </summary>
+    [Fact]
+    public void DiscoverCalendars_InvalidCharInName_SynthesizesValidFolderPath()
+    {
+        string profile = Path.Combine(Path.GetTempPath(), $"m2p-badname-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(profile);
+        string calDataDir = Path.Combine(profile, "calendar-data");
+        Directory.CreateDirectory(calDataDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(profile, "prefs.js"),
+                "user_pref(\"calendar.registry.BAD.name\", \"Home / Work\");\n" +
+                "user_pref(\"calendar.registry.BAD.type\", \"storage\");\n");
+            MakeCalStore(Path.Combine(calDataDir, "local.sqlite"), "BAD", addEvent: true, addTodo: true);
+
+            var res = MailProfileDiscovery.DiscoverCalendars(profile);
+            var cal = Assert.Single(res.Calendars, c => c.CalId == "BAD");
+
+            Assert.Equal("Home / Work", cal.DisplayName);   // real name preserved for display
+            // Synthesized folder paths must pass the engine's folder-name validator (no throw).
+            Mail2Pst.Core.Config.FolderNameValidator.ValidatePath(cal.DefaultCalendarFolderPath);
+            Mail2Pst.Core.Config.FolderNameValidator.ValidatePath(cal.DefaultTaskFolderPath);
+        }
+        finally { Directory.Delete(profile, true); }
+    }
+
     [Fact]
     public void DiscoverCalendars_RegistryPlusOrphan()
     {

--- a/tests/Mail2Pst.Core.Tests/Discovery/DiscoverCalendarsTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Discovery/DiscoverCalendarsTests.cs
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Data.Sqlite;
+using Mail2Pst.Core.Discovery;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Discovery;
+
+public class DiscoverCalendarsTests
+{
+    // Creates a minimal calendar SQLite store with all required tables.
+    // addEvent=true inserts one master event row for calId; addTodo=true inserts one master todo row.
+    private static void MakeCalStore(string path, string calId, bool addEvent = true, bool addTodo = false)
+    {
+        using var c = new SqliteConnection($"Data Source={path}"); c.Open();
+        void X(string sql) { using var cmd = c.CreateCommand(); cmd.CommandText = sql; cmd.ExecuteNonQuery(); }
+        X("CREATE TABLE cal_events (cal_id TEXT,id TEXT,time_created INTEGER,last_modified INTEGER,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,event_start INTEGER,event_end INTEGER,event_stamp INTEGER,event_start_tz TEXT,event_end_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,alarm_last_ack INTEGER,offline_journal INTEGER);");
+        X("CREATE TABLE cal_todos (cal_id TEXT,id TEXT,time_created INTEGER,last_modified INTEGER,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,todo_entry INTEGER,todo_due INTEGER,todo_completed INTEGER,todo_complete INTEGER,todo_entry_tz TEXT,todo_due_tz TEXT,todo_completed_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,alarm_last_ack INTEGER,todo_stamp INTEGER,offline_journal INTEGER);");
+        X("CREATE TABLE cal_recurrence (item_id TEXT,cal_id TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_attendees (item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_alarms (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_attachments (item_id TEXT,cal_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_relations (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_properties (item_id TEXT,key TEXT,value BLOB,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT);");
+        X("CREATE TABLE cal_parameters (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,key1 TEXT,key2 TEXT,value TEXT);");
+        if (addEvent)
+            X($"INSERT INTO cal_events (cal_id,id,title,flags,event_start,event_end,recurrence_id) " +
+              $"VALUES ('{calId}','ev1','Test Event',0,1782810000000000,1782811800000000,NULL);");
+        if (addTodo)
+            X($"INSERT INTO cal_todos (cal_id,id,title,flags,todo_entry,todo_due,todo_complete,recurrence_id) " +
+              $"VALUES ('{calId}','td1','Test Todo',0,1782810000000000,1782820000000000,0,NULL);");
+    }
+
+    [Fact]
+    public void DiscoverCalendars_RegistryPlusOrphan()
+    {
+        string profile = Path.Combine(Path.GetTempPath(), $"m2p-cal-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(profile);
+        string calDataDir = Path.Combine(profile, "calendar-data");
+        Directory.CreateDirectory(calDataDir);
+        try
+        {
+            // prefs.js: REG1 = "Home", type=storage, visible; reserved/synthetic data
+            File.WriteAllText(Path.Combine(profile, "prefs.js"),
+                "user_pref(\"calendar.registry.REG1.name\", \"Home\");\n" +
+                "user_pref(\"calendar.registry.REG1.type\", \"storage\");\n" +
+                "user_pref(\"calendar.registry.REG1.calendar-main-in-composite\", true);\n");
+
+            // local.sqlite: one event row for registered calendar REG1
+            MakeCalStore(Path.Combine(calDataDir, "local.sqlite"), "REG1", addEvent: true);
+
+            // cache.sqlite: one event row for unregistered ORPH — no prefs.js entry
+            MakeCalStore(Path.Combine(calDataDir, "cache.sqlite"), "ORPH", addEvent: true);
+
+            var res = MailProfileDiscovery.DiscoverCalendars(profile);
+
+            // Registered calendar: name + store from prefs.js; count from actual rows
+            var home = res.Calendars.Single(c => c.CalId == "REG1");
+            Assert.Equal("Home", home.DisplayName);
+            Assert.Equal("local", home.StoreKind);
+            Assert.Equal(1, home.EventCount);       // one EventGroup (master only)
+            Assert.Equal(new[] { "Calendars", "Home" }, home.DefaultCalendarFolderPath);
+
+            // Unregistered orphan: synthesized name, cache store, not visible, warning emitted
+            var orphan = res.Calendars.Single(c => c.CalId == "ORPH");
+            Assert.Equal("cache", orphan.StoreKind);
+            Assert.False(orphan.IsVisibleInThunderbird);
+            Assert.Contains("ORPH", orphan.DisplayName);
+            Assert.Contains(res.Warnings, w => w.Message.Contains("ORPH"));
+        }
+        finally { Directory.Delete(profile, true); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Discovery/DiscoverCalendarsTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Discovery/DiscoverCalendarsTests.cs
@@ -35,6 +35,48 @@ public class DiscoverCalendarsTests
               $"VALUES ('{calId}','td1','Test Todo',0,1782810000000000,1782820000000000,0,NULL);");
     }
 
+    // Both-stores: same cal_id present in local.sqlite AND cache.sqlite.
+    // registry type="storage" -> local wins; type="caldav" -> cache wins.
+    [Theory]
+    [InlineData("storage", "local",  "cache store ignored")]
+    [InlineData("caldav",  "cache",  "local store ignored")]
+    public void DiscoverCalendars_BothStores_RegistryTypeControlsWinner(
+        string calType, string expectedStore, string warningSnippet)
+    {
+        string profile = Path.Combine(Path.GetTempPath(), $"m2p-both-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(profile);
+        string calDataDir = Path.Combine(profile, "calendar-data");
+        Directory.CreateDirectory(calDataDir);
+        try
+        {
+            // Register BOTH with the supplied type; synthetic/reserved data only.
+            File.WriteAllText(Path.Combine(profile, "prefs.js"),
+                $"user_pref(\"calendar.registry.BOTH.name\", \"Work\");\n" +
+                $"user_pref(\"calendar.registry.BOTH.type\", \"{calType}\");\n" +
+                $"user_pref(\"calendar.registry.BOTH.calendar-main-in-composite\", true);\n");
+
+            // Insert the same cal_id into BOTH stores so both-stores branch is taken.
+            MakeCalStore(Path.Combine(calDataDir, "local.sqlite"), "BOTH", addEvent: true);
+            MakeCalStore(Path.Combine(calDataDir, "cache.sqlite"), "BOTH", addEvent: true);
+
+            var res = MailProfileDiscovery.DiscoverCalendars(profile);
+
+            // Calendar must appear exactly once (no duplication).
+            var cal = Assert.Single(res.Calendars, c => c.CalId == "BOTH");
+
+            // Registry-driven store preference.
+            Assert.Equal(expectedStore, cal.StoreKind);
+
+            // Chosen store path must point at the winning file.
+            string expectedFile = expectedStore == "local" ? "local.sqlite" : "cache.sqlite";
+            Assert.Equal(expectedFile, Path.GetFileName(cal.StorePath), StringComparer.OrdinalIgnoreCase);
+
+            // A warning about the ignored store must be emitted.
+            Assert.Contains(res.Warnings, w => w.Message.Contains("BOTH") && w.Message.Contains(warningSnippet));
+        }
+        finally { Directory.Delete(profile, true); }
+    }
+
     [Fact]
     public void DiscoverCalendars_RegistryPlusOrphan()
     {

--- a/tests/Mail2Pst.Core.Tests/Discovery/DiscoveredCalendarSourceTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Discovery/DiscoveredCalendarSourceTests.cs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+using Mail2Pst.Core.Discovery;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Discovery;
+
+public class DiscoveredCalendarSourceTests
+{
+    [Fact]
+    public void Defaults_are_safe()
+    {
+        var s = new DiscoveredCalendarSource();
+        Assert.Empty(s.DefaultCalendarFolderPath);
+        Assert.Empty(s.DefaultTaskFolderPath);
+        var r = new CalendarDiscoveryResult();
+        Assert.Empty(r.Calendars);
+        Assert.Empty(r.Warnings);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Mail2Pst.Core.Tests.csproj
+++ b/tests/Mail2Pst.Core.Tests/Mail2Pst.Core.Tests.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="Ical.Net" Version="5.2.2" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Mail2Pst.Core.Tests/Mapping/MappingEngineAppointmentTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mapping/MappingEngineAppointmentTests.cs
@@ -1,0 +1,232 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Collections.Generic;
+using System.Linq;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Mapping;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Mapping;
+
+public class MappingEngineAppointmentTests
+{
+    [Fact]
+    public void BuildPlan_AppointmentExplicitFolder_UsesCustomPath()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    Sources = new List<SourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "/p/local.sqlite",
+                            CalId = "home",
+                            IncludeAppointments = true,
+                            AppointmentFolderPath = new[] { "Calendars", "Home" },
+                        },
+                    },
+                },
+            },
+        };
+        PstOutputPlan plan = MappingEngine.BuildPlan(config).Single();
+        AppointmentMapping am = plan.AppointmentMappings.Single();
+        Assert.Equal(new[] { "Calendars", "Home" }, am.TargetFolderPath);
+        Assert.Same(config.Outputs[0].Calendars[0], am.Source);
+    }
+
+    [Fact]
+    public void BuildPlan_AppointmentDefaultFolder_IsCalendarsSlashCalId()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    Sources = new List<SourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "/p/local.sqlite",
+                            CalId = "home-cal",
+                            IncludeAppointments = true,
+                            // AppointmentFolderPath intentionally null → should default to ["Calendars", CalId]
+                        },
+                    },
+                },
+            },
+        };
+        PstOutputPlan plan = MappingEngine.BuildPlan(config).Single();
+        AppointmentMapping am = plan.AppointmentMappings.Single();
+        Assert.Equal(new[] { "Calendars", "home-cal" }, am.TargetFolderPath);
+    }
+
+    [Fact]
+    public void BuildPlan_CalendarWithBothFlags_ProducesTaskMappingAndAppointmentMapping()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    Sources = new List<SourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "/p/local.sqlite",
+                            CalId = "home",
+                            IncludeTasks = true,
+                            TaskFolderPath = new[] { "Tasks", "Home" },
+                            IncludeAppointments = true,
+                            AppointmentFolderPath = new[] { "Calendars", "Home" },
+                        },
+                    },
+                },
+            },
+        };
+        PstOutputPlan plan = MappingEngine.BuildPlan(config).Single();
+        Assert.Single(plan.TaskMappings);
+        Assert.Single(plan.AppointmentMappings);
+        Assert.Equal(new[] { "Tasks", "Home" }, plan.TaskMappings[0].TargetFolderPath);
+        Assert.Equal(new[] { "Calendars", "Home" }, plan.AppointmentMappings[0].TargetFolderPath);
+    }
+
+    [Fact]
+    public void BuildPlan_AppointmentPathCollidesWithMailFolder_Throws()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    FolderMapping = FolderMappingMode.Flatten,
+                    Sources = new List<SourceConfig>
+                    {
+                        new() { Path = "/p/x.mbox", Type = "mbox",
+                                TargetFolderPath = new List<string> { "Calendars", "Home" } },
+                    },
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "/p/local.sqlite",
+                            CalId = "home",
+                            IncludeAppointments = true,
+                            AppointmentFolderPath = new[] { "Calendars", "Home" },
+                        },
+                    },
+                },
+            },
+        };
+        Assert.Throws<ConfigValidationException>(() => MappingEngine.BuildPlan(config));
+    }
+
+    [Fact]
+    public void BuildPlan_AppointmentPathCollidesWithContactFolder_Throws()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    Sources = new List<SourceConfig>(),
+                    Contacts = new List<ContactSourceConfig>
+                    {
+                        new()
+                        {
+                            Path = "/p/abook.sqlite",
+                            Format = "thunderbird-sqlite",
+                            TargetFolderPath = new[] { "Calendars", "Home" },
+                        },
+                    },
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "/p/local.sqlite",
+                            CalId = "home",
+                            IncludeAppointments = true,
+                            AppointmentFolderPath = new[] { "Calendars", "Home" },
+                        },
+                    },
+                },
+            },
+        };
+        Assert.Throws<ConfigValidationException>(() => MappingEngine.BuildPlan(config));
+    }
+
+    [Fact]
+    public void BuildPlan_AppointmentPathCollidesWithTaskFolder_Throws()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    Sources = new List<SourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "/p/local.sqlite",
+                            CalId = "home",
+                            IncludeTasks = true,
+                            TaskFolderPath = new[] { "Shared", "home" },
+                            IncludeAppointments = true,
+                            AppointmentFolderPath = new[] { "Shared", "home" },
+                        },
+                    },
+                },
+            },
+        };
+        Assert.Throws<ConfigValidationException>(() => MappingEngine.BuildPlan(config));
+    }
+
+    [Fact]
+    public void BuildPlan_IncludeAppointmentsFalse_NoAppointmentMapping()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    Sources = new List<SourceConfig>
+                    {
+                        new() { Path = "/p/x.mbox", Type = "mbox" },
+                    },
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "/p/local.sqlite",
+                            CalId = "home",
+                            IncludeAppointments = false,
+                            // IncludeTasks also false — bypass validator; engine skips both
+                        },
+                    },
+                },
+            },
+        };
+        PstOutputPlan plan = MappingEngine.BuildPlan(config).Single();
+        Assert.Empty(plan.AppointmentMappings);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Mapping/MappingEngineAppointmentTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mapping/MappingEngineAppointmentTests.cs
@@ -220,7 +220,8 @@ public class MappingEngineAppointmentTests
                             StorePath = "/p/local.sqlite",
                             CalId = "home",
                             IncludeAppointments = false,
-                            // IncludeTasks also false — bypass validator; engine skips both
+                            // IncludeTasks not set (defaults to false); this test only asserts
+                            // that no appointment mapping is produced when IncludeAppointments=false.
                         },
                     },
                 },

--- a/tests/Mail2Pst.Core.Tests/Mapping/MappingEngineTaskTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mapping/MappingEngineTaskTests.cs
@@ -1,0 +1,207 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Collections.Generic;
+using System.Linq;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Mapping;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Mapping;
+
+public class MappingEngineTaskTests
+{
+    [Fact]
+    public void BuildPlan_TaskExplicitFolder_UsesCustomPath()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    Sources = new List<SourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "/p/local.sqlite",
+                            CalId = "home",
+                            IncludeTasks = true,
+                            TaskFolderPath = new[] { "Tasks", "Home" },
+                        },
+                    },
+                },
+            },
+        };
+        PstOutputPlan plan = MappingEngine.BuildPlan(config).Single();
+        TaskMapping tm = plan.TaskMappings.Single();
+        Assert.Equal(new[] { "Tasks", "Home" }, tm.TargetFolderPath);
+        Assert.Same(config.Outputs[0].Calendars[0], tm.Source);
+    }
+
+    [Fact]
+    public void BuildPlan_TaskDefaultFolder_IsTasksSlashCalId()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    Sources = new List<SourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "/p/local.sqlite",
+                            CalId = "home-cal",
+                            IncludeTasks = true,
+                            // TaskFolderPath intentionally null → should default to ["Tasks", CalId]
+                        },
+                    },
+                },
+            },
+        };
+        PstOutputPlan plan = MappingEngine.BuildPlan(config).Single();
+        TaskMapping tm = plan.TaskMappings.Single();
+        Assert.Equal(new[] { "Tasks", "home-cal" }, tm.TargetFolderPath);
+    }
+
+    [Fact]
+    public void BuildPlan_TwoCalendarsInSameStore_ProduceTwoDistinctMappings()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    Sources = new List<SourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "/p/local.sqlite",
+                            CalId = "work",
+                            IncludeTasks = true,
+                            TaskFolderPath = new[] { "Tasks", "Work" },
+                        },
+                        new()
+                        {
+                            StorePath = "/p/local.sqlite",
+                            CalId = "personal",
+                            IncludeTasks = true,
+                            TaskFolderPath = new[] { "Tasks", "Personal" },
+                        },
+                    },
+                },
+            },
+        };
+        PstOutputPlan plan = MappingEngine.BuildPlan(config).Single();
+        Assert.Equal(2, plan.TaskMappings.Count);
+        Assert.Equal(new[] { "Tasks", "Work" }, plan.TaskMappings[0].TargetFolderPath);
+        Assert.Equal(new[] { "Tasks", "Personal" }, plan.TaskMappings[1].TargetFolderPath);
+    }
+
+    [Fact]
+    public void BuildPlan_TaskPathCollidesWithMailFolder_Throws()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    FolderMapping = FolderMappingMode.Flatten,
+                    Sources = new List<SourceConfig>
+                    {
+                        new() { Path = "/p/x.mbox", Type = "mbox",
+                                TargetFolderPath = new List<string> { "Tasks", "Home" } },
+                    },
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "/p/local.sqlite",
+                            CalId = "home",
+                            IncludeTasks = true,
+                            TaskFolderPath = new[] { "Tasks", "Home" },
+                        },
+                    },
+                },
+            },
+        };
+        Assert.Throws<ConfigValidationException>(() => MappingEngine.BuildPlan(config));
+    }
+
+    [Fact]
+    public void BuildPlan_TaskPathCollidesWithContactFolder_Throws()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    Sources = new List<SourceConfig>(),
+                    Contacts = new List<ContactSourceConfig>
+                    {
+                        new()
+                        {
+                            Path = "/p/abook.sqlite",
+                            Format = "thunderbird-sqlite",
+                            TargetFolderPath = new[] { "Tasks", "Home" },
+                        },
+                    },
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "/p/local.sqlite",
+                            CalId = "home",
+                            IncludeTasks = true,
+                            TaskFolderPath = new[] { "Tasks", "Home" },
+                        },
+                    },
+                },
+            },
+        };
+        Assert.Throws<ConfigValidationException>(() => MappingEngine.BuildPlan(config));
+    }
+
+    [Fact]
+    public void BuildPlan_IncludeTasksFalse_NoTaskMapping()
+    {
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    Sources = new List<SourceConfig>
+                    {
+                        new() { Path = "/p/x.mbox", Type = "mbox" },
+                    },
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath = "/p/local.sqlite",
+                            CalId = "home",
+                            IncludeTasks = false,
+                            // IncludeAppointments defaults false too, but we bypass validator here
+                        },
+                    },
+                },
+            },
+        };
+        PstOutputPlan plan = MappingEngine.BuildPlan(config).Single();
+        Assert.Empty(plan.TaskMappings);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Models/AppointmentAttendeeTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Models/AppointmentAttendeeTests.cs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+using Mail2Pst.Core.Models;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Models;
+
+public class AppointmentAttendeeTests
+{
+    [Fact]
+    public void Attendee_defaults_are_required_no_response_not_organizer()
+    {
+        var att = new AppointmentAttendee { DisplayName = "Req One", Email = "req1@example.com" };
+        Assert.Equal(AttendeeKind.Required, att.Kind);
+        Assert.Equal(AttendeeResponse.None, att.Response);
+        Assert.False(att.IsOrganizer);
+    }
+
+    [Fact]
+    public void Response_enum_uses_canonical_msoxocal_values()
+    {
+        Assert.Equal(1, (int)AttendeeResponse.Organized);
+        Assert.Equal(2, (int)AttendeeResponse.Tentative);
+        Assert.Equal(3, (int)AttendeeResponse.Accepted);
+        Assert.Equal(4, (int)AttendeeResponse.Declined);
+        Assert.Equal(5, (int)AttendeeResponse.NotResponded);
+    }
+
+    [Fact]
+    public void AppointmentRecord_defaults_to_no_organizer_and_empty_attendees()
+    {
+        var a = new AppointmentRecord { Subject = "Sync" };
+        Assert.Null(a.Organizer);
+        Assert.Empty(a.Attendees);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Models/AppointmentRecordTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Models/AppointmentRecordTests.cs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using Mail2Pst.Core.Models;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Models;
+
+public class AppointmentRecordTests
+{
+    [Fact]
+    public void Defaults_are_busy_normal_importance_not_allday_no_reminder()
+    {
+        var a = new AppointmentRecord { Subject = "Standup" };
+        Assert.Equal(2, a.BusyStatus);          // Busy
+        Assert.Equal(1, a.Importance);          // Normal
+        Assert.False(a.IsAllDay);
+        Assert.False(a.ReminderSet);
+        Assert.Null(a.TimeZone);
+        Assert.Empty(a.Categories);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Models/AttachmentContentTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Models/AttachmentContentTests.cs
@@ -137,6 +137,19 @@ public class AttachmentContentTests
         }
         finally { File.Delete(path); }
     }
+
+    [Fact]
+    public void FromExistingFile_does_not_delete_source_on_dispose()
+    {
+        string f = Path.Combine(Path.GetTempPath(), $"src-{Guid.NewGuid():N}.bin");
+        File.WriteAllBytes(f, new byte[] { 7 });
+        try
+        {
+            using (var c = AttachmentContent.FromExistingFile(f)) { Assert.Equal(1, c.Length); }
+            Assert.True(File.Exists(f));
+        }
+        finally { File.Delete(f); }
+    }
 }
 
 public class AttachmentContentLengthOnlyTests

--- a/tests/Mail2Pst.Core.Tests/Models/TaskRecordTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Models/TaskRecordTests.cs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using Mail2Pst.Core.Models;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Models;
+
+public class TaskRecordTests
+{
+    [Fact]
+    public void Defaults_are_not_started_normal_importance_no_reminder()
+    {
+        var t = new TaskRecord { Subject = "Buy milk" };
+        Assert.Equal(TaskStatusKind.NotStarted, t.Status);
+        Assert.Equal(0, t.PercentComplete);
+        Assert.Equal(1, t.Importance);
+        Assert.False(t.ReminderSet);
+        Assert.Empty(t.Categories);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Reporting/ConversionReportCalendarCountersTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Reporting/ConversionReportCalendarCountersTests.cs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+using Mail2Pst.Core.Reporting;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Reporting;
+
+public class ConversionReportCalendarCountersTests
+{
+    [Fact]
+    public void Appointment_and_task_counters_increment_independently()
+    {
+        var r = new ConversionReport();
+        r.RecordAppointmentConverted();
+        r.RecordAppointmentConverted();
+        r.RecordAppointmentSkipped("Home", "bad recurrence");
+        r.RecordAppointmentWarning("tz fallback");
+        r.RecordTaskConverted();
+        r.RecordTaskSkipped("Home", "bad due date");
+
+        Assert.Equal(2, r.AppointmentsConverted);
+        Assert.Equal(1, r.AppointmentsSkipped);
+        Assert.Equal(1, r.AppointmentWarningCount);
+        Assert.Equal(1, r.TasksConverted);
+        Assert.Equal(1, r.TasksSkipped);
+        // exactly 3 shared warnings: appointment-skipped, appointment-warning, task-skipped
+        Assert.Equal(3, r.WarningCount);
+    }
+
+    [Fact]
+    public void Counters_default_to_zero()
+    {
+        var r = new ConversionReport();
+        Assert.Equal(0, r.AppointmentsConverted);
+        Assert.Equal(0, r.TasksConverted);
+        Assert.Equal(0, r.AppointmentsSkipped);
+        Assert.Equal(0, r.TasksSkipped);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Reporting/ConversionReportJsonTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Reporting/ConversionReportJsonTests.cs
@@ -27,6 +27,34 @@ public class ConversionReportJsonTests
     }
 
     [Fact]
+    public void ToJson_WithAllItemTypes_SerializesContactAppointmentTaskCounters()
+    {
+        var report = new ConversionReport();
+        // mail
+        report.RecordConverted();
+        // contacts
+        report.RecordContactConverted();
+        report.RecordContactConverted();
+        report.RecordContactSkipped("abook.sqlite", "unresolvable name");
+        // appointments
+        report.RecordAppointmentConverted();
+        report.RecordAppointmentConverted();
+        report.RecordAppointmentConverted();
+        // tasks
+        report.RecordTaskConverted();
+
+        string json = report.ToJson();
+        using var doc = JsonDocument.Parse(json);
+        JsonElement root = doc.RootElement;
+
+        Assert.Equal(1, root.GetProperty("converted").GetInt32());
+        Assert.Equal(2, root.GetProperty("contactsConverted").GetInt32());
+        Assert.Equal(1, root.GetProperty("contactsSkipped").GetInt32());
+        Assert.Equal(3, root.GetProperty("appointmentsConverted").GetInt32());
+        Assert.Equal(1, root.GetProperty("tasksConverted").GetInt32());
+    }
+
+    [Fact]
     public void ToJson_WithSkipAndWarning_SerializesEntries()
     {
         var report = new ConversionReport();

--- a/tests/Mail2Pst.Core.Tests/Reporting/ConversionReportVerifyCountTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Reporting/ConversionReportVerifyCountTests.cs
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+using Mail2Pst.Core.Reporting;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Reporting;
+
+// Locks the contract that the post-conversion verifier's expected total = all written item types.
+public class ConversionReportVerifyCountTests
+{
+    [Fact]
+    public void Expected_message_total_sums_all_item_types()
+    {
+        var r = new ConversionReport();
+        r.RecordConverted();                 // mail
+        r.RecordContactConverted();          // contact
+        r.RecordAppointmentConverted();      // appointment
+        r.RecordTaskConverted();             // task
+
+        // Assert the PROPERTY the runner actually consumes, so this test fails if the runner drifts.
+        Assert.Equal(4, r.TotalWrittenItems);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Storage/SqliteSnapshotTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Storage/SqliteSnapshotTests.cs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 using System;
 using System.IO;
-using Mail2Pst.Core.Contacts;
+using Mail2Pst.Core.Storage;
 using Microsoft.Data.Sqlite;
 using Xunit;
 
-namespace Mail2Pst.Core.Tests.Contacts;
+namespace Mail2Pst.Core.Tests.Storage;
 
 public class SqliteSnapshotTests
 {

--- a/tests/Mail2Pst.Core.Tests/Vendor/AppointmentWriteSmokeTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Vendor/AppointmentWriteSmokeTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.IO;
+using PSTFileFormat;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Mail2Pst.Core.Tests.Vendor;
+
+// PR1 gate: proves the recovered MS-OXOCAL substrate can write an IPM.Appointment into a
+// from-scratch CreateEmptyStore PST and read it back through the vendored reader (incl. the
+// restored CalendarFolder branch in PSTFolder.GetFolder). Unicode subject locks UTF-8 fidelity.
+public class AppointmentWriteSmokeTests
+{
+    private readonly ITestOutputHelper _out;
+    public AppointmentWriteSmokeTests(ITestOutputHelper output) => _out = output;
+
+    [Fact]
+    public void SingleAppointment_RoundTrips_ThroughFromScratchStore()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"appt-smoke-{Guid.NewGuid():N}.pst");
+        // Set MAIL2PST_KEEP_SMOKE_PST=1 to keep the file for manual Outlook / pst-validate inspection.
+        bool keep = Environment.GetEnvironmentVariable("MAIL2PST_KEEP_SMOKE_PST") == "1";
+        _out.WriteLine($"smoke PST: {path}");
+        const string subject = "Tandlæge 🦷";   // Danish + emoji on purpose
+
+        try
+        {
+            // 1. Build a fresh store, add a calendar folder, write one appointment.
+            PSTFile.CreateEmptyStore(path);
+            PSTFile file = new PSTFile(path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+            try
+            {
+                file.BeginSavingChanges();   // required before named-property allocation (appointments)
+                PSTFolder cal = file.TopOfPersonalFolders.CreateChildFolder("Calendar", FolderItemTypeName.Appointment);
+
+                SingleAppointment appt = SingleAppointment.CreateNewSingleAppointment(file, cal.NodeID);
+                appt.Subject = subject;
+                appt.InternetCodepage = 65001;                         // UTF-8 (default 1255 Hebrew — gotcha)
+                appt.SetStartAndDuration(new DateTime(2026, 6, 30, 9, 0, 0, DateTimeKind.Utc), 60);
+                appt.SaveChanges();
+
+                cal.AddMessage(appt);
+                cal.SaveChanges();                                     // BEFORE EndSavingChanges (gotcha)
+                file.EndSavingChanges();
+            }
+            finally { file.CloseFile(); }
+
+            // 2. Reopen and assert the appointment round-trips.
+            PSTFile reopened = new PSTFile(path, FileAccess.Read, WriterCompatibilityMode.Outlook2007RTM);
+            try
+            {
+                PSTFolder found = reopened.TopOfPersonalFolders.FindChildFolder("Calendar");
+                CalendarFolder cal = Assert.IsType<CalendarFolder>(found);   // GetFolder calendar branch
+                Assert.Equal(1, cal.AppointmentCount);
+                Appointment read = cal.GetAppointment(0);
+                Assert.Equal(subject, read.Subject);
+            }
+            finally { reopened.CloseFile(); }
+        }
+        finally { if (!keep && File.Exists(path)) File.Delete(path); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Vendor/RecurringAppointmentBlobTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Vendor/RecurringAppointmentBlobTests.cs
@@ -199,6 +199,102 @@ public class RecurringAppointmentBlobTests
         finally { if (File.Exists(path)) File.Delete(path); }
     }
 
+    // ────────────────── Task 1 (PR7b): bare-pattern serializer tests ──────────────────
+
+    // Builds the GT Task Weekly structure (weekly Mon, end-after-5, due 2026-07-06).
+    // Reused by GetRecurrencePatternBytes_is_the_prefix test and the weekly oracle gate.
+    private static WeeklyRecurrencePatternStructure BuildWeeklyMondayCount5Structure()
+    {
+        var s = new WeeklyRecurrencePatternStructure();
+        s.PatternType = PatternType.Week;
+        s.DaysOfWeek = DaysOfWeekFlags.Monday;
+        s.Period = 1;
+        s.FirstDateTimeInDays = AppointmentRecurrencePatternStructure.CalculateFirstDateTimeInDays(
+            RecurrenceFrequency.Weekly, PatternType.Week, 1, new DateTime(2026, 7, 6));
+        s.EndType = RecurrenceEndType.EndAfterNOccurrences;
+        s.OccurrenceCount = 5;
+        s.FirstDOW = 0;
+        s.StartDTZone = new DateTime(2026, 7, 6, 0, 0, 0, DateTimeKind.Unspecified);
+        s.LastInstanceStartDate = new DateTime(2026, 8, 3);
+        return s;
+    }
+
+    [Fact]
+    public void GetRecurrencePatternBytes_is_the_prefix_of_GetBytes()
+    {
+        // The bare prefix must equal the leading bytes of the full appointment blob —
+        // proves the split is a pure extraction that changes nothing for the appointment path.
+        var s = BuildWeeklyMondayCount5Structure();
+        byte[] full = s.GetBytes(WriterCompatibilityMode.Outlook2007RTM);
+        byte[] bare = s.GetRecurrencePatternBytes();
+        Assert.True(bare.Length < full.Length);
+        Assert.Equal(full.AsSpan(0, bare.Length).ToArray(), bare); // prefix-equality
+    }
+
+    // Builder for the exact GT task structures from the research doc.
+    private static AppointmentRecurrencePatternStructure BuildTaskGtStructure(string freq)
+    {
+        switch (freq)
+        {
+            case "weekly":
+                // GT Task Weekly: weekly Mon, end-after-5, due 2026-07-06
+                return BuildWeeklyMondayCount5Structure();
+
+            case "monthly":
+            {
+                // GT Task Monthly: day 6, end-by 2026-12-31, OccurrenceCount=6
+                var s = new MonthlyRecurrencePatternStructure();
+                s.PatternType = PatternType.Month;
+                s.DayOfMonth = 6;
+                s.Period = 1;
+                s.FirstDateTimeInDays = AppointmentRecurrencePatternStructure.CalculateFirstDateTimeInDays(
+                    RecurrenceFrequency.Monthly, PatternType.Month, 1, new DateTime(2026, 7, 6));
+                s.EndType = RecurrenceEndType.EndAfterDate;
+                s.OccurrenceCount = 6;
+                s.FirstDOW = 0;
+                s.StartDTZone = new DateTime(2026, 7, 6, 0, 0, 0, DateTimeKind.Unspecified);
+                s.LastInstanceStartDate = new DateTime(2026, 12, 31);
+                return s;
+            }
+
+            case "daily":
+            {
+                // GT Task Daily: daily (every day), no-end, OccurrenceCount=10 (sentinel), due 2026-07-01
+                var s = new DailyRecurrencePatternStructure();
+                s.PatternType = PatternType.Day;
+                s.Period = 1440; // minutes
+                s.FirstDateTimeInDays = AppointmentRecurrencePatternStructure.CalculateFirstDateTimeInDays(
+                    RecurrenceFrequency.Daily, PatternType.Day, 1, new DateTime(2026, 7, 1));
+                s.EndType = RecurrenceEndType.NeverEnd;
+                s.OccurrenceCount = 10;
+                s.FirstDOW = 0;
+                s.StartDTZone = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Unspecified);
+                s.LastInstanceStartDate = new DateTime(4500, 8, 31);
+                return s;
+            }
+
+            default:
+                throw new ArgumentException($"Unknown freq: {freq}");
+        }
+    }
+
+    // Identical to HexBytes but named per the brief spec (strips spaces, parses hex pairs).
+    private static byte[] HexToBytes(string hex) => HexBytes(hex);
+
+    [Theory]
+    // GT Task Weekly (weekly Mon, end-after-5, due 2026-07-06) — 54 B
+    [InlineData("04 30 04 30 0B 20 01 00 00 00 C0 21 00 00 01 00 00 00 00 00 00 00 02 00 00 00 22 20 00 00 05 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 C0 DB 56 0D 40 79 57 0D", "weekly")]
+    // GT Task Monthly (day 6, end-by 2026-12-31) — 54 B
+    [InlineData("04 30 04 30 0C 20 02 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00 06 00 00 00 21 20 00 00 06 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 C0 DB 56 0D 00 C5 5A 0D", "monthly")]
+    // GT Task Daily (no-end) — 50 B
+    [InlineData("04 30 04 30 0A 20 00 00 00 00 00 00 00 00 A0 05 00 00 00 00 00 00 23 20 00 00 0A 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 A0 BF 56 0D DF 80 E9 5A", "daily")]
+    public void Bare_pattern_matches_task_GT_oracle(string hex, string freq)
+    {
+        byte[] oracle = HexToBytes(hex);
+        var s = BuildTaskGtStructure(freq);
+        Assert.Equal(oracle, s.GetRecurrencePatternBytes());
+    }
+
     private static byte[] HexBytes(string hex)
     {
         string[] parts = hex.Split(' ', StringSplitOptions.RemoveEmptyEntries);

--- a/tests/Mail2Pst.Core.Tests/Vendor/RecurringAppointmentBlobTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Vendor/RecurringAppointmentBlobTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using PSTFileFormat;
+using Utilities;
 using Xunit;
 
 namespace Mail2Pst.Core.Tests.Vendor;
@@ -332,6 +333,53 @@ public class RecurringAppointmentBlobTests
             Assert.Same(zone, appt.OriginalTimeZone);
         }
         finally { file?.CloseFile(); if (File.Exists(path)) File.Delete(path); }
+    }
+
+    /// <summary>
+    /// Cross-platform regression: reconstructing a zone from a TimeZoneStructure must not require the Windows
+    /// registry. On non-Windows the registry has no display names (GetDisplayName returns null), which used to
+    /// make CreateCustomTimeZone throw when a recurring appointment was read back (the calendar tests do this,
+    /// so they failed on Linux/macOS CI). Simulated on Windows by an UNKNOWN zone id: its registry key is
+    /// absent, so GetDisplayName returns null exactly as on Linux/macOS. Must fall back to the id, not throw.
+    /// </summary>
+    [Fact]
+    public void ToTimeZoneInfo_without_registry_display_names_does_not_throw()
+    {
+        var s = new TimeZoneStructure
+        {
+            lBias = -420, lStandardBias = 0, lDaylightBias = 0,   // UTC+7, no DST (like the SE Asia gate zone)
+            stStandardDate = new SystemTime(),                     // wMonth == 0 -> no-DST branch
+            stDaylightDate = new SystemTime(),
+        };
+
+        TimeZoneInfo tz = s.ToTimeZoneInfo("M2P Unknown Zone Id");   // no such registry key -> GetDisplayName null
+
+        Assert.NotNull(tz);
+        Assert.Equal("M2P Unknown Zone Id", tz.Id);
+        Assert.Equal(TimeSpan.FromHours(7), tz.BaseUtcOffset);
+    }
+
+    /// <summary>
+    /// Cross-platform regression: some non-Windows (ICU) TimeZoneInfo rules use a fixed calendar date over a
+    /// multi-year span, which SYSTEMTIME's one-time absolute form can't hold. AdjustmentRuleHelper must convert
+    /// it to a relative-yearly rule instead of throwing (which aborted writing any appointment in such a zone
+    /// on Linux/macOS). Deterministic on Windows: build such a rule directly.
+    /// </summary>
+    [Fact]
+    public void FromTransitionTime_multi_year_fixed_date_becomes_relative_rule()
+    {
+        var dstStart = TimeZoneInfo.TransitionTime.CreateFixedDateRule(new DateTime(1, 1, 1, 2, 0, 0), 3, 31);   // Mar 31
+        var dstEnd   = TimeZoneInfo.TransitionTime.CreateFixedDateRule(new DateTime(1, 1, 1, 3, 0, 0), 10, 31);  // Oct 31
+        var rule = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule(
+            new DateTime(2000, 1, 1), new DateTime(2020, 12, 31), TimeSpan.FromHours(1), dstStart, dstEnd);
+
+        SystemTime std = AdjustmentRuleHelper.GetStandardDate(rule);   // DaylightTransitionEnd (Oct 31) — must not throw
+        Assert.Equal(0, std.wYear);    // relative (yearly), not a one-time absolute date
+        Assert.Equal(10, std.wMonth);  // October
+        Assert.Equal(5, std.wDay);     // day 31 -> last (5th) occurrence within the month
+
+        SystemTime dlt = AdjustmentRuleHelper.GetDaylightDate(rule);   // DaylightTransitionStart (Mar 31)
+        Assert.Equal(3, dlt.wMonth);   // March
     }
 
     private static byte[] HexBytes(string hex)

--- a/tests/Mail2Pst.Core.Tests/Vendor/RecurringAppointmentBlobTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Vendor/RecurringAppointmentBlobTests.cs
@@ -1,0 +1,209 @@
+using System;
+using System.IO;
+using PSTFileFormat;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Vendor;
+
+// PR7a Task 0 — byte-gate the vendored recurrence serializer (RecurringAppointment +
+// AppointmentRecurrencePatternStructure) against the real Outlook PidLidAppointmentRecur blobs
+// captured in docs/research/2026-07-01-pr7a-recurrence-ground-truth.md. Clean (no deletion/
+// exception) cases assert the FULL blob; the deletion/exception cases parse and assert semantic
+// fields (byte equality there is brittle — exact ExceptionInfo/ExtendedException layout). All
+// blobs were re-dumped read-only from the Outlook-authored GT store (SE Asia Standard Time).
+public class RecurringAppointmentBlobTests
+{
+    // PSTFile is NOT IDisposable and CreateEmptyStore returns void — close in try/finally.
+    private static byte[] WriteAndReadRecurBlob(string path, Action<RecurringAppointment> configure)
+    {
+        PSTFile.CreateEmptyStore(path);
+        PSTFile? file = null;
+        try
+        {
+            file = new PSTFile(path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+            file.BeginSavingChanges();
+            PSTFolder cal = file.TopOfPersonalFolders.CreateChildFolder("Calendar", FolderItemTypeName.Appointment);
+            RecurringAppointment appt = RecurringAppointment.CreateNewRecurringAppointment(file, cal.NodeID);
+            appt.InternetCodepage = 65001;
+            configure(appt);
+            appt.SaveChanges();
+            cal.AddMessage(appt);
+            cal.SaveChanges();
+            file.EndSavingChanges();
+        }
+        finally { file?.CloseFile(); }
+
+        PSTFile? ro = null;
+        try
+        {
+            ro = new PSTFile(path, FileAccess.Read, WriterCompatibilityMode.Outlook2007RTM);
+            var cal = (CalendarFolder)ro.TopOfPersonalFolders.FindChildFolder("Calendar");
+            return cal.GetAppointment(0).PC.GetBytesProperty(PropertyNames.PidLidAppointmentRecur);
+        }
+        finally { ro?.CloseFile(); }
+    }
+
+    // SE Asia Standard Time = the ground-truth zone (UTC+07, no DST).
+    private static TimeZoneInfo SeAsia() =>
+        TimeZoneInfo.CreateCustomTimeZone("SE Asia Standard Time", TimeSpan.FromHours(7),
+            "(UTC+07:00) Bangkok, Hanoi, Jakarta", "SE Asia Standard Time");
+
+    // The dump's "1# GT Daily every 2 days" blob (DeletedInstanceCount=0) — full-equality oracle.
+    private static readonly byte[] DailyEvery2DaysBlob = HexBytes(
+        "04 30 04 30 0A 20 00 00 00 00 A0 05 00 00 40 0B 00 00 00 00 00 00 22 20 00 00 05 00 00 00 " +
+        "00 00 00 00 00 00 00 00 00 00 00 00 A0 BF 56 0D A0 EC 56 0D 06 30 00 00 09 30 00 00 E0 01 " +
+        "00 00 FE 01 00 00 00 00 00 00 00 00 00 00 00 00");
+
+    // The dump's "3# GT Monthly" blob (2nd Tuesday, end-by-date, OccurrenceCount=7, no deletions).
+    private static readonly byte[] Monthly2ndTuesdayBlob = HexBytes(
+        "04 30 04 30 0C 20 03 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00 04 00 00 00 02 00 00 00 " +
+        "21 20 00 00 07 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 C0 08 57 0D 60 73 5B 0D 06 30 " +
+        "00 00 09 30 00 00 E0 01 00 00 FE 01 00 00 00 00 00 00 00 00 00 00 00 00");
+
+    // The dump's "4# GT yearly" blob (July 6, no end / NeverEnd, OccurrenceCount=10, no deletions).
+    private static readonly byte[] YearlyJul6Blob = HexBytes(
+        "04 30 04 30 0D 20 02 00 00 00 20 FA 03 00 0C 00 00 00 00 00 00 00 06 00 00 00 23 20 00 00 " +
+        "0A 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 C0 DB 56 0D DF 80 E9 5A 06 30 00 00 09 30 " +
+        "00 00 E0 01 00 00 FE 01 00 00 00 00 00 00 00 00 00 00 00 00");
+
+    [Fact]
+    public void Daily_every2days_count5_full_blob_matches_dump()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"recur-d2-{Guid.NewGuid():N}.pst");
+        try
+        {
+            byte[] blob = WriteAndReadRecurBlob(path, a =>
+            {
+                a.SetOriginalTimeZone(SeAsia());
+                a.RecurrenceType = RecurrenceType.EveryNDays; a.Period = 2;
+                a.SetStartAndDuration(new DateTime(2026, 7, 1, 1, 0, 0, DateTimeKind.Utc), 30);
+                a.EndAfterNumberOfOccurences = true;
+                a.LastInstanceStartDate = new DateTime(2026, 7, 9, 1, 0, 0, DateTimeKind.Utc); // 5th: Jul 1,3,5,7,9
+            });
+            Assert.Equal(DailyEvery2DaysBlob, blob);   // FULL blob equality
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+
+    [Fact]
+    public void Monthly_2ndTuesday_full_blob_matches_dump()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"recur-m-{Guid.NewGuid():N}.pst");
+        try
+        {
+            byte[] blob = WriteAndReadRecurBlob(path, a =>
+            {
+                a.SetOriginalTimeZone(SeAsia());
+                a.RecurrenceType = RecurrenceType.EveryNthDayOfEveryNMonths; a.Period = 1;
+                a.Day = (int)OutlookDayOfWeek.Tuesday;
+                a.DayOccurenceNumber = DayOccurenceNumber.Second;
+                a.SetStartAndDuration(new DateTime(2026, 7, 14, 1, 0, 0, DateTimeKind.Utc), 30); // 2nd Tue of Jul 2026
+                a.EndAfterNumberOfOccurences = false;                                            // end-by-date (UNTIL)
+                a.LastInstanceStartDate = new DateTime(2027, 1, 31, 1, 0, 0, DateTimeKind.Utc);  // EndDate from dump → OccurrenceCount=7
+            });
+            Assert.Equal(Monthly2ndTuesdayBlob, blob);   // FULL blob equality
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+
+    [Fact]
+    public void Yearly_Jul6_noEnd_full_blob_matches_dump()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"recur-y-{Guid.NewGuid():N}.pst");
+        try
+        {
+            byte[] blob = WriteAndReadRecurBlob(path, a =>
+            {
+                a.SetOriginalTimeZone(SeAsia());
+                a.RecurrenceType = RecurrenceType.EveryNYears; a.Period = 1;
+                a.Day = 6;                                                                       // day-of-month; month derived from start
+                a.SetStartAndDuration(new DateTime(2026, 7, 6, 1, 0, 0, DateTimeKind.Utc), 30);  // start = first occurrence (Jul 6)
+                a.EndAfterNumberOfOccurences = false;
+                a.LastInstanceStartDate = new DateTime(4500, 8, 31, 0, 0, 0, DateTimeKind.Utc);  // → NeverEnd, OccurrenceCount=10
+            });
+            Assert.Equal(YearlyJul6Blob, blob);   // FULL blob equality
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+
+    // Daily, every day, COUNT=5, with the 3rd occurrence deleted (a pure EXDATE deletion).
+    // Semantic-field gate (§7 confirmed rule): OccurrenceCount stays the raw COUNT (5), NOT the
+    // visible count after deletion (4); the deleted date is in DeletedInstanceDates with no exception.
+    [Fact]
+    public void Daily_with_deletion_keeps_raw_count_and_one_deleted_date()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"recur-ddel-{Guid.NewGuid():N}.pst");
+        try
+        {
+            TimeZoneInfo tz = SeAsia();
+            DateTime deletedOccUtc = new(2026, 7, 3, 1, 0, 0, DateTimeKind.Utc); // 3rd occurrence (Jul 3)
+            byte[] blob = WriteAndReadRecurBlob(path, a =>
+            {
+                a.SetOriginalTimeZone(tz);
+                a.RecurrenceType = RecurrenceType.EveryNDays; a.Period = 1;
+                a.SetStartAndDuration(new DateTime(2026, 7, 1, 1, 0, 0, DateTimeKind.Utc), 30);
+                a.EndAfterNumberOfOccurences = true;
+                a.LastInstanceStartDate = new DateTime(2026, 7, 5, 1, 0, 0, DateTimeKind.Utc); // 5th occ = Jul 5
+                a.DeletedInstanceDates.Add(DateTime.SpecifyKind(
+                    TimeZoneInfo.ConvertTimeFromUtc(deletedOccUtc, tz).Date, DateTimeKind.Unspecified));
+            });
+            var s = AppointmentRecurrencePatternStructure.GetRecurrencePatternStructure(blob);
+            Assert.Equal(0x0A, blob[4]); Assert.Equal(0x20, blob[5]);              // Daily
+            Assert.Equal(RecurrenceEndType.EndAfterNOccurrences, s.EndType);
+            Assert.Equal(5u, s.OccurrenceCount);                                   // raw COUNT, not 4
+            Assert.Equal(1, s.DeletedInstanceDates.Count);
+            Assert.Empty(s.ModifiedInstanceDates);
+            Assert.Empty(s.ExceptionList);
+            Assert.Equal(new DateTime(2026, 7, 3), s.DeletedInstanceDates[0].Date);
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+
+    // Weekly Mon+Wed COUNT=6 (last occ Jul 20) with one overridden (modified) occurrence.
+    // Semantic gate: the overridden occurrence's original date appears in BOTH the deleted-dates
+    // and modified-dates arrays (§7 confirmed rule), and exactly one ExceptionInfo is serialized.
+    [Fact]
+    public void Weekly_with_override_modified_date_in_both_arrays()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"recur-wex-{Guid.NewGuid():N}.pst");
+        try
+        {
+            TimeZoneInfo tz = SeAsia();
+            DateTime origStartUtc = new(2026, 7, 8, 1, 0, 0, DateTimeKind.Utc);     // the overridden occurrence (Jul 8 Wed)
+            byte[] blob = WriteAndReadRecurBlob(path, a =>
+            {
+                a.SetOriginalTimeZone(tz);
+                a.RecurrenceType = RecurrenceType.EveryNWeeks; a.Period = 1;
+                a.Day = (int)(DaysOfWeekFlags.Monday | DaysOfWeekFlags.Wednesday);
+                a.SetStartAndDuration(new DateTime(2026, 7, 1, 1, 0, 0, DateTimeKind.Utc), 30);
+                a.EndAfterNumberOfOccurences = true;
+                a.LastInstanceStartDate = new DateTime(2026, 7, 20, 1, 0, 0, DateTimeKind.Utc); // 6th occ = Jul 20
+
+                a.AddModifiedInstanceAttachment(origStartUtc, 30, origStartUtc.AddHours(6), 30,
+                    "GT weekly MODIFIED", "", BusyStatus.Busy, 0, MessagePriority.Normal, tz);
+                var ex = new ExceptionInfoStructure();
+                ex.SetOriginalStartDTUtc(origStartUtc, tz);
+                ex.SetStartAndDuration(origStartUtc.AddHours(6), 30, tz);
+                ex.HasModifiedSubject = true; ex.Subject = "GT weekly MODIFIED";
+                a.ExceptionList.Add(ex);
+                a.DeletedInstanceDates.Add(DateTime.SpecifyKind(
+                    TimeZoneInfo.ConvertTimeFromUtc(origStartUtc, tz).Date, DateTimeKind.Unspecified));
+            });
+            var s = AppointmentRecurrencePatternStructure.GetRecurrencePatternStructure(blob);
+            Assert.Equal(0x0B, blob[4]); Assert.Equal(0x20, blob[5]);   // Weekly
+            Assert.Single(s.ExceptionList);
+            Assert.Single(s.ModifiedInstanceDates);
+            Assert.Equal(1, s.DeletedInstanceDates.Count);
+            Assert.Equal(s.DeletedInstanceDates[0].Date, s.ModifiedInstanceDates[0].Date);  // both arrays
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+
+    private static byte[] HexBytes(string hex)
+    {
+        string[] parts = hex.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        byte[] b = new byte[parts.Length];
+        for (int i = 0; i < parts.Length; i++) b[i] = Convert.ToByte(parts[i], 16);
+        return b;
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Vendor/RecurringAppointmentBlobTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Vendor/RecurringAppointmentBlobTests.cs
@@ -295,6 +295,45 @@ public class RecurringAppointmentBlobTests
         Assert.Equal(oracle, s.GetRecurrencePatternBytes());
     }
 
+    // ────────────────── Pre-merge review #2: write path must not depend on the registry ──────────────────
+
+    /// <summary>
+    /// Regression (pre-merge review #2, cross-platform): the recurring-appointment write path
+    /// (StartDTUtc setter, LastInstanceStartDate setter, SaveChanges) reads <c>OriginalTimeZone</c>
+    /// repeatedly. Before the fix the getter re-derived the zone from the serialized blob via
+    /// <c>RegistryTimeZoneUtils</c>, which throws <see cref="PlatformNotSupportedException"/> off-Windows
+    /// (and, for a zone whose key name is not in the registry, silently falls back to the local system
+    /// zone). The fix caches the zone passed to <c>SetOriginalTimeZone</c> and returns it directly.
+    ///
+    /// Proven by identity: after SetOriginalTimeZone the getter returns the EXACT instance we set — a
+    /// zone with a made-up key name that does not exist in the Windows registry, so a blob round-trip
+    /// could not reconstruct it. This is deterministic on every platform.
+    /// </summary>
+    [Fact]
+    public void SetOriginalTimeZone_is_cached_not_re_derived_from_registry()
+    {
+        var zone = TimeZoneInfo.CreateCustomTimeZone(
+            "M2P Cross-Platform Test Zone",           // NOT a Windows time-zone key name
+            TimeSpan.FromMinutes(330),                // UTC+05:30 — distinct from any test host's local zone
+            "(UTC+05:30) M2P Test", "M2P Test");
+
+        string path = Path.Combine(Path.GetTempPath(), $"recur-tzcache-{Guid.NewGuid():N}.pst");
+        PSTFile.CreateEmptyStore(path);
+        PSTFile? file = null;
+        try
+        {
+            file = new PSTFile(path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+            file.BeginSavingChanges();
+            PSTFolder cal = file.TopOfPersonalFolders.CreateChildFolder("Calendar", FolderItemTypeName.Appointment);
+            RecurringAppointment appt = RecurringAppointment.CreateNewRecurringAppointment(file, cal.NodeID);
+            appt.SetOriginalTimeZone(zone);
+
+            // Cached field short-circuits the registry-backed blob derivation.
+            Assert.Same(zone, appt.OriginalTimeZone);
+        }
+        finally { file?.CloseFile(); if (File.Exists(path)) File.Delete(path); }
+    }
+
     private static byte[] HexBytes(string hex)
     {
         string[] parts = hex.Split(' ', StringSplitOptions.RemoveEmptyEntries);

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterAttachmentTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterAttachmentTests.cs
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Writing;
+using PSTFileFormat;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Writing;
+
+/// <summary>
+/// TDD round-trip tests for attachment emission from <see cref="AppointmentWriter"/>.
+/// InlineBytes → visible ByValue PST attachment; LinkOnly → body appendix, no embedded row.
+/// </summary>
+public class AppointmentWriterAttachmentTests
+{
+    private static readonly DateTime S = new(2026, 7, 6, 9, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime E = new(2026, 7, 6, 10, 0, 0, DateTimeKind.Utc);
+
+    // -----------------------------------------------------------------------
+    // Round-trip infrastructure (mirrors AppointmentWriterTests.RoundTripAppointment)
+    // -----------------------------------------------------------------------
+
+    private static T RoundTripAppointment<T>(AppointmentRecord record, Func<PSTFile, Appointment, T> read)
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"m2p-awatt-{Guid.NewGuid():N}.pst");
+        PSTFile? pst = null;
+        try
+        {
+            PSTFile.CreateEmptyStore(path);
+
+            try
+            {
+                pst = new PSTFile(path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+                pst.BeginSavingChanges();
+                PSTFolder folder = pst.TopOfPersonalFolders.CreateChildFolder(
+                    "Calendar", FolderItemTypeName.Appointment);
+                new AppointmentWriter().WriteAppointment(pst, folder, record);
+                folder.SaveChanges();
+                pst.EndSavingChanges();
+            }
+            finally { pst?.CloseFile(); pst = null; }
+
+            try
+            {
+                pst = new PSTFile(path, FileAccess.Read, WriterCompatibilityMode.Outlook2007RTM);
+                PSTFolder found = pst.TopOfPersonalFolders.FindChildFolder("Calendar");
+                CalendarFolder cal = Assert.IsType<CalendarFolder>(found);
+                Assert.Equal(1, cal.AppointmentCount);
+                Appointment appt = cal.GetAppointment(0);
+                return read(pst, appt);
+            }
+            finally { pst?.CloseFile(); pst = null; }
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Inline_attachment_is_written_by_value_and_visible()
+    {
+        var rec = new AppointmentRecord
+        {
+            Subject = "s", StartUtc = S, EndUtc = E,
+            Attachments = new[]
+            {
+                new CalendarAttachment(CalendarAttachmentKind.InlineBytes,
+                    "n.txt", "text/plain", new byte[] { 1, 2, 3 }, null, null)
+            }
+        };
+
+        var (count, bytes, hidden) = RoundTripAppointment(rec, (f, a) => (
+            a.AttachmentCount,
+            a.GetAttachmentObject(0).PC.GetBytesProperty(PropertyID.PidTagAttachData),
+            a.GetAttachmentObject(0).PC.GetBooleanProperty(PropertyID.PidTagAttachmentHidden)));
+
+        Assert.Equal(1, count);
+        Assert.Equal(new byte[] { 1, 2, 3 }, bytes);
+        Assert.NotEqual(true, hidden);   // calendar InlineBytes is a VISIBLE attachment, not a hidden CID
+    }
+
+    [Fact]
+    public void Link_only_attachment_is_appended_to_body_not_embedded()
+    {
+        var rec = new AppointmentRecord
+        {
+            Subject = "s", StartUtc = S, EndUtc = E,
+            Attachments = new[]
+            {
+                new CalendarAttachment(CalendarAttachmentKind.LinkOnly,
+                    "doc.pdf", "application/pdf", null, null, "https://x.example.com/doc.pdf")
+            }
+        };
+
+        var (count, body) = RoundTripAppointment(rec, (f, a) => (
+            a.AttachmentCount,
+            a.PC.GetStringProperty(PropertyID.PidTagBody) ?? ""));
+
+        Assert.Equal(0, count);                                      // no embedded row for a link
+        Assert.Contains("https://x.example.com/doc.pdf", body);     // preserved in body
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterAttendeeTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterAttendeeTests.cs
@@ -61,9 +61,16 @@ public class AppointmentWriterAttendeeTests
         finally { if (File.Exists(path)) File.Delete(path); }
     }
 
-    /// <summary>Resolve a named-prop ID on a reopen.</summary>
+    /// <summary>Resolve a named-prop ID on a reopen (allocates if absent — use for props known to have been written).</summary>
     private static PropertyID Named(PSTFile pst, PropertyLongID lid, Guid set)
         => pst.NameToIDMap.ObtainIDFromName(new PropertyName(lid, set));
+
+    /// <summary>
+    /// Look up a named-prop ID without allocating. Returns null when the prop was never
+    /// registered in this PST — the correct "absent" check on a read-only file.
+    /// </summary>
+    private static PropertyID? TryNamed(PSTFile pst, PropertyLongID lid, Guid set)
+        => pst.NameToIDMap.GetIDFromName(new PropertyName(lid, set));
 
     /// <summary>Read RecipientType for row <paramref name="rowIndex"/> from the table.</summary>
     private static int? RowRecipientType(Appointment appt, int rowIndex)
@@ -297,5 +304,81 @@ public class AppointmentWriterAttendeeTests
         string? cls = RoundTripAppointment(a,
             (_, appt) => appt.PC.GetStringProperty(PropertyID.PidTagMessageClass));
         Assert.Equal("IPM.Appointment", cls);
+    }
+
+    // -----------------------------------------------------------------------
+    // Item 1 (TDD): Organizer == null → StateFlags set, PidLidResponseStatus absent
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void AttendeesWithoutOrganizer_StateFlagsSet_but_PidLidResponseStatus_absent()
+    {
+        // A meeting with attendees but NO explicit Organizer.
+        // The asfMeeting bit in PidLidAppointmentStateFlags MUST still be set (it's meeting-presence
+        // derived from Attendees.Count > 0), but PidLidResponseStatus must NOT be written —
+        // the organizer-copy response-status is meaningless when no organizer is known.
+        var a = new AppointmentRecord
+        {
+            Subject  = "Attendees but no organizer",
+            StartUtc = new DateTime(2026, 7, 1, 10, 0, 0, DateTimeKind.Utc),
+            EndUtc   = new DateTime(2026, 7, 1, 11, 0, 0, DateTimeKind.Utc),
+            Organizer = null,
+            Attendees = new[]
+            {
+                new AppointmentAttendee { DisplayName = "Bob", Email = "bob@example.com",
+                    Kind = AttendeeKind.Required, Response = AttendeeResponse.Accepted },
+            },
+        };
+
+        RoundTripAppointment(a, (pst, appt) =>
+        {
+            // asfMeeting bit must be set (Attendees.Count > 0 promotes to meeting).
+            PropertyID sfId = Named(pst, PropertyLongID.PidLidAppointmentStateFlags, PropertySetGuid.PSETID_Appointment);
+            int? stateFlags = appt.PC.GetInt32Property(sfId);
+            Assert.NotNull(stateFlags);
+            Assert.True((stateFlags!.Value & 1) != 0, "asfMeeting bit (0x1) must be set even without an explicit organizer");
+
+            // PidLidResponseStatus must NOT be present when Organizer is null.
+            // Use TryNamed (GetIDFromName, nullable) — ObtainIDFromName would try to
+            // allocate a new entry on the read-only file and throw if the prop was never registered.
+            PropertyID? rsId = TryNamed(pst, PropertyLongID.PidLidResponseStatus, PropertySetGuid.PSETID_Appointment);
+            int? rs = rsId.HasValue ? appt.PC.GetInt32Property(rsId.Value) : null;
+            Assert.Null(rs);
+
+            return true;
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // Item 5 (T3): SentRepresentingAddressType assertions
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Organizer_SentRepresentingAddressType_is_SMTP_when_email_present()
+    {
+        // When organizer has an email, PidTagSentRepresentingAddressType must be "SMTP".
+        var a = MakeMeetingRecord(organizerHasEmail: true);
+
+        RoundTripAppointment(a, (_, appt) =>
+        {
+            string? addrType = appt.PC.GetStringProperty(PropertyID.PidTagSentRepresentingAddressType);
+            Assert.Equal("SMTP", addrType);
+            return true;
+        });
+    }
+
+    [Fact]
+    public void Organizer_SentRepresentingAddressType_absent_when_email_empty()
+    {
+        // When organizer has no email, PidTagSentRepresentingAddressType must NOT be written.
+        var a = MakeMeetingRecord(organizerHasEmail: false);
+
+        RoundTripAppointment(a, (_, appt) =>
+        {
+            string? addrType = appt.PC.GetStringProperty(PropertyID.PidTagSentRepresentingAddressType);
+            Assert.True(string.IsNullOrEmpty(addrType),
+                "PidTagSentRepresentingAddressType must not be set when organizer email is empty");
+            return true;
+        });
     }
 }

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterAttendeeTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterAttendeeTests.cs
@@ -1,0 +1,301 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Writing;
+using PSTFileFormat;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Writing;
+
+/// <summary>
+/// TDD tests for the attendee/organizer/meeting-state block in <see cref="AppointmentWriter"/>.
+/// Each test writes one appointment (with or without attendees), closes, reopens, and asserts
+/// the MAPI recipient table, SentRepresenting*, StateFlags, and PidLidResponseStatus round-trip.
+///
+/// Lifecycle matches AppointmentWriterTests: BeginSavingChanges → WriteAppointment →
+/// folder.SaveChanges → EndSavingChanges.
+/// </summary>
+public class AppointmentWriterAttendeeTests
+{
+    // -----------------------------------------------------------------------
+    // Round-trip infrastructure (mirrors AppointmentWriterTests)
+    // -----------------------------------------------------------------------
+
+    private static T RoundTripAppointment<T>(AppointmentRecord record, Func<PSTFile, Appointment, T> read)
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"m2p-att-{Guid.NewGuid():N}.pst");
+        PSTFile? pst = null;
+        try
+        {
+            PSTFile.CreateEmptyStore(path);
+
+            // Write phase
+            try
+            {
+                pst = new PSTFile(path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+                pst.BeginSavingChanges();
+                PSTFolder folder = pst.TopOfPersonalFolders.CreateChildFolder(
+                    "Calendar", FolderItemTypeName.Appointment);
+                new AppointmentWriter().WriteAppointment(pst, folder, record);
+                folder.SaveChanges();
+                pst.EndSavingChanges();
+            }
+            finally { pst?.CloseFile(); pst = null; }
+
+            // Read phase
+            try
+            {
+                pst = new PSTFile(path, FileAccess.Read, WriterCompatibilityMode.Outlook2007RTM);
+                PSTFolder found = pst.TopOfPersonalFolders.FindChildFolder("Calendar");
+                CalendarFolder cal = Assert.IsType<CalendarFolder>(found);
+                Assert.Equal(1, cal.AppointmentCount);
+                Appointment appt = cal.GetAppointment(0);
+                return read(pst, appt);
+            }
+            finally { pst?.CloseFile(); pst = null; }
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+
+    /// <summary>Resolve a named-prop ID on a reopen.</summary>
+    private static PropertyID Named(PSTFile pst, PropertyLongID lid, Guid set)
+        => pst.NameToIDMap.ObtainIDFromName(new PropertyName(lid, set));
+
+    /// <summary>Read RecipientType for row <paramref name="rowIndex"/> from the table.</summary>
+    private static int? RowRecipientType(Appointment appt, int rowIndex)
+        => appt.RecipientsTable?.GetInt32Property(rowIndex, PropertyID.PidTagRecipientType);
+
+    // -----------------------------------------------------------------------
+    // Helpers: canned records
+    // -----------------------------------------------------------------------
+
+    private static AppointmentRecord MakePlainRecord(string subject = "Plain event") => new AppointmentRecord
+    {
+        Subject  = subject,
+        StartUtc = new DateTime(2026, 7, 1, 9, 0, 0, DateTimeKind.Utc),
+        EndUtc   = new DateTime(2026, 7, 1, 9, 30, 0, DateTimeKind.Utc),
+    };
+
+    private static AppointmentRecord MakeMeetingRecord(
+        bool organizerHasEmail = true,
+        AttendeeResponse organizerResponse = AttendeeResponse.None) => new AppointmentRecord
+    {
+        Subject  = "Team meeting",
+        StartUtc = new DateTime(2026, 7, 1, 10, 0, 0, DateTimeKind.Utc),
+        EndUtc   = new DateTime(2026, 7, 1, 11, 0, 0, DateTimeKind.Utc),
+        Organizer = new AppointmentAttendee
+        {
+            DisplayName = "Alice Organizer",
+            Email       = organizerHasEmail ? "alice@example.com" : "",
+            Kind        = AttendeeKind.Required,
+            Response    = organizerResponse,
+            IsOrganizer = true,
+        },
+        Attendees = new[]
+        {
+            new AppointmentAttendee { DisplayName = "Bob Required1", Email = "bob1@example.com", Kind = AttendeeKind.Required, Response = AttendeeResponse.Accepted },
+            new AppointmentAttendee { DisplayName = "Carol Required2", Email = "carol@example.com", Kind = AttendeeKind.Required, Response = AttendeeResponse.None },
+            new AppointmentAttendee { DisplayName = "Dave Optional", Email = "dave@example.com", Kind = AttendeeKind.Optional, Response = AttendeeResponse.Declined },
+            new AppointmentAttendee { DisplayName = "Room Resource", Email = "room@example.com", Kind = AttendeeKind.Resource, Response = AttendeeResponse.None },
+        },
+    };
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Meeting_RecipientCount_is_5_and_types_are_correct()
+    {
+        // organizer (To, isOrganizer) + 2×Required (To) + 1×Optional (Cc) + 1×Resource (Bcc) = 5
+        var a = MakeMeetingRecord();
+
+        RoundTripAppointment(a, (_, appt) =>
+        {
+            Assert.Equal(5, appt.RecipientCount);
+
+            // Row 0 = organizer (isOrganizer=true, To)
+            MessageRecipient org = appt.GetRecipient(0);
+            Assert.True(org.IsOrganizer, "Row 0 must be IsOrganizer");
+            Assert.Equal((int)RecipientType.To, RowRecipientType(appt, 0));
+
+            // Rows 1-2 = Required → To
+            Assert.Equal((int)RecipientType.To, RowRecipientType(appt, 1));
+            Assert.Equal((int)RecipientType.To, RowRecipientType(appt, 2));
+
+            // Row 3 = Optional → Cc
+            Assert.Equal((int)RecipientType.Cc, RowRecipientType(appt, 3));
+
+            // Row 4 = Resource → Bcc
+            Assert.Equal((int)RecipientType.Bcc, RowRecipientType(appt, 4));
+
+            // Message class must stay IPM.Appointment even for a meeting
+            Assert.Equal("IPM.Appointment", appt.PC.GetStringProperty(PropertyID.PidTagMessageClass));
+
+            return true;
+        });
+    }
+
+    [Fact]
+    public void Accepted_attendee_ResponseStatus_is_3_on_readback()
+    {
+        // Bob Required1 has Response = Accepted (3).
+        var a = MakeMeetingRecord();
+
+        RoundTripAppointment(a, (_, appt) =>
+        {
+            // Row 1 = Bob Required1 (Accepted)
+            MessageRecipient bob = appt.GetRecipient(1);
+            Assert.Equal((int)AttendeeResponse.Accepted, bob.ResponseStatus);
+            return true;
+        });
+    }
+
+    [Fact]
+    public void Organizer_SentRepresenting_is_set_and_row_ResponseStatus_is_Organized_regardless_of_record()
+    {
+        // Organizer.Response = None (0) but the writer must FORCE the organizer row to Organized(1).
+        var a = MakeMeetingRecord(organizerHasEmail: true, organizerResponse: AttendeeResponse.None);
+
+        RoundTripAppointment(a, (_, appt) =>
+        {
+            // SentRepresentingName must be set to the organizer's display name.
+            string? name = appt.PC.GetStringProperty(PropertyID.PidTagSentRepresentingName);
+            Assert.Equal("Alice Organizer", name);
+
+            // SentRepresentingEmailAddress must be set (organizer has an email).
+            string? email = appt.PC.GetStringProperty(PropertyID.PidTagSentRepresentingEmailAddress);
+            Assert.Equal("alice@example.com", email);
+
+            // Organizer recipient row (row 0) ResponseStatus must be Organized(1) — writer forces it.
+            MessageRecipient orgRow = appt.GetRecipient(0);
+            Assert.Equal((int)AttendeeResponse.Organized, orgRow.ResponseStatus);
+
+            return true;
+        });
+    }
+
+    [Fact]
+    public void Meeting_StateFlags_has_asfMeeting_bit_and_PidLidResponseStatus_is_Organized()
+    {
+        var a = MakeMeetingRecord();
+
+        RoundTripAppointment(a, (pst, appt) =>
+        {
+            // PidLidAppointmentStateFlags (PSETID_Appointment 0x8217): asfMeeting bit (0x1) must be set.
+            PropertyID sfId = Named(pst, PropertyLongID.PidLidAppointmentStateFlags, PropertySetGuid.PSETID_Appointment);
+            int? stateFlags = appt.PC.GetInt32Property(sfId);
+            Assert.NotNull(stateFlags);
+            Assert.True((stateFlags!.Value & 1) != 0, "asfMeeting bit (0x1) must be set in PidLidAppointmentStateFlags");
+
+            // PidLidResponseStatus (PSETID_Appointment 0x8218) must be Organized(1).
+            PropertyID rsId = Named(pst, PropertyLongID.PidLidResponseStatus, PropertySetGuid.PSETID_Appointment);
+            int? rs = appt.PC.GetInt32Property(rsId);
+            Assert.Equal((int)AttendeeResponse.Organized, rs);
+
+            return true;
+        });
+    }
+
+    [Fact]
+    public void No_attendee_appointment_writes_no_recipients_no_SentRepresenting_no_meeting_props()
+    {
+        // Regression guard: a plain appointment (no attendees) must NOT write any meeting state.
+        var a = MakePlainRecord("Plain appointment");
+
+        RoundTripAppointment(a, (pst, appt) =>
+        {
+            // No recipient table rows.
+            Assert.Equal(0, appt.RecipientCount);
+
+            // No SentRepresentingName.
+            string? name = appt.PC.GetStringProperty(PropertyID.PidTagSentRepresentingName);
+            Assert.True(string.IsNullOrEmpty(name), "SentRepresentingName must not be set for a plain appointment");
+
+            // PidLidAppointmentStateFlags must not be present (plain appointment).
+            PropertyID sfId = Named(pst, PropertyLongID.PidLidAppointmentStateFlags, PropertySetGuid.PSETID_Appointment);
+            int? stateFlags = appt.PC.GetInt32Property(sfId);
+            Assert.Null(stateFlags);
+
+            return true;
+        });
+    }
+
+    [Fact]
+    public void OrganizerOnly_record_is_treated_as_plain_appointment()
+    {
+        // Organizer set but Attendees is empty → WriteAttendees returns early → no recipient rows,
+        // no SentRepresenting*, no meeting-state props.
+        var a = new AppointmentRecord
+        {
+            Subject  = "Organizer-only event",
+            StartUtc = new DateTime(2026, 7, 1, 9, 0, 0, DateTimeKind.Utc),
+            EndUtc   = new DateTime(2026, 7, 1, 10, 0, 0, DateTimeKind.Utc),
+            Organizer = new AppointmentAttendee
+            {
+                DisplayName = "Alice Organizer",
+                Email       = "alice@example.com",
+                Kind        = AttendeeKind.Required,
+                IsOrganizer = true,
+            },
+            Attendees = Array.Empty<AppointmentAttendee>(),  // empty — must NOT promote to meeting
+        };
+
+        RoundTripAppointment(a, (pst, appt) =>
+        {
+            Assert.Equal(0, appt.RecipientCount);
+
+            string? name = appt.PC.GetStringProperty(PropertyID.PidTagSentRepresentingName);
+            Assert.True(string.IsNullOrEmpty(name), "SentRepresentingName must not be set for an organizer-only appointment");
+
+            PropertyID sfId = Named(pst, PropertyLongID.PidLidAppointmentStateFlags, PropertySetGuid.PSETID_Appointment);
+            int? stateFlags = appt.PC.GetInt32Property(sfId);
+            Assert.Null(stateFlags);
+
+            return true;
+        });
+    }
+
+    [Fact]
+    public void Organizer_with_empty_email_omits_organizer_row_but_still_writes_attendees()
+    {
+        // Organizer without an email address: SentRepresentingName is set (display-only), but no
+        // organizer recipient row is written (a row with empty address is invalid MAPI).
+        // Attendee rows must still be written.
+        var a = MakeMeetingRecord(organizerHasEmail: false);
+
+        RoundTripAppointment(a, (_, appt) =>
+        {
+            // 4 attendees but NO organizer row → total 4 rows
+            Assert.Equal(4, appt.RecipientCount);
+
+            // No row should be IsOrganizer=true
+            for (int i = 0; i < appt.RecipientCount; i++)
+                Assert.False(appt.GetRecipient(i).IsOrganizer, $"Row {i} must not have IsOrganizer=true");
+
+            // SentRepresentingName is still set (display-only organizer)
+            string? name = appt.PC.GetStringProperty(PropertyID.PidTagSentRepresentingName);
+            Assert.Equal("Alice Organizer", name);
+
+            // SentRepresentingEmailAddress must NOT be set (empty email)
+            string? email = appt.PC.GetStringProperty(PropertyID.PidTagSentRepresentingEmailAddress);
+            Assert.True(string.IsNullOrEmpty(email), "SentRepresentingEmailAddress must not be set when organizer email is empty");
+
+            return true;
+        });
+    }
+
+    [Fact]
+    public void Meeting_message_class_stays_IPM_Appointment()
+    {
+        // The recipient/meeting-state block must not change the message class.
+        var a = MakeMeetingRecord();
+        string? cls = RoundTripAppointment(a,
+            (_, appt) => appt.PC.GetStringProperty(PropertyID.PidTagMessageClass));
+        Assert.Equal("IPM.Appointment", cls);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterGoidTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterGoidTests.cs
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Writing;
+using PSTFileFormat;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Writing;
+
+/// <summary>
+/// TDD round-trip tests for GlobalObjectId / CleanGlobalObjectId written by <see cref="AppointmentWriter"/>
+/// (PidLidGlobalObjectId LID 0x0003 and PidLidCleanGlobalObjectId LID 0x0023, both PSETID_Meeting).
+/// </summary>
+public class AppointmentWriterGoidTests
+{
+    // 112-char Exchange GOID hex (bytes 16-19 are 00 so full == clean for this sample).
+    private const string GoidHex =
+        "040000008200E00074C5B7101A82E00800000000B40F44F359B6DC01000000000000000010000000DC21992D2F90224BB5EE6F8189627094";
+
+    // -----------------------------------------------------------------------
+    // Round-trip infrastructure (mirrors AppointmentWriterTests.RoundTripAppointment)
+    // -----------------------------------------------------------------------
+
+    private static T RoundTripAppointment<T>(AppointmentRecord record, Func<PSTFile, Appointment, T> read)
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"m2p-awgoid-{Guid.NewGuid():N}.pst");
+        PSTFile? pst = null;
+        try
+        {
+            PSTFile.CreateEmptyStore(path);
+
+            try
+            {
+                pst = new PSTFile(path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+                pst.BeginSavingChanges();
+                PSTFolder folder = pst.TopOfPersonalFolders.CreateChildFolder(
+                    "Calendar", FolderItemTypeName.Appointment);
+                new AppointmentWriter().WriteAppointment(pst, folder, record);
+                folder.SaveChanges();
+                pst.EndSavingChanges();
+            }
+            finally { pst?.CloseFile(); pst = null; }
+
+            try
+            {
+                pst = new PSTFile(path, FileAccess.Read, WriterCompatibilityMode.Outlook2007RTM);
+                PSTFolder found = pst.TopOfPersonalFolders.FindChildFolder("Calendar");
+                CalendarFolder cal = Assert.IsType<CalendarFolder>(found);
+                Assert.Equal(1, cal.AppointmentCount);
+                Appointment appt = cal.GetAppointment(0);
+                return read(pst, appt);
+            }
+            finally { pst?.CloseFile(); pst = null; }
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Goid_written_round_trips_both_props()
+    {
+        // GlobalObjectId set (Exchange-cached event) → PidLidGlobalObjectId == raw bytes,
+        // PidLidCleanGlobalObjectId == date-zeroed clone (bytes 16-19 == 0).
+        byte[] goidBytes = Convert.FromHexString(GoidHex);
+
+        var a = new AppointmentRecord
+        {
+            Subject        = "Exchange meeting",
+            StartUtc       = new DateTime(2026, 8, 1, 10, 0, 0, DateTimeKind.Utc),
+            EndUtc         = new DateTime(2026, 8, 1, 11, 0, 0, DateTimeKind.Utc),
+            GlobalObjectId = goidBytes,
+        };
+
+        RoundTripAppointment(a, (pst, appt) =>
+        {
+            // PidLidGlobalObjectId (PSETID_Meeting 0x0003) — use ObtainIDFromName on a reopen (prop was written).
+            PropertyID goidId = pst.NameToIDMap.ObtainIDFromName(
+                new PropertyName(PropertyLongID.PidLidGlobalObjectId, PropertySetGuid.PSETID_Meeting));
+            byte[]? readGoid = appt.PC.GetBytesProperty(goidId);
+            Assert.NotNull(readGoid);
+            Assert.Equal(goidBytes, readGoid);
+
+            // PidLidCleanGlobalObjectId (PSETID_Meeting 0x0023)
+            PropertyID cleanId = pst.NameToIDMap.ObtainIDFromName(
+                new PropertyName(PropertyLongID.PidLidCleanGlobalObjectId, PropertySetGuid.PSETID_Meeting));
+            byte[]? readClean = appt.PC.GetBytesProperty(cleanId);
+            Assert.NotNull(readClean);
+            Assert.Equal(56, readClean!.Length);
+
+            // CleanGlobalObjectId: bytes [16..20) must be zero (exception-date zeroed).
+            for (int i = 16; i < 20; i++)
+                Assert.Equal(0, readClean[i]);
+
+            // Prefix [0..16) and tail [20..56) must match the original GOID.
+            for (int i = 0; i < 16; i++)
+                Assert.Equal(readGoid![i], readClean[i]);
+            for (int i = 20; i < 56; i++)
+                Assert.Equal(readGoid![i], readClean[i]);
+
+            return true;
+        });
+    }
+
+    [Fact]
+    public void No_goid_writes_neither_prop()
+    {
+        // GlobalObjectId == null (Mozilla UUID / CalDAV event) → both props ABSENT.
+        // CRITICAL: check absence with GetIDFromName (non-mutating) — NOT ObtainIDFromName,
+        // which CREATES the mapping and would make the test lie.
+        var a = new AppointmentRecord
+        {
+            Subject        = "Local event",
+            StartUtc       = new DateTime(2026, 8, 1, 10, 0, 0, DateTimeKind.Utc),
+            EndUtc         = new DateTime(2026, 8, 1, 11, 0, 0, DateTimeKind.Utc),
+            GlobalObjectId = null,
+        };
+
+        RoundTripAppointment(a, (pst, appt) =>
+        {
+            // Non-mutating lookup: returns null if the name was never registered.
+            PropertyID? goidId = pst.NameToIDMap.GetIDFromName(
+                new PropertyName(PropertyLongID.PidLidGlobalObjectId, PropertySetGuid.PSETID_Meeting));
+            PropertyID? cleanId = pst.NameToIDMap.GetIDFromName(
+                new PropertyName(PropertyLongID.PidLidCleanGlobalObjectId, PropertySetGuid.PSETID_Meeting));
+
+            // Absent = name not registered at all, OR registered but no value on this message.
+            bool goidAbsent  = goidId  is null || appt.PC.GetBytesProperty(goidId.Value)  is null;
+            bool cleanAbsent = cleanId is null || appt.PC.GetBytesProperty(cleanId.Value) is null;
+
+            Assert.True(goidAbsent,  "PidLidGlobalObjectId must be absent when GlobalObjectId is null");
+            Assert.True(cleanAbsent, "PidLidCleanGlobalObjectId must be absent when GlobalObjectId is null");
+
+            return true;
+        });
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
@@ -8,6 +8,8 @@ using Mail2Pst.Core.Calendar;
 using Mail2Pst.Core.Models;
 using Mail2Pst.Core.Writing;
 using PSTFileFormat;
+// Alias disambiguates our model enum from PSTFileFormat.RecurrenceFrequency (the vendor blob type).
+using RecurrenceFrequency = Mail2Pst.Core.Models.RecurrenceFrequency;
 using Xunit;
 
 namespace Mail2Pst.Core.Tests.Writing;
@@ -84,7 +86,7 @@ public class AppointmentWriterRecurrenceTests
         OriginatingTimeZoneId = "UTC",
         Recurrence = new RecurrenceSpec
         {
-            Frequency           = AppointmentRecurrenceFrequency.Weekly,
+            Frequency           = RecurrenceFrequency.Weekly,
             Interval            = 1,
             DaysOfWeek          = new[] { DayOfWeek.Monday, DayOfWeek.Wednesday },
             EndKind             = RecurrenceEndKind.Count,
@@ -107,7 +109,7 @@ public class AppointmentWriterRecurrenceTests
         OriginatingTimeZoneId = "Asia/Bangkok",
         Recurrence = new RecurrenceSpec
         {
-            Frequency             = AppointmentRecurrenceFrequency.Daily,
+            Frequency             = RecurrenceFrequency.Daily,
             Interval              = 1,
             DaysOfWeek            = Array.Empty<DayOfWeek>(),
             EndKind               = RecurrenceEndKind.NoEnd,
@@ -175,7 +177,7 @@ public class AppointmentWriterRecurrenceTests
             OriginatingTimeZoneId = "Asia/Bangkok",
             Recurrence = new RecurrenceSpec
             {
-                Frequency             = AppointmentRecurrenceFrequency.Yearly,
+                Frequency             = RecurrenceFrequency.Yearly,
                 Interval              = 1,
                 DaysOfWeek            = Array.Empty<DayOfWeek>(),
                 EndKind               = RecurrenceEndKind.NoEnd,
@@ -234,7 +236,7 @@ public class AppointmentWriterRecurrenceTests
             OriginatingTimeZoneId = null,             // triggers UTC fallback
             Recurrence = new RecurrenceSpec
             {
-                Frequency    = AppointmentRecurrenceFrequency.Daily,
+                Frequency    = RecurrenceFrequency.Daily,
                 Interval     = 1,
                 DaysOfWeek   = Array.Empty<DayOfWeek>(),
                 EndKind      = RecurrenceEndKind.NoEnd,
@@ -430,7 +432,7 @@ public class AppointmentWriterRecurrenceTests
             OriginatingTimeZoneId = "Asia/Bangkok",
             Recurrence = new RecurrenceSpec
             {
-                Frequency             = AppointmentRecurrenceFrequency.Daily,
+                Frequency             = RecurrenceFrequency.Daily,
                 Interval              = 1,
                 DaysOfWeek            = Array.Empty<DayOfWeek>(),
                 EndKind               = RecurrenceEndKind.NoEnd,

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using Mail2Pst.Core.Calendar;
 using Mail2Pst.Core.Models;
 using Mail2Pst.Core.Writing;
 using PSTFileFormat;
@@ -115,6 +116,27 @@ public class AppointmentWriterRecurrenceTests
             OriginatingTimeZoneId = "Asia/Bangkok",
         },
     };
+
+    /// <summary>
+    /// All-day weekly event on Monday starting 2026-07-14 (UTC midnight boundaries, flags=4).
+    /// Used as input to <see cref="CalendarEventMapper.Map"/> so that PR5's all-day normalisation
+    /// (midnight boundaries / IsAllDay flag) is applied before writing.
+    /// </summary>
+    private static RawEventGroup AllDayWeeklyGroup()
+    {
+        var ev = new RawEvent
+        {
+            Id           = "allday-weekly-001@example.com",
+            Title        = "All-Day Weekly Review",
+            EventStart   = new DateTimeOffset(2026, 7, 14, 0, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds() * 1000L,
+            EventStartTz = "UTC",
+            EventEnd     = new DateTimeOffset(2026, 7, 15, 0, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds() * 1000L,
+            EventEndTz   = "UTC",
+            Flags        = 4, // EVENT_ALLDAY
+        };
+        ev.Recurrence.Add(new RawSideText("RRULE:FREQ=WEEKLY;BYDAY=MO;COUNT=4"));
+        return new RawEventGroup { Master = ev };
+    }
 
     // -----------------------------------------------------------------------
     // Tests
@@ -396,5 +418,41 @@ public class AppointmentWriterRecurrenceTests
         // Bangkok midnight for the 2026-07-01 event date = 2026-06-30T17:00:00Z.
         // Before the fix (zone applied AFTER SetStartAndDuration) this would be 2026-07-01T00:00:00Z on a UTC host.
         Assert.Equal(new DateTime(2026, 6, 30, 17, 0, 0, DateTimeKind.Utc), clipStart!.Value.ToUniversalTime());
+    }
+
+    // -----------------------------------------------------------------------
+    // Task 7: all-day recurring writer test
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// An all-day weekly event (flags=4) mapped through <see cref="CalendarEventMapper.Map"/>
+    /// must produce both a recurrence blob (<c>PidLidAppointmentRecur</c>) and
+    /// <c>PidLidAppointmentSubType == true</c> (all-day) on the written item.
+    ///
+    /// The record is built via the mapper so that PR5's all-day normalisation (midnight
+    /// boundaries, IsAllDay flag) is applied before the writer sees it — mirroring what the
+    /// production pipeline does. Named-prop reads happen inside the inspect callback while
+    /// the PST file is still open (lazy-load gotcha).
+    /// </summary>
+    [Fact]
+    public void AllDay_weekly_recurring_writes_subtype_and_blob()
+    {
+        // Build the record through the mapper so that all-day normalisation applies.
+        var g = AllDayWeeklyGroup();
+        var rec = CalendarEventMapper.Map(g, out _);
+        Assert.True(rec!.IsAllDay, "mapper must set IsAllDay from flags=4");
+        Assert.NotNull(rec.Recurrence);
+
+        bool isAllDayEvent = false;
+        var (count, blob, _) = WriteAndReadAppointment(rec, (_, appt) =>
+        {
+            // IsAllDayEvent wraps PidLidAppointmentSubType (PT_BOOLEAN) — read while file is open.
+            isAllDayEvent = appt.IsAllDayEvent;
+            return appt;
+        });
+
+        Assert.Equal(1, count);
+        Assert.NotNull(blob);   // PidLidAppointmentRecur must be present
+        Assert.True(isAllDayEvent, "PidLidAppointmentSubType must be true for an all-day recurring appointment");
     }
 }

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
@@ -146,14 +146,6 @@ public class AppointmentWriterRecurrenceTests
     [Fact]
     public void Recurring_with_Bangkok_tz_writes_tz_definition_blobs()
     {
-        // Skip on platforms where IANA→Windows TZ mapping is unavailable.
-        // .NET 6+ on Linux with globalization invariant mode cannot map IANA ids.
-        if (!TimeZoneInfo.TryConvertIanaIdToWindowsId("Asia/Bangkok", out _))
-        {
-            // On this platform the zone resolution would fall back to UTC — the blob
-            // will still be present (UTC TZ blobs), so we just assert non-null below.
-        }
-
         var rec = BangkokRecord();
         var (count, blob, appt) = WriteAndReadAppointment(rec);
         Assert.Equal(1, count);
@@ -203,5 +195,56 @@ public class AppointmentWriterRecurrenceTests
         // UTC zone definition blobs must be present (SetOriginalTimeZone(UTC) was called).
         byte[]? tzStruct = appt.PC.GetBytesProperty(PropertyNames.PidLidTimeZoneStruct);
         Assert.NotNull(tzStruct);
+    }
+
+    /// <summary>
+    /// Regression test for the zone-before-start ordering fix.
+    ///
+    /// <para>
+    /// <c>RecurringAppointment.StartDTUtc</c> setter (inside <c>SetStartAndDuration</c>) computes
+    /// <c>PidLidClipStart</c> as local-midnight in <c>this.OriginalTimeZone</c>.  Before the fix,
+    /// <c>SetOriginalTimeZone</c> was called AFTER <c>SetStartAndDuration</c>, so on a UTC CI host
+    /// <c>ClipStart</c> was midnight-UTC rather than midnight in the event's zone — the wrong date
+    /// for events where start-of-day differs between the event zone and UTC.
+    /// </para>
+    /// <para>
+    /// Scenario: Bangkok (UTC+7) recurring appointment, <c>StartUtc = 2026-07-01T02:00:00Z</c>
+    /// (= 09:00 Bangkok local).  Bangkok local-midnight = 2026-07-01T00:00:00+07:00 = 2026-06-30T17:00:00Z.
+    /// After the fix <c>ClipStart</c> must be <c>2026-06-30T17:00:00Z</c>;
+    /// before the fix it would be <c>2026-07-01T00:00:00Z</c> on any UTC host.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void Recurring_Bangkok_ClipStart_is_event_zone_midnight_not_utc_midnight()
+    {
+        var rec = new AppointmentRecord
+        {
+            Subject               = "Bangkok ClipStart regression",
+            StartUtc              = new DateTime(2026, 7, 1, 2, 0, 0, DateTimeKind.Utc),  // 09:00 Bangkok
+            EndUtc                = new DateTime(2026, 7, 1, 2, 30, 0, DateTimeKind.Utc),
+            OriginatingTimeZoneId = "Asia/Bangkok",
+            Recurrence = new RecurrenceSpec
+            {
+                Frequency             = AppointmentRecurrenceFrequency.Daily,
+                Interval              = 1,
+                DaysOfWeek            = Array.Empty<DayOfWeek>(),
+                EndKind               = RecurrenceEndKind.NoEnd,
+                FirstStartUtc         = new DateTime(2026, 7, 1, 2, 0, 0, DateTimeKind.Utc),
+                FirstStartLocal       = new DateTime(2026, 7, 1, 9, 0, 0),   // UTC+7
+                OriginatingTimeZoneId = "Asia/Bangkok",
+            },
+        };
+
+        DateTime? clipStart = null;
+        WriteAndReadAppointment(rec, (_, appt) =>
+        {
+            clipStart = appt.PC.GetDateTimeProperty(PropertyNames.PidLidClipStart);
+            return appt;
+        });
+
+        Assert.NotNull(clipStart);
+        // Bangkok midnight for the 2026-07-01 event date = 2026-06-30T17:00:00Z.
+        // Before the fix (zone applied AFTER SetStartAndDuration) this would be 2026-07-01T00:00:00Z on a UTC host.
+        Assert.Equal(new DateTime(2026, 6, 30, 17, 0, 0, DateTimeKind.Utc), clipStart!.Value.ToUniversalTime());
     }
 }

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
@@ -409,6 +409,44 @@ public class AppointmentWriterRecurrenceTests
     }
 
     /// <summary>
+    /// Pre-merge review #10: MS-OXOCAL 2.2.1.44 requires the ExceptionInfo array and ModifiedInstanceDates
+    /// to be in the SAME ascending order and to correspond positionally. Overrides can arrive in arbitrary
+    /// (SQLite row) order; here two are supplied newest-first. ModifiedInstanceDates is always written
+    /// sorted, so before the fix the unsorted ExceptionInfo array desynced from it. After the fix both are
+    /// ascending and ExceptionInfo[i].NewStartDT.Date == ModifiedInstanceDates[i].
+    /// </summary>
+    [Fact]
+    public void Out_of_order_overrides_keep_exception_and_modified_date_arrays_corresponding()
+    {
+        var rec = WeeklyRecord();
+        rec.Exceptions = new[]
+        {
+            // Jul 15 first (later), then Jul 8 (earlier) — reverse chronological input order.
+            new AppointmentException {
+                OriginalInstance = new RecurrenceInstanceId(new DateTime(2026,7,15,1,0,0,DateTimeKind.Utc),
+                    new DateTime(2026,7,15,1,0,0,DateTimeKind.Unspecified), "UTC", false),
+                NewStartUtc = new(2026,7,15,7,0,0,DateTimeKind.Utc), NewEndUtc = new(2026,7,15,7,30,0,DateTimeKind.Utc),
+                Subject = "Later moved", ChangeFlags = AppointmentExceptionChangeFlags.Subject | AppointmentExceptionChangeFlags.StartEnd },
+            new AppointmentException {
+                OriginalInstance = new RecurrenceInstanceId(new DateTime(2026,7,8,1,0,0,DateTimeKind.Utc),
+                    new DateTime(2026,7,8,1,0,0,DateTimeKind.Unspecified), "UTC", false),
+                NewStartUtc = new(2026,7,8,7,0,0,DateTimeKind.Utc), NewEndUtc = new(2026,7,8,7,30,0,DateTimeKind.Utc),
+                Subject = "Earlier moved", ChangeFlags = AppointmentExceptionChangeFlags.Subject | AppointmentExceptionChangeFlags.StartEnd },
+        };
+
+        var (_, blob, _) = WriteAndReadAppointment(rec);
+        var s = AppointmentRecurrencePatternStructure.GetRecurrencePatternStructure(blob!);
+
+        Assert.Equal(2, s.ExceptionList.Count);
+        Assert.Equal(2, s.ModifiedInstanceDates.Count);
+        // ExceptionInfo array must be ascending by new start...
+        Assert.True(s.ExceptionList[0].NewStartDT < s.ExceptionList[1].NewStartDT);
+        // ...and correspond positionally to ModifiedInstanceDates (both ascending).
+        for (int i = 0; i < s.ExceptionList.Count; i++)
+            Assert.Equal(s.ModifiedInstanceDates[i], s.ExceptionList[i].NewStartDT.Date);
+    }
+
+    /// <summary>
     /// A unicode subject on an overridden occurrence must round-trip through the embedded
     /// <c>method=5</c> attachment's <see cref="ModifiedAppointmentInstance.Subject"/> property
     /// (stored as MAPI PT_UNICODE — full UTF-16, not the ANSI blob ExceptionInfo field).

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
@@ -345,6 +345,41 @@ public class AppointmentWriterRecurrenceTests
         Assert.Equal((uint)5, s.OccurrenceCount);
     }
 
+    /// <summary>
+    /// Should-fix (SF-A): a weekly series with an empty day-mask must fall back to the DTSTART weekday
+    /// (matching TaskRecurrenceBlob), not write Day=0 (an invalid empty weekly pattern). 2026-07-01 is a
+    /// Wednesday, so the mask must be non-zero.
+    /// </summary>
+    [Fact]
+    public void Weekly_empty_day_mask_falls_back_to_start_weekday()
+    {
+        var start = new DateTime(2026, 7, 1, 1, 0, 0, DateTimeKind.Utc); // Wednesday
+        var rec = new AppointmentRecord
+        {
+            Subject  = "Weekly no mask",
+            StartUtc = start,
+            EndUtc   = start.AddMinutes(30),
+            TimeZone = TimeZoneInfo.Utc,
+            OriginatingTimeZoneId = "UTC",
+            Recurrence = new RecurrenceSpec
+            {
+                Frequency             = RecurrenceFrequency.Weekly,
+                Interval              = 1,
+                DaysOfWeek            = Array.Empty<DayOfWeek>(),   // empty mask
+                EndKind               = RecurrenceEndKind.Count,
+                Count                 = 3,
+                LastInstanceStartUtc  = new DateTime(2026, 7, 15, 1, 0, 0, DateTimeKind.Utc),
+                FirstStartUtc         = start,
+                FirstStartLocal       = start,
+                TimeZone              = TimeZoneInfo.Utc,
+                OriginatingTimeZoneId = "UTC",
+            },
+        };
+        var (_, _, appt) = WriteAndReadAppointment(rec);
+        var ra = Assert.IsType<RecurringAppointment>(appt);
+        Assert.NotEqual(0, ra.Day);   // fell back to the DTSTART weekday mask
+    }
+
     // -----------------------------------------------------------------------
     // Task 4: EXDATE deleted occurrences
     // -----------------------------------------------------------------------

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
@@ -421,6 +421,52 @@ public class AppointmentWriterRecurrenceTests
     }
 
     // -----------------------------------------------------------------------
+    // I1: bare FREQ=WEEKLY writer round-trip — weekday mask bit
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Bare FREQ=WEEKLY (no BYDAY) where DTSTART is Monday 2026-07-06.
+    /// The mapper defaults DaysOfWeek to [Monday]; the writer must reflect that in
+    /// the PidLidAppointmentRecur blob (DaysOfWeekFlags.Monday = 0x02).
+    /// </summary>
+    private static RawEventGroup BareWeeklyGroup()
+    {
+        var ev = new RawEvent
+        {
+            Id           = "bare-weekly-001@example.com",
+            Title        = "Bare Weekly",
+            EventStart   = new DateTimeOffset(2026, 7, 6, 14, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds() * 1000L,
+            EventStartTz = "UTC",
+            EventEnd     = new DateTimeOffset(2026, 7, 6, 15, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds() * 1000L,
+            EventEndTz   = "UTC",
+            Flags        = 0,
+        };
+        ev.Recurrence.Add(new RawSideText("RRULE:FREQ=WEEKLY"));
+        return new RawEventGroup { Master = ev };
+    }
+
+    /// <summary>
+    /// Writer round-trip for I1: a bare FREQ=WEEKLY (no BYDAY) with DTSTART on Monday
+    /// must produce a PidLidAppointmentRecur blob whose WeeklyRecurrencePatternStructure
+    /// has DaysOfWeek == Monday (0x02).
+    /// </summary>
+    [Fact]
+    public void Weekly_no_byday_blob_has_monday_mask()
+    {
+        var g   = BareWeeklyGroup();
+        var rec = CalendarEventMapper.Map(g, out _);
+        Assert.NotNull(rec);
+        // Mapper must have defaulted DaysOfWeek to Monday (I1 fix).
+        Assert.Equal(new[] { DayOfWeek.Monday }, rec!.Recurrence!.DaysOfWeek);
+
+        var (_, blob, _) = WriteAndReadAppointment(rec);
+        Assert.NotNull(blob);
+        var weekly = (WeeklyRecurrencePatternStructure)
+            AppointmentRecurrencePatternStructure.GetRecurrencePatternStructure(blob!);
+        Assert.Equal(DaysOfWeekFlags.Monday, weekly.DaysOfWeek);
+    }
+
+    // -----------------------------------------------------------------------
     // Task 7: all-day recurring writer test
     // -----------------------------------------------------------------------
 

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
@@ -309,6 +309,42 @@ public class AppointmentWriterRecurrenceTests
         Assert.NotNull(tzStruct);
     }
 
+    /// <summary>
+    /// Pre-merge review #5: for a COUNT-terminated series the blob's OccurrenceCount must be the RRULE
+    /// COUNT, not a date-span heuristic. A month-overflow pattern (BYMONTHDAY=31 skips 30-day months)
+    /// exposes the bug: 5 occurrences of "day 31" from Jan 2026 land on Jan/Mar/May/Jul/Aug 31, a
+    /// 7-month span → the old heuristic wrote 8. Outlook must see exactly 5.
+    /// </summary>
+    [Fact]
+    public void Count_series_month_overflow_writes_exact_occurrence_count()
+    {
+        var rec = new AppointmentRecord
+        {
+            Subject  = "Day-31 monthly",
+            StartUtc = new DateTime(2026, 1, 31, 9, 0, 0, DateTimeKind.Utc),
+            EndUtc   = new DateTime(2026, 1, 31, 9, 30, 0, DateTimeKind.Utc),
+            TimeZone = TimeZoneInfo.Utc,
+            OriginatingTimeZoneId = "UTC",
+            Recurrence = new RecurrenceSpec
+            {
+                Frequency             = RecurrenceFrequency.Monthly,
+                Interval              = 1,
+                DayOfMonth            = 31,
+                DaysOfWeek            = Array.Empty<DayOfWeek>(),
+                EndKind               = RecurrenceEndKind.Count,
+                Count                 = 5,
+                LastInstanceStartUtc  = new DateTime(2026, 8, 31, 9, 0, 0, DateTimeKind.Utc), // Jan,Mar,May,Jul,Aug
+                FirstStartUtc         = new DateTime(2026, 1, 31, 9, 0, 0, DateTimeKind.Utc),
+                FirstStartLocal       = new DateTime(2026, 1, 31, 9, 0, 0),
+                TimeZone              = TimeZoneInfo.Utc,
+                OriginatingTimeZoneId = "UTC",
+            },
+        };
+        var (_, blob, _) = WriteAndReadAppointment(rec);
+        var s = AppointmentRecurrencePatternStructure.GetRecurrencePatternStructure(blob!);
+        Assert.Equal((uint)5, s.OccurrenceCount);
+    }
+
     // -----------------------------------------------------------------------
     // Task 4: EXDATE deleted occurrences
     // -----------------------------------------------------------------------

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
@@ -289,6 +289,64 @@ public class AppointmentWriterRecurrenceTests
         Assert.Equal(UnicodeSubject, attachSubject);
     }
 
+    // -----------------------------------------------------------------------
+    // Task 6: recurring MEETING preserves PR6 attendees + meeting state + recur blob
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// A recurring meeting (organizer + ≥1 attendee) must write BOTH the
+    /// <c>PidLidAppointmentRecur</c> blob (recurrence preserved) AND the PR6 meeting surface:
+    /// recipient table populated, <c>PidLidAppointmentStateFlags</c> has <c>asfMeeting</c>
+    /// (bit 0x1), and <c>PidLidResponseStatus == respOrganized</c> (1).
+    ///
+    /// Proves <c>WriteAttendees</c> runs on the recurring path — Task 3 routed it through
+    /// BOTH the single and recurring code paths in <see cref="AppointmentWriter.WriteAppointment"/>.
+    ///
+    /// All recipient-table / named-prop reads happen inside the <c>inspect</c> callback while
+    /// the <see cref="PSTFile"/> is still open (lazy-load gotcha — Task 5).
+    /// </summary>
+    [Fact]
+    public void Recurring_meeting_writes_state_recipients_and_recur_blob()
+    {
+        var rec = WeeklyRecord();
+        rec.Organizer = new AppointmentAttendee
+        {
+            DisplayName = "Org",
+            Email       = "org@example.com",
+            Kind        = AttendeeKind.Required,
+            Response    = AttendeeResponse.Organized,
+        };
+        rec.Attendees = new[]
+        {
+            new AppointmentAttendee { DisplayName = "Req", Email = "req@example.com", Kind = AttendeeKind.Required, Response = AttendeeResponse.None },
+        };
+
+        int recipientCount = 0;
+        int stateFlags = 0;
+        int? responseStatus = null;
+
+        var (_, blob, _) = WriteAndReadAppointment(rec, (pst, appt) =>
+        {
+            recipientCount = appt.RecipientCount;   // inside callback — recipient table lazily loaded from subnode tree
+
+            // PidLidAppointmentStateFlags (write-only on Appointment) — read via named prop, same as AppointmentWriterAttendeeTests
+            PropertyID sfId = pst.NameToIDMap.ObtainIDFromName(
+                new PropertyName(PropertyLongID.PidLidAppointmentStateFlags, PropertySetGuid.PSETID_Appointment));
+            stateFlags = appt.PC.GetInt32Property(sfId) ?? 0;
+
+            PropertyID rsId = pst.NameToIDMap.ObtainIDFromName(
+                new PropertyName(PropertyLongID.PidLidResponseStatus, PropertySetGuid.PSETID_Appointment));
+            responseStatus = appt.PC.GetInt32Property(rsId);
+
+            return appt;
+        });
+
+        Assert.NotNull(blob);                                               // recurrence preserved (Task 3)
+        Assert.True(recipientCount >= 1, "RecipientCount must be >= 1 for a recurring meeting");   // PR6 recipients
+        Assert.Equal(0x1, stateFlags & 0x1);                               // asfMeeting bit set (PidLidAppointmentStateFlags)
+        Assert.Equal(1, responseStatus);                                    // respOrganized (PidLidResponseStatus)
+    }
+
     /// <summary>
     /// Regression test for the zone-before-start ordering fix.
     ///

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
@@ -254,6 +254,61 @@ public class AppointmentWriterRecurrenceTests
         Assert.NotNull(tzStruct);
     }
 
+    /// <summary>
+    /// Regression (pre-merge review #1, CRITICAL): a recurring appointment in a timezone that carries
+    /// MULTIPLE DST adjustment rules (e.g. America/New_York → "Eastern Standard Time", which has
+    /// historical rules) must NOT throw. The recurring path writes the legacy PidLidTimeZoneStruct via
+    /// <c>TimeZoneStructure.FromTimeZoneInfo</c>, which throws <see cref="ArgumentException"/> on a zone
+    /// with &gt;1 DST rule — aborting the ENTIRE conversion. Every prior recurrence test used a
+    /// zero/one-rule zone (UTC / Asia-Bangkok), so this crash was invisible to CI and the owner's
+    /// Thailand render-gate. The writer must collapse the resolved zone to a single-rule static zone
+    /// (keeping the first rule, matching the vendor's own <c>GetFirstRule</c> choice) before handing it
+    /// to the vendor blob writer.
+    /// </summary>
+    [Fact]
+    public void Recurring_with_multi_DST_rule_timezone_does_not_throw()
+    {
+        // Precondition: resolve the Windows zone the same way the writer does and confirm it is genuinely
+        // multi-rule, so this test exercises the crash path (not a vacuous pass).
+        TimeZoneInfo winZone =
+            TimeZoneInfo.TryConvertIanaIdToWindowsId("America/New_York", out string? winId) && winId is not null
+                ? TimeZoneInfo.FindSystemTimeZoneById(winId)
+                : TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
+        Assert.True(winZone.GetAdjustmentRules().Length > 1,
+            "test precondition: America/New_York must resolve to a multi-DST-rule zone");
+
+        var rec = new AppointmentRecord
+        {
+            Subject               = "Eastern weekly",
+            StartUtc              = new DateTime(2026, 7, 1, 13, 0, 0, DateTimeKind.Utc), // 09:00 EDT
+            EndUtc                = new DateTime(2026, 7, 1, 13, 30, 0, DateTimeKind.Utc),
+            TimeZone              = winZone,
+            OriginatingTimeZoneId = "America/New_York",
+            Recurrence = new RecurrenceSpec
+            {
+                Frequency             = RecurrenceFrequency.Weekly,
+                Interval              = 1,
+                DaysOfWeek            = new[] { DayOfWeek.Wednesday },
+                EndKind               = RecurrenceEndKind.Count,
+                Count                 = 6,
+                LastInstanceStartUtc  = new DateTime(2026, 8, 5, 13, 0, 0, DateTimeKind.Utc),
+                FirstStartUtc         = new DateTime(2026, 7, 1, 13, 0, 0, DateTimeKind.Utc),
+                FirstStartLocal       = new DateTime(2026, 7, 1, 9, 0, 0),
+                TimeZone              = winZone,
+                OriginatingTimeZoneId = "America/New_York",
+            },
+        };
+
+        // Must not throw (currently throws ArgumentException "...multiple DST rules").
+        var (count, blob, appt) = WriteAndReadAppointment(rec);
+        Assert.Equal(1, count);
+        Assert.NotNull(blob);
+
+        // Legacy PidLidTimeZoneStruct must be present (proving SetOriginalTimeZone succeeded).
+        byte[]? tzStruct = appt.PC.GetBytesProperty(PropertyNames.PidLidTimeZoneStruct);
+        Assert.NotNull(tzStruct);
+    }
+
     // -----------------------------------------------------------------------
     // Task 4: EXDATE deleted occurrences
     // -----------------------------------------------------------------------

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
@@ -380,6 +380,61 @@ public class AppointmentWriterRecurrenceTests
         Assert.NotEqual(0, ra.Day);   // fell back to the DTSTART weekday mask
     }
 
+    /// <summary>
+    /// Mutation-coverage (Stryker): the MonthlyNth "Nth weekday" appointment path was uncovered.
+    /// "2nd Tuesday of every month" must map to RecurrenceType=EveryNthDayOfEveryNMonths, Day=Tuesday
+    /// (OutlookDayOfWeek 0x04), DayOccurenceNumber=Second.
+    /// </summary>
+    [Fact]
+    public void MonthlyNth_second_Tuesday_sets_day_and_occurrence()
+    {
+        var (ra, _) = WriteMonthlyNth(new[] { DayOfWeek.Tuesday }, nth: 2);
+        Assert.Equal(RecurrenceType.EveryNthDayOfEveryNMonths, ra.RecurrenceType);
+        Assert.Equal((int)OutlookDayOfWeek.Tuesday, ra.Day);
+        Assert.Equal(DayOccurenceNumber.Second, ra.DayOccurenceNumber);
+    }
+
+    /// <summary>
+    /// Mutation-coverage (Stryker): "Last Friday of the month" (NthOccurrence=-1) must map to
+    /// Day=Friday (0x20) and DayOccurenceNumber=Last — the previously-untested `Last` branch.
+    /// </summary>
+    [Fact]
+    public void MonthlyNth_last_Friday_sets_occurrence_Last()
+    {
+        var (ra, _) = WriteMonthlyNth(new[] { DayOfWeek.Friday }, nth: -1);
+        Assert.Equal((int)OutlookDayOfWeek.Friday, ra.Day);
+        Assert.Equal(DayOccurenceNumber.Last, ra.DayOccurenceNumber);
+    }
+
+    // Writes a MonthlyNth (Nth weekday of every month, no end) master and returns the reopened
+    // RecurringAppointment + its recur blob.
+    private static (RecurringAppointment ra, byte[] blob) WriteMonthlyNth(DayOfWeek[] days, int nth)
+    {
+        var start = new DateTime(2026, 7, 14, 9, 0, 0, DateTimeKind.Utc); // 2nd Tuesday of Jul 2026
+        var rec = new AppointmentRecord
+        {
+            Subject  = "Nth-day monthly",
+            StartUtc = start,
+            EndUtc   = start.AddMinutes(30),
+            TimeZone = TimeZoneInfo.Utc,
+            OriginatingTimeZoneId = "UTC",
+            Recurrence = new RecurrenceSpec
+            {
+                Frequency             = RecurrenceFrequency.MonthlyNth,
+                Interval              = 1,
+                DaysOfWeek            = days,
+                NthOccurrence         = nth,
+                EndKind               = RecurrenceEndKind.NoEnd,
+                FirstStartUtc         = start,
+                FirstStartLocal       = start,
+                TimeZone              = TimeZoneInfo.Utc,
+                OriginatingTimeZoneId = "UTC",
+            },
+        };
+        var (_, blob, appt) = WriteAndReadAppointment(rec);
+        return (Assert.IsType<RecurringAppointment>(appt), blob!);
+    }
+
     // -----------------------------------------------------------------------
     // Task 4: EXDATE deleted occurrences
     // -----------------------------------------------------------------------

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
@@ -158,6 +158,39 @@ public class AppointmentWriterRecurrenceTests
     }
 
     /// <summary>
+    /// Regression: an all-day event anchored to a positive-offset zone stores StartUtc as
+    /// local-midnight-in-UTC (July 1 00:00 Bangkok = June 30 17:00 UTC). The recurrence
+    /// day-of-month must be derived from the LOCAL date (1), not the UTC date (30).
+    /// </summary>
+    [Fact]
+    public void Yearly_all_day_local_anchor_uses_local_day_of_month()
+    {
+        var startUtc = new DateTime(2026, 6, 30, 17, 0, 0, DateTimeKind.Utc); // = July 1 00:00 Bangkok (UTC+7)
+        var rec = new AppointmentRecord
+        {
+            Subject  = "Bare yearly all-day",
+            StartUtc = startUtc,
+            EndUtc   = startUtc.AddDays(1),
+            IsAllDay = true,
+            OriginatingTimeZoneId = "Asia/Bangkok",
+            Recurrence = new RecurrenceSpec
+            {
+                Frequency             = AppointmentRecurrenceFrequency.Yearly,
+                Interval              = 1,
+                DaysOfWeek            = Array.Empty<DayOfWeek>(),
+                EndKind               = RecurrenceEndKind.NoEnd,
+                FirstStartUtc         = startUtc,                          // .Day == 30 (UTC)
+                FirstStartLocal       = new DateTime(2026, 7, 1, 0, 0, 0), // .Day == 1 (local)
+                OriginatingTimeZoneId = "Asia/Bangkok",
+            },
+        };
+
+        var (_, _, appt) = WriteAndReadAppointment(rec);
+        var ra = Assert.IsType<RecurringAppointment>(appt);
+        Assert.Equal(1, ra.Day);   // day-of-month = LOCAL day (July 1), not UTC day (June 30)
+    }
+
+    /// <summary>
     /// A recurring appointment with OriginatingTimeZoneId="Asia/Bangkok" must produce
     /// a non-null PidLidTimeZoneStruct (0x8233) AND PidLidAppointmentTimeZoneDefinitionStartDisplay
     /// (0x825E) on the written item — proving SetOriginalTimeZone was called with the Bangkok zone.

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
@@ -118,7 +118,7 @@ public class AppointmentWriterRecurrenceTests
     };
 
     /// <summary>
-    /// All-day weekly event on Monday starting 2026-07-13 (UTC midnight boundaries, flags=4).
+    /// All-day weekly event on Monday starting 2026-07-13 (UTC midnight boundaries, flags=8=EVENT_ALLDAY).
     /// Used as input to <see cref="CalendarEventMapper.Map"/> so that PR5's all-day normalisation
     /// (midnight boundaries / IsAllDay flag) is applied before writing.
     /// </summary>
@@ -132,7 +132,7 @@ public class AppointmentWriterRecurrenceTests
             EventStartTz = "UTC",
             EventEnd     = new DateTimeOffset(2026, 7, 14, 0, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds() * 1000L,
             EventEndTz   = "UTC",
-            Flags        = 4, // EVENT_ALLDAY
+            Flags        = 8, // EVENT_ALLDAY
         };
         ev.Recurrence.Add(new RawSideText("RRULE:FREQ=WEEKLY;BYDAY=MO;COUNT=4"));
         return new RawEventGroup { Master = ev };

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
@@ -219,6 +219,76 @@ public class AppointmentWriterRecurrenceTests
         Assert.Equal(new DateTime(2026, 7, 8), s.DeletedInstanceDates[0].Date);
     }
 
+    // -----------------------------------------------------------------------
+    // Task 5: overridden occurrences (modified instances / embedded attachments)
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Returns the number of attachments on the written appointment, read while the PST file is still
+    /// open (AttachmentTable is lazily loaded from the file via the subnode tree — accessing it after
+    /// CloseFile throws ObjectDisposedException).
+    /// </summary>
+    private static int ReopenAttachmentCount(AppointmentRecord rec)
+    {
+        int count = 0;
+        WriteAndReadAppointment(rec, (_, appt) => { count = appt.AttachmentCount; return appt; });
+        return count;
+    }
+
+    /// <summary>
+    /// A single overridden occurrence must produce:
+    /// <list type="bullet">
+    ///   <item>Exactly one entry in <c>ExceptionList</c> (→ one <c>ModifiedInstanceDates</c> entry).</item>
+    ///   <item><c>DeletedInstanceDates.Count ≥ ModifiedInstanceDates.Count</c> (vendored GetBytes invariant).</item>
+    ///   <item>Exactly one embedded <c>method=5</c> exception attachment on the master item.</item>
+    /// </list>
+    /// </summary>
+    [Fact]
+    public void Override_writes_exception_blob_entry_and_attachment()
+    {
+        var rec = WeeklyRecord();
+        rec.Exceptions = new[] { new AppointmentException {
+            OriginalInstance = new RecurrenceInstanceId(new DateTime(2026,7,8,1,0,0,DateTimeKind.Utc),
+                new DateTime(2026,7,8,8,0,0,DateTimeKind.Unspecified), "UTC", false),
+            NewStartUtc = new(2026,7,8,7,0,0,DateTimeKind.Utc), NewEndUtc = new(2026,7,8,7,30,0,DateTimeKind.Utc),
+            Subject = "Standup MOVED", ChangeFlags = AppointmentExceptionChangeFlags.Subject | AppointmentExceptionChangeFlags.StartEnd } };
+        var (_, blob, _) = WriteAndReadAppointment(rec);
+        var s = AppointmentRecurrencePatternStructure.GetRecurrencePatternStructure(blob!);
+        Assert.Single(s.ExceptionList);
+        Assert.Single(s.ModifiedInstanceDates);
+        Assert.True(s.DeletedInstanceDates.Count >= s.ModifiedInstanceDates.Count);  // GetBytes invariant
+        Assert.Equal(1, ReopenAttachmentCount(rec));   // embedded method=5 exception
+    }
+
+    /// <summary>
+    /// A unicode subject on an overridden occurrence must round-trip through the embedded
+    /// <c>method=5</c> attachment's <see cref="ModifiedAppointmentInstance.Subject"/> property
+    /// (stored as MAPI PT_UNICODE — full UTF-16, not the ANSI blob ExceptionInfo field).
+    /// </summary>
+    [Fact]
+    public void Override_unicode_subject_survives_from_embedded_attachment()
+    {
+        const string UnicodeSubject = "Mødet ✅ æøå";
+        var rec = WeeklyRecord();
+        rec.Exceptions = new[] { new AppointmentException {
+            OriginalInstance = new RecurrenceInstanceId(new DateTime(2026,7,8,1,0,0,DateTimeKind.Utc),
+                new DateTime(2026,7,8,1,0,0,DateTimeKind.Unspecified), "UTC", false),
+            NewStartUtc = new(2026,7,8,7,0,0,DateTimeKind.Utc), NewEndUtc = new(2026,7,8,7,30,0,DateTimeKind.Utc),
+            Subject = UnicodeSubject,
+            ChangeFlags = AppointmentExceptionChangeFlags.Subject | AppointmentExceptionChangeFlags.StartEnd } };
+
+        // Read the embedded attachment's Subject while the file is open (GetModifiedInstance accesses
+        // the subnode tree, which requires the file handle).
+        string? attachSubject = null;
+        WriteAndReadAppointment(rec, (_, appt) =>
+        {
+            if (appt is RecurringAppointment ra && ra.AttachmentCount > 0)
+                attachSubject = ra.GetModifiedInstance(0).Subject;
+            return appt;
+        });
+        Assert.Equal(UnicodeSubject, attachSubject);
+    }
+
     /// <summary>
     /// Regression test for the zone-before-start ordering fix.
     ///

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
@@ -118,7 +118,7 @@ public class AppointmentWriterRecurrenceTests
     };
 
     /// <summary>
-    /// All-day weekly event on Monday starting 2026-07-14 (UTC midnight boundaries, flags=4).
+    /// All-day weekly event on Monday starting 2026-07-13 (UTC midnight boundaries, flags=4).
     /// Used as input to <see cref="CalendarEventMapper.Map"/> so that PR5's all-day normalisation
     /// (midnight boundaries / IsAllDay flag) is applied before writing.
     /// </summary>
@@ -128,9 +128,9 @@ public class AppointmentWriterRecurrenceTests
         {
             Id           = "allday-weekly-001@example.com",
             Title        = "All-Day Weekly Review",
-            EventStart   = new DateTimeOffset(2026, 7, 14, 0, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds() * 1000L,
+            EventStart   = new DateTimeOffset(2026, 7, 13, 0, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds() * 1000L, // Monday
             EventStartTz = "UTC",
-            EventEnd     = new DateTimeOffset(2026, 7, 15, 0, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds() * 1000L,
+            EventEnd     = new DateTimeOffset(2026, 7, 14, 0, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds() * 1000L,
             EventEndTz   = "UTC",
             Flags        = 4, // EVENT_ALLDAY
         };

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
@@ -1,0 +1,207 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Writing;
+using PSTFileFormat;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Writing;
+
+/// <summary>
+/// TDD tests for the recurrence-master-blob path in <see cref="AppointmentWriter"/>.
+/// Mirrors the harness from <see cref="AppointmentWriterTests"/> but returns the
+/// PidLidAppointmentRecur blob for structural assertions.
+///
+/// PR7a Task 3: write recurring master blob + timezone definitions (IANA→Windows).
+/// </summary>
+public class AppointmentWriterRecurrenceTests
+{
+    // -----------------------------------------------------------------------
+    // Round-trip infrastructure — write, close, reopen, return (count, blob?)
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Write one appointment record, close, reopen, and return the folder item count
+    /// plus the PidLidAppointmentRecur blob (null for a non-recurring item).
+    /// </summary>
+    private static (int count, byte[]? blob, Appointment appt_) WriteAndReadAppointment(AppointmentRecord record,
+        Func<PSTFile, Appointment, Appointment>? inspect = null)
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"m2p-recur-{Guid.NewGuid():N}.pst");
+        PSTFile? pst = null;
+        try
+        {
+            PSTFile.CreateEmptyStore(path);
+
+            // Write phase
+            try
+            {
+                pst = new PSTFile(path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+                pst.BeginSavingChanges();
+                PSTFolder folder = pst.TopOfPersonalFolders.CreateChildFolder(
+                    "Calendar", FolderItemTypeName.Appointment);
+                new AppointmentWriter().WriteAppointment(pst, folder, record);
+                folder.SaveChanges();
+                pst.EndSavingChanges();
+            }
+            finally { pst?.CloseFile(); pst = null; }
+
+            // Read phase
+            try
+            {
+                pst = new PSTFile(path, FileAccess.Read, WriterCompatibilityMode.Outlook2007RTM);
+                PSTFolder found = pst.TopOfPersonalFolders.FindChildFolder("Calendar");
+                CalendarFolder cal = Assert.IsType<CalendarFolder>(found);
+                Appointment appt = cal.GetAppointment(0);
+                byte[]? blob = appt.PC.GetBytesProperty(PropertyNames.PidLidAppointmentRecur);
+                inspect?.Invoke(pst, appt);
+                return (cal.AppointmentCount, blob, appt);
+            }
+            finally { pst?.CloseFile(); pst = null; }
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers: canned records
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Weekly Mon+Wed, 6 occurrences starting Wed 2026-07-01 01:00 UTC, last 2026-07-20 01:00 UTC.
+    /// TimeZone = Utc, OriginatingTimeZoneId = "UTC".
+    /// </summary>
+    private static AppointmentRecord WeeklyRecord() => new AppointmentRecord
+    {
+        Subject  = "Weekly recurring",
+        StartUtc = new DateTime(2026, 7, 1, 1, 0, 0, DateTimeKind.Utc),
+        EndUtc   = new DateTime(2026, 7, 1, 1, 30, 0, DateTimeKind.Utc),
+        TimeZone = TimeZoneInfo.Utc,
+        OriginatingTimeZoneId = "UTC",
+        Recurrence = new RecurrenceSpec
+        {
+            Frequency           = AppointmentRecurrenceFrequency.Weekly,
+            Interval            = 1,
+            DaysOfWeek          = new[] { DayOfWeek.Monday, DayOfWeek.Wednesday },
+            EndKind             = RecurrenceEndKind.Count,
+            Count               = 6,
+            LastInstanceStartUtc = new DateTime(2026, 7, 20, 1, 0, 0, DateTimeKind.Utc),
+            FirstStartUtc       = new DateTime(2026, 7, 1, 1, 0, 0, DateTimeKind.Utc),
+            FirstStartLocal     = new DateTime(2026, 7, 1, 1, 0, 0, DateTimeKind.Utc),
+            TimeZone            = TimeZoneInfo.Utc,
+            OriginatingTimeZoneId = "UTC",
+        },
+    };
+
+    /// <summary>Daily, no end (NoEnd sentinel), OriginatingTimeZoneId = "Asia/Bangkok".</summary>
+    private static AppointmentRecord BangkokRecord() => new AppointmentRecord
+    {
+        Subject  = "Bangkok daily",
+        StartUtc = new DateTime(2026, 7, 1, 1, 0, 0, DateTimeKind.Utc),
+        EndUtc   = new DateTime(2026, 7, 1, 1, 30, 0, DateTimeKind.Utc),
+        // TimeZone left null intentionally — OriginatingTimeZoneId drives zone resolution
+        OriginatingTimeZoneId = "Asia/Bangkok",
+        Recurrence = new RecurrenceSpec
+        {
+            Frequency             = AppointmentRecurrenceFrequency.Daily,
+            Interval              = 1,
+            DaysOfWeek            = Array.Empty<DayOfWeek>(),
+            EndKind               = RecurrenceEndKind.NoEnd,
+            FirstStartUtc         = new DateTime(2026, 7, 1, 1, 0, 0, DateTimeKind.Utc),
+            FirstStartLocal       = new DateTime(2026, 7, 1, 8, 0, 0), // UTC+7
+            OriginatingTimeZoneId = "Asia/Bangkok",
+        },
+    };
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Weekly Mon+Wed with COUNT=6: exactly one folder item is written and the
+    /// PidLidAppointmentRecur blob is present with RecurrenceFrequency=Weekly (0x200B).
+    /// </summary>
+    [Fact]
+    public void Weekly_recurring_writes_recur_blob_and_one_item()
+    {
+        var rec = WeeklyRecord();
+        var (count, blob, _) = WriteAndReadAppointment(rec);
+        Assert.Equal(1, count);
+        Assert.NotNull(blob);
+        Assert.Equal(0x0B, blob![4]);   // RecurrenceFrequency low byte  = 0x0B (weekly = 0x200B)
+        Assert.Equal(0x20, blob[5]);    // RecurrenceFrequency high byte = 0x20
+    }
+
+    /// <summary>
+    /// A recurring appointment with OriginatingTimeZoneId="Asia/Bangkok" must produce
+    /// a non-null PidLidTimeZoneStruct (0x8233) AND PidLidAppointmentTimeZoneDefinitionStartDisplay
+    /// (0x825E) on the written item — proving SetOriginalTimeZone was called with the Bangkok zone.
+    ///
+    /// Guarded with SkipOnPlatform since TryConvertIanaIdToWindowsId has no ICU on non-Windows .NET
+    /// embedded test hosts without globalization data (Linux musl etc.) — best effort on this path.
+    /// </summary>
+    [Fact]
+    public void Recurring_with_Bangkok_tz_writes_tz_definition_blobs()
+    {
+        // Skip on platforms where IANA→Windows TZ mapping is unavailable.
+        // .NET 6+ on Linux with globalization invariant mode cannot map IANA ids.
+        if (!TimeZoneInfo.TryConvertIanaIdToWindowsId("Asia/Bangkok", out _))
+        {
+            // On this platform the zone resolution would fall back to UTC — the blob
+            // will still be present (UTC TZ blobs), so we just assert non-null below.
+        }
+
+        var rec = BangkokRecord();
+        var (count, blob, appt) = WriteAndReadAppointment(rec);
+        Assert.Equal(1, count);
+
+        // The recur blob must be present (proving we hit the recurring path).
+        Assert.NotNull(blob);
+
+        // PidLidTimeZoneStruct (0x8233) — written by RecurringAppointment.SetOriginalTimeZone
+        byte[]? tzStruct = appt.PC.GetBytesProperty(PropertyNames.PidLidTimeZoneStruct);
+        Assert.NotNull(tzStruct);
+
+        // PidLidAppointmentTimeZoneDefinitionStartDisplay (0x825E) — written by SetOriginalTimeZone
+        byte[]? tzDefStart = appt.PC.GetBytesProperty(PropertyNames.PidLidAppointmentTimeZoneDefinitionStartDisplay);
+        Assert.NotNull(tzDefStart);
+    }
+
+    /// <summary>
+    /// A recurring appointment with OriginatingTimeZoneId=null AND TimeZone=null must not throw.
+    /// The writer falls back to UTC (recurring appt always gets a non-null zone to avoid the
+    /// Win32 SaveChanges() fallback). UTC TZ blobs must be present.
+    /// </summary>
+    [Fact]
+    public void Recurring_with_null_tz_id_falls_back_to_utc_no_throw()
+    {
+        var rec = new AppointmentRecord
+        {
+            Subject               = "No-TZ recurring",
+            StartUtc              = new DateTime(2026, 7, 1, 1, 0, 0, DateTimeKind.Utc),
+            EndUtc                = new DateTime(2026, 7, 1, 1, 30, 0, DateTimeKind.Utc),
+            TimeZone              = null,             // floating
+            OriginatingTimeZoneId = null,             // triggers UTC fallback
+            Recurrence = new RecurrenceSpec
+            {
+                Frequency    = AppointmentRecurrenceFrequency.Daily,
+                Interval     = 1,
+                DaysOfWeek   = Array.Empty<DayOfWeek>(),
+                EndKind      = RecurrenceEndKind.NoEnd,
+                FirstStartUtc = new DateTime(2026, 7, 1, 1, 0, 0, DateTimeKind.Utc),
+            },
+        };
+
+        // Must not throw — UTC fallback keeps RecurringAppointment.SaveChanges() off the Win32 path.
+        var (count, blob, appt) = WriteAndReadAppointment(rec);
+        Assert.Equal(1, count);
+        Assert.NotNull(blob);
+
+        // UTC zone definition blobs must be present (SetOriginalTimeZone(UTC) was called).
+        byte[]? tzStruct = appt.PC.GetBytesProperty(PropertyNames.PidLidTimeZoneStruct);
+        Assert.NotNull(tzStruct);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
@@ -197,6 +197,28 @@ public class AppointmentWriterRecurrenceTests
         Assert.NotNull(tzStruct);
     }
 
+    // -----------------------------------------------------------------------
+    // Task 4: EXDATE deleted occurrences
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// A single EXDATE (deleted occurrence) must produce exactly one entry in
+    /// <c>DeletedInstanceDates</c> on the PidLidAppointmentRecur blob, set to the
+    /// zone-local day-start (date only, Kind=Unspecified).
+    /// </summary>
+    [Fact]
+    public void Exdate_adds_one_deleted_instance()
+    {
+        var rec = WeeklyRecord();
+        rec.DeletedOccurrences = new[] { new RecurrenceInstanceId(
+            new DateTime(2026, 7, 8, 1, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 7, 8, 1, 0, 0, DateTimeKind.Unspecified), "UTC", false) };
+        var (_, blob, _) = WriteAndReadAppointment(rec);
+        var s = AppointmentRecurrencePatternStructure.GetRecurrencePatternStructure(blob!);
+        Assert.Single(s.DeletedInstanceDates);
+        Assert.Equal(new DateTime(2026, 7, 8), s.DeletedInstanceDates[0].Date);
+    }
+
     /// <summary>
     /// Regression test for the zone-before-start ordering fix.
     ///

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterTests.cs
@@ -109,6 +109,8 @@ public class AppointmentWriterTests
 
         RoundTripAppointment(a, (_, appt) =>
         {
+            Assert.Equal("Timed with TZ", appt.Subject);
+
             // PidLidAppointmentStartWhole must round-trip as the original UTC instant.
             Assert.Equal(start, appt.StartDTUtc);
 

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterTests.cs
@@ -1,0 +1,354 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Writing;
+using PSTFileFormat;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Writing;
+
+/// <summary>
+/// TDD read-back tests for <see cref="AppointmentWriter"/> driving the vendored
+/// <see cref="SingleAppointment"/> substrate. Each test writes one appointment, closes,
+/// reopens, and asserts specific MAPI properties round-trip correctly.
+///
+/// Lifecycle order (mirrors AppointmentWriteSmokeTests):
+///   BeginSavingChanges → WriteAppointment → folder.SaveChanges → EndSavingChanges.
+/// </summary>
+public class AppointmentWriterTests
+{
+    // -----------------------------------------------------------------------
+    // Round-trip infrastructure
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Write one appointment, close, reopen, expose the PST and Appointment to
+    /// <paramref name="read"/>, close, delete. Handles teardown even if assertions throw.
+    /// </summary>
+    private static T RoundTripAppointment<T>(AppointmentRecord record, Func<PSTFile, Appointment, T> read)
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"m2p-aw-{Guid.NewGuid():N}.pst");
+        PSTFile? pst = null;
+        try
+        {
+            PSTFile.CreateEmptyStore(path);
+
+            // Write phase
+            try
+            {
+                pst = new PSTFile(path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+                pst.BeginSavingChanges();   // required before named-property allocation
+                PSTFolder folder = pst.TopOfPersonalFolders.CreateChildFolder(
+                    "Calendar", FolderItemTypeName.Appointment);
+                new AppointmentWriter().WriteAppointment(pst, folder, record);
+                folder.SaveChanges();       // BEFORE EndSavingChanges (vendored gotcha)
+                pst.EndSavingChanges();
+            }
+            finally { pst?.CloseFile(); pst = null; }
+
+            // Read phase
+            try
+            {
+                pst = new PSTFile(path, FileAccess.Read, WriterCompatibilityMode.Outlook2007RTM);
+                PSTFolder found = pst.TopOfPersonalFolders.FindChildFolder("Calendar");
+                CalendarFolder cal = Assert.IsType<CalendarFolder>(found);
+                Assert.Equal(1, cal.AppointmentCount);
+                Appointment appt = cal.GetAppointment(0);
+                return read(pst, appt);
+            }
+            finally { pst?.CloseFile(); pst = null; }
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+
+    /// <summary>Resolve a named-prop ID on a reopen (the prop must have been written already).</summary>
+    private static PropertyID Named(PSTFile pst, PropertyLongID lid, Guid set)
+        => pst.NameToIDMap.ObtainIDFromName(new PropertyName(lid, set));
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void WriteAppointment_message_class_is_IPM_Appointment()
+    {
+        // Guards against accidentally writing a Note/Task into an Appointment folder.
+        var a = new AppointmentRecord
+        {
+            Subject  = "Class check",
+            StartUtc = new DateTime(2026, 7, 1, 9, 0, 0, DateTimeKind.Utc),
+            EndUtc   = new DateTime(2026, 7, 1, 9, 30, 0, DateTimeKind.Utc),
+        };
+
+        string? cls = RoundTripAppointment(a,
+            (_, appt) => appt.PC.GetStringProperty(PropertyID.PidTagMessageClass));
+        Assert.Equal("IPM.Appointment", cls);
+    }
+
+    [Fact]
+    public void WriteAppointment_timed_with_timezone_round_trips_start_end_and_tz_definition()
+    {
+        var start = new DateTime(2026, 7, 1, 9, 0, 0, DateTimeKind.Utc);
+        var end   = new DateTime(2026, 7, 1, 9, 30, 0, DateTimeKind.Utc);
+
+        // Romance Standard Time (CET/CEST) — used in the Task 0 ground-truth dump.
+        TimeZoneInfo tz = TimeZoneInfo.FindSystemTimeZoneById("Romance Standard Time");
+
+        var a = new AppointmentRecord
+        {
+            Subject  = "Timed with TZ",
+            StartUtc = start,
+            EndUtc   = end,
+            TimeZone = tz,
+        };
+
+        RoundTripAppointment(a, (_, appt) =>
+        {
+            // PidLidAppointmentStartWhole must round-trip as the original UTC instant.
+            Assert.Equal(start, appt.StartDTUtc);
+
+            // Duration derived from EndWhole − StartWhole (SetStartAndDuration guarantees this).
+            Assert.Equal(30, appt.Duration);
+
+            // The timezone definition blob must be present for a timed appointment with a known zone.
+            Assert.True(appt.HasTimeZoneDefinition,
+                "Expected PidLidAppointmentTimeZoneDefinitionStartDisplay to be written for a timed appointment with a timezone");
+
+            return true;
+        });
+    }
+
+    [Fact]
+    public void WriteAppointment_allday_matches_dump()
+    {
+        // Reproduces the Task 0 all-day dump invariants:
+        //   AppointmentSubType (IsAllDayEvent) == true, Duration == 1440 min, StartWhole = mapper-supplied midnight UTC.
+        // The mapper (Task 3) computes the local-midnight-in-UTC values; here we use plain UTC midnight
+        // to keep the test self-contained.
+        var utcMidnight = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+        var utcNextDay  = utcMidnight.AddMinutes(1440);
+
+        var a = new AppointmentRecord
+        {
+            Subject    = "All-day event",
+            StartUtc   = utcMidnight,
+            EndUtc     = utcNextDay,
+            IsAllDay   = true,
+            BusyStatus = 0,   // Free — default for all-day events per Task 0 dump
+        };
+
+        RoundTripAppointment(a, (_, appt) =>
+        {
+            Assert.True(appt.IsAllDayEvent,
+                "PidLidAppointmentSubType (IsAllDayEvent) must be true");
+            Assert.Equal(1440, appt.Duration);
+            Assert.Equal(utcMidnight, appt.StartDTUtc);
+            return true;
+        });
+    }
+
+    [Fact]
+    public void WriteAppointment_free_and_busy_status_round_trips()
+    {
+        // Free=0
+        var aFree = new AppointmentRecord
+        {
+            Subject    = "Free slot",
+            StartUtc   = new DateTime(2026, 7, 1, 9, 0, 0, DateTimeKind.Utc),
+            EndUtc     = new DateTime(2026, 7, 1, 10, 0, 0, DateTimeKind.Utc),
+            BusyStatus = 0,
+        };
+        BusyStatus freeResult = RoundTripAppointment(aFree, (_, appt) => appt.BusyStatus);
+        Assert.Equal(BusyStatus.Avaiable, freeResult);
+
+        // Busy=2
+        var aBusy = new AppointmentRecord
+        {
+            Subject    = "Busy slot",
+            StartUtc   = new DateTime(2026, 7, 2, 10, 0, 0, DateTimeKind.Utc),
+            EndUtc     = new DateTime(2026, 7, 2, 11, 0, 0, DateTimeKind.Utc),
+            BusyStatus = 2,
+        };
+        BusyStatus busyResult = RoundTripAppointment(aBusy, (_, appt) => appt.BusyStatus);
+        Assert.Equal(BusyStatus.Busy, busyResult);
+    }
+
+    [Fact]
+    public void WriteAppointment_private_sets_sensitivity_and_private_flag()
+    {
+        // A Private appointment must set BOTH PidTagSensitivity=2 AND PidLidPrivate=true
+        // (mirroring the Task 0 ground-truth and TaskWriter Private coupling).
+        var a = new AppointmentRecord
+        {
+            Subject     = "Secret meeting",
+            StartUtc    = new DateTime(2026, 7, 1, 9, 0, 0, DateTimeKind.Utc),
+            EndUtc      = new DateTime(2026, 7, 1, 9, 30, 0, DateTimeKind.Utc),
+            Sensitivity = 2,   // Private
+        };
+
+        RoundTripAppointment(a, (_, appt) =>
+        {
+            Assert.Equal(2, appt.PC.GetInt32Property(PropertyID.PidTagSensitivity));
+            Assert.True(appt.IsPrivate, "PidLidPrivate must be true for Sensitivity=2");
+            return true;
+        });
+    }
+
+    [Fact]
+    public void WriteAppointment_reminder_with_15min_delta_and_signal_time()
+    {
+        var start = new DateTime(2026, 7, 1, 14, 0, 0, DateTimeKind.Utc);
+        var a = new AppointmentRecord
+        {
+            Subject               = "Dentist",
+            StartUtc              = start,
+            EndUtc                = start.AddMinutes(60),
+            ReminderSet           = true,
+            ReminderMinutesBefore = 15,
+        };
+
+        RoundTripAppointment(a, (pst, appt) =>
+        {
+            // PidLidReminderSet (PSETID_Common 0x8503) == true
+            PropertyID rsId = Named(pst, PropertyLongID.PidLidReminderSet, PropertySetGuid.PSETID_Common);
+            Assert.True(appt.PC.GetBooleanProperty(rsId));
+
+            // PidLidReminderDelta (PSETID_Common 0x8501) == 15 minutes
+            PropertyID rdId = Named(pst, PropertyLongID.PidLidReminderDelta, PropertySetGuid.PSETID_Common);
+            Assert.Equal(15, appt.PC.GetInt32Property(rdId));
+
+            // PidLidReminderSignalTime (PSETID_Common 0x8560) == start − 15 min
+            PropertyID rstId = Named(pst, PropertyLongID.PidLidReminderSignalTime, PropertySetGuid.PSETID_Common);
+            DateTime? signal = appt.PC.GetDateTimeProperty(rstId);
+            Assert.NotNull(signal);
+            Assert.Equal(start.AddMinutes(-15), signal!.Value);
+
+            return true;
+        });
+    }
+
+    [Fact]
+    public void WriteAppointment_categories_round_trip()
+    {
+        var a = new AppointmentRecord
+        {
+            Subject    = "Tagged event",
+            StartUtc   = new DateTime(2026, 7, 1, 9, 0, 0, DateTimeKind.Utc),
+            EndUtc     = new DateTime(2026, 7, 1, 9, 30, 0, DateTimeKind.Utc),
+            Categories = new[] { "Work", "Meeting" },
+        };
+
+        IReadOnlyList<string>? cats = RoundTripAppointment(a, (pst, appt) =>
+        {
+            // Resolve the dynamic PropertyID for "Keywords" (string-named prop, guidHint=2=PS_PUBLIC_STRINGS)
+            ushort? kid = PropertyNameToIDMap.ResolveStringNamedProperty(pst, 2, "Keywords");
+            Assert.NotNull(kid);
+            var rec = appt.PC.GetRecordByPropertyID((PropertyID)kid!.Value);
+            Assert.NotNull(rec);
+            return (IReadOnlyList<string>)PropertyContext.DeserializeMultiString(
+                appt.PC.GetExternalRecordData(rec!));
+        });
+
+        Assert.Equal(new[] { "Work", "Meeting" }, cats);
+    }
+
+    [Fact]
+    public void WriteAppointment_importance_high_round_trips()
+    {
+        var a = new AppointmentRecord
+        {
+            Subject    = "Critical meeting",
+            StartUtc   = new DateTime(2026, 7, 1, 9, 0, 0, DateTimeKind.Utc),
+            EndUtc     = new DateTime(2026, 7, 1, 9, 30, 0, DateTimeKind.Utc),
+            Importance = 2,   // High
+        };
+
+        int? imp = RoundTripAppointment(a, (_, appt) =>
+            appt.PC.GetInt32Property(PropertyID.PidTagImportance));
+        Assert.Equal(2, imp);
+    }
+
+    [Fact]
+    public void WriteAppointment_html_only_body_writes_html_native_and_derived_plain()
+    {
+        // HTML-only body (Body=null): writer must produce PidTagHtml + PidTagNativeBody=3
+        // AND a derived PidTagBody via PstWriter.HtmlToPlainText (no duplicated logic).
+        const string html = "<html><body><b>Hello</b> world</body></html>";
+        var a = new AppointmentRecord
+        {
+            Subject  = "HTML body",
+            StartUtc = new DateTime(2026, 7, 1, 9, 0, 0, DateTimeKind.Utc),
+            EndUtc   = new DateTime(2026, 7, 1, 9, 30, 0, DateTimeKind.Utc),
+            BodyHtml = html,
+            Body     = null,   // no explicit plain text — must be auto-derived
+        };
+
+        RoundTripAppointment(a, (_, appt) =>
+        {
+            // PidTagHtml must contain the original HTML as UTF-8 bytes
+            byte[]? htmlBytes = appt.PC.GetBytesProperty(PropertyID.PidTagHtml);
+            Assert.NotNull(htmlBytes);
+            Assert.Equal(html, Encoding.UTF8.GetString(htmlBytes!));
+
+            // PidTagNativeBody must be 3 (HTML)
+            Assert.Equal(3, appt.PC.GetInt32Property(PropertyID.PidTagNativeBody));
+
+            // PidTagBody must be present and non-empty (derived from HTML via HtmlToPlainText)
+            string? plain = appt.PC.GetStringProperty(PropertyID.PidTagBody);
+            Assert.NotNull(plain);
+            Assert.False(string.IsNullOrWhiteSpace(plain), "Derived plain body must not be blank");
+            // Basic smoke: the tag-stripped result must contain some content from the HTML
+            Assert.Contains("Hello", plain, StringComparison.OrdinalIgnoreCase);
+
+            return true;
+        });
+    }
+
+    [Fact]
+    public void WriteAppointment_floating_tz_does_not_touch_registry_and_writes_no_tz_blob()
+    {
+        // TimeZone=null means a floating/unresolved timezone. The write path must NOT call
+        // SetOriginalTimeZone — which would be the only path to Win32 registry access.
+        // On non-Windows platforms this path would throw PlatformNotSupportedException.
+        // Assert: write completes without exception AND no tz-definition blob is written.
+        var a = new AppointmentRecord
+        {
+            Subject  = "Floating event",
+            StartUtc = new DateTime(2026, 7, 1, 9, 0, 0, DateTimeKind.Utc),
+            EndUtc   = new DateTime(2026, 7, 1, 9, 30, 0, DateTimeKind.Utc),
+            TimeZone = null,   // floating — writer must skip SetOriginalTimeZone
+        };
+
+        bool completed = RoundTripAppointment(a, (_, appt) =>
+        {
+            // No PidLidAppointmentTimeZoneDefinitionStartDisplay blob for a floating appointment.
+            Assert.False(appt.HasTimeZoneDefinition,
+                "Floating appointment must NOT have PidLidAppointmentTimeZoneDefinitionStartDisplay");
+            return true;
+        });
+
+        // If we reach here, no exception was thrown during write — registry access was skipped.
+        Assert.True(completed);
+    }
+
+    [Fact]
+    public void WriteAppointment_out_of_range_busy_status_normalizes_to_busy()
+    {
+        // Defensive normalization: BusyStatus=9 is invalid; writer must clamp to Busy=2.
+        var a = new AppointmentRecord
+        {
+            Subject    = "Bad busy value",
+            StartUtc   = new DateTime(2026, 7, 1, 9, 0, 0, DateTimeKind.Utc),
+            EndUtc     = new DateTime(2026, 7, 1, 9, 30, 0, DateTimeKind.Utc),
+            BusyStatus = 9,   // out of range — must normalize to Busy=2
+        };
+
+        BusyStatus result = RoundTripAppointment(a, (_, appt) => appt.BusyStatus);
+        Assert.Equal(BusyStatus.Busy, result);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Writing/AttachmentWriterTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AttachmentWriterTests.cs
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.IO;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Writing;
+using PSTFileFormat;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Writing;
+
+public class AttachmentWriterTests
+{
+    [Fact]
+    public void ByValue_attachment_round_trips_filename_and_bytes()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"attw-{Guid.NewGuid():N}.pst");
+        PSTFile? file = null;
+        try
+        {
+            PSTFile.CreateEmptyStore(path);                               // returns void
+            try
+            {
+                file = new PSTFile(path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+                file.BeginSavingChanges();
+                PSTFolder inbox = file.TopOfPersonalFolders.CreateChildFolder("Inbox", FolderItemTypeName.Note);
+                Note note = Note.CreateNewNote(file, inbox.NodeID);
+                note.Subject = "carrier";
+                new AttachmentWriter().Write(file, note, new AttachmentSpec(
+                    "readme.txt", "text/plain", AttachmentContent.FromBytes(new byte[] { 1, 2, 3, 4 })));
+                note.SaveChanges();
+                inbox.AddMessage(note);
+                inbox.SaveChanges();
+                file.EndSavingChanges();
+            }
+            finally { file?.CloseFile(); file = null; }
+
+            try
+            {
+                file = new PSTFile(path, FileAccess.Read);
+                PSTFolder inbox = file.TopOfPersonalFolders.FindChildFolder("Inbox");
+                Note note = Note.GetNote(file, inbox.GetMessage(0).NodeID);
+                AttachmentObject att = note.GetAttachmentObject(0);
+                Assert.Equal("readme.txt", att.PC.GetStringProperty(PropertyID.PidTagAttachLongFilename));
+                Assert.Equal(new byte[] { 1, 2, 3, 4 }, att.PC.GetBytesProperty(PropertyID.PidTagAttachData));
+            }
+            finally { file?.CloseFile(); file = null; }
+        }
+        finally { File.Delete(path); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Writing/CalendarUnicodeRoundTripTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/CalendarUnicodeRoundTripTests.cs
@@ -1,0 +1,446 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using System.Text;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Writing;
+using PSTFileFormat;
+using Xunit;
+// Disambiguates our model enum from PSTFileFormat.RecurrenceFrequency (the vendor blob type).
+using RecurrenceFrequency = Mail2Pst.Core.Models.RecurrenceFrequency;
+
+namespace Mail2Pst.Core.Tests.Writing;
+
+/// <summary>
+/// Unicode round-trip regression LOCKS for the calendar/task attachment + body pipeline.
+/// Each test writes a real <see cref="AppointmentRecord"/> or <see cref="TaskRecord"/>,
+/// closes the PST, reopens it, and reads back a specific MAPI property.
+///
+/// These are LOCK tests: the behavior already exists (Tasks 1–5 landed it); they exist to
+/// PIN it so a future encoding regression fails loudly.
+/// If a lock test fails it is a REAL encoding bug — fix the writer/resolver/mapper, NOT the test.
+/// </summary>
+public class CalendarUnicodeRoundTripTests
+{
+    // -----------------------------------------------------------------------
+    // Round-trip infrastructure
+    // -----------------------------------------------------------------------
+
+    private static readonly DateTime S = new(2026, 7, 10, 9, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime E = new(2026, 7, 10, 10, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>
+    /// Write one appointment, close, reopen, invoke <paramref name="read"/> (while the file is
+    /// still open — required for lazy-loaded subnodes such as attachments on RecurringAppointment),
+    /// close, delete. Handles teardown even when assertions throw.
+    /// </summary>
+    private static T RoundTripAppointment<T>(AppointmentRecord record, Func<PSTFile, Appointment, T> read)
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"m2p-uni-appt-{Guid.NewGuid():N}.pst");
+        PSTFile? pst = null;
+        try
+        {
+            PSTFile.CreateEmptyStore(path);
+
+            try
+            {
+                pst = new PSTFile(path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+                pst.BeginSavingChanges();
+                PSTFolder folder = pst.TopOfPersonalFolders.CreateChildFolder(
+                    "Calendar", FolderItemTypeName.Appointment);
+                new AppointmentWriter().WriteAppointment(pst, folder, record);
+                folder.SaveChanges();
+                pst.EndSavingChanges();
+            }
+            finally { pst?.CloseFile(); pst = null; }
+
+            try
+            {
+                pst = new PSTFile(path, FileAccess.Read, WriterCompatibilityMode.Outlook2007RTM);
+                PSTFolder found = pst.TopOfPersonalFolders.FindChildFolder("Calendar");
+                CalendarFolder cal = Assert.IsType<CalendarFolder>(found);
+                Assert.Equal(1, cal.AppointmentCount);
+                Appointment appt = cal.GetAppointment(0);
+                return read(pst, appt);
+            }
+            finally { pst?.CloseFile(); pst = null; }
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+
+    /// <summary>
+    /// Write one task, close, reopen, invoke <paramref name="read"/> (file still open),
+    /// close, delete.
+    /// </summary>
+    private static T RoundTripTask<T>(TaskRecord record, Func<PSTFile, MessageObject, T> read)
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"m2p-uni-task-{Guid.NewGuid():N}.pst");
+        PSTFile? pst = null;
+        try
+        {
+            PSTFile.CreateEmptyStore(path);
+
+            try
+            {
+                pst = new PSTFile(path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+                pst.BeginSavingChanges();
+                PSTFolder folder = pst.TopOfPersonalFolders.CreateChildFolder("Tasks", FolderItemTypeName.Task);
+                new TaskWriter().WriteTask(pst, folder, record);
+                folder.SaveChanges();
+                pst.EndSavingChanges();
+            }
+            finally { pst?.CloseFile(); pst = null; }
+
+            try
+            {
+                pst = new PSTFile(path, FileAccess.Read);
+                PSTFolder readFolder = pst.TopOfPersonalFolders.FindChildFolder("Tasks");
+                MessageObject msg = TaskMessage.GetTask(pst, readFolder.GetMessage(0).NodeID);
+                return read(pst, msg);
+            }
+            finally { pst?.CloseFile(); pst = null; }
+        }
+        finally { File.Delete(path); }
+    }
+
+    // -----------------------------------------------------------------------
+    // Lock 1: InlineBytes attachment filename æøå + emoji — event
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// "vedlegg-æøå-🦷.txt" in an <see cref="CalendarAttachmentKind.InlineBytes"/> attachment
+    /// on an appointment must survive <see cref="AppointmentWriter"/> → PidTagAttachLongFilename
+    /// unchanged. Pins UTF-16 emoji round-trip through the vendored PST store.
+    /// </summary>
+    [Fact]
+    public void Attachment_filename_unicode_round_trips_event()
+    {
+        const string FileName = "vedlegg-æøå-🦷.txt";
+        var rec = new AppointmentRecord
+        {
+            Subject = "Unicode attachment — event",
+            StartUtc = S, EndUtc = E,
+            Attachments = new[]
+            {
+                new CalendarAttachment(CalendarAttachmentKind.InlineBytes,
+                    FileName, "text/plain", new byte[] { 1, 2, 3 }, null, null)
+            }
+        };
+
+        string? name = RoundTripAppointment(rec,
+            (_, appt) => appt.GetAttachmentObject(0).PC.GetStringProperty(PropertyID.PidTagAttachLongFilename));
+
+        Assert.Equal(FileName, name);
+    }
+
+    // -----------------------------------------------------------------------
+    // Lock 2: InlineBytes attachment filename æøå + emoji — task
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Same filename on an IPM.Task via <see cref="TaskWriter"/>.
+    /// Pins the shared <see cref="AttachmentWriter"/> path for the task attachment pipeline.
+    /// </summary>
+    [Fact]
+    public void Attachment_filename_unicode_round_trips_task()
+    {
+        const string FileName = "vedlegg-æøå-🦷.txt";
+        var rec = new TaskRecord
+        {
+            Subject = "Unicode attachment — task",
+            Attachments = new[]
+            {
+                new CalendarAttachment(CalendarAttachmentKind.InlineBytes,
+                    FileName, "text/plain", new byte[] { 4, 5, 6 }, null, null)
+            }
+        };
+
+        string? name = RoundTripTask(rec,
+            (_, msg) => msg.GetAttachmentObject(0).PC.GetStringProperty(PropertyID.PidTagAttachLongFilename));
+
+        Assert.Equal(FileName, name);
+    }
+
+    // -----------------------------------------------------------------------
+    // Lock 3: HTML body + inline attachment + Teams URL all coexist
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// An appointment with <see cref="AppointmentRecord.BodyHtml"/> containing a Teams join URL
+    /// AND an <see cref="CalendarAttachmentKind.InlineBytes"/> attachment must survive all three
+    /// together in the reopened PST:
+    /// <list type="bullet">
+    ///   <item>PidTagHtml preserved (UTF-8 bytes, Teams URL intact)</item>
+    ///   <item>PidTagNativeBody = 3 (HTML)</item>
+    ///   <item>AttachmentCount = 1 and filename preserved</item>
+    /// </list>
+    /// </summary>
+    [Fact]
+    public void Body_html_attachment_and_online_meeting_link_coexist()
+    {
+        const string JoinUrl  = "https://teams.example.com/l/meeting-unicode-lock-test";
+        const string FileName = "notes-møte.txt";
+        string html = $"<html><body><p>Bli med: <a href=\"{JoinUrl}\">{JoinUrl}</a></p></body></html>";
+
+        var rec = new AppointmentRecord
+        {
+            Subject  = "HTML + attach + Teams URL",
+            StartUtc = S, EndUtc = E,
+            BodyHtml = html,
+            Attachments = new[]
+            {
+                new CalendarAttachment(CalendarAttachmentKind.InlineBytes,
+                    FileName, "text/plain", new byte[] { 7, 8, 9 }, null, null)
+            }
+        };
+
+        RoundTripAppointment(rec, (_, appt) =>
+        {
+            byte[]? htmlBytes = appt.PC.GetBytesProperty(PropertyID.PidTagHtml);
+            Assert.NotNull(htmlBytes);
+            Assert.Contains(JoinUrl, Encoding.UTF8.GetString(htmlBytes!));
+            Assert.Equal(3, appt.PC.GetInt32Property(PropertyID.PidTagNativeBody));
+            Assert.Equal(1, appt.AttachmentCount);
+            Assert.Equal(FileName,
+                appt.GetAttachmentObject(0).PC.GetStringProperty(PropertyID.PidTagAttachLongFilename));
+            return true;
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // Lock 4: Recurring override subject with Unicode survives embedded attachment
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// An override occurrence with subject "Møte 🌍" must survive the <c>method=5</c>
+    /// embedded-attachment path in <see cref="AppointmentWriter.ApplyExceptions"/>.
+    /// The subject is read back via <see cref="RecurringAppointment.GetModifiedInstance"/> while
+    /// the PST file is still open (lazy-load gotcha — subnodes require an open file handle).
+    /// Pins the PR7a exception/embedded-attachment Unicode path.
+    /// </summary>
+    [Fact]
+    public void Recurring_override_subject_unicode()
+    {
+        const string UnicodeSubject = "Møte 🌍";
+
+        var rec = new AppointmentRecord
+        {
+            Subject               = "Weekly meeting",
+            StartUtc              = new DateTime(2026, 7, 1, 1, 0, 0, DateTimeKind.Utc),
+            EndUtc                = new DateTime(2026, 7, 1, 1, 30, 0, DateTimeKind.Utc),
+            TimeZone              = TimeZoneInfo.Utc,
+            OriginatingTimeZoneId = "UTC",
+            Recurrence = new RecurrenceSpec
+            {
+                Frequency             = RecurrenceFrequency.Weekly,
+                Interval              = 1,
+                DaysOfWeek            = new[] { DayOfWeek.Monday, DayOfWeek.Wednesday },
+                EndKind               = RecurrenceEndKind.Count,
+                Count                 = 6,
+                FirstStartUtc         = new DateTime(2026, 7, 1, 1, 0, 0, DateTimeKind.Utc),
+                FirstStartLocal       = new DateTime(2026, 7, 1, 1, 0, 0, DateTimeKind.Utc),
+                LastInstanceStartUtc  = new DateTime(2026, 7, 20, 1, 0, 0, DateTimeKind.Utc),
+                TimeZone              = TimeZoneInfo.Utc,
+                OriginatingTimeZoneId = "UTC",
+            },
+            Exceptions = new[]
+            {
+                new AppointmentException
+                {
+                    OriginalInstance = new RecurrenceInstanceId(
+                        new DateTime(2026, 7, 8, 1, 0, 0, DateTimeKind.Utc),
+                        new DateTime(2026, 7, 8, 1, 0, 0, DateTimeKind.Unspecified),
+                        "UTC", false),
+                    NewStartUtc = new DateTime(2026, 7, 8, 7, 0, 0, DateTimeKind.Utc),
+                    NewEndUtc   = new DateTime(2026, 7, 8, 7, 30, 0, DateTimeKind.Utc),
+                    Subject     = UnicodeSubject,
+                    ChangeFlags = AppointmentExceptionChangeFlags.Subject | AppointmentExceptionChangeFlags.StartEnd,
+                }
+            }
+        };
+
+        // Read the embedded attachment's Subject while the file is open (GetModifiedInstance accesses
+        // the subnode tree — requires an open file handle, same pattern as AppointmentWriterRecurrenceTests).
+        string? attachSubject = null;
+        RoundTripAppointment(rec, (_, appt) =>
+        {
+            if (appt is RecurringAppointment ra && ra.AttachmentCount > 0)
+                attachSubject = ra.GetModifiedInstance(0).Subject;
+            return true;
+        });
+
+        Assert.Equal(UnicodeSubject, attachSubject);
+    }
+
+    // -----------------------------------------------------------------------
+    // Lock 5: Inline attachment ContentId with non-ASCII (shared AttachmentWriter)
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// A non-ASCII <see cref="AttachmentSpec.ContentId"/> written via the shared
+    /// <see cref="AttachmentWriter"/> (mail Note path) must survive into
+    /// <c>PidTagAttachContentId</c> unchanged. Pins the CID Unicode path through the
+    /// vendored PST store — exercising the byte that <see cref="AppointmentWriter"/> and
+    /// <see cref="TaskWriter"/> ultimately share for inline attachments.
+    /// </summary>
+    [Fact]
+    public void Inline_attachment_content_id_unicode()
+    {
+        const string Cid = "cid-æøå@example.com";
+
+        string path = Path.Combine(Path.GetTempPath(), $"m2p-uni-cid-{Guid.NewGuid():N}.pst");
+        PSTFile? pst = null;
+        try
+        {
+            PSTFile.CreateEmptyStore(path);
+
+            try
+            {
+                pst = new PSTFile(path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+                pst.BeginSavingChanges();
+                PSTFolder inbox = pst.TopOfPersonalFolders.CreateChildFolder("Inbox", FolderItemTypeName.Note);
+                Note note = Note.CreateNewNote(pst, inbox.NodeID);
+                note.Subject = "CID carrier";
+                new AttachmentWriter().Write(pst, note, new AttachmentSpec(
+                    "image.png", "image/png",
+                    AttachmentContent.FromBytes(new byte[] { 1, 2, 3 }),
+                    ContentId: Cid, IsInline: true));
+                note.SaveChanges();
+                inbox.AddMessage(note);
+                inbox.SaveChanges();
+                pst.EndSavingChanges();
+            }
+            finally { pst?.CloseFile(); pst = null; }
+
+            try
+            {
+                pst = new PSTFile(path, FileAccess.Read);
+                PSTFolder inbox = pst.TopOfPersonalFolders.FindChildFolder("Inbox");
+                Note note = Note.GetNote(pst, inbox.GetMessage(0).NodeID);
+                AttachmentObject att = note.GetAttachmentObject(0);
+                string? cid = att.PC.GetStringProperty(PropertyID.PidTagAttachContentId);
+                Assert.Equal(Cid, cid);
+            }
+            finally { pst?.CloseFile(); pst = null; }
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+
+    // -----------------------------------------------------------------------
+    // Lock 6: LinkOnly attachment with æøå in URL preserved in body — event
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// A <see cref="CalendarAttachmentKind.LinkOnly"/> attachment whose
+    /// <see cref="CalendarAttachment.PreservedReference"/> contains æøå must appear in the
+    /// plain-text body via <see cref="CalendarBodyAppendix"/>. No PST attachment row is created.
+    /// </summary>
+    [Fact]
+    public void Remote_url_title_unicode_preserved_in_body()
+    {
+        const string Url = "https://ex.example.com/vedlegg-æøå";
+        var rec = new AppointmentRecord
+        {
+            Subject = "Link with Unicode URL",
+            StartUtc = S, EndUtc = E,
+            Attachments = new[]
+            {
+                new CalendarAttachment(CalendarAttachmentKind.LinkOnly,
+                    "vedlegg-æøå.pdf", "application/pdf", null, null, Url)
+            }
+        };
+
+        var (count, body) = RoundTripAppointment(rec, (_, appt) => (
+            appt.AttachmentCount,
+            appt.PC.GetStringProperty(PropertyID.PidTagBody) ?? ""));
+
+        Assert.Equal(0, count);     // no embedded PST attachment row for a LinkOnly
+        Assert.Contains(Url, body); // URL appears in the CalendarBodyAppendix output
+    }
+
+    // -----------------------------------------------------------------------
+    // Lock 7: Online-meeting body fallback with Unicode surrounding text
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// A <see cref="AppointmentRecord.Body"/> containing Unicode text (including emoji) surrounding
+    /// an online-meeting URL must survive round-trip into PidTagBody intact.
+    /// Pins the UTF-16 plain-text body path through <see cref="AppointmentWriter.WriteBody"/>.
+    /// </summary>
+    [Fact]
+    public void Online_meeting_body_fallback_unicode_surrounding_text()
+    {
+        const string MeetingUrl  = "https://teams.example.com/l/meet-unicode-lock-test";
+        const string UnicodeBody = "Bli med 👉 " + MeetingUrl + "\n\nDenne møtelenken er viktig 🌍";
+
+        var rec = new AppointmentRecord
+        {
+            Subject  = "Online meeting with Unicode body",
+            StartUtc = S, EndUtc = E,
+            Body     = UnicodeBody,
+        };
+
+        string? body = RoundTripAppointment(rec,
+            (_, appt) => appt.PC.GetStringProperty(PropertyID.PidTagBody));
+
+        Assert.NotNull(body);
+        Assert.Contains("Bli med 👉", body);
+        Assert.Contains(MeetingUrl, body);
+        Assert.Contains("🌍", body);
+    }
+
+    // -----------------------------------------------------------------------
+    // Lock 8a: Relation UID with non-ASCII preserved — event
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// A non-ASCII relation UID in <see cref="AppointmentRecord.Relations"/> must appear in
+    /// the plain-text body via <see cref="CalendarBodyAppendix"/> after
+    /// <see cref="AppointmentWriter.WriteBody"/>.
+    /// Pins the relation → body-appendix → PidTagBody pipeline for appointments.
+    /// </summary>
+    [Fact]
+    public void Relation_uid_non_ascii_preserved_event()
+    {
+        const string RelUid = "uid-æøå";
+        var rec = new AppointmentRecord
+        {
+            Subject   = "Event with Unicode relation",
+            StartUtc  = S, EndUtc = E,
+            Relations = new[] { RelUid },
+        };
+
+        string? body = RoundTripAppointment(rec,
+            (_, appt) => appt.PC.GetStringProperty(PropertyID.PidTagBody));
+
+        Assert.NotNull(body);
+        Assert.Contains(RelUid, body);
+    }
+
+    // -----------------------------------------------------------------------
+    // Lock 8b: Relation UID with non-ASCII preserved — task
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Same relation-UID path via <see cref="TaskWriter"/> / <see cref="CalendarBodyAppendix"/>.
+    /// Pins the relation → body-appendix → PidTagBody pipeline for tasks (RawTodo.Relations path).
+    /// </summary>
+    [Fact]
+    public void Relation_uid_non_ascii_preserved_task()
+    {
+        const string RelUid = "uid-æøå";
+        var rec = new TaskRecord
+        {
+            Subject   = "Task with Unicode relation",
+            Relations = new[] { RelUid },
+        };
+
+        string? body = RoundTripTask(rec,
+            (_, msg) => msg.PC.GetStringProperty(PropertyID.PidTagBody));
+
+        Assert.NotNull(body);
+        Assert.Contains(RelUid, body);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Writing/PstPartManagerContactTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/PstPartManagerContactTests.cs
@@ -24,9 +24,9 @@ public class PstPartManagerContactTests
                 writeMessage: (f, fo, m) => { },
                 writeContact: (f, fo, c) => writer.WriteContact(f, fo, c));
             var contactFolder = new List<string> { "Contacts", "Personal Address Book" };
-            // IMPORTANT: pre-create via the CONTACT folder list (two-arg Begin), else the leaf is made
-            // IPF.Note first and WriteContact would (correctly) throw a collision.
-            mgr.Begin(Array.Empty<IReadOnlyList<string>>(), new[] { (IReadOnlyList<string>)contactFolder });
+            // IMPORTANT: pre-create as Contact type, else the leaf is made IPF.Note first and
+            // WriteContact would (correctly) throw a collision.
+            mgr.Begin(new[] { new FolderToPrecreate(contactFolder, FolderItemTypeName.Contact) });
             mgr.WriteContact(contactFolder, new ContactRecord { DisplayName = "Eve" });
             mgr.OnWritten(256);
             mgr.Finish();

--- a/tests/Mail2Pst.Core.Tests/Writing/PstPartManagerFolderTypeTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/PstPartManagerFolderTypeTests.cs
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Writing;
+using PSTFileFormat;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Writing;
+
+public class PstPartManagerFolderTypeTests
+{
+    private static PstPartManager NewManager(string dir) => new PstPartManager(
+        "Test", dir, long.MaxValue, 500,
+        writeMessage: (_, _, _) => { },
+        writeContact: (_, _, _) => { });
+
+    private static FolderToPrecreate F(FolderItemTypeName type, params string[] path) =>
+        new FolderToPrecreate(path, type);
+
+    [Fact]
+    public void Calendar_and_task_folders_with_same_leaf_name_coexist_under_different_parents()
+    {
+        string dir = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            var mgr = NewManager(dir);
+            // ["Calendars","Home"] (IPF.Appointment) and ["Tasks","Home"] (IPF.Task) are DISTINCT paths.
+            mgr.Begin(new[]
+            {
+                F(FolderItemTypeName.Appointment, "Calendars", "Home"),
+                F(FolderItemTypeName.Task,        "Tasks",      "Home"),
+            });
+            mgr.Finish();
+            mgr.Close();
+
+            PSTFile pst = new PSTFile(Path.Combine(dir, "Test.pst"), FileAccess.Read);
+            try
+            {
+                PSTFolder cals = pst.TopOfPersonalFolders.FindChildFolder("Calendars");
+                PSTFolder tasks = pst.TopOfPersonalFolders.FindChildFolder("Tasks");
+                Assert.Equal("IPF.Appointment", cals.FindChildFolder("Home").ContainerClass);
+                Assert.Equal("IPF.Task",        tasks.FindChildFolder("Home").ContainerClass);
+            }
+            finally { pst.CloseFile(); }
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Same_path_requested_as_two_different_item_types_throws_before_writing()
+    {
+        string dir = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            var mgr = NewManager(dir);
+            var ex = Assert.Throws<ConfigValidationException>(() => mgr.Begin(new[]
+            {
+                F(FolderItemTypeName.Appointment, "Shared"),
+                F(FolderItemTypeName.Task,        "Shared"),   // same path, different leaf class
+            }));
+            Assert.Contains("Shared", ex.Message);
+            mgr.Close();
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Same_path_same_type_is_reused_not_duplicated()
+    {
+        string dir = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            var mgr = NewManager(dir);
+            mgr.Begin(new[]
+            {
+                F(FolderItemTypeName.Appointment, "Calendars", "Home"),
+                F(FolderItemTypeName.Appointment, "Calendars", "Home"),   // duplicate → reused
+            });
+            mgr.Finish();
+            mgr.Close();
+
+            PSTFile pst = new PSTFile(Path.Combine(dir, "Test.pst"), FileAccess.Read);
+            try
+            {
+                PSTFolder cals = pst.TopOfPersonalFolders.FindChildFolder("Calendars");
+                int homeCount = 0;
+                foreach (PSTFolder child in cals.GetChildFolders())
+                    if (child.DisplayName == "Home") homeCount++;
+                Assert.Equal(1, homeCount);
+            }
+            finally { pst.CloseFile(); }
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Writing/PstWriterAppointmentPhaseTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/PstWriterAppointmentPhaseTests.cs
@@ -89,6 +89,7 @@ public class PstWriterAppointmentPhaseTests
                 PSTFolder workFolder = calRoot.FindChildFolder("Work");
                 Assert.NotNull(workFolder);
                 Assert.Equal("IPF.Appointment", workFolder.ContainerClass);
+                Assert.IsType<CalendarFolder>(workFolder);
                 Assert.Equal(0, report.AppointmentsConverted);
             }
             finally { f?.CloseFile(); }

--- a/tests/Mail2Pst.Core.Tests/Writing/PstWriterAppointmentPhaseTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/PstWriterAppointmentPhaseTests.cs
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Mail2Pst.Core.Mapping;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Reporting;
+using Mail2Pst.Core.Writing;
+using PSTFileFormat;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Writing;
+
+public class PstWriterAppointmentPhaseTests
+{
+    [Fact]
+    public void WritePlan_WritesAppointments_IntoIPFAppointmentFolder_AndCountsConverted()
+    {
+        string dir = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            var plan = new PstOutputPlan { Name = "Out", MaxSizeBytes = long.MaxValue };
+            var appointmentFolders = new List<IReadOnlyList<string>> { new[] { "Calendars", "Home" } };
+            var appointments = new List<PlannedAppointment>
+            {
+                new()
+                {
+                    Appointment = new AppointmentRecord
+                    {
+                        Subject = "Team meeting",
+                        SourceId = "appt-1",
+                        StartUtc = new DateTime(2026, 6, 30, 9, 0, 0, DateTimeKind.Utc),
+                        EndUtc   = new DateTime(2026, 6, 30, 10, 0, 0, DateTimeKind.Utc),
+                    },
+                    TargetFolderPath = new[] { "Calendars", "Home" },
+                },
+            };
+            var report = new ConversionReport();
+
+            new PstWriter().WritePlan(plan, new List<PlannedMessage>(),
+                new List<PlannedContact>(), new List<IReadOnlyList<string>>(),
+                new List<PlannedTask>(), new List<IReadOnlyList<string>>(),
+                appointments, appointmentFolders,
+                dir, report);
+
+            PSTFile? f = null;
+            try
+            {
+                f = new PSTFile(Path.Combine(dir, "Out.pst"), FileAccess.Read);
+                PSTFolder calRoot = f.TopOfPersonalFolders.FindChildFolder("Calendars");
+                Assert.NotNull(calRoot);
+                PSTFolder homeFolder = calRoot.FindChildFolder("Home");
+                Assert.NotNull(homeFolder);
+                Assert.Equal("IPF.Appointment", homeFolder.ContainerClass);
+                var calFolder = Assert.IsType<CalendarFolder>(homeFolder);
+                Assert.Equal(1, calFolder.AppointmentCount);
+                Appointment appt = calFolder.GetAppointment(0);
+                Assert.Equal("IPM.Appointment", appt.MessageClass);
+                Assert.Equal(1, report.AppointmentsConverted);
+            }
+            finally { f?.CloseFile(); }
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void WritePlan_EmptyAppointmentFolders_StillCreatesIPFAppointmentFolder()
+    {
+        string dir = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            var plan = new PstOutputPlan { Name = "Out", MaxSizeBytes = long.MaxValue };
+            var appointmentFolders = new List<IReadOnlyList<string>> { new[] { "Calendars", "Work" } };
+            var report = new ConversionReport();
+
+            new PstWriter().WritePlan(plan, new List<PlannedMessage>(),
+                new List<PlannedContact>(), new List<IReadOnlyList<string>>(),
+                new List<PlannedTask>(), new List<IReadOnlyList<string>>(),
+                new List<PlannedAppointment>(), appointmentFolders,
+                dir, report);
+
+            PSTFile? f = null;
+            try
+            {
+                f = new PSTFile(Path.Combine(dir, "Out.pst"), FileAccess.Read);
+                PSTFolder calRoot = f.TopOfPersonalFolders.FindChildFolder("Calendars");
+                Assert.NotNull(calRoot);
+                PSTFolder workFolder = calRoot.FindChildFolder("Work");
+                Assert.NotNull(workFolder);
+                Assert.Equal("IPF.Appointment", workFolder.ContainerClass);
+                Assert.Equal(0, report.AppointmentsConverted);
+            }
+            finally { f?.CloseFile(); }
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Writing/PstWriterAppointmentPhaseTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/PstWriterAppointmentPhaseTests.cs
@@ -134,6 +134,46 @@ public class PstWriterAppointmentPhaseTests
         finally { Directory.Delete(dir, true); }
     }
 
+    /// <summary>
+    /// Pre-merge review #7: the appointment/task size estimate (used for maxSizeMB split sizing) must
+    /// include attachment bytes — otherwise a folder of large-attachment events silently blows past the
+    /// split cap. A 10 KB inline attachment must add ≥ 10 KB to the estimate.
+    /// </summary>
+    [Fact]
+    public void EstimateAppointmentSize_IncludesAttachmentBytes()
+    {
+        var without = new AppointmentRecord { Subject = "s" };
+        var with = new AppointmentRecord
+        {
+            Subject = "s",
+            Attachments = new[]
+            {
+                new CalendarAttachment(CalendarAttachmentKind.InlineBytes, "f.bin",
+                    "application/octet-stream", new byte[10_000], null, null),
+            },
+        };
+        long delta = PstWriter.EstimateAppointmentSize(with) - PstWriter.EstimateAppointmentSize(without);
+        Assert.True(delta >= 10_000, $"attachment bytes must be counted in the estimate; delta={delta}");
+    }
+
+    /// <summary>Pre-merge review #7: the task estimate must also include attachment bytes.</summary>
+    [Fact]
+    public void EstimateTaskSize_IncludesAttachmentBytes()
+    {
+        var without = new TaskRecord { Subject = "s" };
+        var with = new TaskRecord
+        {
+            Subject = "s",
+            Attachments = new[]
+            {
+                new CalendarAttachment(CalendarAttachmentKind.InlineBytes, "f.bin",
+                    "application/octet-stream", new byte[10_000], null, null),
+            },
+        };
+        long delta = PstWriter.EstimateTaskSize(with) - PstWriter.EstimateTaskSize(without);
+        Assert.True(delta >= 10_000, $"attachment bytes must be counted in the estimate; delta={delta}");
+    }
+
     [Fact]
     public void WritePlan_EmptyAppointmentFolders_StillCreatesIPFAppointmentFolder()
     {

--- a/tests/Mail2Pst.Core.Tests/Writing/PstWriterAppointmentPhaseTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/PstWriterAppointmentPhaseTests.cs
@@ -64,6 +64,76 @@ public class PstWriterAppointmentPhaseTests
         finally { Directory.Delete(dir, true); }
     }
 
+    /// <summary>
+    /// Pre-merge review #8: a recoverable write-time attachment failure (here: a local-file ByValue
+    /// attachment whose file does not exist → IOException when read at write time) must be recorded
+    /// as a per-item skip, NOT abort the whole phase. A good appointment written afterwards must still
+    /// land, and the store must reopen cleanly. Before the fix only ConfigValidationException was
+    /// caught, so the IOException was fatal and deleted the in-progress part (all prior items).
+    /// </summary>
+    [Fact]
+    public void WritePlan_AppointmentWithUnreadableAttachment_IsSkipped_NotFatal()
+    {
+        string dir = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string missing = Path.Combine(dir, "does-not-exist.bin");
+            var plan = new PstOutputPlan { Name = "Out", MaxSizeBytes = long.MaxValue };
+            var appointmentFolders = new List<IReadOnlyList<string>> { new[] { "Calendars", "Home" } };
+            var appointments = new List<PlannedAppointment>
+            {
+                new()
+                {
+                    Appointment = new AppointmentRecord
+                    {
+                        Subject = "Bad attachment", SourceId = "appt-bad",
+                        StartUtc = new DateTime(2026, 6, 30, 9, 0, 0, DateTimeKind.Utc),
+                        EndUtc   = new DateTime(2026, 6, 30, 10, 0, 0, DateTimeKind.Utc),
+                        Attachments = new[]
+                        {
+                            new CalendarAttachment(CalendarAttachmentKind.LocalFileByValue,
+                                "does-not-exist.bin", "application/octet-stream", null, missing, null),
+                        },
+                    },
+                    TargetFolderPath = new[] { "Calendars", "Home" },
+                },
+                new()
+                {
+                    Appointment = new AppointmentRecord
+                    {
+                        Subject = "Good appointment", SourceId = "appt-good",
+                        StartUtc = new DateTime(2026, 6, 30, 11, 0, 0, DateTimeKind.Utc),
+                        EndUtc   = new DateTime(2026, 6, 30, 12, 0, 0, DateTimeKind.Utc),
+                    },
+                    TargetFolderPath = new[] { "Calendars", "Home" },
+                },
+            };
+            var report = new ConversionReport();
+
+            // Must not throw.
+            new PstWriter().WritePlan(plan, new List<PlannedMessage>(),
+                new List<PlannedContact>(), new List<IReadOnlyList<string>>(),
+                new List<PlannedTask>(), new List<IReadOnlyList<string>>(),
+                appointments, appointmentFolders, dir, report);
+
+            Assert.Equal(1, report.AppointmentsConverted);       // only the good one
+            Assert.True(report.AppointmentsSkipped >= 1);        // the bad one skipped
+
+            // Store must reopen cleanly with exactly the good appointment.
+            PSTFile? f = null;
+            try
+            {
+                f = new PSTFile(Path.Combine(dir, "Out.pst"), FileAccess.Read);
+                var cal = Assert.IsType<CalendarFolder>(
+                    f.TopOfPersonalFolders.FindChildFolder("Calendars").FindChildFolder("Home"));
+                Assert.Equal(1, cal.AppointmentCount);
+                Assert.Equal("Good appointment", cal.GetAppointment(0).Subject);
+            }
+            finally { f?.CloseFile(); }
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
     [Fact]
     public void WritePlan_EmptyAppointmentFolders_StillCreatesIPFAppointmentFolder()
     {

--- a/tests/Mail2Pst.Core.Tests/Writing/PstWriterTaskPhaseTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/PstWriterTaskPhaseTests.cs
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Collections.Generic;
+using System.IO;
+using Mail2Pst.Core.Mapping;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Reporting;
+using Mail2Pst.Core.Writing;
+using PSTFileFormat;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Writing;
+
+public class PstWriterTaskPhaseTests
+{
+    [Fact]
+    public void WritePlan_WritesTasks_IntoIPFTaskFolder_AndCountsConverted()
+    {
+        string dir = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            var plan = new PstOutputPlan { Name = "Out", MaxSizeBytes = long.MaxValue };
+            var taskFolders = new List<IReadOnlyList<string>> { new[] { "Tasks", "Home" } };
+            var tasks = new List<PlannedTask>
+            {
+                new()
+                {
+                    Task = new TaskRecord { Subject = "Buy milk", SourceId = "task-1" },
+                    TargetFolderPath = new[] { "Tasks", "Home" },
+                },
+            };
+            var report = new ConversionReport();
+
+            new PstWriter().WritePlan(plan, new List<PlannedMessage>(),
+                new List<PlannedContact>(), new List<IReadOnlyList<string>>(),
+                tasks, taskFolders,
+                dir, report);
+
+            PSTFile? f = null;
+            try
+            {
+                f = new PSTFile(Path.Combine(dir, "Out.pst"), FileAccess.Read);
+                PSTFolder tasksRoot = f.TopOfPersonalFolders.FindChildFolder("Tasks");
+                Assert.NotNull(tasksRoot);
+                PSTFolder homeFolder = tasksRoot.FindChildFolder("Home");
+                Assert.NotNull(homeFolder);
+                Assert.Equal("IPF.Task", homeFolder.ContainerClass);
+                Assert.Equal(1, homeFolder.MessageCount);
+                Assert.Equal(1, report.TasksConverted);
+            }
+            finally { f?.CloseFile(); }
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void WritePlan_EmptyTaskFolders_StillCreatesIPFTaskFolder()
+    {
+        string dir = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            var plan = new PstOutputPlan { Name = "Out", MaxSizeBytes = long.MaxValue };
+            var taskFolders = new List<IReadOnlyList<string>> { new[] { "Tasks", "Work" } };
+            var report = new ConversionReport();
+
+            new PstWriter().WritePlan(plan, new List<PlannedMessage>(),
+                new List<PlannedContact>(), new List<IReadOnlyList<string>>(),
+                new List<PlannedTask>(), taskFolders,
+                dir, report);
+
+            PSTFile? f = null;
+            try
+            {
+                f = new PSTFile(Path.Combine(dir, "Out.pst"), FileAccess.Read);
+                PSTFolder tasksRoot = f.TopOfPersonalFolders.FindChildFolder("Tasks");
+                Assert.NotNull(tasksRoot);
+                PSTFolder workFolder = tasksRoot.FindChildFolder("Work");
+                Assert.NotNull(workFolder);
+                Assert.Equal("IPF.Task", workFolder.ContainerClass);
+                Assert.Equal(0, report.TasksConverted);
+            }
+            finally { f?.CloseFile(); }
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Writing/RecipientTrackStatusTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/RecipientTrackStatusTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using PSTFileFormat;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Mail2Pst.Core.Tests.Writing;
+
+/// <summary>
+/// PR6 Task 2 gate: proves that MessageRecipient.ResponseStatus round-trips through
+/// AddRecipient → GetRecipient (PidTagRecipientTrackStatus), and that PidLidResponseStatus
+/// resolves in the named-property map.
+/// </summary>
+public class RecipientTrackStatusTests
+{
+    private readonly ITestOutputHelper _out;
+    public RecipientTrackStatusTests(ITestOutputHelper output) => _out = output;
+
+    [Fact]
+    public void AddRecipient_with_response_status_round_trips_via_GetRecipient()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"track-status-{Guid.NewGuid():N}.pst");
+        _out.WriteLine($"PST: {path}");
+        try
+        {
+            // Build store + calendar folder + appointment with one recipient carrying ResponseStatus=3.
+            PSTFile.CreateEmptyStore(path);
+            PSTFile file = new PSTFile(path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+            try
+            {
+                file.BeginSavingChanges();
+                PSTFolder cal = file.TopOfPersonalFolders.CreateChildFolder("Calendar", FolderItemTypeName.Appointment);
+
+                SingleAppointment appt = SingleAppointment.CreateNewSingleAppointment(file, cal.NodeID);
+                appt.Subject = "Meeting with track status";
+                appt.InternetCodepage = 65001;
+                appt.SetStartAndDuration(new DateTime(2026, 6, 30, 10, 0, 0, DateTimeKind.Utc), 60);
+
+                appt.AddRecipients(new List<MessageRecipient>
+                {
+                    new MessageRecipient("Req One", "req1@example.com", isOrganizer: false, RecipientType.To)
+                    {
+                        ResponseStatus = 3
+                    }
+                });
+
+                appt.SaveChanges();
+                cal.AddMessage(appt);
+                cal.SaveChanges();
+                file.EndSavingChanges();
+            }
+            finally { file.CloseFile(); }
+
+            // Reopen and verify round-trip.
+            PSTFile reopened = new PSTFile(path, FileAccess.Read, WriterCompatibilityMode.Outlook2007RTM);
+            try
+            {
+                PSTFolder found = reopened.TopOfPersonalFolders.FindChildFolder("Calendar");
+                CalendarFolder calRo = Assert.IsType<CalendarFolder>(found);
+                Appointment read = calRo.GetAppointment(0);
+                MessageRecipient r = read.GetRecipient(0);
+                Assert.Equal(3, r.ResponseStatus);
+            }
+            finally { reopened.CloseFile(); }
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+
+    [Fact]
+    public void PidLidResponseStatus_name_resolves()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"pidlid-resolve-{Guid.NewGuid():N}.pst");
+        try
+        {
+            PSTFile.CreateEmptyStore(path);
+            PSTFile file = new PSTFile(path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+            try
+            {
+                file.BeginSavingChanges();
+                // Should not throw; returns a usable named-property ID.
+                PropertyID id = file.NameToIDMap.ObtainIDFromName(
+                    new PropertyName(PropertyLongID.PidLidResponseStatus, PropertySetGuid.PSETID_Appointment));
+                Assert.True((int)id >= 0x8000, $"Expected mapped named-property ID ≥ 0x8000, got {(int)id:X}");
+                file.EndSavingChanges();
+            }
+            finally { file.CloseFile(); }
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+
+    [Fact]
+    public void Default_recipient_with_no_response_status_round_trips_zero()
+    {
+        // Backward-compat regression: a recipient added WITHOUT setting ResponseStatus (the mail path)
+        // must still read back 0.
+        string path = Path.Combine(Path.GetTempPath(), $"track-compat-{Guid.NewGuid():N}.pst");
+        try
+        {
+            PSTFile.CreateEmptyStore(path);
+            PSTFile file = new PSTFile(path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+            try
+            {
+                file.BeginSavingChanges();
+                PSTFolder cal = file.TopOfPersonalFolders.CreateChildFolder("Calendar", FolderItemTypeName.Appointment);
+
+                SingleAppointment appt = SingleAppointment.CreateNewSingleAppointment(file, cal.NodeID);
+                appt.Subject = "Plain meeting";
+                appt.InternetCodepage = 65001;
+                appt.SetStartAndDuration(new DateTime(2026, 6, 30, 11, 0, 0, DateTimeKind.Utc), 30);
+
+                // No ResponseStatus set — default 0.
+                appt.AddRecipients(new List<MessageRecipient>
+                {
+                    new MessageRecipient("Plain To", "to@example.com", isOrganizer: false, RecipientType.To)
+                });
+
+                appt.SaveChanges();
+                cal.AddMessage(appt);
+                cal.SaveChanges();
+                file.EndSavingChanges();
+            }
+            finally { file.CloseFile(); }
+
+            PSTFile reopened = new PSTFile(path, FileAccess.Read, WriterCompatibilityMode.Outlook2007RTM);
+            try
+            {
+                PSTFolder found = reopened.TopOfPersonalFolders.FindChildFolder("Calendar");
+                CalendarFolder calRo = Assert.IsType<CalendarFolder>(found);
+                Appointment read = calRo.GetAppointment(0);
+                MessageRecipient r = read.GetRecipient(0);
+                Assert.Equal(0, r.ResponseStatus);
+            }
+            finally { reopened.CloseFile(); }
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Writing/TaskMessageFactoryTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/TaskMessageFactoryTests.cs
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.IO;
+using PSTFileFormat;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Writing;
+
+public class TaskMessageFactoryTests
+{
+    /// <summary>
+    /// Round-trip helper: creates a store, runs <paramref name="write"/>, closes it,
+    /// re-opens read-only, and returns the result of <paramref name="read"/>.
+    /// Mirrors the RoundTrip pattern in ContactWriterTests.cs exactly.
+    /// </summary>
+    private static T RoundTrip<T>(
+        Action<PSTFile, PSTFolder> write,
+        Func<PSTFile, PSTFolder, T> read)
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"m2p-tmf-{Guid.NewGuid():N}.pst");
+        PSTFile? pst = null;
+        try
+        {
+            PSTFile.CreateEmptyStore(path);
+
+            try
+            {
+                pst = new PSTFile(path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+                pst.BeginSavingChanges();
+                PSTFolder folder = pst.TopOfPersonalFolders.CreateChildFolder("Tasks", FolderItemTypeName.Task);
+                write(pst, folder);
+                folder.SaveChanges();
+                pst.EndSavingChanges();
+            }
+            finally { pst?.CloseFile(); pst = null; }
+
+            try
+            {
+                pst = new PSTFile(path, FileAccess.Read);
+                PSTFolder folder = pst.TopOfPersonalFolders.FindChildFolder("Tasks");
+                return read(pst, folder);
+            }
+            finally { pst?.CloseFile(); pst = null; }
+        }
+        finally { File.Delete(path); }
+    }
+
+    /// <summary>
+    /// Helper: retrieve the first task in the folder as a TaskMessage.
+    /// Mirrors FirstContact in ContactWriterTests.cs.
+    /// </summary>
+    private static TaskMessage FirstTask(PSTFile pst, PSTFolder folder) =>
+        TaskMessage.GetTask(pst, folder.GetMessage(0).NodeID);
+
+    [Fact]
+    public void CreateNewTask_yields_IPM_Task_in_UTF8()
+    {
+        var (messageClass, subject) = RoundTrip(
+            (pst, folder) =>
+            {
+                TaskMessage task = TaskMessage.CreateNewTask(pst, folder.NodeID);
+                task.PC.SetStringProperty(PropertyID.PidTagSubject, "Buy milk");
+                task.SaveChanges();
+                folder.AddMessage(task);
+            },
+            (pst, folder) =>
+            {
+                TaskMessage m = FirstTask(pst, folder);
+                return (
+                    m.PC.GetStringProperty(PropertyID.PidTagMessageClass),
+                    m.PC.GetStringProperty(PropertyID.PidTagSubject)
+                );
+            });
+
+        Assert.Equal("IPM.Task", messageClass);
+        Assert.Equal("Buy milk", subject);
+    }
+
+    [Fact]
+    public void CreateNewTask_defaults_to_MSGFLAG_READ_and_Normal_importance()
+    {
+        var (flags, importance) = RoundTrip(
+            (pst, folder) =>
+            {
+                TaskMessage task = TaskMessage.CreateNewTask(pst, folder.NodeID);
+                task.SaveChanges();
+                folder.AddMessage(task);
+            },
+            (pst, folder) =>
+            {
+                TaskMessage m = FirstTask(pst, folder);
+                // Importance and InternetCodepage are write-only on the vendored MessageObject;
+                // read them back via the raw PC so we can assert the values set in CreateNewTask.
+                return (
+                    m.MessageFlags,
+                    (MessageImportance)m.PC.GetInt32Property(PropertyID.PidTagImportance)
+                );
+            });
+
+        Assert.True(flags.HasFlag(MessageFlags.MSGFLAG_READ));
+        Assert.Equal(MessageImportance.Normal, importance);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Writing/TaskWriterAttachmentTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/TaskWriterAttachmentTests.cs
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Writing;
+using PSTFileFormat;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Writing;
+
+/// <summary>
+/// TDD round-trip tests for attachment emission from <see cref="TaskWriter"/>.
+/// InlineBytes → visible ByValue PST attachment; LinkOnly → body appendix, no embedded row.
+/// </summary>
+public class TaskWriterAttachmentTests
+{
+    // -----------------------------------------------------------------------
+    // Round-trip infrastructure (mirrors TaskWriterTests.RoundTripTask)
+    // -----------------------------------------------------------------------
+
+    private static T RoundTripTask<T>(TaskRecord record, Func<PSTFile, MessageObject, T> read)
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"m2p-twatt-{Guid.NewGuid():N}.pst");
+        PSTFile? pst = null;
+        try
+        {
+            PSTFile.CreateEmptyStore(path);
+
+            try
+            {
+                pst = new PSTFile(path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+                pst.BeginSavingChanges();
+                PSTFolder folder = pst.TopOfPersonalFolders.CreateChildFolder("Tasks", FolderItemTypeName.Task);
+                new TaskWriter().WriteTask(pst, folder, record);
+                folder.SaveChanges();
+                pst.EndSavingChanges();
+            }
+            finally { pst?.CloseFile(); pst = null; }
+
+            try
+            {
+                pst = new PSTFile(path, FileAccess.Read);
+                PSTFolder readFolder = pst.TopOfPersonalFolders.FindChildFolder("Tasks");
+                MessageObject msg = TaskMessage.GetTask(pst, readFolder.GetMessage(0).NodeID);
+                return read(pst, msg);
+            }
+            finally { pst?.CloseFile(); pst = null; }
+        }
+        finally { File.Delete(path); }
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Inline_task_attachment_is_written_by_value_and_visible()
+    {
+        var rec = new TaskRecord
+        {
+            Subject = "t",
+            Attachments = new[]
+            {
+                new CalendarAttachment(CalendarAttachmentKind.InlineBytes,
+                    "note.txt", "text/plain", new byte[] { 4, 5, 6 }, null, null)
+            }
+        };
+
+        var (count, bytes, hidden) = RoundTripTask(rec, (f, msg) => (
+            msg.AttachmentCount,
+            msg.GetAttachmentObject(0).PC.GetBytesProperty(PropertyID.PidTagAttachData),
+            msg.GetAttachmentObject(0).PC.GetBooleanProperty(PropertyID.PidTagAttachmentHidden)));
+
+        Assert.Equal(1, count);
+        Assert.Equal(new byte[] { 4, 5, 6 }, bytes);
+        Assert.NotEqual(true, hidden);   // task InlineBytes is a VISIBLE attachment, not a hidden CID
+    }
+
+    [Fact]
+    public void Link_only_task_attachment_is_appended_to_body_not_embedded()
+    {
+        var rec = new TaskRecord
+        {
+            Subject = "t",
+            Attachments = new[]
+            {
+                new CalendarAttachment(CalendarAttachmentKind.LinkOnly,
+                    "report.pdf", "application/pdf", null, null, "https://tasks.example.com/report.pdf")
+            }
+        };
+
+        var (count, body) = RoundTripTask(rec, (f, msg) => (
+            msg.AttachmentCount,
+            msg.PC.GetStringProperty(PropertyID.PidTagBody) ?? ""));
+
+        Assert.Equal(0, count);                                              // no embedded row for a link
+        Assert.Contains("https://tasks.example.com/report.pdf", body);      // preserved in body
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Writing/TaskWriterTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/TaskWriterTests.cs
@@ -15,46 +15,6 @@ public class TaskWriterTests
     // Round-trip infrastructure (mirrors ContactWriterTests / TaskMessageFactoryTests)
     // ---------------------------------------------------------------------------
 
-    private static MessageObject RoundTripTask(TaskRecord record)
-    {
-        string path = Path.Combine(Path.GetTempPath(), $"m2p-tw-{Guid.NewGuid():N}.pst");
-        PSTFile? pst = null;
-        try
-        {
-            PSTFile.CreateEmptyStore(path);
-
-            try
-            {
-                pst = new PSTFile(path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
-                pst.BeginSavingChanges();
-                PSTFolder folder = pst.TopOfPersonalFolders.CreateChildFolder("Tasks", FolderItemTypeName.Task);
-                new TaskWriter().WriteTask(pst, folder, record);
-                folder.SaveChanges();
-                pst.EndSavingChanges();
-            }
-            finally { pst?.CloseFile(); pst = null; }
-
-            // Re-open read-only, load the first task, detach from file lifecycle.
-            // We close and delete the file in the outer finally, but MessageObject references
-            // remain valid after CloseFile (data is in-memory). Store the PSTFile reference
-            // so named-property lookups can use the same NameToIDMap that was written.
-            pst = new PSTFile(path, FileAccess.Read);
-            PSTFolder readFolder = pst.TopOfPersonalFolders.FindChildFolder("Tasks");
-            MessageObject msg = readFolder.GetMessage(0);
-            // Reload via TaskMessage to ensure full PC hydration (mirrors FirstTask helper).
-            return TaskMessage.GetTask(pst, msg.NodeID);
-        }
-        catch
-        {
-            pst?.CloseFile();
-            File.Delete(path);
-            throw;
-        }
-        // NOTE: pst is intentionally left open; we close + delete inside each test via the
-        // wrapper below that owns the lifecycle. Tests that need pst for named-prop lookups
-        // use the overload below.
-    }
-
     /// <summary>
     /// Full round-trip: write, close, reopen; expose both the open PSTFile (for named-prop
     /// ID lookups) and the first MessageObject, then invoke <paramref name="read"/>, close,

--- a/tests/Mail2Pst.Core.Tests/Writing/TaskWriterTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/TaskWriterTests.cs
@@ -343,6 +343,32 @@ public class TaskWriterTests
         Assert.Equal((uint)5, BitConverter.ToUInt32(blob, 30));
     }
 
+    /// <summary>
+    /// Mutation-coverage (Stryker): the MonthlyNth "Nth weekday" task blob path was entirely uncovered.
+    /// For MonthNth the bare RecurrencePattern writes DayOfWeek (uint at offset 22) then DayOccurenceNumber
+    /// (uint at offset 26). "2nd Tuesday" → Tuesday(0x04)/Second(2); "Last Friday" → Friday(0x20)/Last(5).
+    /// </summary>
+    [Theory]
+    [InlineData(DayOfWeek.Tuesday, 2,  (uint)OutlookDayOfWeek.Tuesday, (uint)DayOccurenceNumber.Second)]
+    [InlineData(DayOfWeek.Friday, -1,  (uint)OutlookDayOfWeek.Friday,  (uint)DayOccurenceNumber.Last)]
+    public void MonthlyNth_task_blob_writes_day_and_occurrence(DayOfWeek day, int nth, uint expectDow, uint expectOcc)
+    {
+        var spec = new RecurrenceSpec
+        {
+            Frequency       = RecurrenceFrequency.MonthlyNth,
+            Interval        = 1,
+            DaysOfWeek      = new[] { day },
+            NthOccurrence   = nth,
+            EndKind         = RecurrenceEndKind.NoEnd,
+            FirstStartUtc   = new DateTime(2026, 7, 14, 0, 0, 0, DateTimeKind.Utc),
+            FirstStartLocal = new DateTime(2026, 7, 14, 0, 0, 0),
+        };
+
+        byte[] blob = TaskRecurrenceBlob.Build(spec, TimeZoneInfo.Utc);
+        Assert.Equal(expectDow, BitConverter.ToUInt32(blob, 22));   // DayOfWeek
+        Assert.Equal(expectOcc, BitConverter.ToUInt32(blob, 26));   // DayOccurenceNumber
+    }
+
     [Fact]
     public void Recurring_task_writes_TaskRecurrence_and_FRecurring_true()
     {

--- a/tests/Mail2Pst.Core.Tests/Writing/TaskWriterTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/TaskWriterTests.cs
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 using System;
 using System.IO;
+using System.Linq;
 using Mail2Pst.Core.Models;
 using Mail2Pst.Core.Writing;
 using PSTFileFormat;
 using Xunit;
+// Disambiguates Mail2Pst.Core.Models.RecurrenceFrequency from PSTFileFormat.RecurrenceFrequency.
+using RecurrenceFrequency = Mail2Pst.Core.Models.RecurrenceFrequency;
 
 namespace Mail2Pst.Core.Tests.Writing;
 
@@ -255,6 +258,130 @@ public class TaskWriterTests
             DateTime? due = msg.PC.GetDateTimeProperty(dueId);
             Assert.NotNull(due);
             Assert.Equal(new DateTime(2026, 6, 30, 0, 0, 0, DateTimeKind.Utc), due!.Value);
+            return true;
+        });
+    }
+
+    // ---------------------------------------------------------------------------
+    // PR7b recurrence tests (Task 4)
+    // ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// Byte-gate: <see cref="TaskRecurrenceBlob.Build"/> must reproduce the exact
+    /// PidLidTaskRecurrence bytes dumped from real Outlook for "GT Task Weekly"
+    /// (weekly Mon, COUNT=5, due 2026-07-06).
+    /// Oracle source: docs/research/2026-07-01-pr7a-recurrence-ground-truth.md,
+    /// "Task recurrence ground truth" section.
+    /// </summary>
+    [Fact]
+    public void Weekly_task_due_monday_writes_GT_oracle_bytes()
+    {
+        // GT Task Weekly oracle — 54 bytes, weekly Mon COUNT=5 starting 2026-07-06.
+        // Decoded:
+        //   ReaderVersion=0x3004, WriterVersion=0x3004
+        //   RecurFrequency=0x200B (Weekly), PatternType=0x0001 (Week), CalendarType=0
+        //   FirstDateTime=8640 (6 days × 1440 min — week-start offset from 1601-01-01)
+        //   Period=1, SlidingFlag=0
+        //   DaysOfWeek=0x02 (Monday)
+        //   EndType=0x2022 (EndAfterNOccurrences), OccurrenceCount=5, FirstDOW=0
+        //   DeletedInstanceCount=0, ModifiedInstanceCount=0
+        //   StartDate=2026-07-06 (155,414 × 1440 = 0x0D56DBC0)
+        //   EndDate=2026-08-03 (155,442 × 1440 = 0x0D577940)
+        byte[] oracle = Convert.FromHexString(
+            // 54 bytes: bare RecurrencePattern (no appointment tail).
+            // Fields: ReaderVer+WriterVer+RecurFreq+PatType+CalType+FirstDateTime+Period+SlidingFlag
+            //       + DaysOfWeek+EndType+OccurrenceCount+FirstDOW+DeletedCount+ModifiedCount
+            //       + StartDate+EndDate
+            "043004300B2001000000C02100000100000000000000" +  // header+FirstDateTime+Period+SlidingFlag (22 bytes)
+            "020000002220000005000000" +                        // DaysOfWeek+EndType+OccurrenceCount (12 bytes)
+            "000000000000000000000000" +                        // FirstDOW+DeletedCount+ModifiedCount (12 bytes)
+            "C0DB560D4079570D");                                // StartDate+EndDate (8 bytes)
+
+        var spec = new RecurrenceSpec
+        {
+            Frequency         = RecurrenceFrequency.Weekly,
+            Interval          = 1,
+            DaysOfWeek        = new[] { DayOfWeek.Monday },
+            EndKind           = RecurrenceEndKind.Count,
+            Count             = 5,
+            FirstStartUtc     = new DateTime(2026, 7, 6, 0, 0, 0, DateTimeKind.Utc),
+            FirstStartLocal   = new DateTime(2026, 7, 6, 0, 0, 0),
+            LastInstanceStartUtc = new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc),
+        };
+
+        byte[] actual = TaskRecurrenceBlob.Build(spec, TimeZoneInfo.Utc);
+
+        Assert.Equal(54, actual.Length);
+        Assert.True(oracle.SequenceEqual(actual),
+            $"Bytes differ.\nExpected: {Convert.ToHexString(oracle)}\nActual:   {Convert.ToHexString(actual)}");
+    }
+
+    [Fact]
+    public void Recurring_task_writes_TaskRecurrence_and_FRecurring_true()
+    {
+        // A TaskRecord with a RecurrenceSpec must round-trip with PidLidTaskFRecurring=true
+        // and PidLidTaskRecurrence present (non-null bytes).
+        var spec = new RecurrenceSpec
+        {
+            Frequency         = RecurrenceFrequency.Weekly,
+            Interval          = 1,
+            DaysOfWeek        = new[] { DayOfWeek.Monday },
+            EndKind           = RecurrenceEndKind.Count,
+            Count             = 5,
+            FirstStartUtc     = new DateTime(2026, 7, 6, 0, 0, 0, DateTimeKind.Utc),
+            FirstStartLocal   = new DateTime(2026, 7, 6, 0, 0, 0),
+            LastInstanceStartUtc = new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc),
+        };
+        var t = new TaskRecord
+        {
+            Subject    = "Recurring GT Weekly",
+            DueDate    = new DateTimeOffset(2026, 7, 6, 0, 0, 0, TimeSpan.Zero),
+            Recurrence = spec,
+        };
+
+        RoundTripTask(t, (pst, msg) =>
+        {
+            // PidLidTaskFRecurring == true
+            PropertyID frId = pst.NameToIDMap.ObtainIDFromName(
+                new PropertyName(PropertyLongID.PidLidTaskFRecurring, PropertySetGuid.PSETID_Task));
+            Assert.True(msg.PC.GetBooleanProperty(frId),
+                "PidLidTaskFRecurring should be true for a recurring task");
+
+            // PidLidTaskRecurrence present and non-empty
+            PropertyID recId = pst.NameToIDMap.ObtainIDFromName(
+                new PropertyName(PropertyLongID.PidLidTaskRecurrence, PropertySetGuid.PSETID_Task));
+            byte[]? recBytes = msg.PC.GetBytesProperty(recId);
+            Assert.NotNull(recBytes);
+            Assert.True(recBytes!.Length > 0, "PidLidTaskRecurrence should be non-empty");
+
+            return true;
+        });
+    }
+
+    [Fact]
+    public void Non_recurring_task_writes_no_recurrence_props()
+    {
+        // A non-recurring TaskRecord (Recurrence=null) must NOT write PidLidTaskRecurrence
+        // or PidLidTaskFRecurring — absent is the correct state (PR7b ground-truth confirms
+        // Outlook omits these props on non-recurring tasks; writing them absent is equivalent
+        // to FRecurring=false without the prop overhead).
+        var t = new TaskRecord { Subject = "Non-recurring" };
+
+        RoundTripTask(t, (pst, msg) =>
+        {
+            // Use GetIDFromName (non-mutating) so we don't allocate these names in the store.
+            PropertyID? recId = pst.NameToIDMap.GetIDFromName(
+                new PropertyName(PropertyLongID.PidLidTaskRecurrence, PropertySetGuid.PSETID_Task));
+            PropertyID? frId = pst.NameToIDMap.GetIDFromName(
+                new PropertyName(PropertyLongID.PidLidTaskFRecurring, PropertySetGuid.PSETID_Task));
+
+            // Prop is absent if: name was never registered (null) OR registered but no value on this message.
+            bool recAbsent = recId is null || msg.PC.GetBytesProperty(recId.Value) is null;
+            bool frAbsent  = frId  is null || msg.PC.GetBooleanProperty(frId.Value) is null;
+
+            Assert.True(recAbsent, "PidLidTaskRecurrence should not be written for a non-recurring task");
+            Assert.True(frAbsent,  "PidLidTaskFRecurring should not be written for a non-recurring task");
+
             return true;
         });
     }

--- a/tests/Mail2Pst.Core.Tests/Writing/TaskWriterTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/TaskWriterTests.cs
@@ -316,6 +316,33 @@ public class TaskWriterTests
             $"Bytes differ.\nExpected: {Convert.ToHexString(oracle)}\nActual:   {Convert.ToHexString(actual)}");
     }
 
+    /// <summary>
+    /// Pre-merge review #5 (task path): for a COUNT-terminated task series the blob's OccurrenceCount
+    /// must be the RRULE COUNT, not a date-span heuristic. Month-overflow (BYMONTHDAY=31 skips 30-day
+    /// months) exposes the bug: 5 "day 31" occurrences from Jan 2026 span 7 months → the old heuristic
+    /// wrote 8. OccurrenceCount is a 4-byte LE field at offset 30 in the bare RecurrencePattern
+    /// (22-byte header + 4-byte pattern field + 4-byte EndType).
+    /// </summary>
+    [Fact]
+    public void Count_task_month_overflow_writes_exact_occurrence_count()
+    {
+        var spec = new RecurrenceSpec
+        {
+            Frequency            = RecurrenceFrequency.Monthly,
+            Interval             = 1,
+            DayOfMonth           = 31,
+            DaysOfWeek           = Array.Empty<DayOfWeek>(),
+            EndKind              = RecurrenceEndKind.Count,
+            Count                = 5,
+            FirstStartUtc        = new DateTime(2026, 1, 31, 0, 0, 0, DateTimeKind.Utc),
+            FirstStartLocal      = new DateTime(2026, 1, 31, 0, 0, 0),
+            LastInstanceStartUtc = new DateTime(2026, 8, 31, 0, 0, 0, DateTimeKind.Utc), // Jan,Mar,May,Jul,Aug
+        };
+
+        byte[] blob = TaskRecurrenceBlob.Build(spec, TimeZoneInfo.Utc);
+        Assert.Equal((uint)5, BitConverter.ToUInt32(blob, 30));
+    }
+
     [Fact]
     public void Recurring_task_writes_TaskRecurrence_and_FRecurring_true()
     {

--- a/tests/Mail2Pst.Core.Tests/Writing/TaskWriterTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/TaskWriterTests.cs
@@ -1,0 +1,301 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.IO;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Writing;
+using PSTFileFormat;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Writing;
+
+public class TaskWriterTests
+{
+    // ---------------------------------------------------------------------------
+    // Round-trip infrastructure (mirrors ContactWriterTests / TaskMessageFactoryTests)
+    // ---------------------------------------------------------------------------
+
+    private static MessageObject RoundTripTask(TaskRecord record)
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"m2p-tw-{Guid.NewGuid():N}.pst");
+        PSTFile? pst = null;
+        try
+        {
+            PSTFile.CreateEmptyStore(path);
+
+            try
+            {
+                pst = new PSTFile(path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+                pst.BeginSavingChanges();
+                PSTFolder folder = pst.TopOfPersonalFolders.CreateChildFolder("Tasks", FolderItemTypeName.Task);
+                new TaskWriter().WriteTask(pst, folder, record);
+                folder.SaveChanges();
+                pst.EndSavingChanges();
+            }
+            finally { pst?.CloseFile(); pst = null; }
+
+            // Re-open read-only, load the first task, detach from file lifecycle.
+            // We close and delete the file in the outer finally, but MessageObject references
+            // remain valid after CloseFile (data is in-memory). Store the PSTFile reference
+            // so named-property lookups can use the same NameToIDMap that was written.
+            pst = new PSTFile(path, FileAccess.Read);
+            PSTFolder readFolder = pst.TopOfPersonalFolders.FindChildFolder("Tasks");
+            MessageObject msg = readFolder.GetMessage(0);
+            // Reload via TaskMessage to ensure full PC hydration (mirrors FirstTask helper).
+            return TaskMessage.GetTask(pst, msg.NodeID);
+        }
+        catch
+        {
+            pst?.CloseFile();
+            File.Delete(path);
+            throw;
+        }
+        // NOTE: pst is intentionally left open; we close + delete inside each test via the
+        // wrapper below that owns the lifecycle. Tests that need pst for named-prop lookups
+        // use the overload below.
+    }
+
+    /// <summary>
+    /// Full round-trip: write, close, reopen; expose both the open PSTFile (for named-prop
+    /// ID lookups) and the first MessageObject, then invoke <paramref name="read"/>, close,
+    /// delete. This avoids leaking file handles even when assertions throw.
+    /// </summary>
+    private static T RoundTripTask<T>(TaskRecord record, Func<PSTFile, MessageObject, T> read)
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"m2p-tw-{Guid.NewGuid():N}.pst");
+        PSTFile? pst = null;
+        try
+        {
+            PSTFile.CreateEmptyStore(path);
+
+            try
+            {
+                pst = new PSTFile(path, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+                pst.BeginSavingChanges();
+                PSTFolder folder = pst.TopOfPersonalFolders.CreateChildFolder("Tasks", FolderItemTypeName.Task);
+                new TaskWriter().WriteTask(pst, folder, record);
+                folder.SaveChanges();
+                pst.EndSavingChanges();
+            }
+            finally { pst?.CloseFile(); pst = null; }
+
+            try
+            {
+                pst = new PSTFile(path, FileAccess.Read);
+                PSTFolder readFolder = pst.TopOfPersonalFolders.FindChildFolder("Tasks");
+                MessageObject msg = TaskMessage.GetTask(pst, readFolder.GetMessage(0).NodeID);
+                return read(pst, msg);
+            }
+            finally { pst?.CloseFile(); pst = null; }
+        }
+        finally { File.Delete(path); }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Tests
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void WriteTask_message_class_is_IPM_Task()
+    {
+        // Guards against accidentally writing a Note into a Task folder.
+        var t = new TaskRecord { Subject = "Class check" };
+        string cls = RoundTripTask(t, (_, msg) =>
+            msg.PC.GetStringProperty(PropertyID.PidTagMessageClass));
+        Assert.Equal("IPM.Task", cls);
+    }
+
+    [Fact]
+    public void WriteTask_round_trips_core_fields()
+    {
+        var t = new TaskRecord
+        {
+            Subject     = "Prepare Q3 report",
+            Body        = "Draft and circulate",
+            Status      = TaskStatusKind.InProgress,
+            PercentComplete = 50,
+            StartDate   = new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero),
+            DueDate     = new DateTimeOffset(2026, 6, 30, 0, 0, 0, TimeSpan.Zero),
+            Importance  = 2,
+            Categories  = new[] { "Work", "Finance" },
+        };
+
+        RoundTripTask(t, (pst, msg) =>
+        {
+            Assert.Equal("Prepare Q3 report", msg.PC.GetStringProperty(PropertyID.PidTagSubject));
+            Assert.Equal("Draft and circulate", msg.PC.GetStringProperty(PropertyID.PidTagBody));
+            Assert.Equal(2, msg.PC.GetInt32Property(PropertyID.PidTagImportance));
+
+            // Status (PidLidTaskStatus) named-prop read-back
+            PropertyID statusId = pst.NameToIDMap.ObtainIDFromName(
+                new PropertyName(PropertyLongID.PidLidTaskStatus, PropertySetGuid.PSETID_Task));
+            Assert.Equal(1, msg.PC.GetInt32Property(statusId));
+
+            return true;
+        });
+    }
+
+    [Fact]
+    public void WriteTask_percent_round_trips_as_floating64()
+    {
+        // PidLidPercentComplete is PtypFloating64; SetExternalProperty writes IEEE-754 bytes.
+        // Read back via GetFloat64Property (NOT GetBytesProperty — that checks PtypBinary).
+        var t = new TaskRecord { Subject = "Half done", PercentComplete = 50 };
+        RoundTripTask(t, (pst, msg) =>
+        {
+            PropertyID pcId = pst.NameToIDMap.ObtainIDFromName(
+                new PropertyName(PropertyLongID.PidLidPercentComplete, PropertySetGuid.PSETID_Task));
+            double? value = msg.PC.GetFloat64Property(pcId);
+            Assert.NotNull(value);
+            Assert.Equal(0.5, value!.Value, 3);
+            return true;
+        });
+    }
+
+    [Fact]
+    public void WriteTask_completed_sets_complete_flag_and_100_percent()
+    {
+        var completedAt = new DateTimeOffset(2026, 6, 25, 14, 30, 0, TimeSpan.Zero);
+        var t = new TaskRecord
+        {
+            Subject         = "All done",
+            Status          = TaskStatusKind.Complete,
+            PercentComplete = 100,
+            CompletedDate   = completedAt,
+        };
+
+        RoundTripTask(t, (pst, msg) =>
+        {
+            // PidLidTaskStatus == 2
+            PropertyID statusId = pst.NameToIDMap.ObtainIDFromName(
+                new PropertyName(PropertyLongID.PidLidTaskStatus, PropertySetGuid.PSETID_Task));
+            Assert.Equal(2, msg.PC.GetInt32Property(statusId));
+
+            // PidLidTaskComplete == true
+            PropertyID completeId = pst.NameToIDMap.ObtainIDFromName(
+                new PropertyName(PropertyLongID.PidLidTaskComplete, PropertySetGuid.PSETID_Task));
+            Assert.True(msg.PC.GetBooleanProperty(completeId));
+
+            // PidLidPercentComplete == 1.0
+            PropertyID pcId = pst.NameToIDMap.ObtainIDFromName(
+                new PropertyName(PropertyLongID.PidLidPercentComplete, PropertySetGuid.PSETID_Task));
+            double? pct = msg.PC.GetFloat64Property(pcId);
+            Assert.NotNull(pct);
+            Assert.Equal(1.0, pct!.Value, 3);
+
+            // PidLidTaskDateCompleted written as instant
+            PropertyID dcId = pst.NameToIDMap.ObtainIDFromName(
+                new PropertyName(PropertyLongID.PidLidTaskDateCompleted, PropertySetGuid.PSETID_Task));
+            DateTime? dc = msg.PC.GetDateTimeProperty(dcId);
+            Assert.NotNull(dc);
+            Assert.Equal(completedAt.UtcDateTime, dc!.Value);
+
+            return true;
+        });
+    }
+
+    [Fact]
+    public void WriteTask_with_reminder_sets_absolute_reminder_time()
+    {
+        var reminderAt = new DateTimeOffset(2026, 6, 30, 9, 0, 0, TimeSpan.Zero);
+        var t = new TaskRecord
+        {
+            Subject      = "Reminded task",
+            ReminderSet  = true,
+            ReminderTime = reminderAt,
+        };
+
+        RoundTripTask(t, (pst, msg) =>
+        {
+            // PidLidReminderSet == true
+            PropertyID rsId = pst.NameToIDMap.ObtainIDFromName(
+                new PropertyName(PropertyLongID.PidLidReminderSet, PropertySetGuid.PSETID_Common));
+            Assert.True(msg.PC.GetBooleanProperty(rsId));
+
+            // PidLidReminderTime == the instant
+            PropertyID rtId = pst.NameToIDMap.ObtainIDFromName(
+                new PropertyName(PropertyLongID.PidLidReminderTime, PropertySetGuid.PSETID_Common));
+            DateTime? rt = msg.PC.GetDateTimeProperty(rtId);
+            Assert.NotNull(rt);
+            Assert.Equal(reminderAt.UtcDateTime, rt!.Value);
+
+            // PidLidReminderSignalTime == the same instant (delta=0 — absolute, not minutes-before)
+            PropertyID rstId = pst.NameToIDMap.ObtainIDFromName(
+                new PropertyName(PropertyLongID.PidLidReminderSignalTime, PropertySetGuid.PSETID_Common));
+            DateTime? rst = msg.PC.GetDateTimeProperty(rstId);
+            Assert.NotNull(rst);
+            Assert.Equal(rt!.Value, rst!.Value);
+
+            // PidLidReminderDelta == 0
+            PropertyID rdId = pst.NameToIDMap.ObtainIDFromName(
+                new PropertyName(PropertyLongID.PidLidReminderDelta, PropertySetGuid.PSETID_Common));
+            Assert.Equal(0, msg.PC.GetInt32Property(rdId));
+
+            return true;
+        });
+    }
+
+    [Fact]
+    public void WriteTask_private_sets_sensitivity_and_PidLidPrivate()
+    {
+        // Task 0 ground-truth: a Private task sets BOTH PidTagSensitivity=2 AND PidLidPrivate=true.
+        var t = new TaskRecord { Subject = "Secret task", Sensitivity = 2 };
+        RoundTripTask(t, (pst, msg) =>
+        {
+            Assert.Equal(2, msg.PC.GetInt32Property(PropertyID.PidTagSensitivity));
+
+            PropertyID privateId = pst.NameToIDMap.ObtainIDFromName(
+                new PropertyName(PropertyLongID.PidLidPrivate, PropertySetGuid.PSETID_Common));
+            Assert.True(msg.PC.GetBooleanProperty(privateId));
+
+            return true;
+        });
+    }
+
+    [Fact]
+    public void WriteTask_no_dates_omits_start_and_due()
+    {
+        // StartDate=DueDate=null → the named props should be absent.
+        // Use GetIDFromName (non-mutating) because on a read-only reopen the props were never
+        // registered, and ObtainIDFromName would try to add them (requiring BeginSavingChanges).
+        var t = new TaskRecord { Subject = "No dates" };
+        RoundTripTask(t, (pst, msg) =>
+        {
+            PropertyID? startId = pst.NameToIDMap.GetIDFromName(
+                new PropertyName(PropertyLongID.PidLidTaskStartDate, PropertySetGuid.PSETID_Task));
+            PropertyID? dueId = pst.NameToIDMap.GetIDFromName(
+                new PropertyName(PropertyLongID.PidLidTaskDueDate, PropertySetGuid.PSETID_Task));
+
+            // If the prop was never written it won't be in the NameToIDMap at all (null),
+            // or if somehow allocated it must have no value on this specific message.
+            bool startAbsent = startId is null || msg.PC.GetDateTimeProperty(startId.Value) is null;
+            bool dueAbsent   = dueId   is null || msg.PC.GetDateTimeProperty(dueId.Value) is null;
+            Assert.True(startAbsent, "PidLidTaskStartDate should not be written when StartDate is null");
+            Assert.True(dueAbsent,   "PidLidTaskDueDate should not be written when DueDate is null");
+
+            return true;
+        });
+    }
+
+    [Fact]
+    public void WriteTask_due_date_round_trips_as_same_calendar_day_in_nonUTC_offset()
+    {
+        // A due date authored in a +07:00 offset must read back as the same Y/M/D at UTC midnight,
+        // not shifted. NormalizeDateOnly uses the DTO's own Y/M/D, so no tz-shift occurs.
+        var t = new TaskRecord
+        {
+            Subject = "TZ check",
+            DueDate = new DateTimeOffset(2026, 6, 30, 0, 0, 0, TimeSpan.FromHours(7)),
+        };
+
+        RoundTripTask(t, (pst, msg) =>
+        {
+            PropertyID dueId = pst.NameToIDMap.ObtainIDFromName(
+                new PropertyName(PropertyLongID.PidLidTaskDueDate, PropertySetGuid.PSETID_Task));
+            DateTime? due = msg.PC.GetDateTimeProperty(dueId);
+            Assert.NotNull(due);
+            Assert.Equal(new DateTime(2026, 6, 30, 0, 0, 0, DateTimeKind.Utc), due!.Value);
+            return true;
+        });
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/stryker-config.json
+++ b/tests/Mail2Pst.Core.Tests/stryker-config.json
@@ -1,0 +1,29 @@
+{
+  "_comment": "Manual mutation-testing gate for the Thunderbird calendar/tasks code. NOT run in CI (slow). Run: `dotnet-stryker` from this directory. See TESTING.md.",
+  "stryker-config": {
+    "project": "Mail2Pst.Core.csproj",
+    "mutate": [
+      "**/Calendar/CalendarEventMapper.cs",
+      "**/Calendar/CalendarTaskMapper.cs",
+      "**/Calendar/RecurrenceMapping.cs",
+      "**/Calendar/CalendarAttachmentResolver.cs",
+      "**/Calendar/GlobalObjectIdCodec.cs",
+      "**/Calendar/ICalTextParser.cs",
+      "**/Calendar/IcalDataUri.cs",
+      "**/Calendar/IcalParseSupport.cs",
+      "**/Calendar/TimeZoneResolver.cs",
+      "**/Calendar/SqliteCalendarReader.cs",
+      "**/Calendar/CalendarReadResult.cs",
+      "**/Calendar/CalendarRegistryReader.cs",
+      "**/Writing/AppointmentWriter.cs",
+      "**/Writing/TaskWriter.cs",
+      "**/Writing/TaskRecurrenceBlob.cs",
+      "**/Writing/AttachmentWriter.cs",
+      "**/Writing/CalendarBodyAppendix.cs",
+      "**/Config/FolderNameValidator.cs"
+    ],
+    "reporters": ["html", "progress"],
+    "concurrency": 6,
+    "thresholds": { "high": 85, "low": 70, "break": 0 }
+  }
+}

--- a/tests/Mail2Pst.Integration.Tests/AppointmentIndependentValidationTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/AppointmentIndependentValidationTests.cs
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core;
+using Mail2Pst.Core.Config;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests;
+
+/// <summary>
+/// Opt-in independent-reader gate for appointment folders.
+/// Requires MAIL2PST_PST_VALIDATOR to be set (same env-var as IndependentValidationTests).
+/// Without it the test is skipped so CI (no Rust validator) stays green.
+/// </summary>
+public class AppointmentIndependentValidationTests
+{
+    // Zero-count folders the independent reader may surface that the converter did not create
+    // (known template/system folders). Mirrors IndependentValidationTests.ZeroCountAllowlist.
+    private static readonly HashSet<string> ZeroCountAllowlist = new(StringComparer.Ordinal)
+    {
+        // The from-scratch store (PSTFile.CreateEmptyStore) seeds a default "Deleted Items"
+        // folder under the IPM subtree, which the independent reader surfaces with 0 messages.
+        FolderPathKey.Join(new[] { "Deleted Items" }),
+    };
+
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(60);
+
+    [SkippableFact]
+    public void Convert_CalendarWithEvents_ValidatesAppointmentFolderCounts()
+    {
+        Skip.If(PstValidatorRunner.ValidatorPath is null,
+            "Set MAIL2PST_PST_VALIDATOR to the built pst-validate exe to run the independent-reader gate.");
+
+        // 2 non-recurring events → 2 IPM.Appointment items written; 1 recurring event → skipped by mapper.
+        const int NonRecurringCount = 2;
+
+        string outDir = Path.Combine(Path.GetTempPath(), "mail2pst-appt-indep-" + Guid.NewGuid());
+        Directory.CreateDirectory(outDir);
+        string dbPath = Path.Combine(outDir, "local.sqlite");
+
+        try
+        {
+            // Arrange: build a temp SQLite calendar store with synthetic events.
+            CreateSqliteCalendarStore(dbPath, NonRecurringCount);
+
+            ConversionConfig config = CalendarOnlyConfig(dbPath);
+
+            // Act: convert.
+            var (outputs, _) = RoundTripHarness.Convert(config, outDir);
+            Assert.NotEmpty(outputs); // a conversion that produced no PST parts would otherwise pass vacuously
+
+            // Expected path-keyed counts from the converter's own truth model (includes appointment folders).
+            Dictionary<string, int> expected = RoundTripHarness.BuildTruth(config)
+                .ToDictionary(kv => kv.Key, kv => kv.Value.Count, StringComparer.Ordinal);
+
+            // Actual path-keyed counts, aggregated across all output parts via the INDEPENDENT reader.
+            var actual = new Dictionary<string, long>(StringComparer.Ordinal);
+            foreach (string part in outputs)
+            {
+                ValidatorResult r = PstValidatorRunner.Run(part, Timeout);
+                Assert.True(r.Opened, $"validator could not open {Path.GetFileName(part)}: " +
+                    string.Join("; ", r.Errors.Select(e => $"{e.Stage}:{e.Message}")));
+                Assert.Empty(r.Errors);
+                foreach (ValidatedFolder f in r.Folders)
+                {
+                    string key = FolderPathKey.Join(f.Path);
+                    actual[key] = actual.GetValueOrDefault(key) + f.MessageCount;
+                }
+            }
+
+            // Every expected path must match exactly (includes the IPM.Appointment folder with N items).
+            foreach ((string key, int count) in expected)
+            {
+                Assert.True(actual.TryGetValue(key, out long got),
+                    $"expected folder '{key}' missing from independent reader output");
+                Assert.Equal(count, got);
+            }
+
+            // Any UNEXPECTED folder with messages is a failure; zero-count surprises must be allowlisted.
+            foreach ((string key, long got) in actual)
+            {
+                if (expected.ContainsKey(key)) continue;
+                if (got == 0 && ZeroCountAllowlist.Contains(key)) continue;
+                Assert.Fail($"unexpected folder '{key}' with {got} message(s) in independent reader output");
+            }
+        }
+        finally { Directory.Delete(outDir, true); }
+    }
+
+    /// <summary>
+    /// Creates a minimal Thunderbird SQLite calendar store with <paramref name="nonRecurringCount"/>
+    /// non-recurring events plus one recurring event (which CalendarEventMapper skips).
+    /// Schema mirrors what SqliteCalendarReader expects: cal_events, cal_recurrence, and
+    /// companion side-table stubs (cal_todos, cal_alarms, cal_attendees, cal_attachments,
+    /// cal_relations, cal_properties, cal_parameters).
+    /// All data is synthetic — reserved example.org/example.com domains, no real PII.
+    /// </summary>
+    private static void CreateSqliteCalendarStore(string dbPath, int nonRecurringCount)
+    {
+        using var conn = new SqliteConnection($"Data Source={dbPath}");
+        conn.Open();
+
+        void Exec(string sql)
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = sql;
+            cmd.ExecuteNonQuery();
+        }
+
+        // Schema — mirrors what SqliteCalendarReader reads (full column list so the reader doesn't fail).
+        Exec("CREATE TABLE cal_events (cal_id TEXT,id TEXT,time_created INTEGER,last_modified INTEGER,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,event_start INTEGER,event_end INTEGER,event_stamp INTEGER,event_start_tz TEXT,event_end_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,alarm_last_ack INTEGER,offline_journal INTEGER);");
+        Exec("CREATE TABLE cal_todos (cal_id TEXT,id TEXT,time_created INTEGER,last_modified INTEGER,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,todo_entry INTEGER,todo_due INTEGER,todo_completed INTEGER,todo_complete INTEGER,todo_entry_tz TEXT,todo_due_tz TEXT,todo_completed_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,alarm_last_ack INTEGER,todo_stamp INTEGER,offline_journal INTEGER);");
+        Exec("CREATE TABLE cal_recurrence (item_id TEXT,cal_id TEXT,icalString TEXT);");
+        Exec("CREATE TABLE cal_attendees (item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT,icalString TEXT);");
+        Exec("CREATE TABLE cal_alarms (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        Exec("CREATE TABLE cal_attachments (item_id TEXT,cal_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        Exec("CREATE TABLE cal_relations (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        Exec("CREATE TABLE cal_properties (item_id TEXT,key TEXT,value BLOB,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT);");
+        Exec("CREATE TABLE cal_parameters (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,key1 TEXT,key2 TEXT,value TEXT);");
+
+        // Non-recurring events: E1, E2, … (master rows; no cal_recurrence entries → mapper writes them).
+        for (int i = 1; i <= nonRecurringCount; i++)
+        {
+            // event_start / event_end: synthetic PRTime values (µs since Unix epoch, 2026-07-10 UTC).
+            long start = 1752148800000000L + (long)(i - 1) * 86_400_000_000L; // 2026-07-10 + (i-1) days
+            long end   = start + 3_600_000_000L;                               // +1 hour
+
+            using var insert = conn.CreateCommand();
+            insert.CommandText =
+                "INSERT INTO cal_events (cal_id,id,title,flags,event_start,event_end,event_start_tz,event_end_tz,recurrence_id) " +
+                "VALUES (@cal,@id,@title,0,@start,@end,'UTC','UTC',NULL)";
+            insert.Parameters.AddWithValue("@cal",   "TESTCAL");
+            insert.Parameters.AddWithValue("@id",    $"E{i}@example.com");
+            insert.Parameters.AddWithValue("@title", $"Test Event {i}");
+            insert.Parameters.AddWithValue("@start", start);
+            insert.Parameters.AddWithValue("@end",   end);
+            insert.ExecuteNonQuery();
+        }
+
+        // One recurring event: EREC — master row + a cal_recurrence entry → mapper skips it.
+        Exec("INSERT INTO cal_events (cal_id,id,title,flags,event_start,event_end,event_start_tz,event_end_tz,recurrence_id) " +
+             "VALUES ('TESTCAL','EREC@example.com','Recurring Event (skipped)',0,1752148800000000,1752152400000000,'UTC','UTC',NULL);");
+        Exec("INSERT INTO cal_recurrence (item_id,cal_id,icalString) VALUES ('EREC@example.com','TESTCAL','RRULE:FREQ=WEEKLY');");
+    }
+
+    private static ConversionConfig CalendarOnlyConfig(string dbPath) => new()
+    {
+        Outputs = new List<OutputGroupConfig>
+        {
+            new()
+            {
+                Name = "Appointments",
+                MaxSizeMB = 50_000,
+                // No mail or contact sources — appointments only.
+                Sources = new List<SourceConfig>(),
+                Contacts = new List<ContactSourceConfig>(),
+                Calendars = new List<CalendarSourceConfig>
+                {
+                    new()
+                    {
+                        StorePath = dbPath,
+                        CalId = "TESTCAL",
+                        IncludeAppointments = true,
+                        IncludeTasks = false,
+                        AppointmentFolderPath = new[] { "Calendars", "TestCalendar" },
+                    },
+                },
+            },
+        },
+    };
+}

--- a/tests/Mail2Pst.Integration.Tests/CalendarAttachmentCorpusTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/CalendarAttachmentCorpusTests.cs
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Mail2Pst.Core;
+using Mail2Pst.Core.Config;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests;
+
+/// <summary>
+/// Opt-in real-corpus smoke test for the calendar attachment pipeline (Task 6).
+///
+/// Set <c>MAIL2PST_CALENDAR_CORPUS</c> to the full path of a Thunderbird
+/// <c>local.sqlite</c> (or <c>cache.sqlite</c>) to enable. Skipped in CI (no corpus, no PII).
+/// Mirrors the <c>VCardCorpusTests.RealAddressBook_…</c> env-var + early-return pattern exactly.
+///
+/// Asserts:
+/// <list type="bullet">
+///   <item>Conversion completes without exception.</item>
+///   <item>At least one appointment or task is converted.</item>
+///   <item>All emitted warnings match a known structured pattern (no raw exception traces).</item>
+/// </list>
+/// Reserved <c>@example.com</c> only in committed fixtures — this test emits no PII.
+/// </summary>
+public class CalendarAttachmentCorpusTests
+{
+    // Known structured warning prefixes produced by the attachment / relation / recurrence pipeline.
+    // Any warning not matching one of these patterns is treated as an unstructured leak (test failure).
+    private static readonly Regex[] StructuredWarningPatterns =
+    {
+        // CalendarAttachmentResolver — attachment parse / remote / local-file warnings
+        new Regex(@"attachment on '.*':", RegexOptions.IgnoreCase),
+        new Regex(@"remote URL preserved as link", RegexOptions.IgnoreCase),
+        new Regex(@"local file (outside|missing|unreadable|symlink)", RegexOptions.IgnoreCase),
+        // ConversionRunner appointment/task skip lines
+        new Regex(@"Appointment skipped \[", RegexOptions.IgnoreCase),
+        new Regex(@"Task skipped \[", RegexOptions.IgnoreCase),
+        // CalendarEventMapper / CalendarTaskMapper structured degrades
+        new Regex(@"skipping recurring (event|task)", RegexOptions.IgnoreCase),
+        new Regex(@"exception.*skipped", RegexOptions.IgnoreCase),
+        new Regex(@"ignored.*change flag", RegexOptions.IgnoreCase),
+        new Regex(@"RRULE.*unparseable", RegexOptions.IgnoreCase),
+        new Regex(@"unparseable.*RRULE", RegexOptions.IgnoreCase),
+        new Regex(@"task recurrence.*warn", RegexOptions.IgnoreCase),
+        // Relation lines preserved in body
+        new Regex(@"relation not natively converted", RegexOptions.IgnoreCase),
+    };
+
+    [Fact]
+    public void RealCalendarCorpus_ConvertsCleansAndStructuredWarnings()
+    {
+        // Opt-in: set MAIL2PST_CALENDAR_CORPUS to a real local.sqlite or cache.sqlite path.
+        // CI without it passes silently — same early-return pattern as VCardCorpusTests.
+        string? storePath = Environment.GetEnvironmentVariable("MAIL2PST_CALENDAR_CORPUS");
+        if (string.IsNullOrWhiteSpace(storePath)) return;
+        if (!File.Exists(storePath)) return;   // misconfigured path — skip silently
+
+        // CalId="" reads all calendars in the store. ConfigValidator requires explicit folder
+        // paths when CalId is empty — use simple single-folder paths for both item types.
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name      = "CorpusCalendar",
+                    MaxSizeMB = 50_000,
+                    Sources   = new List<SourceConfig>(),
+                    Contacts  = new List<ContactSourceConfig>(),
+                    Calendars = new List<CalendarSourceConfig>
+                    {
+                        new()
+                        {
+                            StorePath            = storePath,
+                            CalId                = "",   // "" = all calendars in store
+                            IncludeAppointments  = true,
+                            IncludeTasks         = true,
+                            AppointmentFolderPath = new[] { "Calendar" },
+                            TaskFolderPath        = new[] { "Tasks" },
+                        },
+                    },
+                },
+            },
+        };
+
+        string outDir = Path.Combine(Path.GetTempPath(), "mail2pst-cal-corpus-" + Guid.NewGuid());
+        Directory.CreateDirectory(outDir);
+        try
+        {
+            // Conversion must complete without exception.
+            var (_, report) = RoundTripHarness.Convert(config, outDir);
+
+            // Must have converted at least one appointment or task.
+            int calCount = report.AppointmentsConverted + report.TasksConverted;
+            Assert.True(calCount > 0,
+                $"Expected >= 1 appointment or task converted; got 0. " +
+                $"Check MAIL2PST_CALENDAR_CORPUS points to a populated store (path={storePath}).");
+
+            // Every warning must match a known structured pattern (no raw exception traces).
+            foreach (var w in report.Warnings)
+            {
+                bool recognised = StructuredWarningPatterns.Any(rx => rx.IsMatch(w.Reason));
+                Assert.True(recognised,
+                    $"Unrecognised (possibly unstructured) warning — check if a new code path " +
+                    $"needs a pattern added to StructuredWarningPatterns:\n  {w.Reason}");
+            }
+        }
+        finally { Directory.Delete(outDir, recursive: true); }
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/ConvertInputTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/ConvertInputTests.cs
@@ -140,4 +140,28 @@ public class ConvertInputTests
             new[] { "--config", "c.json", "--output", "out", "--expected-total", "-5" });
         Assert.NotNull(r.Error);
     }
+
+    /// <summary>
+    /// Should-fix (SF-C): --no-contacts must be honored in explicit --config mode (it was silently
+    /// ignored there while --no-tasks/--no-appointments were honored). Contact sources are stripped.
+    /// </summary>
+    [Fact]
+    public void Resolve_ConfigWithNoContacts_StripsContactSources()
+    {
+        string cfg = Path.Combine(Path.GetTempPath(), "mail2pst-nc-" + Guid.NewGuid() + ".json");
+        File.WriteAllText(cfg,
+            "{\"outputs\":[{\"name\":\"Out\",\"sources\":[]," +
+            "\"contacts\":[{\"path\":\"abook.sqlite\",\"format\":\"thunderbird-sqlite\"}]}]}");
+        try
+        {
+            ConvertResolution with = ConvertInput.Resolve(new[] { "--config", cfg, "--output", "out" });
+            Assert.Null(with.Error);
+            Assert.Single(with.Config!.Outputs[0].Contacts);   // present without the flag
+
+            ConvertResolution without = ConvertInput.Resolve(new[] { "--config", cfg, "--output", "out", "--no-contacts" });
+            Assert.Null(without.Error);
+            Assert.Empty(without.Config!.Outputs[0].Contacts);  // stripped by --no-contacts
+        }
+        finally { File.Delete(cfg); }
+    }
 }

--- a/tests/Mail2Pst.Integration.Tests/RoundTripHarness.cs
+++ b/tests/Mail2Pst.Integration.Tests/RoundTripHarness.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Mail2Pst.Core;
+using Mail2Pst.Core.Calendar;
 using Mail2Pst.Core.Config;
 using Mail2Pst.Core.Contacts;
 using Mail2Pst.Core.Mapping;
@@ -143,6 +144,35 @@ public static class RoundTripHarness
                     else
                         throw new InvalidOperationException(
                             $"Contact read failure while building truth for '{cm.Source.Path}': {r.Error}");
+                }
+            }
+
+            // Count tasks analogously.
+            // The writer ALWAYS pre-creates every task folder in Begin() (same as contacts),
+            // so an empty calendar still yields an IPF.Task folder. Mirror that: always
+            // EnsurePrefixes for every TaskMapping, then add one placeholder MailMessage per
+            // task that CalendarTaskMapper.Map would actually write (non-null result only —
+            // so recurring/skipped todos don't inflate the expected count).
+            foreach (TaskMapping tm in plan.TaskMappings)
+            {
+                IReadOnlyList<string> taskPath = tm.TargetFolderPath;
+                EnsurePrefixes(taskPath);
+                string taskLeafKey = FolderPathKey.Join(taskPath);
+
+                CalendarReadResult calRead = new SqliteCalendarReader().Read(tm.Source.StorePath);
+
+                IEnumerable<RawCalendarRead> cals = string.IsNullOrEmpty(tm.Source.CalId)
+                    ? calRead.Calendars
+                    : calRead.Calendars.Where(c => c.CalId == tm.Source.CalId);
+
+                foreach (RawCalendarRead cal in cals)
+                {
+                    foreach (RawTodoGroup group in cal.TodoGroups)
+                    {
+                        TaskRecord? mapped = CalendarTaskMapper.Map(group, out _);
+                        if (mapped is not null)
+                            truth[taskLeafKey].Add(new MailMessage());
+                    }
                 }
             }
         }

--- a/tests/Mail2Pst.Integration.Tests/RoundTripHarness.cs
+++ b/tests/Mail2Pst.Integration.Tests/RoundTripHarness.cs
@@ -181,6 +181,40 @@ public static class RoundTripHarness
                     }
                 }
             }
+
+            // Count appointments analogously.
+            // The writer ALWAYS pre-creates every appointment folder in Begin() (same as contacts/tasks),
+            // so an empty calendar still yields an IPM.Appointment folder. Mirror that: always
+            // EnsurePrefixes for every AppointmentMapping, then add one placeholder MailMessage per
+            // appointment that CalendarEventMapper.Map would actually write (non-null result only —
+            // so recurring/skipped events don't inflate the expected count).
+            foreach (AppointmentMapping am in plan.AppointmentMappings)
+            {
+                IReadOnlyList<string> apptPath = am.TargetFolderPath;
+                // Always pre-create the folder (mirrors runner's Begin() which pre-creates appointment folders).
+                EnsurePrefixes(apptPath);
+                string apptLeafKey = FolderPathKey.Join(apptPath);
+
+                // Mirror ConversionRunner.ReadStore: an unreadable store warns + continues with 0 appointments.
+                // BuildTruth mirrors that by catching the same exception types and yielding count 0.
+                CalendarReadResult calRead;
+                try { calRead = new SqliteCalendarReader().Read(am.Source.StorePath); }
+                catch (Exception ex) when (ex is IOException or SqliteException) { continue; }
+
+                IEnumerable<RawCalendarRead> apptCals = string.IsNullOrEmpty(am.Source.CalId)
+                    ? calRead.Calendars
+                    : calRead.Calendars.Where(c => c.CalId == am.Source.CalId);
+
+                foreach (RawCalendarRead cal in apptCals)
+                {
+                    foreach (RawEventGroup group in cal.EventGroups)
+                    {
+                        AppointmentRecord? mapped = CalendarEventMapper.Map(group, out _);
+                        if (mapped is not null)
+                            truth[apptLeafKey].Add(new MailMessage());
+                    }
+                }
+            }
         }
         return truth;
     }

--- a/tests/Mail2Pst.Integration.Tests/RoundTripHarness.cs
+++ b/tests/Mail2Pst.Integration.Tests/RoundTripHarness.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Mail2Pst.Core;
 using Mail2Pst.Core.Calendar;
 using Mail2Pst.Core.Config;
+using Microsoft.Data.Sqlite;
 using Mail2Pst.Core.Contacts;
 using Mail2Pst.Core.Mapping;
 using Mail2Pst.Core.Models;
@@ -156,10 +157,15 @@ public static class RoundTripHarness
             foreach (TaskMapping tm in plan.TaskMappings)
             {
                 IReadOnlyList<string> taskPath = tm.TargetFolderPath;
+                // Always pre-create the folder (mirrors runner's Begin() which pre-creates task folders).
                 EnsurePrefixes(taskPath);
                 string taskLeafKey = FolderPathKey.Join(taskPath);
 
-                CalendarReadResult calRead = new SqliteCalendarReader().Read(tm.Source.StorePath);
+                // Mirror ConversionRunner.ReadStore: an unreadable store warns + continues with 0 tasks.
+                // BuildTruth mirrors that by catching the same exception types and yielding count 0.
+                CalendarReadResult calRead;
+                try { calRead = new SqliteCalendarReader().Read(tm.Source.StorePath); }
+                catch (Exception ex) when (ex is IOException or SqliteException) { continue; }
 
                 IEnumerable<RawCalendarRead> cals = string.IsNullOrEmpty(tm.Source.CalId)
                     ? calRead.Calendars

--- a/tests/Mail2Pst.Integration.Tests/TaskIndependentValidationTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/TaskIndependentValidationTests.cs
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core;
+using Mail2Pst.Core.Config;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests;
+
+/// <summary>
+/// Opt-in independent-reader gate for task folders.
+/// Requires MAIL2PST_PST_VALIDATOR to be set (same env-var as IndependentValidationTests).
+/// Without it the test is skipped so CI (no Rust validator) stays green.
+/// </summary>
+public class TaskIndependentValidationTests
+{
+    // Zero-count folders the independent reader may surface that the converter did not create
+    // (known template/system folders). Mirrors IndependentValidationTests.ZeroCountAllowlist.
+    private static readonly HashSet<string> ZeroCountAllowlist = new(StringComparer.Ordinal)
+    {
+        // The from-scratch store (PSTFile.CreateEmptyStore) seeds a default "Deleted Items"
+        // folder under the IPM subtree, which the independent reader surfaces with 0 messages.
+        FolderPathKey.Join(new[] { "Deleted Items" }),
+    };
+
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(60);
+
+    [SkippableFact]
+    public void Convert_CalendarWithTasks_ValidatesTaskFolderCounts()
+    {
+        Skip.If(PstValidatorRunner.ValidatorPath is null,
+            "Set MAIL2PST_PST_VALIDATOR to the built pst-validate exe to run the independent-reader gate.");
+
+        // 2 non-recurring todos → 2 IPM.Task items written; 1 recurring todo → skipped by mapper.
+        const int NonRecurringCount = 2;
+
+        string outDir = Path.Combine(Path.GetTempPath(), "mail2pst-task-indep-" + Guid.NewGuid());
+        Directory.CreateDirectory(outDir);
+        string dbPath = Path.Combine(outDir, "local.sqlite");
+
+        try
+        {
+            // Arrange: build a temp SQLite calendar store with synthetic todos.
+            CreateSqliteCalendarStore(dbPath, NonRecurringCount);
+
+            ConversionConfig config = CalendarOnlyConfig(dbPath);
+
+            // Act: convert.
+            var (outputs, _) = RoundTripHarness.Convert(config, outDir);
+            Assert.NotEmpty(outputs); // a conversion that produced no PST parts would otherwise pass vacuously
+
+            // Expected path-keyed counts from the converter's own truth model (includes task folders).
+            Dictionary<string, int> expected = RoundTripHarness.BuildTruth(config)
+                .ToDictionary(kv => kv.Key, kv => kv.Value.Count, StringComparer.Ordinal);
+
+            // Actual path-keyed counts, aggregated across all output parts via the INDEPENDENT reader.
+            var actual = new Dictionary<string, long>(StringComparer.Ordinal);
+            foreach (string part in outputs)
+            {
+                ValidatorResult r = PstValidatorRunner.Run(part, Timeout);
+                Assert.True(r.Opened, $"validator could not open {Path.GetFileName(part)}: " +
+                    string.Join("; ", r.Errors.Select(e => $"{e.Stage}:{e.Message}")));
+                Assert.Empty(r.Errors);
+                foreach (ValidatedFolder f in r.Folders)
+                {
+                    string key = FolderPathKey.Join(f.Path);
+                    actual[key] = actual.GetValueOrDefault(key) + f.MessageCount;
+                }
+            }
+
+            // Every expected path must match exactly (includes the IPF.Task folder with N tasks).
+            foreach ((string key, int count) in expected)
+            {
+                Assert.True(actual.TryGetValue(key, out long got),
+                    $"expected folder '{key}' missing from independent reader output");
+                Assert.Equal(count, got);
+            }
+
+            // Any UNEXPECTED folder with messages is a failure; zero-count surprises must be allowlisted.
+            foreach ((string key, long got) in actual)
+            {
+                if (expected.ContainsKey(key)) continue;
+                if (got == 0 && ZeroCountAllowlist.Contains(key)) continue;
+                Assert.Fail($"unexpected folder '{key}' with {got} message(s) in independent reader output");
+            }
+        }
+        finally { Directory.Delete(outDir, true); }
+    }
+
+    /// <summary>
+    /// Creates a minimal Thunderbird SQLite calendar store with <paramref name="nonRecurringCount"/>
+    /// non-recurring todos plus one recurring todo (which CalendarTaskMapper skips).
+    /// Schema mirrors what SqliteCalendarReader expects: cal_todos, cal_recurrence, and
+    /// companion side-table stubs (cal_events, cal_alarms, cal_attendees, cal_attachments,
+    /// cal_relations, cal_properties, cal_parameters).
+    /// All data is synthetic — reserved example.org/example.com domains, no real PII.
+    /// </summary>
+    private static void CreateSqliteCalendarStore(string dbPath, int nonRecurringCount)
+    {
+        using var conn = new SqliteConnection($"Data Source={dbPath}");
+        conn.Open();
+
+        void Exec(string sql)
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = sql;
+            cmd.ExecuteNonQuery();
+        }
+
+        // Schema — mirrors what SqliteCalendarReader reads (full column list so the reader doesn't fail).
+        Exec("CREATE TABLE cal_events (cal_id TEXT,id TEXT,time_created INTEGER,last_modified INTEGER,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,event_start INTEGER,event_end INTEGER,event_stamp INTEGER,event_start_tz TEXT,event_end_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,alarm_last_ack INTEGER,offline_journal INTEGER);");
+        Exec("CREATE TABLE cal_todos (cal_id TEXT,id TEXT,time_created INTEGER,last_modified INTEGER,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,todo_entry INTEGER,todo_due INTEGER,todo_completed INTEGER,todo_complete INTEGER,todo_entry_tz TEXT,todo_due_tz TEXT,todo_completed_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,alarm_last_ack INTEGER,todo_stamp INTEGER,offline_journal INTEGER);");
+        Exec("CREATE TABLE cal_recurrence (item_id TEXT,cal_id TEXT,icalString TEXT);");
+        Exec("CREATE TABLE cal_attendees (item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT,icalString TEXT);");
+        Exec("CREATE TABLE cal_alarms (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        Exec("CREATE TABLE cal_attachments (item_id TEXT,cal_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        Exec("CREATE TABLE cal_relations (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        Exec("CREATE TABLE cal_properties (item_id TEXT,key TEXT,value BLOB,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT);");
+        Exec("CREATE TABLE cal_parameters (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,key1 TEXT,key2 TEXT,value TEXT);");
+
+        // Non-recurring todos: T1, T2, … (master rows; no cal_recurrence entries → mapper writes them).
+        for (int i = 1; i <= nonRecurringCount; i++)
+        {
+            // todo_entry / todo_due: synthetic PRTime values (µs since Unix epoch, 2026-06-30 UTC).
+            long entry = 1782864000000000L; // 2026-06-30 00:00:00 UTC in microseconds
+            long due   = entry + (long)i * 3_600_000_000L; // +i hours
+
+            using var insert = conn.CreateCommand();
+            insert.CommandText =
+                "INSERT INTO cal_todos (cal_id,id,title,flags,todo_entry,todo_due,todo_complete,recurrence_id) " +
+                "VALUES (@cal,@id,@title,0,@entry,@due,0,NULL)";
+            insert.Parameters.AddWithValue("@cal",   "TESTCAL");
+            insert.Parameters.AddWithValue("@id",    $"T{i}");
+            insert.Parameters.AddWithValue("@title", $"Test Task {i}");
+            insert.Parameters.AddWithValue("@entry", entry);
+            insert.Parameters.AddWithValue("@due",   due);
+            insert.ExecuteNonQuery();
+        }
+
+        // One recurring todo: TREC — master row + a cal_recurrence entry → mapper skips it.
+        Exec("INSERT INTO cal_todos (cal_id,id,title,flags,todo_entry,todo_complete,recurrence_id) " +
+             "VALUES ('TESTCAL','TREC','Recurring Task (skipped)',0,1782864000000000,0,NULL);");
+        Exec("INSERT INTO cal_recurrence (item_id,cal_id,icalString) VALUES ('TREC','TESTCAL','RRULE:FREQ=WEEKLY');");
+    }
+
+    private static ConversionConfig CalendarOnlyConfig(string dbPath) => new()
+    {
+        Outputs = new List<OutputGroupConfig>
+        {
+            new()
+            {
+                Name = "Tasks",
+                MaxSizeMB = 50_000,
+                // No mail or contact sources — tasks only.
+                Sources = new List<SourceConfig>(),
+                Contacts = new List<ContactSourceConfig>(),
+                Calendars = new List<CalendarSourceConfig>
+                {
+                    new()
+                    {
+                        StorePath = dbPath,
+                        CalId = "TESTCAL",
+                        IncludeTasks = true,
+                        TaskFolderPath = new[] { "Tasks", "TestCalendar" },
+                    },
+                },
+            },
+        },
+    };
+}

--- a/vendor/PSTFileFormat-MODIFICATIONS.md
+++ b/vendor/PSTFileFormat-MODIFICATIONS.md
@@ -222,4 +222,14 @@ authoritative description of the local PSTFileFormat modifications.
   byte-identical. The end-by-date (UNTIL) branch is unchanged (it still uses the heuristic, which
   matches Outlook there). Proven by `AppointmentWriterRecurrenceTests.Count_series_month_overflow_writes_exact_occurrence_count`.
 
+- `Messaging/Messages/RecurrencePatternStructure/AppointmentRecurrencePatternStructure.cs` (`GetBytes`):
+  emit the `ExceptionInfo` and `ExtendedException` arrays sorted ascending by `NewStartDT` (a sorted copy;
+  caller state untouched) instead of in insertion order (ContinuMail addition 2026: appointment recurrence
+  write, pre-merge review #10). `WriteRecurrencePattern` already writes `ModifiedInstanceDates` sorted, and
+  MS-OXOCAL 2.2.1.44 requires the exception arrays to be in the same ascending order and to correspond
+  positionally. Overrides can arrive in arbitrary (SQLite row) order, which desynced the two arrays and
+  risked scanpst `RepairRequired`. Single-exception and already-ordered cases sort to the same bytes, so
+  existing blob gates are unaffected. Proven by
+  `AppointmentWriterRecurrenceTests.Out_of_order_overrides_keep_exception_and_modified_date_arrays_corresponding`.
+
 See the project git history (`git log -- vendor/PSTFileFormat`) for the full diffs.

--- a/vendor/PSTFileFormat-MODIFICATIONS.md
+++ b/vendor/PSTFileFormat-MODIFICATIONS.md
@@ -187,4 +187,16 @@ authoritative description of the local PSTFileFormat modifications.
 
 - Round-tripped recipient track status (`PidTagRecipientTrackStatus`) via `MessageRecipient.ResponseStatus` (written in `AddRecipient`, read in `GetRecipient`), and registered `PidLidResponseStatus` (0x8218, PSETID_Appointment) for meeting recipients (ContinuMail, 2026).
 
+- `Messaging/Messages/RecurringAppointment.cs` (`GetRecurrencePattern`, end-by-date branch): compute
+  `OccurrenceCount` for an end-by-date (UNTIL) recurring series via
+  `CalendarHelper.CalculateNumberOfOccurences(...)` instead of the upstream hard-coded sentinel `10`
+  (ContinuMail addition 2026: appointment recurrence write). Real classic-Outlook output writes the
+  actual occurrence count even for end-by-date series, so the previous fixed `10` produced a
+  `PidLidAppointmentRecur` blob that did not match Outlook byte-for-byte (e.g. the "2nd Tuesday until
+  31 Jan 2027" ground-truth blob has `OccurrenceCount = 7`, not `10`). The computed count is always
+  `>= 1`, preserving the upstream invariant that it must not be `0` (else Outlook 2003's recurrence
+  window fails to load). Proven against the Outlook-authored ground-truth dump by
+  `tests/Mail2Pst.Core.Tests/Vendor/RecurringAppointmentBlobTests.Monthly_2ndTuesday_full_blob_matches_dump`
+  (full-blob byte equality). The end-after-N and never-end branches are unchanged.
+
 See the project git history (`git log -- vendor/PSTFileFormat`) for the full diffs.

--- a/vendor/PSTFileFormat-MODIFICATIONS.md
+++ b/vendor/PSTFileFormat-MODIFICATIONS.md
@@ -244,4 +244,38 @@ authoritative description of the local PSTFileFormat modifications.
   `tests/Mail2Pst.Core.Tests/Vendor/RecurringAppointmentBlobTests.cs`
   (`GetRecurrencePatternBytes_is_the_prefix_of_GetBytes` + `Bare_pattern_matches_task_GT_oracle`).
 
+- Cross-platform PST read path — the timezone reconstruction used when READING a recurring/single appointment
+  back from a store (`OriginalTimeZone` getter -> `TimeZoneStructure.ToTimeZoneInfo` /
+  `TimeZoneDefinitionRecurStructure.ToTimeZoneInfo` / `TimeZoneInfoUtils.GetSystemStaticTimeZone`) called the
+  Windows registry via `RegistryTimeZoneUtils`, which returns `null` from `Registry.LocalMachine.OpenSubKey`
+  on Linux/macOS and then dereferenced it, throwing `NullReferenceException` (ContinuMail addition 2026;
+  surfaced by CI: the calendar tests read appointments back to assert blob bytes and failed on ubuntu/macOS
+  while passing on Windows). Fixes (all null-guards / fallbacks; Windows behaviour is byte-for-byte unchanged
+  because the registry keys are present there):
+  - `Utils/RegistryTimeZoneUtils.Win32.cs`: `GetStaticTimeZoneInformation`, `GetDisplayName`, and
+    `IsDaylightSavingsEnabled` now return gracefully (null / default) when the registry root key is absent.
+  - `Utils/AdjustmentRuleUtils.Win32.cs` (`GetStaticAdjustmentRule`): returns null when the registry info is null.
+  - `Messaging/Messages/TimeZoneStructure/TimeZoneStructure.cs` (`ToTimeZoneInfo`) and
+    `Messaging/Messages/TimeZoneDefinitionStructure/TimeZoneDefinitionRecurStructure.cs` (`ToTimeZoneInfo`):
+    fall back to the zone id when the registry display names are null, so `CreateCustomTimeZone` (which rejects
+    null names) still succeeds — the zone's offset and DST transitions come from the structure bytes, not the
+    registry, so this is display-only.
+  - `Utils/TimeZoneInfoUtils.Win32.cs` (`GetSystemStaticTimeZone`): when the registry info is null, reconstruct
+    from the runtime's own zone database (`TimeZoneInfo.FindSystemTimeZoneById`, cross-platform via ICU),
+    falling back to UTC. The production WRITE path is registry-free already (the zone is cached at
+    `SetOriginalTimeZone`); this makes the READ path (tests / any cross-platform reader use) equally safe.
+  Regression test: `RecurringAppointmentBlobTests.ToTimeZoneInfo_without_registry_display_names_does_not_throw`
+  (runs on Windows too, by using an unknown zone id whose registry key is absent — the same null path as Linux).
+
+- Cross-platform PST write path — `Messaging/Messages/TimeZoneStructure/AdjustmentRuleHelper.cs`
+  (`FromTransitionTime`): some non-Windows (ICU) `TimeZoneInfo` rules express a DST transition as a fixed
+  calendar date over a multi-year span (e.g. "Romance Standard Time"/Europe zones on Linux/macOS), which the
+  one-time `SYSTEMTIME` absolute form cannot hold. Upstream threw
+  `"Cannot create transition time with absolute date that spans multiple years"`, which aborted writing ANY
+  appointment (single or recurring) in such a zone off-Windows (ContinuMail addition 2026; CI-surfaced). It now
+  converts the fixed date to the equivalent relative-yearly rule (Nth weekday of the month) instead of throwing
+  — approximate but valid. Only reached off-Windows (Windows rules are floating, so Windows byte output is
+  unchanged). Regression test:
+  `RecurringAppointmentBlobTests.FromTransitionTime_multi_year_fixed_date_becomes_relative_rule`.
+
 See the project git history (`git log -- vendor/PSTFileFormat`) for the full diffs.

--- a/vendor/PSTFileFormat-MODIFICATIONS.md
+++ b/vendor/PSTFileFormat-MODIFICATIONS.md
@@ -185,4 +185,6 @@ authoritative description of the local PSTFileFormat modifications.
   the earlier ContinuMail batch; verified against MS-OXPROPS specification and a real Outlook
   contact PST with embedded photo).
 
+- Round-tripped recipient track status (`PidTagRecipientTrackStatus`) via `MessageRecipient.ResponseStatus` (written in `AddRecipient`, read in `GetRecipient`), and registered `PidLidResponseStatus` (0x8218, PSETID_Appointment) for meeting recipients (ContinuMail, 2026).
+
 See the project git history (`git log -- vendor/PSTFileFormat`) for the full diffs.

--- a/vendor/PSTFileFormat-MODIFICATIONS.md
+++ b/vendor/PSTFileFormat-MODIFICATIONS.md
@@ -199,4 +199,16 @@ authoritative description of the local PSTFileFormat modifications.
   `tests/Mail2Pst.Core.Tests/Vendor/RecurringAppointmentBlobTests.Monthly_2ndTuesday_full_blob_matches_dump`
   (full-blob byte equality). The end-after-N and never-end branches are unchanged.
 
+- `Messaging/Messages/RecurringAppointment.cs` (`OriginalTimeZone` getter + `SetOriginalTimeZone` +
+  new `m_originalTimeZone` field): cache the zone supplied to `SetOriginalTimeZone` and return it
+  directly from the `OriginalTimeZone` getter on the write path, instead of re-deriving it from the
+  serialized `PidLidTimeZoneStruct` blob via `RegistryTimeZoneUtils` (ContinuMail addition 2026:
+  cross-platform recurrence write). The getter is read repeatedly while writing (the `StartDTUtc` and
+  `LastInstanceStartDate` setters and `SaveChanges`); the upstream blob-derivation path calls
+  `Microsoft.Win32.Registry`, which throws `PlatformNotSupportedException` on Linux/macOS (and, for a
+  zone whose key name is absent from the registry, silently falls back to the local system zone). The
+  cached field is null when the object is constructed by reading an existing file, so the read path is
+  unchanged. Output PSTs are byte-for-byte unchanged (all `RecurringAppointmentBlobTests` full-blob
+  gates still pass); proven by `RecurringAppointmentBlobTests.SetOriginalTimeZone_is_cached_not_re_derived_from_registry`.
+
 See the project git history (`git log -- vendor/PSTFileFormat`) for the full diffs.

--- a/vendor/PSTFileFormat-MODIFICATIONS.md
+++ b/vendor/PSTFileFormat-MODIFICATIONS.md
@@ -211,4 +211,15 @@ authoritative description of the local PSTFileFormat modifications.
   unchanged. Output PSTs are byte-for-byte unchanged (all `RecurringAppointmentBlobTests` full-blob
   gates still pass); proven by `RecurringAppointmentBlobTests.SetOriginalTimeZone_is_cached_not_re_derived_from_registry`.
 
+- `Messaging/Messages/RecurringAppointment.cs` (new nullable `OccurrenceCount` field +
+  `GetRecurrencePattern` end-after-N branch): when the caller supplies an explicit occurrence count
+  (`OccurrenceCount > 0`), write it verbatim as the blob's `OccurrenceCount` instead of the date-span
+  heuristic `CalendarHelper.CalculateNumberOfOccurences(...)` (ContinuMail addition 2026: appointment
+  recurrence write, pre-merge review #5). The heuristic overcounts period-skipping COUNT series (e.g.
+  `FREQ=MONTHLY;BYMONTHDAY=31;COUNT=5` spans 7 months → wrote 8; Feb-29 yearly `COUNT=3` → wrote 9),
+  producing phantom occurrences in Outlook. The field is null for callers that do not set it (the
+  vendor blob tests set `EndAfterNumberOfOccurences` directly), so those keep the heuristic and stay
+  byte-identical. The end-by-date (UNTIL) branch is unchanged (it still uses the heuristic, which
+  matches Outlook there). Proven by `AppointmentWriterRecurrenceTests.Count_series_month_overflow_writes_exact_occurrence_count`.
+
 See the project git history (`git log -- vendor/PSTFileFormat`) for the full diffs.

--- a/vendor/PSTFileFormat-MODIFICATIONS.md
+++ b/vendor/PSTFileFormat-MODIFICATIONS.md
@@ -232,4 +232,16 @@ authoritative description of the local PSTFileFormat modifications.
   existing blob gates are unaffected. Proven by
   `AppointmentWriterRecurrenceTests.Out_of_order_overrides_keep_exception_and_modified_date_arrays_corresponding`.
 
+- `Messaging/Messages/RecurrencePatternStructure/AppointmentRecurrencePatternStructure.cs`: extracted the
+  RecurrencePattern prefix bytes (ReaderVersion … EndDate) of `GetBytes` into a private
+  `WriteRecurrencePattern(MemoryStream)` and added a public `byte[] GetRecurrencePatternBytes()` that emits
+  ONLY that prefix — the bare MS-OXOCAL RecurrencePattern with no AppointmentRecurrencePattern tail
+  (ContinuMail addition 2026: needed because `PidLidTaskRecurrence` (0x8116, PSETID_Task) stores a bare
+  RecurrencePattern). `GetBytes` delegates the prefix to `WriteRecurrencePattern` and stays byte-identical
+  for every appointment path. Supporting: `Messaging/Enums/PropertyLongID.cs` added
+  `PidLidTaskRecurrence = 0x00008116`; `Messaging/NamedProperties/PropertyNames.cs` registered
+  `PidLidTaskFRecurring` + `PidLidTaskRecurrence` under `PSETID_Task`. Byte-gated by
+  `tests/Mail2Pst.Core.Tests/Vendor/RecurringAppointmentBlobTests.cs`
+  (`GetRecurrencePatternBytes_is_the_prefix_of_GetBytes` + `Bare_pattern_matches_task_GT_oracle`).
+
 See the project git history (`git log -- vendor/PSTFileFormat`) for the full diffs.

--- a/vendor/PSTFileFormat/Messaging/Attachments/AttachmentObject.cs
+++ b/vendor/PSTFileFormat/Messaging/Attachments/AttachmentObject.cs
@@ -33,6 +33,28 @@ namespace PSTFileFormat
             }
         }
 
+        public void StoreModifiedInstance(ModifiedAppointmentInstance modifiedInstance, TimeZoneInfo timezone)
+        {
+            PC.SetDateTimeProperty(PropertyID.PidTagExceptionReplaceTime, modifiedInstance.StartDTUtc);
+            PC.SetDateTimeProperty(PropertyID.PidTagExceptionStartTime, modifiedInstance.GetStartDTZone(timezone));
+            PC.SetDateTimeProperty(PropertyID.PidTagExceptionEndTime, modifiedInstance.GetEndDTZone(timezone));
+            int dataSize;
+            if (this.File.WriterCompatibilityMode < WriterCompatibilityMode.Outlook2007SP2)
+            {
+                dataSize = modifiedInstance.PC.GetTotalLengthOfAllProperties();
+            }
+            else
+            {
+                dataSize = modifiedInstance.DataTree.TotalDataLength;
+            }
+            // The length must include the message size as well, so we add it as placeholder
+            PC.SetInt32Property(PropertyID.PidTagAttachSize, 0);
+            int attachmentSize = this.PC.GetTotalLengthOfAllProperties() + dataSize;
+
+            PC.SetObjectProperty(PropertyID.PidTagAttachData, modifiedInstance.SubnodeID, dataSize);
+            PC.SetInt32Property(PropertyID.PidTagAttachSize, attachmentSize);
+        }
+
         public static AttachmentObject CreateNewAttachmentObject(PSTFile file, SubnodeBTree subnodeBTree)
         {
             PropertyContext pc = PropertyContext.CreateNewPropertyContext(file);
@@ -45,5 +67,25 @@ namespace PSTFileFormat
             return new AttachmentObject(subnode);
         }
 
+        public static AttachmentObject CreateNewExceptionAttachmentObject(PSTFile file, SubnodeBTree subnodeBTree)
+        {
+            AttachmentObject attachment = CreateNewAttachmentObject(file, subnodeBTree);
+            attachment.PC.SetStringProperty(PropertyID.PidTagDisplayName, "Untitled");
+            attachment.PC.SetStringProperty(PropertyID.PidTagAttachEncoding, String.Empty);
+            //attachment.PC.SetBytesProperty(PropertyID.PidTagAttachRendering, AppointmentAttachRendering);
+
+            attachment.PC.SetInt32Property(PropertyID.PidTagAttachMethod, (int)AttachMethod.EmbeddedMessage);
+            attachment.PC.SetInt32Property(PropertyID.PidTagAttachFlags, 0);
+            attachment.PC.SetInt32Property(PropertyID.PidTagAttachmentFlags, (int)AttachmentFlags.afException);
+            attachment.PC.SetInt32Property(PropertyID.PidTagAttachmentLinkId, 0);
+            attachment.PC.SetInt32Property(PropertyID.PidTagRenderingPosition, -1);
+
+            attachment.PC.SetBooleanProperty(PropertyID.PidTagAttachmentHidden, true);
+            attachment.PC.SetBooleanProperty(PropertyID.PidTagAttachmentContactPhoto, false);
+
+            attachment.CreateSubnodeBTreeIfNotExist();
+
+            return attachment;
+        }
     }
 }

--- a/vendor/PSTFileFormat/Messaging/Enums/MeetingType.cs
+++ b/vendor/PSTFileFormat/Messaging/Enums/MeetingType.cs
@@ -1,0 +1,8 @@
+
+namespace PSTFileFormat
+{
+    public enum MeetingType
+    {
+        WindowsNetmeeting = 0x00000000,
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Enums/PropertyLongID.cs
+++ b/vendor/PSTFileFormat/Messaging/Enums/PropertyLongID.cs
@@ -19,6 +19,7 @@ namespace PSTFileFormat
         PidLidTaskEstimatedEffort = 0x00008111,   // Int32
         PidLidTaskVersion = 0x00008112,           // Int32
         PidLidTaskState = 0x00008113,             // Int32
+        PidLidTaskDateCompleted = 0x0000810F,     // DateTime  // ContinuMail addition 2026
         PidLidTaskComplete = 0x0000811C,          // Boolean
         PidLidTaskAssigner = 0x00008121,          // String
         PidLidTaskOrdinal = 0x00008123,           // Int32

--- a/vendor/PSTFileFormat/Messaging/Enums/PropertyLongID.cs
+++ b/vendor/PSTFileFormat/Messaging/Enums/PropertyLongID.cs
@@ -24,6 +24,7 @@ namespace PSTFileFormat
         PidLidTaskAssigner = 0x00008121,          // String
         PidLidTaskOrdinal = 0x00008123,           // Int32
         PidLidTaskNoCompute = 0x00008124,         // Boolean
+        PidLidTaskRecurrence = 0x00008116,        // Binary (bare RecurrencePattern, PR7b ContinuMail 2026)
         PidLidTaskFRecurring = 0x00008126,        // Boolean
         PidLidTaskRole = 0x00008127,              // String
         PidLidTaskOwnership = 0x00008129,         // Int32

--- a/vendor/PSTFileFormat/Messaging/Enums/PropertySetGuid.cs
+++ b/vendor/PSTFileFormat/Messaging/Enums/PropertySetGuid.cs
@@ -13,6 +13,8 @@ namespace PSTFileFormat
         public static readonly Guid PSETID_Appointment = new Guid("{00062002-0000-0000-C000-000000000046}");
         // ContinuMail addition 2026: PSETID_Address (contacts)
         public static readonly Guid PSETID_Address = new Guid("{00062004-0000-0000-C000-000000000046}");
+        // ContinuMail addition 2026: PSETID_Task (tasks)
+        public static readonly Guid PSETID_Task = new Guid("{00062003-0000-0000-C000-000000000046}");
         public static readonly Guid PSETID_Meeting = new Guid("{6ED8DA90-450B-101B-98DA-00AA003F1305}");
     }
 }

--- a/vendor/PSTFileFormat/Messaging/Exceptions/InvalidRecurrencePatternException.cs
+++ b/vendor/PSTFileFormat/Messaging/Exceptions/InvalidRecurrencePatternException.cs
@@ -1,0 +1,21 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PSTFileFormat
+{
+    public class InvalidRecurrencePatternException : InvalidPropertyException
+    {
+        public InvalidRecurrencePatternException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Folders/CalendarFolder.cs
+++ b/vendor/PSTFileFormat/Messaging/Folders/CalendarFolder.cs
@@ -1,0 +1,77 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Utilities;
+
+namespace PSTFileFormat
+{
+    public class CalendarFolder : PSTFolder
+    {
+        public CalendarFolder(PSTNode node) : base(node)
+        {
+        }
+
+        public Appointment GetAppointment(int index)
+        {
+            TableContext tc = GetContentsTable();
+            if (tc != null)
+            {
+                if (index < tc.RowCount)
+                {
+                    // dwRowID is the MessageID
+                    NodeID nodeID = new NodeID(tc.GetRowID(index));
+                    Appointment appointment = Appointment.GetAppointment(this.File, nodeID);
+                    return appointment;
+                }
+            }
+            return null;
+        }
+
+        public override void AddContentTableColumns(NamedTableContext contentsTable)
+        {
+            base.AddContentTableColumns(contentsTable);
+
+            contentsTable.AddPropertyColumnIfNotExist(PropertyID.PidTagCreationTime, PropertyTypeName.PtypTime);
+
+            contentsTable.AddPropertyColumnIfNotExist(PropertyNames.PidLidRecurring, PropertyTypeName.PtypBoolean);
+            contentsTable.AddPropertyColumnIfNotExist(PropertyNames.PidLidAppointmentEndWhole, PropertyTypeName.PtypTime);
+            contentsTable.AddPropertyColumnIfNotExist(PropertyNames.PidLidSideEffects, PropertyTypeName.PtypInteger32);
+            contentsTable.AddPropertyColumnIfNotExist(PropertyNames.PidLidHeaderItem, PropertyTypeName.PtypInteger32);
+            contentsTable.AddPropertyColumnIfNotExist(PropertyNames.PidLidAppointmentStateFlags, PropertyTypeName.PtypInteger32);
+            contentsTable.AddPropertyColumnIfNotExist(PropertyNames.PidLidFInvited, PropertyTypeName.PtypBoolean);
+            contentsTable.AddPropertyColumnIfNotExist(PropertyNames.PidLidAppointmentColor, PropertyTypeName.PtypInteger32);
+            contentsTable.AddPropertyColumnIfNotExist(PropertyNames.PidLidTimeZoneStruct, PropertyTypeName.PtypBinary);
+            contentsTable.AddPropertyColumnIfNotExist(PropertyNames.PidLidLocation, PropertyTypeName.PtypString);
+            contentsTable.AddPropertyColumnIfNotExist(PropertyNames.PidLidReminderSet, PropertyTypeName.PtypBoolean);
+            contentsTable.AddPropertyColumnIfNotExist(PropertyNames.PidLidAppointmentRecur, PropertyTypeName.PtypBinary);
+            contentsTable.AddPropertyColumnIfNotExist(PropertyNames.PidLidAppointmentSubType, PropertyTypeName.PtypBoolean);
+            contentsTable.AddPropertyColumnIfNotExist(PropertyNames.PidLidBusyStatus, PropertyTypeName.PtypInteger32);
+            contentsTable.AddPropertyColumnIfNotExist(PropertyNames.PidLidAppointmentStartWhole, PropertyTypeName.PtypTime);
+            contentsTable.AddPropertyColumnIfNotExist(PropertyNames.PidLidMeetingWorkspaceUrl, PropertyTypeName.PtypString);
+
+            if (this.File.WriterCompatibilityMode >= WriterCompatibilityMode.Outlook2010RTM)
+            {
+                contentsTable.AddPropertyColumnIfNotExist(PropertyNames.PidLidTimeZoneDescription, PropertyTypeName.PtypString);
+                contentsTable.AddPropertyColumnIfNotExist(PropertyNames.PidLidAppointmentTimeZoneDefinitionRecur, PropertyTypeName.PtypBinary);
+                contentsTable.AddPropertyColumnIfNotExist(PropertyNames.PidLidAppointmentTimeZoneDefinitionStartDisplay, PropertyTypeName.PtypBinary);
+                contentsTable.AddPropertyColumnIfNotExist(PropertyNames.PidLidAppointmentTimeZoneDefinitionEndDisplay, PropertyTypeName.PtypBinary);
+            }
+        }
+
+        public int AppointmentCount
+        {
+            get
+            {
+                return this.MessageCount;
+            }
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Folders/PSTFolder.cs
+++ b/vendor/PSTFileFormat/Messaging/Folders/PSTFolder.cs
@@ -731,6 +731,8 @@ namespace PSTFileFormat
                     {
                         case FolderItemTypeName.Note:
                             return new MailFolder(node);
+                        case FolderItemTypeName.Appointment:
+                            return new CalendarFolder(node);
                         default:
                             return new PSTFolder(node);
                     }

--- a/vendor/PSTFileFormat/Messaging/Messages/Appointment.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/Appointment.cs
@@ -1,0 +1,444 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Utilities;
+
+namespace PSTFileFormat
+{
+    public abstract class Appointment : MessageObject
+    {
+        protected Appointment(PSTNode node) : base(node)
+        {
+        }
+
+        public override void SaveChanges()
+        {
+            base.SaveChanges();
+        }
+
+        public abstract void SetStartAndDuration(DateTime startDTUtc, int duration);
+
+        public void SetOriginalTimeZone(TimeZoneInfo staticTimeZone)
+        {
+            int effectiveYear = DateTime.Now.Year;
+            TimeZoneInfo.AdjustmentRule[] adjustmentRules = staticTimeZone.GetAdjustmentRules();
+            if (adjustmentRules.Length == 1)
+            {
+                if (adjustmentRules[0].DateStart.Year == adjustmentRules[0].DateEnd.Year)
+                {
+                    effectiveYear = adjustmentRules[0].DateStart.Year;
+                }
+            }
+            SetOriginalTimeZone(staticTimeZone, null, effectiveYear);
+        }
+
+        /// <param name="dynamicTimeZone">can be set to null if not available</param>
+        public abstract void SetOriginalTimeZone(TimeZoneInfo staticTimeZone, TimeZoneInfo dynamicTimeZone, int effectiveYear);
+
+        public abstract DateTime StartDTUtc
+        {
+            get;
+            set;
+        }
+
+        public abstract int Duration
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Outlook 2007 SP3 has a weird bug:
+        /// On a day that has a DST transition rule such as 02:00 -> 03:00,
+        /// Appointment that start at 02:30 and end at 03:00 will have a negative UTC duration.
+        /// (as reflected by ClipStart and ClipEnd).
+        /// Outlook will later ignore such appointments.
+        /// </summary>
+        public bool IsDurationValid
+        {
+            get
+            {
+                if (Duration < 0)
+                {
+                    return false;
+                }
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// - This property is not required.
+        /// - The number of minutes from start to end in timezone time. (UNDOCUMENTED)
+        /// - Single appointment: 
+        ///   Due to daylight savings, there could be a difference between the timezone duration and the UTC duration.
+        /// </summary>
+        public int AppointmentDuration
+        {
+            get
+            {
+                return PC.GetInt32Property(PropertyNames.PidLidAppointmentDuration, 0);
+            }
+            set
+            {
+                PC.SetInt32Property(PropertyNames.PidLidAppointmentDuration, (int)value);
+            }
+        }
+
+        /// <summary>
+        /// Single Appointment: start date and time of the event in UTC.
+        /// Recurring Appointment: midnight on the date of the first instance in UTC
+        /// Note: for single appointments, StartWhole has precedence.
+        /// </summary>
+        protected DateTime ClipStart
+        {
+            get
+            {
+                return PC.GetDateTimeProperty(PropertyNames.PidLidClipStart, DateTime.MinValue);
+            }
+            set
+            {
+                PC.SetDateTimeProperty(PropertyNames.PidLidClipStart, value);
+            }
+        }
+
+        /// <summary>
+        /// Single Appointment: end date and time of the event in UTC.
+        /// Recurring Appointment: midnight on the date of the last instance in UTC
+        /// (unless the recurring series has no end, in which case the value must be 31 August 4500, 11:59)
+        /// Note: for single appointments, EndWhole has precedence.
+        /// </summary>
+        protected DateTime ClipEnd
+        {
+            get
+            {
+                return PC.GetDateTimeProperty(PropertyNames.PidLidClipEnd, DateTime.MinValue);
+            }
+            set
+            {
+                PC.SetDateTimeProperty(PropertyNames.PidLidClipEnd, value);
+            }
+        }
+
+        /// <summary>
+        /// Start date and time of the first instance (in UTC)
+        /// </summary>
+        protected DateTime CommonStart
+        {
+            get
+            {
+                return PC.GetDateTimeProperty(PropertyNames.PidLidCommonStart, DateTime.MinValue);
+            }
+            set
+            {
+                PC.SetDateTimeProperty(PropertyNames.PidLidCommonStart, value);
+            }
+        }
+
+        /// <summary>
+        /// End date and time of the first instance (in UTC)
+        /// </summary>
+        protected DateTime CommonEnd
+        {
+            get
+            {
+                return PC.GetDateTimeProperty(PropertyNames.PidLidCommonEnd, DateTime.MinValue);
+            }
+            set
+            {
+                PC.SetDateTimeProperty(PropertyNames.PidLidCommonEnd, value);
+            }
+        }
+
+        /// <summary>
+        /// Start date and time of the first instance (in UTC)
+        /// </summary>
+        protected DateTime StartWhole
+        {
+            get
+            {
+                return PC.GetDateTimeProperty(PropertyNames.PidLidAppointmentStartWhole, DateTime.MinValue);
+            }
+            set
+            {
+                PC.SetDateTimeProperty(PropertyNames.PidLidAppointmentStartWhole, value);
+            }
+        }
+
+        /// <summary>
+        /// End date and time of the first instance (in UTC)
+        /// </summary>
+        protected DateTime EndWhole
+        {
+            get
+            {
+                return PC.GetDateTimeProperty(PropertyNames.PidLidAppointmentEndWhole, DateTime.MinValue);
+            }
+            set
+            {
+                PC.SetDateTimeProperty(PropertyNames.PidLidAppointmentEndWhole, value);
+            }
+        }
+
+        /// <summary>
+        /// Maximum length: 255 characters
+        /// </summary>
+        public string Location
+        {
+            get
+            {
+                return PC.GetStringProperty(PropertyNames.PidLidLocation);
+            }
+            set
+            {
+                PC.SetStringProperty(PropertyNames.PidLidLocation, value);
+            }
+        }
+
+        public int Color
+        {
+            get
+            {
+                return PC.GetInt32Property(PropertyNames.PidLidAppointmentColor, 0);
+            }
+            set
+            {
+                PC.SetInt32Property(PropertyNames.PidLidAppointmentColor, value);
+            }
+        }
+
+        public MeetingType ConferencingType
+        {
+            set
+            {
+                PC.SetInt32Property(PropertyNames.PidLidConferencingType, (int)value);
+            }
+        }
+
+        public bool IsPrivate
+        {
+            get
+            {
+                return PC.GetBooleanProperty(PropertyNames.PidLidPrivate, false);
+            }
+            set
+            {
+                PC.SetBooleanProperty(PropertyNames.PidLidPrivate, value);
+            }
+        }
+
+        /// <summary>
+        /// true if represents a recurring series.
+        /// </summary>
+        protected bool Recurring
+        {
+            get
+            {
+                return PC.GetBooleanProperty(PropertyNames.PidLidRecurring, false);
+            }
+            set
+            {
+                PC.SetBooleanProperty(PropertyNames.PidLidRecurring, value);
+            }
+        }
+
+        /// <summary>
+        /// true if associated with a recurring series
+        /// </summary>
+        protected bool IsRecurring
+        {
+            get
+            {
+                return PC.GetBooleanProperty(PropertyNames.PidLidIsRecurring, false);
+            }
+            set
+            {
+                PC.SetBooleanProperty(PropertyNames.PidLidIsRecurring, value);
+            }
+        }
+
+        /// <summary>
+        /// Specify whether this is an all day event
+        /// </summary>
+        public bool AppointmentSubType
+        {
+            get
+            {
+                return PC.GetBooleanProperty(PropertyNames.PidLidAppointmentSubType, false);
+            }
+            set
+            {
+                PC.SetBooleanProperty(PropertyNames.PidLidAppointmentSubType, value);
+            }
+        }
+
+        public bool IsReminderSet
+        {
+            set
+            {
+                PC.SetBooleanProperty(PropertyNames.PidLidReminderSet, value);
+            }
+        }
+
+        public BusyStatus BusyStatus
+        {
+            get
+            {
+                Nullable<int> result = PC.GetInt32Property(PropertyNames.PidLidBusyStatus);
+                if (result.HasValue)
+                {
+                    return (BusyStatus)result.Value;
+                }
+                return BusyStatus.Avaiable;
+            }
+            set
+            {
+                PC.SetInt32Property(PropertyNames.PidLidBusyStatus, (int)value);
+            }
+        }
+
+        public bool InvitationsHaveBeenSent
+        {
+            set
+            {
+                PC.SetBooleanProperty(PropertyNames.PidLidFInvited, value);
+            }
+        }
+
+        public int StateFlags
+        {
+            set
+            {
+                PC.SetInt32Property(PropertyNames.PidLidAppointmentStateFlags, value);
+            }
+        }
+
+        public bool SmartNoAttach
+        {
+            set
+            {
+                PC.SetBooleanProperty(PropertyNames.PidLidSmartNoAttach, value);
+            }
+        }
+
+        /// <summary>
+        /// Outlook 2010 will use PidLidTimeZoneDescription in the following case:
+        /// In order for Outlook 2010 to recalculate the UTC time of an appointment, it needs to know the current timezone of the appointment as well as
+        /// the historic one (PidLidTimeZoneStruct), so if PidLidAppointmentTimeZoneDefinitionStartDisplay is not present, this propery will be used.
+        /// </summary>
+        public string TimeZoneDescription
+        {
+            get
+            {
+                return PC.GetStringProperty(PropertyNames.PidLidTimeZoneDescription);
+            }
+            set
+            {
+                PC.SetStringProperty(PropertyNames.PidLidTimeZoneDescription, value);
+            }
+        }
+
+        public abstract TimeZoneInfo OriginalTimeZone
+        {
+            get;
+        }
+
+        public abstract bool HasTimeZoneDefinition
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Created by Outlook 2003 SP3 and above.
+        /// Used by Outlook 2007 to display single appointments.
+        /// Outlook 2010 will use this to display recurring appointments.
+        /// If this property is missing, the current local time zone is assumed.
+        /// http://msdn.microsoft.com/en-us/library/cc765598.aspx
+        /// 
+        /// the value of the PidLidAppointmentTimeZoneDefinitionStartDisplay property is to be used for all time properties,
+        /// including the PidLidAppointmentEndWhole property.
+        /// http://msdn.microsoft.com/en-us/library/ee219440%28v=exchg.80%29
+        /// </summary>
+        public TimeZoneDefinitionStructure TimeZoneDefinitionStartDisplay
+        {
+            get
+            {
+                byte[] bytes = PC.GetBytesProperty(PropertyNames.PidLidAppointmentTimeZoneDefinitionStartDisplay);
+                if (bytes != null)
+                {
+                    TimeZoneDefinitionStructure structure = new TimeZoneDefinitionStructure(bytes);
+                    return structure;
+                }
+                return null;
+            }
+            set
+            {
+                PC.SetBytesProperty(PropertyNames.PidLidAppointmentTimeZoneDefinitionStartDisplay, value.GetBytes());
+            }
+        }
+
+        /// <summary>
+        /// Created by Outlook 2003 SP3 and above.
+        /// If this property is missing, the time zone specified by the PidLidAppointmentTimeZoneDefinitionStartDisplay property is used,
+        /// If the latter is missing or invalid, the current local time zone is assumed.
+        /// http://msdn.microsoft.com/en-us/library/cc842082%28v=office.12%29.aspx
+        /// </summary>
+        public TimeZoneDefinitionStructure TimeZoneDefinitionEndDisplay
+        {
+            get
+            {
+                byte[] bytes = PC.GetBytesProperty(PropertyNames.PidLidAppointmentTimeZoneDefinitionEndDisplay);
+                if (bytes != null)
+                {
+                    TimeZoneDefinitionStructure structure = new TimeZoneDefinitionStructure(bytes);
+                    return structure;
+                }
+                return null;
+            }
+            set
+            {
+                PC.SetBytesProperty(PropertyNames.PidLidAppointmentTimeZoneDefinitionEndDisplay, value.GetBytes());
+            }
+        }
+
+        public bool IsAllDayEvent
+        {
+            get
+            {
+                return AppointmentSubType;
+            }
+            set
+            {
+                AppointmentSubType = value;
+            }
+        }
+
+        public static Appointment GetAppointment(PSTFile file, NodeID nodeID)
+        {
+            PSTNode node = file.GetNode(nodeID);
+            NamedPropertyContext pc = node.PC;
+            if (pc != null)
+            {
+                bool recurring = pc.GetBooleanProperty(PropertyNames.PidLidRecurring, false);
+                if (recurring)
+                {
+                    return new RecurringAppointment(node);
+                }
+                else
+                {
+                    return new SingleAppointment(node);
+                }
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/ModifiedAppointmentInstance.AppointmentProperties.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/ModifiedAppointmentInstance.AppointmentProperties.cs
@@ -1,0 +1,281 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PSTFileFormat
+{
+    public partial class ModifiedAppointmentInstance
+    {
+        /// <summary>
+        /// - This property is not required.
+        /// - The number of minutes from start to end in timezone time. (UNDOCUMENTED)
+        /// - Due to daylight savings, there could be a difference between the timezone duration and the UTC duration.
+        /// </summary>
+        public int AppointmentDuration
+        {
+            get
+            {
+                return PC.GetInt32Property(PropertyNames.PidLidAppointmentDuration, 0);
+            }
+            set
+            {
+                PC.SetInt32Property(PropertyNames.PidLidAppointmentDuration, (int)value);
+            }
+        }
+
+        /// <summary>
+        /// Single Appointment: start date and time of the event in UTC.
+        /// Recurring Appointment: midnight on the date of the first instance in UTC
+        /// </summary>
+        protected DateTime ClipStart
+        {
+            get
+            {
+                return PC.GetDateTimeProperty(PropertyNames.PidLidClipStart, DateTime.MinValue);
+            }
+            set
+            {
+                PC.SetDateTimeProperty(PropertyNames.PidLidClipStart, value);
+            }
+        }
+
+        /// <summary>
+        /// Single Appointment: end date and time of the event in UTC.
+        /// Recurring Appointment: midnight on the date of the last instance in UTC
+        /// (unless the recurring series has no end, in which case the value must be 31 August 4500, 11:59)
+        /// </summary>
+        protected DateTime ClipEnd
+        {
+            get
+            {
+                return PC.GetDateTimeProperty(PropertyNames.PidLidClipEnd, DateTime.MinValue);
+            }
+            set
+            {
+                PC.SetDateTimeProperty(PropertyNames.PidLidClipEnd, value);
+            }
+        }
+
+        /// <summary>
+        /// Start date and time of the first instance
+        /// </summary>
+        protected DateTime CommonStart
+        {
+            get
+            {
+                return PC.GetDateTimeProperty(PropertyNames.PidLidCommonStart, DateTime.MinValue);
+            }
+            set
+            {
+                PC.SetDateTimeProperty(PropertyNames.PidLidCommonStart, value);
+            }
+        }
+
+        /// <summary>
+        /// End date and time of the first instance
+        /// </summary>
+        protected DateTime CommonEnd
+        {
+            get
+            {
+                return PC.GetDateTimeProperty(PropertyNames.PidLidCommonEnd, DateTime.MinValue);
+            }
+            set
+            {
+                PC.SetDateTimeProperty(PropertyNames.PidLidCommonEnd, value);
+            }
+        }
+
+        /// <summary>
+        /// Start date and time of the first instance
+        /// </summary>
+        protected DateTime StartWhole
+        {
+            get
+            {
+                return PC.GetDateTimeProperty(PropertyNames.PidLidAppointmentStartWhole, DateTime.MinValue);
+            }
+            set
+            {
+                PC.SetDateTimeProperty(PropertyNames.PidLidAppointmentStartWhole, value);
+            }
+        }
+
+        /// <summary>
+        /// End date and time of the first instance
+        /// </summary>
+        protected DateTime EndWhole
+        {
+            get
+            {
+                return PC.GetDateTimeProperty(PropertyNames.PidLidAppointmentEndWhole, DateTime.MinValue);
+            }
+            set
+            {
+                PC.SetDateTimeProperty(PropertyNames.PidLidAppointmentEndWhole, value);
+            }
+        }
+
+        /// <summary>
+        /// Specifies the date and time, in UTC, that the exception will replace
+        /// </summary>
+        public DateTime ExceptionReplaceTime
+        {
+            get
+            {
+                return PC.GetDateTimeProperty(PropertyNames.PidLidExceptionReplaceTime, DateTime.MinValue);
+            }
+            set
+            {
+                PC.SetDateTimeProperty(PropertyNames.PidLidExceptionReplaceTime, value);
+            }
+        }
+
+        /// <summary>
+        /// Original Start DT (not just date)
+        /// </summary>
+        public DateTime StartDate
+        {
+            get
+            {
+                return PC.GetDateTimeProperty(PropertyID.PidTagStartDate, DateTime.MinValue);
+            }
+            set
+            {
+                PC.SetDateTimeProperty(PropertyID.PidTagStartDate, value);
+            }
+        }
+
+        /// <summary>
+        /// Original End DT (not just date)
+        /// </summary>
+        public DateTime EndDate
+        {
+            get
+            {
+                return PC.GetDateTimeProperty(PropertyID.PidTagEndDate, DateTime.MinValue);
+            }
+            set
+            {
+                PC.SetDateTimeProperty(PropertyID.PidTagEndDate, value);
+            }
+        }
+
+        /// <summary>
+        /// Maximum length: 255 characters
+        /// </summary>
+        public string Location
+        {
+            get
+            {
+                return PC.GetStringProperty(PropertyNames.PidLidLocation);
+            }
+            set
+            {
+                PC.SetStringProperty(PropertyNames.PidLidLocation, value);
+            }
+        }
+
+        public int Color
+        {
+            get
+            {
+                return PC.GetInt32Property(PropertyNames.PidLidAppointmentColor, 0);
+            }
+            set
+            {
+                PC.SetInt32Property(PropertyNames.PidLidAppointmentColor, value);
+            }
+        }
+
+        public MeetingType ConferencingType
+        {
+            set
+            {
+                PC.SetInt32Property(PropertyNames.PidLidConferencingType, (int)value);
+            }
+        }
+
+        public bool IsPrivate
+        {
+            set
+            {
+                PC.SetBooleanProperty(PropertyNames.PidLidPrivate, value);
+            }
+        }
+
+        /// <summary>
+        /// true if represents a recurring series.
+        /// </summary>
+        protected bool Recurring
+        {
+            get
+            {
+                return PC.GetBooleanProperty(PropertyNames.PidLidRecurring, false);
+            }
+            set
+            {
+                PC.SetBooleanProperty(PropertyNames.PidLidRecurring, value);
+            }
+        }
+
+        /// <summary>
+        /// true if associated with a recurring series
+        /// </summary>
+        protected bool IsRecurring
+        {
+            set
+            {
+                PC.SetBooleanProperty(PropertyNames.PidLidIsRecurring, value);
+            }
+        }
+
+        /// <summary>
+        /// Specify whether this is an all day event
+        /// </summary>
+        public bool AppointmentSubType
+        {
+            get
+            {
+                return PC.GetBooleanProperty(PropertyNames.PidLidAppointmentSubType, false);
+            }
+            set
+            {
+                PC.SetBooleanProperty(PropertyNames.PidLidAppointmentSubType, value);
+            }
+        }
+
+        public bool IsReminderSet
+        {
+            set
+            {
+                PC.SetBooleanProperty(PropertyNames.PidLidReminderSet, value);
+            }
+        }
+
+        public BusyStatus BusyStatus
+        {
+            get
+            {
+                Nullable<int> result = PC.GetInt32Property(PropertyNames.PidLidBusyStatus);
+                if (result.HasValue)
+                {
+                    return (BusyStatus)result.Value;
+                }
+                return BusyStatus.Avaiable;
+            }
+            set
+            {
+                PC.SetInt32Property(PropertyNames.PidLidBusyStatus, (int)value);
+            }
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/ModifiedAppointmentInstance.MessageProperties.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/ModifiedAppointmentInstance.MessageProperties.cs
@@ -1,0 +1,102 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Utilities;
+
+namespace PSTFileFormat
+{
+    public partial class ModifiedAppointmentInstance
+    {
+        public string MessageClass
+        {
+            get
+            {
+                return PC.GetStringProperty(PropertyID.PidTagMessageClass);
+            }
+            set
+            {
+                PC.SetStringProperty(PropertyID.PidTagMessageClass, value);
+            }
+        }
+
+        /// <summary>
+        /// Maximum length: 255 characters
+        /// </summary>
+        public string Subject
+        {
+            get
+            {
+                return this.PC.GetStringProperty(PropertyID.PidTagSubject);
+            }
+            set
+            {
+                PC.SetStringProperty(PropertyID.PidTagSubject, value);
+                PC.SetStringProperty(PropertyID.PidTagConversationTopic, value);
+            }
+        }
+
+        public string Body
+        {
+            get
+            {
+                return this.PC.GetStringProperty(PropertyID.PidTagBody);
+            }
+            set
+            {
+                PC.SetStringProperty(PropertyID.PidTagBody, value);
+            }
+        }
+
+        public bool AlternateRecipientAllowed
+        {
+            set
+            {
+                PC.SetBooleanProperty(PropertyID.PidTagAlternateRecipientAllowed, value);
+            }
+        }
+
+        public MessageFlags MessageFlags
+        {
+            get
+            {
+                return (MessageFlags)PC.GetInt32Property(PropertyID.PidTagMessageFlags);
+            }
+            set
+            {
+                PC.SetInt32Property(PropertyID.PidTagMessageFlags, (int)value);
+            }
+        }
+
+        public MessageImportance Importance
+        {
+            set
+            {
+                PC.SetInt32Property(PropertyID.PidTagImportance, (int)value);
+            }
+        }
+
+        public MessagePriority Priority
+        {
+            set
+            {
+                PC.SetInt32Property(PropertyID.PidTagPriority, (int)value);
+            }
+        }
+
+        public MessageSensitivity Sensitivity
+        {
+            set
+            {
+                PC.SetInt32Property(PropertyID.PidTagSensitivity, (int)value);
+            }
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/ModifiedAppointmentInstance.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/ModifiedAppointmentInstance.cs
@@ -1,0 +1,122 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Utilities;
+
+namespace PSTFileFormat
+{
+    public partial class ModifiedAppointmentInstance : Subnode
+    {
+        public const string RecurringAppointmentExceptionMessageClass = "IPM.OLE.CLASS.{00061055-0000-0000-C000-000000000046}";
+        
+        public ModifiedAppointmentInstance(Subnode subnode)
+            : base(subnode.File, subnode.SubnodeID, subnode.DataTree, subnode.SubnodeBTree)
+        {
+
+        }
+
+        public override void SaveChanges()
+        {
+            PC.SetDateTimeProperty(PropertyID.PidTagLastModificationTime, DateTime.UtcNow);
+            // The length must include the message size as well, so we add it as placeholder
+            PC.SetInt32Property(PropertyID.PidTagMessageSize, 0);
+            int messageSize;
+            if (this.File.WriterCompatibilityMode < WriterCompatibilityMode.Outlook2007SP2)
+            {
+                messageSize = PC.GetTotalLengthOfAllProperties();
+            }
+            else
+            {
+                PC.FlushToDataTree();
+                messageSize = this.DataTree.TotalDataLength;
+            }
+            PC.SetInt32Property(PropertyID.PidTagMessageSize, messageSize);
+
+            base.SaveChanges();
+        }
+        
+        public void SetStartAndDuration(DateTime startDTUtc, int duration)
+        {
+            this.StartDTUtc = startDTUtc;
+            this.AppointmentDuration = duration;
+            this.EndDTUtc = startDTUtc.AddMinutes(duration);
+        }
+        
+        public DateTime StartDTUtc
+        {
+            get
+            {
+                return this.StartWhole;
+            }
+            set
+            {
+                this.ClipStart = value;
+                this.CommonStart = value;
+                this.StartWhole = value;
+            }
+        }
+
+        public DateTime EndDTUtc
+        {
+            get
+            {
+                return this.EndWhole;
+            }
+            set
+            {
+                this.ClipEnd = value;
+                this.CommonEnd = value;
+                this.EndWhole = value;
+            }
+        }
+
+        /// <summary>
+        /// The timespan in minutes from the start time in UTC to end time in UTC.
+        /// </summary>
+        public int Duration
+        {
+            get
+            {
+                TimeSpan ts = EndDTUtc - StartDTUtc;
+                return (int)ts.TotalMinutes;
+            }
+        }
+
+        public DateTime GetStartDTZone(TimeZoneInfo timezone)
+        {
+            return TimeZoneInfo.ConvertTimeFromUtc(StartDTUtc, timezone);
+        }
+
+        public DateTime GetEndDTZone(TimeZoneInfo timezone)
+        {
+            return TimeZoneInfo.ConvertTimeFromUtc(EndDTUtc, timezone);
+        }
+
+        public static ModifiedAppointmentInstance CreateNewModifiedInstance(PSTFile file, SubnodeBTree attachmentSubnodeBTree)
+        {
+            PropertyContext pc = PropertyContext.CreateNewPropertyContext(file);
+            pc.SetStringProperty(PropertyID.PidTagMessageClass, RecurringAppointmentExceptionMessageClass);
+            pc.SetDateTimeProperty(PropertyID.PidTagCreationTime, DateTime.UtcNow);
+            pc.SetDateTimeProperty(PropertyID.PidTagLastModificationTime, DateTime.UtcNow);
+            
+            // PidTagSearchKey is apparently a GUID
+            pc.SetBytesProperty(PropertyID.PidTagSearchKey, LittleEndianConverter.GetBytes(Guid.NewGuid()));
+
+            pc.SaveChanges();
+
+            NodeID subnodeID = file.Header.AllocateNextNodeID(NodeTypeName.NID_TYPE_NORMAL_MESSAGE);
+            attachmentSubnodeBTree.InsertSubnodeEntry(subnodeID, pc.DataTree, pc.SubnodeBTree);
+
+            Subnode subnode = new Subnode(file, subnodeID, pc.DataTree, pc.SubnodeBTree);
+            return new ModifiedAppointmentInstance(subnode);
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/AppointmentRecurrencePatternStructure.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/AppointmentRecurrencePatternStructure.cs
@@ -1,0 +1,404 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Utilities;
+
+namespace PSTFileFormat
+{
+    // http://msdn.microsoft.com/en-us/library/ee237146%28v=exchg.80%29.aspx
+    public abstract class AppointmentRecurrencePatternStructure
+    {
+        //public const ushort Outlook1997VersionSignature = 0x3006;
+        //public const ushort Outlook2000VersionSignature = 0x3006;
+        //public const ushort Outlook2002VersionSignature = 0x3007;
+        public const ushort Outlook2003VersionSignature = 0x3008;
+        public const ushort Outlook2007VersionSignature = 0x3009;
+        public const ushort Outlook2010VersionSignature = 0x3009;
+        
+        // If the recurrence does not have an end date, the value of the EndDate field MUST be set to 0x5AE980DF
+        // DateTimeKind.Local means the current timezone on the client computer, while we use the timezone specified by the appointment
+        public static readonly DateTime NoEndDate = DateTimeHelper.GetDateTime(0x5AE980DF, DateTimeKind.Unspecified);
+
+        /* Start of RecurrencePattern */
+        public ushort ReaderVersion = 0x3004;
+        public ushort WriterVersion = 0x3004;
+        public RecurrenceFrequency RecurFrequency;
+        public PatternType PatternType;
+        public ushort CalendarType;
+        public uint FirstDateTime;
+        public uint Period;
+        public uint SlidingFlag;
+        // PatternTypeSpecific
+        public RecurrenceEndType EndType;
+        public uint OccurrenceCount;
+        public uint FirstDOW; // first day of week
+        // uint DeletedInstanceCount;
+        public List<DateTime> DeletedInstanceDates = new List<DateTime>(); // The original start date
+        // uint ModifiedInstanceCount; // NumberOfNewDates can be lower than NumberOfExceptions if an appointment has been deleted
+        public List<DateTime> ModifiedInstanceDates = new List<DateTime>(); // The new start date
+        private DateTime StartDate; // Timezone date
+        private DateTime EndDate; // Date of the start of the last appointment in the series
+        /* End of RecurrencePattern */
+        public uint ReaderVersion2 = 0x3006;
+        public uint WriterVersion2 = Outlook2003VersionSignature;
+        private uint StartTimeOffset; // In minutes, Timezone time
+        private uint EndTimeOffset; // In minutes, Timezone time
+        // ushort NumberOfExceptions repeat
+        public List<ExceptionInfoStructure> ExceptionList = new List<ExceptionInfoStructure>();
+
+        public AppointmentRecurrencePatternStructure()
+        { 
+        }
+
+        public AppointmentRecurrencePatternStructure(byte[] buffer)
+        {
+            int position = 0;
+            ReaderVersion = LittleEndianReader.ReadUInt16(buffer, ref position);
+            WriterVersion = LittleEndianReader.ReadUInt16(buffer, ref position);
+            RecurFrequency = (RecurrenceFrequency)LittleEndianReader.ReadUInt16(buffer, ref position);
+            PatternType = (PatternType)LittleEndianReader.ReadUInt16(buffer, ref position);
+            CalendarType = LittleEndianReader.ReadUInt16(buffer, ref position);
+            FirstDateTime = LittleEndianReader.ReadUInt32(buffer, ref position);
+            Period = LittleEndianReader.ReadUInt32(buffer, ref position);
+            SlidingFlag = LittleEndianReader.ReadUInt32(buffer, ref position);
+
+            ReadPatternTypeSpecific(buffer, ref position);
+
+            EndType = (RecurrenceEndType)LittleEndianReader.ReadUInt32(buffer, ref position);
+            if ((uint)EndType == 0xFFFFFFFF) // SHOULD be 0x00002023 but can be 0xFFFFFFFF
+            {
+                EndType = RecurrenceEndType.NeverEnd;
+            }
+            OccurrenceCount = LittleEndianReader.ReadUInt32(buffer, ref position);
+            FirstDOW = LittleEndianReader.ReadUInt32(buffer, ref position);
+            uint DeletedInstanceCount = LittleEndianReader.ReadUInt32(buffer, ref position);
+            for (int index = 0; index < DeletedInstanceCount; index++)
+            {
+                DateTime date = DateTimeHelper.ReadDateTimeFromMinutes(buffer, ref position);
+                DeletedInstanceDates.Add(date);
+            }
+
+            uint ModifiedInstanceCount = LittleEndianReader.ReadUInt32(buffer, ref position);
+            if (ModifiedInstanceCount > DeletedInstanceCount)
+            {
+                throw new InvalidRecurrencePatternException("Invalid structure format");
+            }
+            for (int index = 0; index < ModifiedInstanceCount; index++)
+            {
+                DateTime date = DateTimeHelper.ReadDateTimeFromMinutes(buffer, ref position);
+                ModifiedInstanceDates.Add(date);
+            }
+
+            StartDate = DateTimeHelper.ReadDateTimeFromMinutes(buffer, ref position);
+            // end date will be in 31/12/4500 23:59:00 if there is no end date
+            EndDate = DateTimeHelper.ReadDateTimeFromMinutes(buffer, ref position);
+
+            ReaderVersion2 = LittleEndianReader.ReadUInt32(buffer, ref position);
+            WriterVersion2 = LittleEndianReader.ReadUInt32(buffer, ref position);
+
+            StartTimeOffset = LittleEndianReader.ReadUInt32(buffer, ref position);
+            EndTimeOffset = LittleEndianReader.ReadUInt32(buffer, ref position);
+            ushort exceptionCount = LittleEndianReader.ReadUInt16(buffer, ref position);
+            if (exceptionCount != ModifiedInstanceCount)
+            {
+                // This MUST be the same value as the value of the ModifiedInstanceCount in the associated ReccurencePattern structure
+                throw new InvalidRecurrencePatternException("Invalid structure format");
+            }
+            for (int index = 0; index < exceptionCount; index++)
+            {
+                ExceptionInfoStructure exception = new ExceptionInfoStructure(buffer, position);
+                ExceptionList.Add(exception);
+                position += exception.RecordLength;
+            }
+
+            // Outlook 2003 SP3 was observed using a signature of older version (0x3006) when there was no need for extended exception
+            if (WriterVersion2 >= Outlook2003VersionSignature)
+            {
+                uint reservedBlock1Size = LittleEndianReader.ReadUInt32(buffer, ref position);
+                position += (int)reservedBlock1Size;
+
+                foreach (ExceptionInfoStructure exception in ExceptionList)
+                {
+                    exception.ReadExtendedException(buffer, ref position, WriterVersion2);
+                }
+
+                uint reservedBlock2Size = LittleEndianReader.ReadUInt32(buffer, ref position);
+                position += (int)reservedBlock2Size;
+            }
+        }
+
+        public abstract void ReadPatternTypeSpecific(byte[] buffer, ref int offset);
+
+        public abstract void WritePatternTypeSpecific(Stream stream);
+
+        public byte[] GetBytes(WriterCompatibilityMode writerCompatibilityMode)
+        {
+            switch (writerCompatibilityMode)
+            { 
+                case WriterCompatibilityMode.Outlook2007RTM:
+                case WriterCompatibilityMode.Outlook2007SP2:
+                    WriterVersion2 = Outlook2007VersionSignature;
+                    break;
+                case WriterCompatibilityMode.Outlook2010RTM:
+                    WriterVersion2 = Outlook2010VersionSignature;
+                    break;
+                default:
+                    WriterVersion2 = Outlook2003VersionSignature;
+                    break;
+            }
+            if (ModifiedInstanceDates.Count > DeletedInstanceDates.Count)
+            {
+                throw new InvalidRecurrencePatternException("Invalid exception data");
+            }
+
+            if (ExceptionList.Count != ModifiedInstanceDates.Count)
+            {
+                throw new InvalidRecurrencePatternException("Invalid exception data");
+            }
+
+            MemoryStream stream = new MemoryStream();
+            LittleEndianWriter.WriteUInt16(stream, ReaderVersion);
+            LittleEndianWriter.WriteUInt16(stream, WriterVersion);
+            LittleEndianWriter.WriteUInt16(stream, (ushort)RecurFrequency);
+            LittleEndianWriter.WriteUInt16(stream, (ushort)PatternType);
+            LittleEndianWriter.WriteUInt16(stream, CalendarType);
+            LittleEndianWriter.WriteUInt32(stream, FirstDateTime);
+            LittleEndianWriter.WriteUInt32(stream, Period);
+            LittleEndianWriter.WriteUInt32(stream, SlidingFlag);
+            WritePatternTypeSpecific(stream);
+
+            LittleEndianWriter.WriteUInt32(stream, (uint)EndType);
+            LittleEndianWriter.WriteUInt32(stream, OccurrenceCount);
+            LittleEndianWriter.WriteUInt32(stream, FirstDOW);
+            LittleEndianWriter.WriteUInt32(stream, (uint)DeletedInstanceDates.Count);
+            // [MS-OXOCAL] DeletedInstanceDates - The dates are ordered from earliest to latest
+            foreach (DateTime date in ListUtils.GetSorted(DeletedInstanceDates))
+            {
+                DateTimeHelper.WriteDateTimeInMinutes(stream, date);
+            }
+
+            LittleEndianWriter.WriteUInt32(stream, (uint)ModifiedInstanceDates.Count);
+            // [MS-OXOCAL] ModifiedInstanceDates - The dates are ordered from earliest to latest
+            foreach (DateTime date in ListUtils.GetSorted(ModifiedInstanceDates))
+            {
+                DateTimeHelper.WriteDateTimeInMinutes(stream, date);
+            }
+
+            DateTimeHelper.WriteDateTimeInMinutes(stream, StartDate);
+            DateTimeHelper.WriteDateTimeInMinutes(stream, EndDate);
+
+            LittleEndianWriter.WriteUInt32(stream, ReaderVersion2);
+            LittleEndianWriter.WriteUInt32(stream, WriterVersion2);
+
+            LittleEndianWriter.WriteUInt32(stream, StartTimeOffset);
+            LittleEndianWriter.WriteUInt32(stream, EndTimeOffset);
+
+            LittleEndianWriter.WriteUInt16(stream, (ushort)ExceptionList.Count);
+            foreach (ExceptionInfoStructure exception in ExceptionList)
+            {
+                exception.WriteBytes(stream);
+            }
+
+            uint reservedBlock1Size = 0;
+            LittleEndianWriter.WriteUInt32(stream, reservedBlock1Size);
+
+            foreach (ExceptionInfoStructure exception in ExceptionList)
+            {
+                exception.WriteExtendedException(stream, writerCompatibilityMode);
+            }
+
+            uint reservedBlock2Size = 0;
+            LittleEndianWriter.WriteUInt32(stream, reservedBlock2Size);
+
+            return stream.ToArray();
+        }
+
+        public void SetStartAndDuration(DateTime startDTUtc, int duration, TimeZoneInfo timezone)
+        {
+            SetStartDTUtc(startDTUtc, timezone);
+            DateTime startDate = DateTimeUtils.GetDayStart(StartDTZone);
+            TimeSpan ts = StartDTZone - startDate;
+            StartTimeOffset = (uint)ts.TotalMinutes;
+            EndTimeOffset = (uint)(duration + StartTimeOffset);
+        }
+
+        public DateTime GetStartDTUtc(TimeZoneInfo timezone)
+        {
+            return TimeZoneInfo.ConvertTimeToUtc(StartDTZone, timezone);
+        }
+
+        public void SetStartDTUtc(DateTime startDTUtc, TimeZoneInfo timezone)
+        {
+            StartDTZone = TimeZoneInfo.ConvertTimeFromUtc(startDTUtc, timezone);
+        }
+
+        /// <summary>
+        /// StartDT of the first appointment, timezone time]
+        /// </summary>
+        public DateTime StartDTZone
+        {
+            get
+            {
+                DateTime result = StartDate.AddMinutes(StartTimeOffset);
+                // DateTimeKind.Local means the current timezone on the client computer, while we use the timezone specified by the appointment
+                result = DateTime.SpecifyKind(result, DateTimeKind.Unspecified);
+                return result;
+            }
+            set
+            {
+                StartDate = DateTimeUtils.GetDayStart(value);
+                StartDate = DateTime.SpecifyKind(StartDate, DateTimeKind.Unspecified);
+                TimeSpan ts = value - StartDate;
+                StartTimeOffset = (uint)ts.TotalMinutes;
+            }
+        }
+
+        /// <summary>
+        /// The timespan in minutes from the start time to end time in timezone time.
+        /// It will differ from the actual duration (UTC) if an appointment instance is spanning both standard time and daylight time.
+        /// </summary>
+        public int Duration
+        {
+            get
+            {
+                return (int)(EndTimeOffset - StartTimeOffset);
+            }
+        }
+
+        public DateTime LastInstanceStartDate
+        {
+            get
+            {
+                // end date will be 31/12/4500 23:59:00 if there is no end date
+                return DateTimeUtils.GetDayStart(EndDate);
+            }
+            set
+            {
+                EndDate = DateTimeUtils.GetDayStart(value);
+                if (EndDate.Year >= 4500)
+                {
+                    EndDate = NoEndDate;
+                }
+            }
+        }
+
+        public RecurrenceType RecurrenceType
+        {
+            get
+            {
+                return RecurrenceTypeHelper.GetRecurrenceType(RecurFrequency, PatternType);
+            }
+        }
+
+        public virtual int PeriodInRecurrenceTypeUnits
+        {
+            get
+            {
+                if (RecurrenceType == RecurrenceType.EveryNDays)
+                {
+                    return (int)(Period / 1440);
+                }
+                else if (RecurrenceType == RecurrenceType.EveryNYears ||
+                         RecurrenceType == RecurrenceType.EveryNthDayOfEveryNYears)
+                {
+                    return (int)Period / 12;
+                }
+                else
+                {
+                    return (int)Period;
+                }
+            }
+            set
+            {
+                if (RecurrenceType == RecurrenceType.EveryNDays)
+                {
+                    Period = (uint)value * 1440;
+                }
+                else if (RecurrenceType == RecurrenceType.EveryNYears ||
+                         RecurrenceType == RecurrenceType.EveryNthDayOfEveryNYears)
+                {
+                    Period = (uint)value * 12;
+                }
+                else
+                {
+                    Period = (uint)value;
+                }
+            }
+        }
+
+        public int FirstDateTimeInDays
+        {
+            get
+            {
+                return (int)(FirstDateTime / 1440);
+            }
+            set
+            {
+                FirstDateTime = (uint)value * 1440;
+            }
+        }
+
+        public static AppointmentRecurrencePatternStructure GetRecurrencePatternStructure(byte[] buffer)
+        {
+            RecurrenceFrequency frequency = (RecurrenceFrequency)LittleEndianConverter.ToInt16(buffer, 4);
+            switch (frequency)
+            { 
+                case RecurrenceFrequency.Daily:
+                    return new DailyRecurrencePatternStructure(buffer);
+                case RecurrenceFrequency.Weekly:
+                    return new WeeklyRecurrencePatternStructure(buffer);
+                case RecurrenceFrequency.Monthly:
+                    return new MonthlyRecurrencePatternStructure(buffer);
+                case RecurrenceFrequency.Yearly:
+                    return new YearlyRecurrencePatternStructure(buffer);
+                default:
+                    throw new InvalidRecurrencePatternException("Invalid recurrence pattern frequency");
+            }
+        }
+
+        // http://msdn.microsoft.com/en-us/library/ee203303%28v=exchg.80%29
+        /// <param name="period">In recurrence type units or recurrence frequency unit</param>
+        /// <param name="startDTZone">Note: The date component of startDTZone may be different than the date of startDTUtc</param>
+        public static int CalculateFirstDateTimeInDays(RecurrenceFrequency recurrenceFrequency, PatternType patternType, int period, DateTime startDTZone)
+        {
+            DateTime minimumDate = new DateTime(1601, 1, 1);
+            switch (recurrenceFrequency)
+            {
+                case RecurrenceFrequency.Daily:
+                    {
+                        int daysSince1601 = (int)(startDTZone - minimumDate).TotalDays;
+                        return daysSince1601 % period;
+                    }
+                case RecurrenceFrequency.Weekly:
+                    {
+                        int daysSince1601 = (int)(DateTimeUtils.GetWeekStart(startDTZone) - minimumDate).TotalDays;
+                        int periodInDays = period * 7;
+                        return daysSince1601 % periodInDays;
+                    }
+                case RecurrenceFrequency.Monthly:
+                    {
+                        int monthSpan = DateTimeHelper.GetMonthSpan(minimumDate, startDTZone);
+                        int remainder = monthSpan % period;
+                        return (int)(minimumDate.AddMonths(remainder) - minimumDate).TotalDays;
+                    }
+                case RecurrenceFrequency.Yearly:
+                    {
+                        int monthSpan = DateTimeHelper.GetMonthSpan(minimumDate, startDTZone);
+                        int remainder = monthSpan % (period * 12);
+                        return (int)(minimumDate.AddMonths(remainder) - minimumDate).TotalDays;
+                    }
+                default:
+                    throw new ArgumentException("Invalid Recurrence Frequency");
+            }
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/AppointmentRecurrencePatternStructure.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/AppointmentRecurrencePatternStructure.cs
@@ -140,10 +140,47 @@ namespace PSTFileFormat
 
         public abstract void WritePatternTypeSpecific(Stream stream);
 
+        // [ContinuMail 2026] Writes the MS-OXOCAL RecurrencePattern prefix (ReaderVersion …
+        // EndDate) into an existing stream. Extracted from GetBytes so that the prefix can be
+        // emitted standalone as PidLidTaskRecurrence (bare RecurrencePattern, no appointment tail).
+        private void WriteRecurrencePattern(MemoryStream stream)
+        {
+            LittleEndianWriter.WriteUInt16(stream, ReaderVersion);
+            LittleEndianWriter.WriteUInt16(stream, WriterVersion);
+            LittleEndianWriter.WriteUInt16(stream, (ushort)RecurFrequency);
+            LittleEndianWriter.WriteUInt16(stream, (ushort)PatternType);
+            LittleEndianWriter.WriteUInt16(stream, CalendarType);
+            LittleEndianWriter.WriteUInt32(stream, FirstDateTime);
+            LittleEndianWriter.WriteUInt32(stream, Period);
+            LittleEndianWriter.WriteUInt32(stream, SlidingFlag);
+            WritePatternTypeSpecific(stream);
+            LittleEndianWriter.WriteUInt32(stream, (uint)EndType);
+            LittleEndianWriter.WriteUInt32(stream, OccurrenceCount);
+            LittleEndianWriter.WriteUInt32(stream, FirstDOW);
+            LittleEndianWriter.WriteUInt32(stream, (uint)DeletedInstanceDates.Count);
+            foreach (DateTime date in ListUtils.GetSorted(DeletedInstanceDates))
+                DateTimeHelper.WriteDateTimeInMinutes(stream, date);
+            LittleEndianWriter.WriteUInt32(stream, (uint)ModifiedInstanceDates.Count);
+            foreach (DateTime date in ListUtils.GetSorted(ModifiedInstanceDates))
+                DateTimeHelper.WriteDateTimeInMinutes(stream, date);
+            DateTimeHelper.WriteDateTimeInMinutes(stream, StartDate);
+            DateTimeHelper.WriteDateTimeInMinutes(stream, EndDate);
+        }
+
+        /// <summary>[ContinuMail 2026] Emits ONLY the MS-OXOCAL RecurrencePattern prefix (no
+        /// AppointmentRecurrencePattern tail) — used to write PidLidTaskRecurrence for recurring
+        /// tasks. Byte-gated against real Outlook task GT oracles (PR7b Task 1).</summary>
+        public byte[] GetRecurrencePatternBytes()
+        {
+            MemoryStream stream = new MemoryStream();
+            WriteRecurrencePattern(stream);
+            return stream.ToArray();
+        }
+
         public byte[] GetBytes(WriterCompatibilityMode writerCompatibilityMode)
         {
             switch (writerCompatibilityMode)
-            { 
+            {
                 case WriterCompatibilityMode.Outlook2007RTM:
                 case WriterCompatibilityMode.Outlook2007SP2:
                     WriterVersion2 = Outlook2007VersionSignature;
@@ -166,35 +203,7 @@ namespace PSTFileFormat
             }
 
             MemoryStream stream = new MemoryStream();
-            LittleEndianWriter.WriteUInt16(stream, ReaderVersion);
-            LittleEndianWriter.WriteUInt16(stream, WriterVersion);
-            LittleEndianWriter.WriteUInt16(stream, (ushort)RecurFrequency);
-            LittleEndianWriter.WriteUInt16(stream, (ushort)PatternType);
-            LittleEndianWriter.WriteUInt16(stream, CalendarType);
-            LittleEndianWriter.WriteUInt32(stream, FirstDateTime);
-            LittleEndianWriter.WriteUInt32(stream, Period);
-            LittleEndianWriter.WriteUInt32(stream, SlidingFlag);
-            WritePatternTypeSpecific(stream);
-
-            LittleEndianWriter.WriteUInt32(stream, (uint)EndType);
-            LittleEndianWriter.WriteUInt32(stream, OccurrenceCount);
-            LittleEndianWriter.WriteUInt32(stream, FirstDOW);
-            LittleEndianWriter.WriteUInt32(stream, (uint)DeletedInstanceDates.Count);
-            // [MS-OXOCAL] DeletedInstanceDates - The dates are ordered from earliest to latest
-            foreach (DateTime date in ListUtils.GetSorted(DeletedInstanceDates))
-            {
-                DateTimeHelper.WriteDateTimeInMinutes(stream, date);
-            }
-
-            LittleEndianWriter.WriteUInt32(stream, (uint)ModifiedInstanceDates.Count);
-            // [MS-OXOCAL] ModifiedInstanceDates - The dates are ordered from earliest to latest
-            foreach (DateTime date in ListUtils.GetSorted(ModifiedInstanceDates))
-            {
-                DateTimeHelper.WriteDateTimeInMinutes(stream, date);
-            }
-
-            DateTimeHelper.WriteDateTimeInMinutes(stream, StartDate);
-            DateTimeHelper.WriteDateTimeInMinutes(stream, EndDate);
+            WriteRecurrencePattern(stream);
 
             LittleEndianWriter.WriteUInt32(stream, ReaderVersion2);
             LittleEndianWriter.WriteUInt32(stream, WriterVersion2);

--- a/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/AppointmentRecurrencePatternStructure.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/AppointmentRecurrencePatternStructure.cs
@@ -211,8 +211,16 @@ namespace PSTFileFormat
             LittleEndianWriter.WriteUInt32(stream, StartTimeOffset);
             LittleEndianWriter.WriteUInt32(stream, EndTimeOffset);
 
-            LittleEndianWriter.WriteUInt16(stream, (ushort)ExceptionList.Count);
-            foreach (ExceptionInfoStructure exception in ExceptionList)
+            // [ContinuMail 2026] MS-OXOCAL 2.2.1.44: the ExceptionInfo/ExtendedException arrays MUST be in
+            // the same ascending order as ModifiedInstanceDates (written sorted by WriteRecurrencePattern
+            // above). Overrides may be supplied in arbitrary (e.g. SQLite row) order, so sort a copy by
+            // NewStartDT — the same key ModifiedInstanceDates is derived from (its day-start) — keeping the
+            // two arrays positionally corresponding. A copy is sorted so caller state is not mutated.
+            List<ExceptionInfoStructure> orderedExceptions = new List<ExceptionInfoStructure>(ExceptionList);
+            orderedExceptions.Sort((a, b) => a.NewStartDT.CompareTo(b.NewStartDT));
+
+            LittleEndianWriter.WriteUInt16(stream, (ushort)orderedExceptions.Count);
+            foreach (ExceptionInfoStructure exception in orderedExceptions)
             {
                 exception.WriteBytes(stream);
             }
@@ -220,7 +228,7 @@ namespace PSTFileFormat
             uint reservedBlock1Size = 0;
             LittleEndianWriter.WriteUInt32(stream, reservedBlock1Size);
 
-            foreach (ExceptionInfoStructure exception in ExceptionList)
+            foreach (ExceptionInfoStructure exception in orderedExceptions)
             {
                 exception.WriteExtendedException(stream, writerCompatibilityMode);
             }

--- a/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/CalendarHelper.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/CalendarHelper.cs
@@ -1,0 +1,90 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Utilities;
+
+namespace PSTFileFormat
+{
+    public class CalendarHelper
+    {
+        public static int CalculateNumberOfOccurences(DateTime startDate, DateTime lastInstanceStartDate, RecurrenceType recurrenceType, int period, int day)
+        {
+            startDate = DateTimeUtils.GetDayStart(startDate);
+            lastInstanceStartDate = DateTimeUtils.GetDayStart(lastInstanceStartDate);
+
+            if (recurrenceType == RecurrenceType.EveryNDays)
+            {
+                    TimeSpan ts = lastInstanceStartDate - startDate;
+                    return ((int)ts.TotalDays) / period + 1;
+            }
+            else if (recurrenceType == RecurrenceType.EveryWeekday)
+            {
+                DaysOfWeekFlags weekdays = DateTimeHelper.Weekdays;
+                return CalculateNumberOfOccurencesInWeek(startDate, lastInstanceStartDate, period, weekdays);
+            }
+            else if (recurrenceType == RecurrenceType.EveryNWeeks)
+            {
+                return CalculateNumberOfOccurencesInWeek(startDate, lastInstanceStartDate, period, (DaysOfWeekFlags)day);
+            }
+            else if (recurrenceType == RecurrenceType.EveryNMonths ||
+                     recurrenceType == RecurrenceType.EveryNthDayOfEveryNMonths)
+            {
+                int numberOfMonths = DateTimeHelper.GetMonthSpan(startDate, lastInstanceStartDate);
+
+                return numberOfMonths / period + 1; // extra day
+            }
+            else
+            {
+                int numberOfYears = lastInstanceStartDate.Year - startDate.Year;
+                return numberOfYears / period + 1;
+            }
+        }
+
+        public static int CalculateNumberOfOccurencesInWeek(DateTime startDate, DateTime lastInstanceStartDate, int period, DaysOfWeekFlags daysOfWeek)
+        {
+            TimeSpan ts = lastInstanceStartDate - startDate;
+            int totalDays = (int)ts.TotalDays + 1;
+            int daysOfWeekCount = GetSetBitCount((int)daysOfWeek);
+            int numberOfWeeks = (totalDays / 7);
+            int extraDays = totalDays - numberOfWeeks * 7;
+            int extraOccurences = 0;
+
+            DateTime date = DateTimeUtils.GetDayStart(startDate).AddDays(numberOfWeeks * 7);
+            while (date <= lastInstanceStartDate)
+            {
+                if ((DateTimeHelper.GetDayOfWeek(date) & daysOfWeek) > 0)
+                {
+                    extraOccurences++;
+                }
+                date = date.AddDays(1);
+            }
+            return numberOfWeeks * daysOfWeekCount / period + extraOccurences;
+        }
+
+        public static int GetSetBitCount(long lValue)
+        {
+            int iCount = 0;
+
+            //Loop the value while there are still bits
+            while (lValue != 0)
+            {
+                //Remove the end bit
+                lValue = lValue & (lValue - 1);
+
+                //Increment the count
+                iCount++;
+            }
+
+            //Return the count
+            return iCount;
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/DailyRecurrencePatternStructure.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/DailyRecurrencePatternStructure.cs
@@ -1,0 +1,106 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Utilities;
+
+namespace PSTFileFormat
+{
+    public enum DailyPatternType : ushort
+    {
+        EveryDay = 0,
+        EveryWeekday = 1,
+    }
+
+    public class DailyRecurrencePatternStructure : AppointmentRecurrencePatternStructure
+    {
+        //public DaysOfWeekFlags DaysOfWeek; // when DailyPattern == EveryWeekday
+
+        public DailyRecurrencePatternStructure()
+        {
+            RecurFrequency = RecurrenceFrequency.Daily;
+        }
+
+        public DailyRecurrencePatternStructure(byte[] buffer) : base(buffer)
+        {}
+
+        public override void ReadPatternTypeSpecific(byte[] buffer, ref int offset)
+        {
+            // we start reading from offset 22
+            if (PatternType == PatternType.Day)
+            {
+            }
+            else if (PatternType == PatternType.Week) // EveryWeekday
+            {
+                DaysOfWeekFlags DaysOfWeek = (DaysOfWeekFlags)LittleEndianReader.ReadUInt32(buffer, ref offset);
+                if (DaysOfWeek != DateTimeHelper.Weekdays)
+                {
+                    throw new InvalidRecurrencePatternException("Invalid DaysOfWeek for Daily Recurrence Pattern");
+                }
+            }
+            else
+            {
+                throw new InvalidRecurrencePatternException("Invalid Pattern Type");
+            }
+        }
+
+        public override void WritePatternTypeSpecific(Stream stream)
+        {
+            if (PatternType == PatternType.Day)
+            {
+            }
+            else if (PatternType == PatternType.Week) // EveryWeekday
+            {
+                LittleEndianWriter.WriteUInt32(stream, (uint)DateTimeHelper.Weekdays);
+            }
+            else
+            {
+                throw new InvalidRecurrencePatternException("Invalid Pattern Type");
+            }
+        }
+
+        [Obsolete]
+        public int PeriodInDays
+        {
+            get
+            {
+                if (PatternType == PatternType.Day)
+                {
+                    return (int)(Period / 1440);
+                }
+                else
+                {
+                    return 7;
+                }
+            }
+            set
+            {
+                if (PatternType == PatternType.Day)
+                {
+                    Period = (uint)value * 1440;
+                }
+                else
+                {
+                    Period = (uint)value / 7;
+                }
+            }
+        }
+
+        [Obsolete]
+        public int DaysToSkip
+        {
+            get
+            {
+                return (int)(FirstDateTime / 1440);
+            }
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/DateTimeHelper.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/DateTimeHelper.cs
@@ -1,0 +1,96 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Utilities;
+
+namespace PSTFileFormat
+{
+    public class DateTimeHelper
+    {
+        public const DaysOfWeekFlags Weekdays = DaysOfWeekFlags.Monday | DaysOfWeekFlags.Tuesday | DaysOfWeekFlags.Wednesday | DaysOfWeekFlags.Thursday | DaysOfWeekFlags.Friday;
+
+        public static DateTime ReadDateTimeFromMinutes(byte[] buffer, ref int offset)
+        {
+            uint minutesSince1601 = LittleEndianReader.ReadUInt32(buffer, ref offset);
+            return GetDateTime(minutesSince1601, DateTimeKind.Unspecified);
+        }
+
+        public static DateTime ToDateTimeFromMinutes(byte[] buffer, int offset)
+        {
+            uint minutesSince1601 = LittleEndianConverter.ToUInt32(buffer, offset);
+            return GetDateTime(minutesSince1601, DateTimeKind.Unspecified);
+        }
+
+        public static DateTime GetDateTime(uint minutesSince1601, DateTimeKind kind)
+        {
+            long fileTimeUtc = (long)minutesSince1601 * 60 * 10000000;
+            DateTime result = DateTime.FromFileTimeUtc(fileTimeUtc);
+            result = DateTime.SpecifyKind(result, kind); // We read as UTC to avoid conversion
+            return result;
+        }
+        
+        public static void WriteDateTimeInMinutes(Stream stream,  DateTime dt)
+        {
+            dt = DateTime.SpecifyKind(dt, DateTimeKind.Utc); // We write as UTC to avoid conversion
+            uint minutesSince1601 = GetMinutesSince1601(dt);
+            LittleEndianWriter.WriteUInt32(stream, minutesSince1601);
+        }
+
+        public static void WriteDateTimeInMinutes(byte[] buffer, ref int offset, DateTime dt)
+        {
+            dt = DateTime.SpecifyKind(dt, DateTimeKind.Utc); // We write as UTC to avoid conversion
+            uint minutesSince1601 = GetMinutesSince1601(dt);
+            LittleEndianWriter.WriteUInt32(buffer, ref offset, minutesSince1601);
+        }
+
+        public static uint GetMinutesSince1601(DateTime dt)
+        {
+            uint minutesSince1601 = (uint)(dt.ToFileTimeUtc() / (60 * 10000000));
+            return minutesSince1601;
+        }
+
+        /// <summary>
+        /// Calculate the Months needed to add to startDate in order for it to be in the same year and month as endDate
+        /// </summary>
+        public static int GetMonthSpan(DateTime startDate, DateTime endDate)
+        {
+            int result = 0;
+
+            result = (endDate.Year - startDate.Year) * 12;
+            result += endDate.Month - startDate.Month;
+
+            return result;
+        }
+
+        public static DaysOfWeekFlags GetDayOfWeek(DateTime dt)
+        {
+            switch (dt.DayOfWeek)
+            {
+                case DayOfWeek.Sunday:
+                    return DaysOfWeekFlags.Sunday;
+                case DayOfWeek.Monday:
+                    return DaysOfWeekFlags.Monday;
+                case DayOfWeek.Tuesday:
+                    return DaysOfWeekFlags.Tuesday;
+                case DayOfWeek.Wednesday:
+                    return DaysOfWeekFlags.Wednesday;
+                case DayOfWeek.Thursday:
+                    return DaysOfWeekFlags.Thursday;
+                case DayOfWeek.Friday:
+                    return DaysOfWeekFlags.Friday;
+                default:
+                case DayOfWeek.Saturday:
+                    return DaysOfWeekFlags.Saturday;
+            }
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/Enums/DayOccurenceNumber.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/Enums/DayOccurenceNumber.cs
@@ -1,0 +1,13 @@
+
+namespace PSTFileFormat
+{
+    public enum DayOccurenceNumber : ushort
+    {
+        NotApplicable = 0, // We need this for serialization
+        First = 1,
+        Second = 2,
+        Third = 3,
+        Fourth = 4,
+        Last = 5,
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/Enums/DaysOfWeekFlags.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/Enums/DaysOfWeekFlags.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace PSTFileFormat
+{
+    [Flags]
+    public enum DaysOfWeekFlags : uint
+    {
+        Sunday = 0x01,
+        Monday = 0x02,
+        Tuesday = 0x04,
+        Wednesday = 0x08,
+        Thursday = 0x10,
+        Friday = 0x20,
+        Saturday = 0x40,
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/Enums/OutlookDayOfWeek.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/Enums/OutlookDayOfWeek.cs
@@ -1,0 +1,17 @@
+
+namespace PSTFileFormat
+{
+    public enum OutlookDayOfWeek : uint
+    {
+        Sunday = 0x01,
+        Monday = 0x02,
+        Tuesday = 0x04,
+        Wednesday = 0x08,
+        Thursday = 0x10,
+        Friday = 0x20,
+        Saturday = 0x40,
+        Weekday = 0x3E,    // e.g. the fourth weekday
+        WeekendDay = 0x41, // e.g. the fourth weekend day
+        Day = 0x7F,        // e.g. the fourth day
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/Enums/RecurrenceEnums.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/Enums/RecurrenceEnums.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace PSTFileFormat
+{
+    public enum RecurrenceFrequency : ushort
+    {
+        Daily = 0x200A,
+        Weekly = 0x200B,
+        Monthly = 0x200C,
+        Yearly = 0x200D,
+    }
+
+    public enum PatternType : ushort
+    {
+        Day = 0x0000,
+        Week = 0x0001,
+        Month = 0x0002,
+        MonthNth = 0x03, // i.e. the fourth monday of every month / the fourth monday of may
+    }
+
+    public enum RecurrenceEndType : uint
+    {
+        EndAfterDate = 0x00002021,
+        EndAfterNOccurrences = 0x00002022,
+        NeverEnd = 0x00002023,
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/Enums/RecurrenceType.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/Enums/RecurrenceType.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace PSTFileFormat
+{
+    /// <summary>
+    /// This enum represents the combinations of RecurrenceFrequency and PatternType
+    /// </summary>
+    public enum RecurrenceType : ushort
+    {
+        None = 0,
+        EveryNDays = 1,
+        EveryWeekday = 2,
+        EveryNWeeks = 3,
+        EveryNMonths = 4,
+        EveryNthDayOfEveryNMonths = 5,
+        EveryNYears = 6,              // Outlook 2007 GUI is no longer limited to 'every year' after applying KB950219 or SP2
+        EveryNthDayOfEveryNYears = 7, // Outlook 2007 GUI is no longer limited to 'every year' after applying KB950219 or SP2
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/ExceptionInfoStructure.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/ExceptionInfoStructure.cs
@@ -1,0 +1,509 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Utilities;
+
+namespace PSTFileFormat
+{
+    // http://msdn.microsoft.com/en-us/library/ee157416%28v=exchg.80%29
+    [Flags]
+    public enum OverrideFlags : ushort
+    { 
+        ModifiedSubject = 0x0001,
+        ModifiedStateFlags = 0x0002, // with other people
+        ModifiedReminderTime = 0x0004,
+        ModifiedIsReminderSet = 0x0008,
+        ModifiedLocation = 0x0010,
+        ModifiedBustStatus = 0x0020,
+        ModifiedHasAttachment = 0x0040,
+        ModifiedIsAllDayEvent = 0x0080,
+        ModifiedColor = 0x0100,
+        ModifiedBody = 0x0200,
+    }
+
+    public class ExceptionInfoStructure
+    {
+        public DateTime NewStartDT;      // In timezone time
+        public DateTime NewEndDT;        // In timezone time
+        public DateTime OriginalStartDT; // In timezone time, this field contains both date and time!
+        public OverrideFlags Flags;
+        public string Subject = String.Empty;
+        public uint AppointmentStateFlags; // PidLidAppointmentStateFlags
+        public uint ReminderTime; // In minutes
+        public bool IsReminderSet;
+        public string Location = String.Empty;
+        public BusyStatus BusyStatus;
+        public bool HasAttachment;
+        public bool IsAllDayEvent; // PidLidAppointmentSubType
+        public uint Color;
+
+        public ExceptionInfoStructure()
+        { 
+        }
+
+        public ExceptionInfoStructure(byte[] buffer, int offset)
+        {
+            int position = offset;
+            NewStartDT = DateTimeHelper.ReadDateTimeFromMinutes(buffer, ref position);
+            NewEndDT = DateTimeHelper.ReadDateTimeFromMinutes(buffer, ref position);
+            OriginalStartDT = DateTimeHelper.ReadDateTimeFromMinutes(buffer, ref position);
+            Flags = (OverrideFlags)LittleEndianReader.ReadUInt16(buffer, ref position);
+
+            if (HasModifiedSubject)
+            {
+                ushort fieldLength = LittleEndianReader.ReadUInt16(buffer, ref position);
+                ushort numberOfCharacters = LittleEndianReader.ReadUInt16(buffer, ref position);
+                Subject = Encoding.Default.GetString(buffer, position, numberOfCharacters);
+                position += numberOfCharacters;
+            }
+
+            if (HasModifiedStateFlags)
+            {
+                AppointmentStateFlags = LittleEndianReader.ReadUInt32(buffer, ref position);
+            }
+
+            if (HasModifiedReminderTime)
+            {
+                ReminderTime = LittleEndianReader.ReadUInt32(buffer, ref position);
+            }
+
+            if (HasModifiedIsReminderSet)
+            {
+                IsReminderSet = LittleEndianReader.ReadUInt32(buffer, ref position) == 0;
+            }
+
+            if (HasModifiedLocation)
+            {
+                ushort fieldLength = LittleEndianReader.ReadUInt16(buffer, ref position);
+                ushort numberOfCharacters = LittleEndianReader.ReadUInt16(buffer, ref position);
+                Location = Encoding.Default.GetString(buffer, position, numberOfCharacters);
+                position += numberOfCharacters;
+            }
+
+            if (HasModifiedBusyStatus)
+            {
+                BusyStatus = (BusyStatus)LittleEndianReader.ReadUInt32(buffer, ref position);
+            }
+
+            if (HasModifiedHasAttachment)
+            {
+                HasAttachment = LittleEndianReader.ReadUInt32(buffer, ref position) == 0;
+            }
+
+            if (HasModifiedIsAllDayEvent)
+            {
+                IsAllDayEvent = LittleEndianReader.ReadUInt32(buffer, ref position) == 0;
+            }
+
+            if (HasModifiedColor)
+            {
+                Color = LittleEndianReader.ReadUInt32(buffer, ref position);
+            }
+        }
+
+        public void WriteBytes(Stream stream)
+        {
+            DateTimeHelper.WriteDateTimeInMinutes(stream, NewStartDT);
+            DateTimeHelper.WriteDateTimeInMinutes(stream, NewEndDT);
+            DateTimeHelper.WriteDateTimeInMinutes(stream, OriginalStartDT);
+            LittleEndianWriter.WriteUInt16(stream, (ushort)Flags);
+
+            if (HasModifiedSubject)
+            {
+                LittleEndianWriter.WriteUInt16(stream, (ushort)(Subject.Length + 1));
+                LittleEndianWriter.WriteUInt16(stream, (ushort)Subject.Length);
+                ByteWriter.WriteAnsiString(stream, Subject, Subject.Length);
+            }
+
+            if (HasModifiedStateFlags)
+            {
+                LittleEndianWriter.WriteUInt32(stream, AppointmentStateFlags);
+            }
+
+            if (HasModifiedReminderTime)
+            {
+                LittleEndianWriter.WriteUInt32(stream, ReminderTime);
+            }
+
+            if (HasModifiedIsReminderSet)
+            {
+                LittleEndianWriter.WriteUInt32(stream, Convert.ToUInt32(IsReminderSet));
+            }
+
+            if (HasModifiedLocation)
+            {
+                LittleEndianWriter.WriteUInt16(stream, (ushort)(Location.Length + 1));
+                LittleEndianWriter.WriteUInt16(stream, (ushort)Location.Length);
+                ByteWriter.WriteAnsiString(stream, Location, Location.Length);
+            }
+
+            if (HasModifiedBusyStatus)
+            {
+                LittleEndianWriter.WriteUInt32(stream, (uint)BusyStatus);
+            }
+
+            if (HasModifiedHasAttachment)
+            {
+                LittleEndianWriter.WriteUInt32(stream, Convert.ToUInt32(HasAttachment));
+            }
+
+            if (HasModifiedIsAllDayEvent)
+            {
+                LittleEndianWriter.WriteUInt32(stream, Convert.ToUInt32(IsAllDayEvent));
+            }
+
+            if (HasModifiedColor)
+            {
+                LittleEndianWriter.WriteUInt32(stream, Color);
+            }
+        }
+
+        // ExtendedException Structure:
+        // http://msdn.microsoft.com/en-us/library/ee159855%28v=exchg.80%29
+        public void ReadExtendedException(byte[] buffer, ref int offset, uint writerVersion2)
+        {
+            if (writerVersion2 >= AppointmentRecurrencePatternStructure.Outlook2007VersionSignature)
+            {
+                // Change highlight structure:
+                // http://msdn.microsoft.com/en-us/library/ee202316%28v=exchg.80%29
+                uint changeHighlightSize = LittleEndianReader.ReadUInt32(buffer, ref offset);
+                if (changeHighlightSize < 4)
+                {
+                    throw new InvalidRecurrencePatternException("Invalid ChangeHighlightSize");
+                }
+                uint changeHighlightValue = LittleEndianReader.ReadUInt32(buffer, ref offset);
+                offset += (int)changeHighlightSize - 4;
+            }
+
+            uint reservedBlockEE1Size = LittleEndianReader.ReadUInt32(buffer, ref offset);
+            offset += (int)reservedBlockEE1Size;
+
+            if (HasModifiedSubject || HasModifiedLocation)
+            {
+                DateTime extensionNewStartDT = DateTimeHelper.ReadDateTimeFromMinutes(buffer, ref offset);
+                DateTime extensionNewEndDT = DateTimeHelper.ReadDateTimeFromMinutes(buffer, ref offset);
+                DateTime extensionOriginalStartDT = DateTimeHelper.ReadDateTimeFromMinutes(buffer, ref offset);
+                if (extensionNewStartDT != NewStartDT ||
+                    extensionNewEndDT != NewEndDT ||
+                    extensionOriginalStartDT != OriginalStartDT)
+                {
+                    throw new InvalidRecurrencePatternException("Extension timestamp mismatch");
+                }
+
+                if (HasModifiedSubject)
+                {
+                    ushort numberOfCharacters = LittleEndianReader.ReadUInt16(buffer, ref offset);
+                    Subject = ByteReader.ReadUTF16String(buffer, ref offset, numberOfCharacters);
+                }
+
+                if (HasModifiedLocation)
+                {
+                    ushort numberOfCharacters = LittleEndianReader.ReadUInt16(buffer, ref offset);
+                    Location = ByteReader.ReadUTF16String(buffer, ref offset, numberOfCharacters);
+                }
+
+                uint reservedBlockEE2Size = LittleEndianReader.ReadUInt32(buffer, ref offset);
+                offset += (int)reservedBlockEE2Size;
+            }
+        }
+
+        // ExtendedException Structure:
+        // http://msdn.microsoft.com/en-us/library/ee159855%28v=exchg.80%29
+        public void WriteExtendedException(Stream stream, WriterCompatibilityMode writerCompatibilityMode)
+        {
+            if (writerCompatibilityMode >= WriterCompatibilityMode.Outlook2007RTM)
+            {
+                // Change highlight structure:
+                uint changeHighlightSize = 4;
+                LittleEndianWriter.WriteUInt32(stream, changeHighlightSize);
+                int changeHighlightValue = 0; // Apparently Outlook 2010 uses 0 regardless of the actual changes
+                LittleEndianWriter.WriteInt32(stream, changeHighlightValue);
+            }
+
+            uint reservedBlockEE1Size = 0;
+            LittleEndianWriter.WriteUInt32(stream, reservedBlockEE1Size);
+
+            if (HasModifiedSubject || HasModifiedLocation)
+            {
+                DateTimeHelper.WriteDateTimeInMinutes(stream, NewStartDT);
+                DateTimeHelper.WriteDateTimeInMinutes(stream, NewEndDT);
+                DateTimeHelper.WriteDateTimeInMinutes(stream, OriginalStartDT);
+
+                if (HasModifiedSubject)
+                {
+                    LittleEndianWriter.WriteUInt16(stream, (ushort)Subject.Length);
+                    ByteWriter.WriteBytes(stream, Encoding.Unicode.GetBytes(Subject));
+                }
+
+                if (HasModifiedLocation)
+                {
+                    LittleEndianWriter.WriteUInt16(stream, (ushort)Location.Length);
+                    ByteWriter.WriteBytes(stream, Encoding.Unicode.GetBytes(Location));
+                }
+                uint reservedBlockEE2Size = 0;
+                LittleEndianWriter.WriteUInt32(stream, reservedBlockEE2Size);
+            }
+        }
+
+        public void SetStartAndDuration(DateTime startDTUtc, int duration, TimeZoneInfo timezone)
+        {
+            NewStartDT = TimeZoneInfo.ConvertTimeFromUtc(startDTUtc, timezone);
+            NewEndDT = NewStartDT.AddMinutes(duration);
+        }
+
+        public bool HasModifiedSubject
+        {
+            get
+            {
+                return (Flags & OverrideFlags.ModifiedSubject) > 0;
+            }
+            set
+            {
+                Flags &= ~OverrideFlags.ModifiedSubject;
+                if (value)
+                {
+                    Flags |= OverrideFlags.ModifiedSubject;
+                }
+            }
+        }
+
+        public bool HasModifiedStateFlags
+        {
+            get
+            {
+                return (Flags & OverrideFlags.ModifiedStateFlags) > 0;
+            }
+        }
+
+        public bool HasModifiedReminderTime
+        {
+            get
+            {
+                return (Flags & OverrideFlags.ModifiedReminderTime) > 0;
+            }
+        }
+
+        public bool HasModifiedIsReminderSet
+        {
+            get
+            {
+                return (Flags & OverrideFlags.ModifiedIsReminderSet) > 0;
+            }
+        }
+
+        public bool HasModifiedLocation
+        {
+            get
+            {
+                return (Flags & OverrideFlags.ModifiedLocation) > 0;
+            }
+            set
+            {
+                Flags &= ~OverrideFlags.ModifiedLocation;
+                if (value)
+                {
+                    Flags |= OverrideFlags.ModifiedLocation;
+                }
+            }
+        }
+
+        public bool HasModifiedBusyStatus
+        {
+            get
+            {
+                return (Flags & OverrideFlags.ModifiedBustStatus) > 0;
+            }
+            set
+            {
+                Flags &= ~OverrideFlags.ModifiedBustStatus;
+                if (value)
+                {
+                    Flags |= OverrideFlags.ModifiedBustStatus;
+                }
+            }
+        }
+
+        public bool HasModifiedHasAttachment
+        {
+            get
+            {
+                return (Flags & OverrideFlags.ModifiedHasAttachment) > 0;
+            }
+        }
+
+        public bool HasModifiedIsAllDayEvent
+        {
+            get
+            {
+                return (Flags & OverrideFlags.ModifiedIsAllDayEvent) > 0;
+            }
+        }
+
+        public bool HasModifiedColor
+        {
+            get
+            {
+                return (Flags & OverrideFlags.ModifiedColor) > 0;
+            }
+            set
+            {
+                Flags &= ~OverrideFlags.ModifiedColor;
+                if (value)
+                {
+                    Flags |= OverrideFlags.ModifiedColor;
+                }
+            }
+        }
+
+        public bool HasExtendedException
+        {
+            get
+            {
+                return (HasModifiedSubject || HasModifiedLocation);
+            }
+        }
+
+        public int RecordLength
+        {
+            get
+            {
+                int length = 14;
+                if (HasModifiedSubject)
+                {
+                    length += 4;
+                    length += Subject.Length;
+                }
+                if (HasModifiedStateFlags)
+                {
+                    length += 4;
+                }
+                if (HasModifiedReminderTime)
+                {
+                    length += 4;
+                }
+                if (HasModifiedIsReminderSet)
+                {
+                    length += 4;
+                }
+                if (HasModifiedLocation)
+                {
+                    length += 4;
+                    length += Location.Length;
+                }
+                if (HasModifiedBusyStatus)
+                {
+                    length += 4;
+                }
+                if (HasModifiedHasAttachment)
+                {
+                    length += 4;
+                }
+                if (HasModifiedIsAllDayEvent)
+                {
+                    length += 4;
+                }
+                if (HasModifiedColor)
+                {
+                    length += 4;
+                }
+                return length;
+            }
+        }
+        
+        [Obsolete]
+        public int GetExtendedExceptionLength(WriterCompatibilityMode writerCompatibilityMode)
+        {
+            int length = 4;
+            if (HasExtendedException)
+            {
+                if (writerCompatibilityMode >= WriterCompatibilityMode.Outlook2007RTM)
+                {
+                    length += 8;
+                }
+                length += 16;
+                if (HasModifiedSubject)
+                {
+                    length += 2;
+                    length += Subject.Length * 2;
+                }
+                if (HasModifiedLocation)
+                {
+                    length += 2;
+                    length += Location.Length * 2;
+                }
+            }
+            return length;
+        }
+
+        public DateTime GetOriginalStartDTUtc(TimeZoneInfo timezone)
+        {
+            // Outlook 2007 SP3 can store invalid OriginalStartDT
+            return TimeZoneInfoUtils.SafeConvertToUtc(OriginalStartDT, timezone);
+        }
+
+        public void SetOriginalStartDTUtc(DateTime originalStartDTUtc, TimeZoneInfo timezone)
+        {
+            OriginalStartDT = TimeZoneInfo.ConvertTimeFromUtc(originalStartDTUtc, timezone);
+        }
+
+        public DateTime GetNewStartDTUtc(TimeZoneInfo timezone)
+        {
+            // Outlook 2007 SP3 can store invalid NewStartDT
+            return TimeZoneInfoUtils.SafeConvertToUtc(NewStartDT, timezone);
+        }
+
+        public void SetNewStartDTUtc(DateTime newStartDTUtc, TimeZoneInfo timezone)
+        {
+            NewStartDT = TimeZoneInfo.ConvertTimeFromUtc(newStartDTUtc, timezone);
+        }
+
+        public DateTime GetNewEndDTUtc(TimeZoneInfo timezone)
+        {
+            // Outlook 2007 SP3 can store invalid NewEndDT
+            return TimeZoneInfoUtils.SafeConvertToUtc(NewEndDT, timezone);
+        }
+
+        /// <summary>
+        /// The timespan in minutes from the start time to end time in timezone time.
+        /// It will differ from the actual duration (UTC) if an appointment instance is spanning both standard time and daylight time.
+        /// </summary>
+        public int Duration
+        {
+            get
+            {
+                TimeSpan ts = NewEndDT - NewStartDT;
+                return (int)ts.TotalMinutes;
+            }
+        }
+
+        /// <summary>
+        /// This should be further improved
+        /// </summary>
+        // http://msdn.microsoft.com/en-us/library/ee204210%28v=exchg.80%29
+        public int ChangeHighlight
+        {
+            get
+            { 
+                int result = 0;
+                if (HasModifiedLocation)
+                {
+                    result |= 0x08;
+                }
+                if (HasModifiedSubject)
+                {
+                    result |= 0x10;
+                }
+                return result;
+            }
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/MonthlyRecurrencePatternStructure.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/MonthlyRecurrencePatternStructure.cs
@@ -1,0 +1,67 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Utilities;
+
+namespace PSTFileFormat
+{
+    public class MonthlyRecurrencePatternStructure : AppointmentRecurrencePatternStructure
+    {
+        public uint DayOfMonth;
+        public OutlookDayOfWeek DayOfWeek;
+        public DayOccurenceNumber DayOccurenceNumber;
+
+        public MonthlyRecurrencePatternStructure()
+        {
+            RecurFrequency = RecurrenceFrequency.Monthly;
+        }
+
+        public MonthlyRecurrencePatternStructure(byte[] buffer) : base(buffer)
+        {
+        }
+
+        public override void ReadPatternTypeSpecific(byte[] buffer, ref int offset)
+        {
+            // we start reading from offset 22
+            if (PatternType == PatternType.Month) // i.e. the 23th of every month
+            {
+                DayOfMonth = LittleEndianReader.ReadUInt32(buffer, ref offset);
+            }
+            else if (PatternType == PatternType.MonthNth) // i.e. the fourth monday of every month
+            {
+                DayOfWeek = (OutlookDayOfWeek)LittleEndianReader.ReadUInt32(buffer, ref offset);
+                DayOccurenceNumber = (DayOccurenceNumber)LittleEndianReader.ReadUInt32(buffer, ref offset);
+            }
+            else
+            {
+                throw new InvalidRecurrencePatternException("Invalid Pattern Type");
+            }
+        }
+
+        public override void WritePatternTypeSpecific(Stream stream)
+        {
+            if (PatternType == PatternType.Month) // i.e. the 23th of every month
+            {
+                LittleEndianWriter.WriteUInt32(stream, DayOfMonth);
+            }
+            else if (PatternType == PatternType.MonthNth) // i.e. the fourth monday of every month
+            {
+                LittleEndianWriter.WriteUInt32(stream, (uint)DayOfWeek);
+                LittleEndianWriter.WriteUInt32(stream, (uint)DayOccurenceNumber);
+            }
+            else
+            {
+                throw new InvalidRecurrencePatternException("Invalid Pattern Type");
+            }
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/RecurrenceTypeHelper.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/RecurrenceTypeHelper.cs
@@ -1,0 +1,94 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Utilities;
+
+namespace PSTFileFormat
+{
+    public class RecurrenceTypeHelper
+    {
+        public static RecurrenceType GetRecurrenceType(RecurrenceFrequency recurrenceFrequency, PatternType patternType)
+        {
+            if (recurrenceFrequency == RecurrenceFrequency.Daily && patternType == PatternType.Day)
+            {
+                return RecurrenceType.EveryNDays;
+            }
+            else if (recurrenceFrequency == RecurrenceFrequency.Daily && patternType == PatternType.Week)
+            {
+                return RecurrenceType.EveryWeekday;
+            }
+            else if (recurrenceFrequency == RecurrenceFrequency.Weekly && patternType == PatternType.Week)
+            {
+                return RecurrenceType.EveryNWeeks;
+            }
+            else if (recurrenceFrequency == RecurrenceFrequency.Monthly && patternType == PatternType.Month)
+            {
+                return RecurrenceType.EveryNMonths;
+            }
+            else if (recurrenceFrequency == RecurrenceFrequency.Monthly && patternType == PatternType.MonthNth)
+            {
+                return RecurrenceType.EveryNthDayOfEveryNMonths;
+            }
+            else if (recurrenceFrequency == RecurrenceFrequency.Yearly && patternType == PatternType.Month)
+            {
+                return RecurrenceType.EveryNYears;
+            }
+            else if (recurrenceFrequency == RecurrenceFrequency.Yearly && patternType == PatternType.MonthNth)
+            {
+                return RecurrenceType.EveryNthDayOfEveryNYears;
+            }
+            else
+            {
+                throw new InvalidRecurrencePatternException("Invalid combination of RecurrenceFrequency and PatternType");
+            }
+        }
+
+        public static RecurrenceFrequency GetRecurrenceFrequency(RecurrenceType recurrenceType)
+        {
+            switch (recurrenceType)
+            { 
+                case RecurrenceType.EveryNDays:
+                case RecurrenceType.EveryWeekday:
+                    return RecurrenceFrequency.Daily;
+                case RecurrenceType.EveryNWeeks:
+                    return RecurrenceFrequency.Weekly;
+                case RecurrenceType.EveryNMonths:
+                case RecurrenceType.EveryNthDayOfEveryNMonths:
+                    return RecurrenceFrequency.Monthly;
+                case RecurrenceType.EveryNYears:
+                case RecurrenceType.EveryNthDayOfEveryNYears:
+                    return RecurrenceFrequency.Yearly;
+                default:
+                    throw new ArgumentException("Invalid recurrence type");
+            }
+        }
+
+        public static PatternType GetPatternType(RecurrenceType recurrenceType)
+        {
+            switch (recurrenceType)
+            {
+                case RecurrenceType.EveryNDays:
+                    return PatternType.Day;
+                case RecurrenceType.EveryWeekday:
+                case RecurrenceType.EveryNWeeks:
+                    return PatternType.Week;
+                case RecurrenceType.EveryNMonths:
+                case RecurrenceType.EveryNYears:
+                    return PatternType.Month;
+                case RecurrenceType.EveryNthDayOfEveryNMonths:
+                case RecurrenceType.EveryNthDayOfEveryNYears:
+                    return PatternType.MonthNth;
+                default:
+                    throw new ArgumentException("Invalid recurrence type");
+            }
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/WeeklyRecurrencePatternStructure.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/WeeklyRecurrencePatternStructure.cs
@@ -1,0 +1,55 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Utilities;
+
+namespace PSTFileFormat
+{
+    public class WeeklyRecurrencePatternStructure : AppointmentRecurrencePatternStructure
+    {
+        public DaysOfWeekFlags DaysOfWeek;
+
+        public WeeklyRecurrencePatternStructure()
+        {
+            RecurFrequency = RecurrenceFrequency.Weekly;
+        }
+
+        public WeeklyRecurrencePatternStructure(byte[] buffer) : base(buffer)
+        {
+        }
+
+        public override void ReadPatternTypeSpecific(byte[] buffer, ref int offset)
+        {
+            // we start reading from offset 22
+            if (PatternType == PatternType.Week) // specific days in week
+            {
+                DaysOfWeek = (DaysOfWeekFlags)LittleEndianReader.ReadUInt32(buffer, ref offset);
+            }
+            else
+            {
+                throw new InvalidRecurrencePatternException("Invalid Pattern Type");
+            }
+        }
+
+        public override void WritePatternTypeSpecific(Stream stream)
+        {
+            if (PatternType == PatternType.Week) // specific days in week
+            {
+                LittleEndianWriter.WriteUInt32(stream, (uint)DaysOfWeek);
+            }
+            else
+            {
+                throw new InvalidRecurrencePatternException("Invalid Pattern Type");
+            }
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/YearlyRecurrencePatternStructure.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/RecurrencePatternStructure/YearlyRecurrencePatternStructure.cs
@@ -1,0 +1,67 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Utilities;
+
+namespace PSTFileFormat
+{
+    public class YearlyRecurrencePatternStructure : AppointmentRecurrencePatternStructure
+    {
+        public uint DayOfMonth;
+        public OutlookDayOfWeek DayOfWeek;
+        public DayOccurenceNumber DayOccurenceNumber;
+        
+        public YearlyRecurrencePatternStructure()
+        {
+            RecurFrequency = RecurrenceFrequency.Yearly;
+        }
+
+        public YearlyRecurrencePatternStructure(byte[] buffer) : base(buffer)
+        {
+        }
+
+        public override void ReadPatternTypeSpecific(byte[] buffer, ref int offset)
+        {
+            // we start reading from offset 22
+            if (PatternType == PatternType.Month) // i.e. the 23rd of may
+            {
+                DayOfMonth = LittleEndianReader.ReadUInt32(buffer, ref offset);
+            }
+            else if (PatternType == PatternType.MonthNth) // i.e. the fourth monday of may
+            {
+                DayOfWeek = (OutlookDayOfWeek)LittleEndianReader.ReadUInt32(buffer, ref offset);
+                DayOccurenceNumber = (DayOccurenceNumber)LittleEndianReader.ReadUInt32(buffer, ref offset);
+            }
+            else
+            {
+                throw new InvalidRecurrencePatternException("Invalid Pattern Type");
+            }
+        }
+
+        public override void WritePatternTypeSpecific(Stream stream)
+        {
+            if (PatternType == PatternType.Month) // i.e. the 23rd of may
+            {
+                LittleEndianWriter.WriteUInt32(stream, DayOfMonth);
+            }
+            else if (PatternType == PatternType.MonthNth) // i.e. the fourth monday of may
+            {
+                LittleEndianWriter.WriteUInt32(stream, (uint)DayOfWeek);
+                LittleEndianWriter.WriteUInt32(stream, (uint)DayOccurenceNumber);
+            }
+            else
+            {
+                throw new InvalidRecurrencePatternException("Invalid Pattern Type");
+            }
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/RecurringAppointment.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/RecurringAppointment.cs
@@ -1,0 +1,452 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Utilities;
+
+namespace PSTFileFormat
+{
+    public class RecurringAppointment : Appointment
+    {
+        private DateTime m_startDTUtc; // In UTC
+        private int m_duration; // in minutes (can be more than 24 hours)
+        public RecurrenceType RecurrenceType;
+        private DateTime m_lastInstanceStartDate;
+        public bool EndAfterNumberOfOccurences;
+        public int Period;
+        public int Day; // Day of Week / Day Of Month
+        public DayOccurenceNumber DayOccurenceNumber;
+        public List<DateTime> DeletedInstanceDates = new List<DateTime>(); // In timezone time
+        public List<ExceptionInfoStructure> ExceptionList = new List<ExceptionInfoStructure>();
+
+        public RecurringAppointment(PSTNode node) : base(node)
+        {
+            this.Recurring = true;
+            byte[] bytes = PC.GetBytesProperty(PropertyNames.PidLidAppointmentRecur);
+            if (bytes != null)
+            {
+                ReadRecurrencePattern(bytes);
+            }
+        }
+
+        private void ReadRecurrencePattern(byte[] bytes)
+        {
+            AppointmentRecurrencePatternStructure structure = AppointmentRecurrencePatternStructure.GetRecurrencePatternStructure(bytes);
+            m_startDTUtc = structure.GetStartDTUtc(this.OriginalTimeZone);
+            m_duration = structure.Duration;
+            RecurrenceType = structure.RecurrenceType;
+            m_lastInstanceStartDate = structure.LastInstanceStartDate;
+            Period = structure.PeriodInRecurrenceTypeUnits;
+
+            if (structure.EndType == RecurrenceEndType.EndAfterNOccurrences)
+            {
+                EndAfterNumberOfOccurences = true;
+            }
+
+            switch (structure.RecurFrequency)
+            {
+                case RecurrenceFrequency.Daily:
+                    {
+                        break;
+                    }
+                case RecurrenceFrequency.Weekly:
+                    {
+                        Day = (int)((WeeklyRecurrencePatternStructure)structure).DaysOfWeek;
+                        break;
+                    }
+                case RecurrenceFrequency.Monthly:
+                    {
+                        if (structure.PatternType == PatternType.Month)
+                        {
+                            Day = (int)((MonthlyRecurrencePatternStructure)structure).DayOfMonth;
+                        }
+                        else // MonthNth
+                        {
+                            Day = (int)((MonthlyRecurrencePatternStructure)structure).DayOfWeek;
+                            DayOccurenceNumber = ((MonthlyRecurrencePatternStructure)structure).DayOccurenceNumber;
+                        }
+                        break;
+                    }
+                case RecurrenceFrequency.Yearly:
+                    {
+                        if (structure.PatternType == PatternType.Month)
+                        {
+                            Day = (int)((YearlyRecurrencePatternStructure)structure).DayOfMonth;
+                        }
+                        else // MonthNth
+                        {
+                            Day = (int)((YearlyRecurrencePatternStructure)structure).DayOfWeek;
+                            DayOccurenceNumber = ((YearlyRecurrencePatternStructure)structure).DayOccurenceNumber;
+                        }
+                    }
+                    break;
+            }
+
+            DeletedInstanceDates = structure.DeletedInstanceDates;
+            ExceptionList = structure.ExceptionList;
+        }
+
+        private AppointmentRecurrencePatternStructure GetRecurrencePattern(TimeZoneInfo timezone)
+        {
+            AppointmentRecurrencePatternStructure structure;
+            RecurrenceFrequency recurrenceFrequency = RecurrenceTypeHelper.GetRecurrenceFrequency(RecurrenceType);
+            PatternType patternType = RecurrenceTypeHelper.GetPatternType(RecurrenceType);
+            
+            switch (recurrenceFrequency)
+            {
+                case RecurrenceFrequency.Daily:
+                    structure = new DailyRecurrencePatternStructure();
+                    break;
+                case RecurrenceFrequency.Weekly:
+                    structure = new WeeklyRecurrencePatternStructure();
+                    ((WeeklyRecurrencePatternStructure)structure).DaysOfWeek = (DaysOfWeekFlags)Day;
+                    break;
+                case RecurrenceFrequency.Monthly:
+                    structure = new MonthlyRecurrencePatternStructure();
+                    if (patternType == PatternType.Month)
+                    {
+                        ((MonthlyRecurrencePatternStructure)structure).DayOfMonth = (uint)Day;
+                    }
+                    else
+                    {
+                        ((MonthlyRecurrencePatternStructure)structure).DayOfWeek = (OutlookDayOfWeek)Day;
+                        ((MonthlyRecurrencePatternStructure)structure).DayOccurenceNumber = DayOccurenceNumber;
+                    }
+                    break;
+                case RecurrenceFrequency.Yearly:
+                    structure = new YearlyRecurrencePatternStructure();
+                    if (patternType == PatternType.Month)
+                    {
+                        ((YearlyRecurrencePatternStructure)structure).DayOfMonth = (uint)Day;
+                    }
+                    else
+                    {
+                        ((YearlyRecurrencePatternStructure)structure).DayOfWeek = (OutlookDayOfWeek)Day;
+                        ((YearlyRecurrencePatternStructure)structure).DayOccurenceNumber = DayOccurenceNumber;
+                    }
+                    break;
+                default:
+                    throw new InvalidRecurrencePatternException("Recurrence frequency is invalid");
+            }
+            structure.PatternType = patternType;
+            structure.PeriodInRecurrenceTypeUnits = Period;
+            structure.SetStartAndDuration(m_startDTUtc, m_duration, timezone);
+            DateTime startDTZone = TimeZoneInfo.ConvertTimeFromUtc(m_startDTUtc, timezone);
+            structure.FirstDateTimeInDays = AppointmentRecurrencePatternStructure.CalculateFirstDateTimeInDays(recurrenceFrequency, patternType, Period, startDTZone);
+            structure.LastInstanceStartDate = m_lastInstanceStartDate;
+            if (EndAfterNumberOfOccurences)
+            {
+                structure.OccurrenceCount = (uint)CalendarHelper.CalculateNumberOfOccurences(StartDTUtc, m_lastInstanceStartDate, this.RecurrenceType, Period, Day);
+                structure.EndType = RecurrenceEndType.EndAfterNOccurrences;
+            }
+            else if (m_lastInstanceStartDate.Year >= 4500)
+            {
+                structure.EndType = RecurrenceEndType.NeverEnd;
+                structure.OccurrenceCount = 10;
+            }
+            else
+            {
+                structure.EndType = RecurrenceEndType.EndAfterDate;
+                // OccurrenceCount should not be 0, or otherwise Outlook 2003's Appointment recurrence window is not loaded properly
+                structure.OccurrenceCount = 10;
+            }
+            
+            structure.DeletedInstanceDates = DeletedInstanceDates;
+            foreach (ExceptionInfoStructure exception in ExceptionList)
+            {
+                structure.ModifiedInstanceDates.Add(DateTimeUtils.GetDayStart(exception.NewStartDT));
+            }
+            structure.ExceptionList = ExceptionList;
+            return structure;
+        }
+
+        public ModifiedAppointmentInstance GetModifiedInstance(int attachmentIndex)
+        {
+            AttachmentObject attachmentObject = this.GetAttachmentObject(attachmentIndex);
+            Subnode subnode = attachmentObject.AttachedNode;
+            if (subnode != null)
+            {
+                ModifiedAppointmentInstance modifiedInstance = new ModifiedAppointmentInstance(subnode);
+                return modifiedInstance;
+            }
+            return null;
+        }
+
+        public override void SaveChanges()
+        {
+            TimeZoneInfo timezone = this.OriginalTimeZone;
+            if (timezone == null)
+            {
+                // if time zone was not provided, store current system time zone definition
+                timezone = TimeZoneInfoUtils.GetSystemStaticTimeZone(TimeZoneInfo.Local.Id);
+            }
+            AppointmentRecurrencePatternStructure structure = GetRecurrencePattern(timezone);
+
+            PC.SetBytesProperty(PropertyNames.PidLidAppointmentRecur, structure.GetBytes(this.File.WriterCompatibilityMode));
+
+            base.SaveChanges();
+        }
+
+        public override void SetStartAndDuration(DateTime startDTUtc, int duration)
+        {
+            this.StartDTUtc = startDTUtc;
+            m_duration = duration;
+            this.AppointmentDuration = duration;
+
+            DateTime endDT = startDTUtc.AddMinutes(duration);
+            this.EndWhole = endDT;
+            this.CommonEnd = endDT;
+        }
+
+        /// <param name="dynamicTimeZone">can be set to null if not available</param>
+        public override void SetOriginalTimeZone(TimeZoneInfo staticTimeZone, TimeZoneInfo dynamicTimeZone, int effectiveYear)
+        {
+            this.TimeZoneStructure = TimeZoneStructure.FromTimeZoneInfo(staticTimeZone);
+            this.TimeZoneDescription = staticTimeZone.DisplayName;
+            if (this.File.WriterCompatibilityMode >= WriterCompatibilityMode.Outlook2003SP3)
+            {
+                TimeZoneInfo.AdjustmentRule effectiveRule = AdjustmentRuleUtils.GetFirstRule(staticTimeZone);
+                TimeZoneInfo definitionTimezone = (dynamicTimeZone == null) ? staticTimeZone : dynamicTimeZone;
+                TimeZoneDefinitionStructure timeZoneDefinitionStartDisplay = TimeZoneDefinitionStructure.FromTimeZoneInfo(definitionTimezone, effectiveRule, effectiveYear, false);
+                this.TimeZoneDefinitionStartDisplay = timeZoneDefinitionStartDisplay;
+                // We do not set TimeZoneDefinitionEndDisplay, so Outlook will use TimeZoneDefinitionStartDisplay.
+
+                // Only Outlook 2007 uses PidLidAppointmentTimeZoneDefinitionRecur
+                if (this.File.WriterCompatibilityMode >= WriterCompatibilityMode.Outlook2007RTM &&
+                    this.File.WriterCompatibilityMode < WriterCompatibilityMode.Outlook2010RTM)
+                {
+                    TimeZoneDefinitionStructure timeZoneDefinitionRecurStructure = TimeZoneDefinitionStructure.FromTimeZoneInfo(definitionTimezone, effectiveRule, effectiveYear, true);
+                    this.TimeZoneDefinitionRecurStructure = timeZoneDefinitionRecurStructure;
+                }
+            }
+        }
+
+        public override DateTime StartDTUtc
+        {
+            get
+            {
+                return m_startDTUtc;
+            }
+            set
+            {
+                m_startDTUtc = value;
+                this.CommonStart = value;
+                this.StartWhole = value;
+
+                DateTime startDTZone = TimeZoneInfo.ConvertTimeFromUtc(value, this.OriginalTimeZone);
+                DateTime midnightDTZone = DateTimeUtils.GetDayStart(startDTZone);
+                this.ClipStart = TimeZoneInfo.ConvertTimeToUtc(midnightDTZone, this.OriginalTimeZone);
+            }
+        }
+
+
+        /// <summary>
+        /// Note:
+        /// 1. For the purpose of calculating the start time of recurring appointments
+        ///    Outlook 2003 uses PidLidTimeZoneStruct, however, this is a simple structure that can hold
+        ///    a single DST (daylight savings time) rule, which does not reflect the fact that over time,
+        ///    time zone rules can change.
+        /// 2. Outlook 2007 uses PidLidAppointmentTimeZoneDefinitionRecur, which contains multiple DST rules,
+        ///    However, it only uses a single rule (the effective rule) for all calculations.
+        /// 3. If DST is enabled but the appointment does not contain a rule,
+        ///     Outlook (both 2003 and 2007) will use the OS static timezone rule.
+        /// </summary>
+        public override TimeZoneInfo OriginalTimeZone
+        {
+            get
+            {
+                TimeZoneStructure timezoneStructure = this.TimeZoneStructure;
+                TimeZoneDefinitionStructure timezoneDefinitionStructure = this.TimeZoneDefinitionRecurStructure;
+
+                if (timezoneStructure == null) // no legacy structure, even if there is Outlook 2007+ structure, it's not consistent
+                {
+                    // assume current system time zone definition
+                    return TimeZoneInfoUtils.GetSystemStaticTimeZone(TimeZoneInfo.Local.Id);
+                }
+                else // legacy structure present
+                {
+                    if (timezoneDefinitionStructure != null)
+                    {
+                        // If the PidLidAppointmentTimeZoneDefinitionRecur property is not set or is
+                        // inconsistent with the associated PidLidTimeZoneStruct structure, the values in the
+                        // PidLidTimeZoneStruct property are used to determine the effective time zone rule.
+                        if (timezoneDefinitionStructure.IsConsistent(timezoneStructure))
+                        {
+                            return timezoneDefinitionStructure.ToTimeZoneInfo();
+                        }
+                    }
+                    
+                    string timezoneDisplayName = this.TimeZoneDescription;
+                    // I've encountered cases where instead of '(GMT+2:00) Jerusalem', the stored value was
+                    // '(GMT+02:00) Israel Standard Time' or
+                    // '(GMT+02:00) (GMT+02:00) Israel Standard Time'
+
+                    // Should we try to get the timezone key name from TimeZoneDefinitionStartDisplay?
+                    string timezoneKeyName = TimeZoneInfo.Local.Id;
+                    if (!String.IsNullOrEmpty(timezoneDisplayName))
+                    {
+                        TimeZoneInfo temp = TimeZoneInfoUtils.FindSystemTimeZoneByDisplayName(timezoneDisplayName);
+                        if (temp != null)
+                        {
+                            timezoneKeyName = temp.Id;
+                        }
+                    }
+
+                    return timezoneStructure.ToTimeZoneInfo(timezoneKeyName);
+                }
+            }
+        }
+
+        public override bool HasTimeZoneDefinition
+        {
+           get 
+           {
+               return (this.TimeZoneStructure != null || this.TimeZoneDefinitionRecurStructure != null);
+           }
+        }
+
+        /// <summary>
+        /// Legacy - Outlook 2003
+        /// </summary>
+        public TimeZoneStructure TimeZoneStructure
+        {
+            get
+            {
+                byte[] bytes = PC.GetBytesProperty(PropertyNames.PidLidTimeZoneStruct);
+                if (bytes != null)
+                {
+                    TimeZoneStructure structure = new TimeZoneStructure(bytes);
+                    return structure;
+                }
+                return null;
+            }
+            set
+            {
+                PC.SetBytesProperty(PropertyNames.PidLidTimeZoneStruct, value.GetBytes());
+            }
+        }
+
+        /// <summary>
+        /// Written by Outlook 2007 and above,
+        /// This should be equivalent to TimeZoneDefinitionStartDisplay
+        /// (except the TZRULE_FLAG_RECUR_CURRENT_TZREG flag).
+        /// </summary>
+        public TimeZoneDefinitionStructure TimeZoneDefinitionRecurStructure
+        {
+            get
+            {
+                byte[] bytes = PC.GetBytesProperty(PropertyNames.PidLidAppointmentTimeZoneDefinitionRecur);
+                if (bytes != null)
+                {
+                    TimeZoneDefinitionStructure structure = new TimeZoneDefinitionStructure(bytes);
+                    return structure;
+                }
+                return null;
+            }
+            set
+            {
+                PC.SetBytesProperty(PropertyNames.PidLidAppointmentTimeZoneDefinitionRecur, value.GetBytes());
+            }
+        }
+
+        public void AddModifiedInstanceAttachment(DateTime originalStartDTUtc, int originalDuration, DateTime newStartDTUtc, int duration, string subject, string location, BusyStatus busyStatus, int color, MessagePriority priority, TimeZoneInfo timezone)
+        {
+            AttachmentObject attachment = AttachmentObject.CreateNewExceptionAttachmentObject(this.File, this.SubnodeBTree);
+            ModifiedAppointmentInstance modifiedInstance = ModifiedAppointmentInstance.CreateNewModifiedInstance(attachment.File, attachment.SubnodeBTree);
+            modifiedInstance.SetStartAndDuration(newStartDTUtc, duration);
+            modifiedInstance.AlternateRecipientAllowed = true;
+            modifiedInstance.Subject = subject;
+            modifiedInstance.Location = location;
+            //modifiedInstance.Sensitivity = 0;
+            modifiedInstance.Priority = priority;
+            modifiedInstance.BusyStatus = busyStatus;
+            modifiedInstance.Color = color;
+            modifiedInstance.MessageFlags = MessageFlags.MSGFLAG_READ;
+            modifiedInstance.ExceptionReplaceTime = originalStartDTUtc;
+            modifiedInstance.StartDate = originalStartDTUtc;
+            modifiedInstance.EndDate = originalStartDTUtc.AddMinutes(originalDuration);
+
+            modifiedInstance.SaveChanges(attachment.SubnodeBTree);
+            attachment.StoreModifiedInstance(modifiedInstance, timezone);
+            attachment.SaveChanges(this.SubnodeBTree);
+            this.AddAttachment(attachment);
+        }
+
+        public DateTime LastInstanceStartDate
+        {
+            get
+            {
+                return m_lastInstanceStartDate;
+            }
+            set
+            {
+                m_lastInstanceStartDate = DateTimeUtils.GetDayStart(value);
+                // DateTimeKind.Local means the current timezone on the client computer, while we use the timezone specified by the appointment
+                DateTime midnightDTZone = DateTime.SpecifyKind(m_lastInstanceStartDate, DateTimeKind.Unspecified);
+                this.ClipEnd = TimeZoneInfo.ConvertTimeToUtc(midnightDTZone, this.OriginalTimeZone);
+            }
+        }
+
+        [Obsolete]
+        public DateTime LastInstanceStartDTUtc
+        {
+            get
+            {
+                // We take daylight saving into account:
+                TimeSpan zoneTimeOfDay = TimeZoneInfo.ConvertTimeFromUtc(StartDTUtc, this.OriginalTimeZone).TimeOfDay;
+                DateTime lastInstanceStartDTZone = TimeZoneInfoUtils.SetValidTimeOfDay(m_lastInstanceStartDate, zoneTimeOfDay, this.OriginalTimeZone);
+                return TimeZoneInfoUtils.AdvancedConvertToUtc(lastInstanceStartDTZone, this.OriginalTimeZone, true);
+            }
+        }
+
+        [Obsolete]
+        public DateTime LastInstanceEndDTUtc
+        {
+            get
+            {
+                return LastInstanceStartDTUtc.AddMinutes(this.Duration);
+            }
+        }
+
+        /// <summary>
+        /// The timespan in minutes from the start time to end time in timezone time.
+        /// It will differ from the actual duration (UTC) if an appointment instance is spanning both standard time and daylight time.
+        /// </summary>
+        public override int Duration
+        {
+            get 
+            {
+                return m_duration;
+            }
+        }
+
+        public static RecurringAppointment CreateNewRecurringAppointment(PSTFile file, NodeID parentNodeID)
+        {
+            return CreateNewRecurringAppointment(file, parentNodeID, Guid.NewGuid());
+        }
+
+        public static RecurringAppointment CreateNewRecurringAppointment(PSTFile file, NodeID parentNodeID, Guid searchKey)
+        {
+            MessageObject message = CreateNewMessage(file, FolderItemTypeName.Appointment, parentNodeID, searchKey);
+            RecurringAppointment appointment = new RecurringAppointment(message);
+            appointment.MessageFlags = MessageFlags.MSGFLAG_READ;
+            appointment.InternetCodepage = 1255;
+            appointment.MessageDeliveryTime = DateTime.UtcNow;
+            appointment.ClientSubmitTime = DateTime.UtcNow;
+            appointment.SideEffects = SideEffectsFlags.seOpenForCtxMenu | SideEffectsFlags.seOpenToMove | SideEffectsFlags.seOpenToCopy | SideEffectsFlags.seCoerceToInbox | SideEffectsFlags.seOpenToDelete;
+            appointment.Importance = MessageImportance.Normal;
+            appointment.Priority = MessagePriority.Normal;
+            appointment.ConferencingType = MeetingType.WindowsNetmeeting;
+
+            appointment.IconIndex = IconIndex.RecurringAppointment;
+            return appointment;
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/RecurringAppointment.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/RecurringAppointment.cs
@@ -154,8 +154,12 @@ namespace PSTFileFormat
             else
             {
                 structure.EndType = RecurrenceEndType.EndAfterDate;
+                // [ContinuMail 2026] Real Outlook stores the actual occurrence count for an end-by-date
+                // (UNTIL) series, not a fixed sentinel; computing it makes the serialized
+                // PidLidAppointmentRecur blob byte-for-byte identical to Outlook's. CalculateNumberOfOccurences
+                // always returns >= 1, so the "must not be 0" requirement below still holds.
                 // OccurrenceCount should not be 0, or otherwise Outlook 2003's Appointment recurrence window is not loaded properly
-                structure.OccurrenceCount = 10;
+                structure.OccurrenceCount = (uint)CalendarHelper.CalculateNumberOfOccurences(StartDTUtc, m_lastInstanceStartDate, this.RecurrenceType, Period, Day);
             }
             
             structure.DeletedInstanceDates = DeletedInstanceDates;

--- a/vendor/PSTFileFormat/Messaging/Messages/RecurringAppointment.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/RecurringAppointment.cs
@@ -20,6 +20,11 @@ namespace PSTFileFormat
         public RecurrenceType RecurrenceType;
         private DateTime m_lastInstanceStartDate;
         public bool EndAfterNumberOfOccurences;
+        // [ContinuMail 2026] Explicit occurrence count for a COUNT-terminated series. When set (>0) and
+        // EndAfterNumberOfOccurences is true, it is written verbatim as the blob's OccurrenceCount instead
+        // of the date-span heuristic (which overcounts period-skipping patterns, e.g. BYMONTHDAY=31).
+        // Null for callers that do not supply it (e.g. the vendor blob tests) — they keep the heuristic.
+        public int? OccurrenceCount;
         public int Period;
         public int Day; // Day of Week / Day Of Month
         public DayOccurenceNumber DayOccurenceNumber;
@@ -150,7 +155,13 @@ namespace PSTFileFormat
             structure.LastInstanceStartDate = m_lastInstanceStartDate;
             if (EndAfterNumberOfOccurences)
             {
-                structure.OccurrenceCount = (uint)CalendarHelper.CalculateNumberOfOccurences(StartDTUtc, m_lastInstanceStartDate, this.RecurrenceType, Period, Day);
+                // [ContinuMail 2026] Prefer the explicit COUNT when supplied; the date-span heuristic
+                // overcounts period-skipping patterns (e.g. BYMONTHDAY=31 skips 30-day months). Falls
+                // back to the heuristic when OccurrenceCount is unset (blob-test callers), preserving
+                // byte-identity there. Must be >= 1 (Outlook 2003 recurrence-window guard).
+                structure.OccurrenceCount = (OccurrenceCount is { } oc && oc > 0)
+                    ? (uint)oc
+                    : (uint)CalendarHelper.CalculateNumberOfOccurences(StartDTUtc, m_lastInstanceStartDate, this.RecurrenceType, Period, Day);
                 structure.EndType = RecurrenceEndType.EndAfterNOccurrences;
             }
             else if (m_lastInstanceStartDate.Year >= 4500)

--- a/vendor/PSTFileFormat/Messaging/Messages/RecurringAppointment.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/RecurringAppointment.cs
@@ -26,6 +26,13 @@ namespace PSTFileFormat
         public List<DateTime> DeletedInstanceDates = new List<DateTime>(); // In timezone time
         public List<ExceptionInfoStructure> ExceptionList = new List<ExceptionInfoStructure>();
 
+        // [ContinuMail 2026] Caches the zone passed to SetOriginalTimeZone so the write path
+        // (StartDTUtc/LastInstanceStartDate setters, SaveChanges) does NOT re-derive it from the
+        // serialized blob via RegistryTimeZoneUtils — which throws PlatformNotSupportedException
+        // off-Windows and, for an unknown key name, silently falls back to the local system zone.
+        // Null when the object was constructed by reading an existing file (getter derives from blob).
+        private TimeZoneInfo m_originalTimeZone;
+
         public RecurringAppointment(PSTNode node) : base(node)
         {
             this.Recurring = true;
@@ -212,6 +219,7 @@ namespace PSTFileFormat
         /// <param name="dynamicTimeZone">can be set to null if not available</param>
         public override void SetOriginalTimeZone(TimeZoneInfo staticTimeZone, TimeZoneInfo dynamicTimeZone, int effectiveYear)
         {
+            this.m_originalTimeZone = staticTimeZone; // [ContinuMail 2026] cache for the write path (see field comment)
             this.TimeZoneStructure = TimeZoneStructure.FromTimeZoneInfo(staticTimeZone);
             this.TimeZoneDescription = staticTimeZone.DisplayName;
             if (this.File.WriterCompatibilityMode >= WriterCompatibilityMode.Outlook2003SP3)
@@ -266,6 +274,13 @@ namespace PSTFileFormat
         {
             get
             {
+                // [ContinuMail 2026] On the write path the zone was supplied via SetOriginalTimeZone;
+                // return it directly instead of re-deriving from the blob (registry-dependent, off-Windows fatal).
+                if (this.m_originalTimeZone != null)
+                {
+                    return this.m_originalTimeZone;
+                }
+
                 TimeZoneStructure timezoneStructure = this.TimeZoneStructure;
                 TimeZoneDefinitionStructure timezoneDefinitionStructure = this.TimeZoneDefinitionRecurStructure;
 

--- a/vendor/PSTFileFormat/Messaging/Messages/SingleAppointment.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/SingleAppointment.cs
@@ -1,0 +1,144 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Utilities;
+
+namespace PSTFileFormat
+{
+    public class SingleAppointment : Appointment // represents single-instance appointment
+    {
+        public SingleAppointment(PSTNode node) : base(node)
+        {
+            this.Recurring = false;
+            //this.IsRecurring = false;
+        }
+
+        public override void SaveChanges()
+        {
+            base.SaveChanges();
+        }
+
+        public override void SetStartAndDuration(DateTime startDTUtc, int duration)
+        {
+            // We work in UTC, this way we avoid any oddities that are due to daylight savings
+            DateTime endDTUtc = startDTUtc.AddMinutes(duration);
+
+            this.StartDTUtc = startDTUtc;
+            this.EndDTUtc = endDTUtc;
+
+            // To prevent daylight savings mistakes, we simply do not set PidLidAppointmentDuration
+        }
+
+        /// <param name="dynamicTimeZone">can be set to null if not available</param>
+        public override void SetOriginalTimeZone(TimeZoneInfo staticTimeZone, TimeZoneInfo dynamicTimeZone, int effectiveYear)
+        {
+            this.TimeZoneDescription = staticTimeZone.DisplayName; // Outlook 2003 RTM writes this for single appointments as well
+            if (this.File.WriterCompatibilityMode >= WriterCompatibilityMode.Outlook2003SP3)
+            {
+                TimeZoneInfo.AdjustmentRule effectiveRule = AdjustmentRuleUtils.GetFirstRule(staticTimeZone);
+                TimeZoneInfo definitionTimezone = (dynamicTimeZone == null) ? staticTimeZone : dynamicTimeZone;
+                this.TimeZoneDefinitionStartDisplay = TimeZoneDefinitionStructure.FromTimeZoneInfo(definitionTimezone, effectiveRule, effectiveYear, false);
+                // We do not set TimeZoneDefinitionEndDisplay, so Outlook will use TimeZoneDefinitionStartDisplay.
+            }
+        }
+
+        /// <summary>
+        /// Outlook will use StartWhole (part of the contents table since Outlook 2003) over ClipStart, and so should we.
+        /// According to MS-OXOCAL, ClipStart & CommonStart MUST be equal to StartWhole,
+        /// In practive however, I've encountered a case where ClipStart wasn't equal
+        /// to StartWhole for a single appointments. (CommonStart was equal to StartWhole in that specific case).
+        /// </summary>
+        public override DateTime StartDTUtc
+        {
+            get
+            {
+                return this.StartWhole;
+            }
+            set
+            {
+                this.ClipStart = value;
+                this.CommonStart = value;
+                this.StartWhole = value;
+            }
+        }
+
+        public DateTime EndDTUtc
+        {
+            get
+            {
+                return this.EndWhole;
+            }
+            set
+            {
+                this.ClipEnd = value;
+                this.CommonEnd = value;
+                this.EndWhole = value;
+            }
+        }
+
+        public override int Duration
+        {
+            get
+            {
+                TimeSpan ts = EndDTUtc - StartDTUtc;
+                return (int)ts.TotalMinutes;
+            }
+        }
+
+        public override TimeZoneInfo OriginalTimeZone
+        {
+            get
+            {
+                TimeZoneDefinitionStructure timezoneDefinitionStructure = this.TimeZoneDefinitionStartDisplay;
+                
+                if (timezoneDefinitionStructure == null) // No Outlook 2007+ structure
+                {
+                    // assume current system time zone definition
+                    return TimeZoneInfoUtils.GetSystemStaticTimeZone(TimeZoneInfo.Local.Id);
+                }
+                else // Outlook 2007+ structure present
+                {
+                    return timezoneDefinitionStructure.ToTimeZoneInfo();
+                }
+            }
+        }
+
+        public override bool HasTimeZoneDefinition
+        {
+            get 
+            {
+                return (this.TimeZoneDefinitionStartDisplay != null);
+            }
+        }
+
+        public static SingleAppointment CreateNewSingleAppointment(PSTFile file, NodeID parentNodeID)
+        { 
+            return CreateNewSingleAppointment(file, parentNodeID, Guid.NewGuid());
+        }
+
+        public static SingleAppointment CreateNewSingleAppointment(PSTFile file, NodeID parentNodeID, Guid searchKey)
+        {
+            MessageObject message = CreateNewMessage(file, FolderItemTypeName.Appointment, parentNodeID, searchKey);
+            SingleAppointment appointment = new SingleAppointment(message);
+            appointment.MessageFlags = MessageFlags.MSGFLAG_READ;
+            appointment.InternetCodepage = 1255;
+            appointment.MessageDeliveryTime = DateTime.UtcNow;
+            appointment.ClientSubmitTime = DateTime.UtcNow;
+            appointment.SideEffects = SideEffectsFlags.seOpenForCtxMenu | SideEffectsFlags.seOpenToMove | SideEffectsFlags.seOpenToCopy | SideEffectsFlags.seCoerceToInbox | SideEffectsFlags.seOpenToDelete;
+            appointment.Importance = MessageImportance.Normal;
+            appointment.Priority = MessagePriority.Normal;
+            appointment.ConferencingType = MeetingType.WindowsNetmeeting;
+
+            appointment.IconIndex = IconIndex.SingleInstanceAppointment;
+            return appointment;
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/TaskMessage.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/TaskMessage.cs
@@ -1,0 +1,34 @@
+/* ContinuMail addition 2026: IPM.Task item factory (mirrors ContactMessage.cs / Note.cs).
+ * Vendored PSTFileFormat is LGPLv3 — see vendor/LICENSE-PSTFileFormat.txt. */
+using System;
+
+namespace PSTFileFormat
+{
+    /// <summary>Outlook task item (IPM.Task).</summary>
+    public class TaskMessage : MessageObject
+    {
+        protected TaskMessage(PSTNode node) : base(node) { }
+
+        public static TaskMessage GetTask(PSTFile file, NodeID nodeID)
+        {
+            PSTNode node = file.GetNode(nodeID);
+            return node.PC != null ? new TaskMessage(node) : null;
+        }
+
+        public static TaskMessage CreateNewTask(PSTFile file, NodeID parentNodeID)
+        {
+            return CreateNewTask(file, parentNodeID, Guid.NewGuid());
+        }
+
+        public static TaskMessage CreateNewTask(PSTFile file, NodeID parentNodeID, Guid searchKey)
+        {
+            MessageObject message = CreateNewMessage(file, FolderItemTypeName.Task, parentNodeID, searchKey);
+            var task = new TaskMessage(message);
+            task.MessageFlags = MessageFlags.MSGFLAG_READ;
+            task.InternetCodepage = 65001; // UTF-8 (Note defaults to 1255 Hebrew — never inherit that)
+            task.Importance = MessageImportance.Normal;
+            task.Priority = MessagePriority.Normal;
+            return task;
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/TimeZoneDefinitionStructure/Enums/TimeZoneRuleFlags.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/TimeZoneDefinitionStructure/Enums/TimeZoneRuleFlags.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace PSTFileFormat
+{
+    [Flags]
+    public enum TimeZoneRuleFlags
+    {
+        RecurringTimeZoneRule = 0x01, // TZRULE_FLAG_RECUR_CURRENT_TZREG, This flag specifies that this rule (4) is associated with a recurring series
+        EffectiveTimeZoneRule = 0x02, // TZRULE_FLAG_EFFECTIVE_TZREG
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/TimeZoneDefinitionStructure/TimeZoneDefinitionRecurStructure.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/TimeZoneDefinitionStructure/TimeZoneDefinitionRecurStructure.cs
@@ -1,0 +1,277 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Utilities;
+
+namespace PSTFileFormat
+{
+    // http://msdn.microsoft.com/en-us/library/ee158467%28v=exchg.80%29.aspx
+    public class TimeZoneDefinitionStructure
+    {
+        public byte MajorVersion = 0x02;
+        public byte MinorVersion = 0x01;
+        // public ushort cbHeader; // The number of bytes contained in the Reserved, cchKeyName, KeyName, and cRules fields
+        public ushort Reserved = 0x0002;
+        // ushort cchKeyName;
+        public string KeyName;
+        // ushort cRules;
+        public TimeZoneRuleStructure[] TZRules;
+
+        public TimeZoneDefinitionStructure()
+        { 
+        }
+
+        public TimeZoneDefinitionStructure(byte[] buffer)
+        {
+            int offset = 0;
+            MajorVersion = ByteReader.ReadByte(buffer, ref offset);
+            MinorVersion = ByteReader.ReadByte(buffer, ref offset);
+            ushort cbHeader = LittleEndianReader.ReadUInt16(buffer, ref offset);
+            Reserved = LittleEndianReader.ReadUInt16(buffer, ref offset);
+            ushort cchKeyName = LittleEndianReader.ReadUInt16(buffer, ref offset);
+            KeyName = ByteReader.ReadUTF16String(buffer, ref offset, cchKeyName);
+            ushort cRules = LittleEndianReader.ReadUInt16(buffer, ref offset);
+            TZRules = new TimeZoneRuleStructure[cRules];
+            for (int index = 0; index < cRules; index++)
+            {
+                TZRules[index] = new TimeZoneRuleStructure(buffer, offset);
+                offset += TimeZoneRuleStructure.Length;
+            }
+        }
+
+        public byte[] GetBytes()
+        {
+            int length = 10 + KeyName.Length * 2 + TZRules.Length * TimeZoneRuleStructure.Length;
+            byte[] buffer = new byte[length];
+            int offset = 0;
+            ByteWriter.WriteByte(buffer, ref offset, MajorVersion);
+            ByteWriter.WriteByte(buffer, ref offset, MinorVersion);
+            LittleEndianWriter.WriteUInt16(buffer, ref offset, (ushort)(6 + KeyName.Length * 2));
+            LittleEndianWriter.WriteUInt16(buffer, ref offset, Reserved);
+            LittleEndianWriter.WriteUInt16(buffer, ref offset, (ushort)KeyName.Length);
+            ByteWriter.WriteUTF16String(buffer, ref offset, KeyName, KeyName.Length);
+            LittleEndianWriter.WriteUInt16(buffer, ref offset, (ushort)TZRules.Length);
+            for (int index = 0; index < TZRules.Length; index++)
+            {
+                TZRules[index].WriteBytes(buffer, offset);
+                offset += TimeZoneRuleStructure.Length;
+            }
+
+            return buffer;
+        }
+
+        /// <summary>
+        /// Despite holding several adjustment rules, Outlook will only use the rule that is marked as effective.
+        /// (see http://msdn.microsoft.com/en-us/library/ff960389.aspx )
+        /// We should ignore all other rules to be consistent with Outlook (all versions).
+        /// </summary>
+        public TimeZoneInfo ToTimeZoneInfo()
+        {
+            TimeZoneRuleStructure effectiveTimeZoneRuleStructure = GetEffectiveTimeZoneRule();
+            if (effectiveTimeZoneRuleStructure == null)
+            {
+                throw new InvalidPropertyException("No timezone rule has been marked as effective");
+            }
+
+            TimeZoneInfo.AdjustmentRule effectiveTimeZoneRule = effectiveTimeZoneRuleStructure.ToStaticAdjustmentRule();
+
+            string standardDisplayName;
+            string daylightDisplayName;
+            string timezoneID = KeyName;
+            if (KeyName == String.Empty)
+            {
+                // It's invalid to have an empty timezone ID, use the ID of current timezone
+                timezoneID = TimeZoneInfo.Local.Id;
+            }
+            string displayName = RegistryTimeZoneUtils.GetDisplayName(timezoneID, out standardDisplayName, out daylightDisplayName);
+            
+            if (effectiveTimeZoneRule == null)
+            {
+                // no daylight savings
+                return TimeZoneInfo.CreateCustomTimeZone(timezoneID, effectiveTimeZoneRuleStructure.BaseUtcOffset, displayName, standardDisplayName);
+            }
+            else
+            {
+                TimeZoneInfo.AdjustmentRule[] adjustmentRules = new TimeZoneInfo.AdjustmentRule[] { effectiveTimeZoneRule };
+                return TimeZoneInfo.CreateCustomTimeZone(timezoneID, effectiveTimeZoneRuleStructure.BaseUtcOffset, displayName, standardDisplayName, daylightDisplayName, adjustmentRules);
+            }
+        }
+
+        public TimeZoneRuleStructure GetEffectiveTimeZoneRule()
+        {
+            // Note: Outlook stores a first and last 'no adjustment' rules
+            for (int index = 0; index < TZRules.Length; index++)
+            {
+                TimeZoneRuleStructure ruleStructure = TZRules[index];
+                if (ruleStructure.IsEffectiveTimeZoneRule)
+                {
+                    return ruleStructure;
+                }
+            }
+            return null;
+        }
+        
+        /// <summary>
+        /// If the effective TZRule structure's lBias, lStandardBias, lDaylightBias,
+        /// stStandardDate, and stDaylightDate fields are not equal to the corresponding
+        /// fields in the PidLidTimeZoneStruct property,
+        /// the PidLidAppointmentTimeZoneDefinitionRecur and PidLidTimeZoneStruct properties
+        /// are considered inconsistent.
+        /// </summary>
+        public bool IsConsistent(TimeZoneStructure structure)
+        {
+            TimeZoneRuleStructure effectiveTimeZoneRule = null;
+
+            foreach(TimeZoneRuleStructure timeZoneRule in TZRules)
+            {
+                if (timeZoneRule.IsEffectiveTimeZoneRule)
+                {
+                    effectiveTimeZoneRule = timeZoneRule;
+                    break;
+                }
+            }
+
+            if (effectiveTimeZoneRule == null)
+            {
+                return false;
+            }
+            else
+            {
+                return (effectiveTimeZoneRule.lBias == structure.lBias &&
+                        effectiveTimeZoneRule.lStandardBias == structure.lStandardBias &&
+                        effectiveTimeZoneRule.lDaylightBias == structure.lDaylightBias &&
+                        effectiveTimeZoneRule.stStandardDate == structure.stStandardDate &&
+                        effectiveTimeZoneRule.stDaylightDate == structure.stDaylightDate);
+            }
+        }
+
+        /// Note about how Outlook selects the effective adjustment rule: 
+        /// For backward compatibility reasons, the effective rule is always the static timezone
+        /// rule used by the OS.
+        /// It's possible however that there is no dynamic rule that matches the static rule,
+        /// If that's the case, Outlook will replace the dynamic rule of the current year
+        /// with the static rule, which will be marked as the effective rule.
+        /// <param name="effectiveRule">null if there are no daylight savings</param>
+        public static TimeZoneDefinitionStructure FromTimeZoneInfo(TimeZoneInfo timezone, TimeZoneInfo.AdjustmentRule effectiveRule, int effectiveRuleYear, bool isRecurringTimeZoneRule)
+        {
+            TimeZoneInfo.AdjustmentRule[] adjustmentRules = timezone.GetAdjustmentRules();
+            if (effectiveRule != null)
+            {
+                if ((effectiveRule.DaylightTransitionStart.IsFixedDateRule || effectiveRule.DaylightTransitionEnd.IsFixedDateRule) &&
+                    effectiveRule.DateStart.Year < effectiveRule.DateEnd.Year)
+                {
+                    // a rule can either be fixed-date (wYear is not zero) or floating-date (wYear is zero)
+                    // a fixed-date rule cannot span multiple years.
+                    throw new NotImplementedException("Effective DST rule cannot be fixed-date and span multiple years");
+                }
+
+                if (adjustmentRules.Length == 0)
+                {
+                    // effective rule != null means timezone rule is defined, but the timezone has no such rule
+                    throw new ArgumentException("Time zone does not match effective rule");
+                }
+            }
+
+            TimeZoneRuleFlags effectiveRuleFlags = TimeZoneRuleFlags.EffectiveTimeZoneRule;
+            if (isRecurringTimeZoneRule)
+            {
+                effectiveRuleFlags |= TimeZoneRuleFlags.RecurringTimeZoneRule;
+            }
+
+            TimeZoneRuleStructure[] tzRules;
+
+            if (adjustmentRules.Length == 0)
+            {
+                // at this point effectiveRule must be null
+                TimeZoneRuleStructure ruleStructure = new TimeZoneRuleStructure();
+                ruleStructure.SetBias(timezone.BaseUtcOffset, new TimeSpan());
+                ruleStructure.wYear = 1601; // That's what Outlook 2007 SP3 uses
+                ruleStructure.TZRuleFlags = effectiveRuleFlags;
+                tzRules = new TimeZoneRuleStructure[] { ruleStructure };
+            }
+            else
+            {
+                List<TimeZoneRuleStructure> rules = new List<TimeZoneRuleStructure>();
+                // First we will create a list of the dynamic rules:
+                
+                // we have an effective rule and at least one dynamic rule
+                int firstRuleYear = adjustmentRules[0].DateStart.Year;
+                if (firstRuleYear > 1)
+                {
+                    TimeZoneRuleStructure firstRule = new TimeZoneRuleStructure();
+                    firstRule.SetBias(timezone.BaseUtcOffset, adjustmentRules[0].DaylightDelta);
+                    firstRule.wYear = (ushort)(firstRuleYear - 1);
+                    rules.Add(firstRule);
+                }
+
+                for (int index = 0; index < adjustmentRules.Length; index++)
+                {
+                    TimeZoneInfo.AdjustmentRule adjustmentRule = adjustmentRules[index];
+                    TimeZoneRuleStructure rule = new TimeZoneRuleStructure();
+                    rule.wYear = (ushort)adjustmentRule.DateStart.Year; ;
+                    rule.SetBias(timezone.BaseUtcOffset, adjustmentRule.DaylightDelta);
+                    rule.stStandardDate = AdjustmentRuleHelper.GetStandardDate(adjustmentRule);
+                    rule.stDaylightDate = AdjustmentRuleHelper.GetDaylightDate(adjustmentRule);
+
+                    rules.Add(rule);
+                }
+
+                int lastRuleYear = adjustmentRules[adjustmentRules.Length - 1].DateEnd.Year;
+                if (lastRuleYear < 9999)
+                {
+                    TimeZoneRuleStructure lastRule = new TimeZoneRuleStructure();
+                    lastRule.SetBias(timezone.BaseUtcOffset, adjustmentRules[adjustmentRules.Length - 1].DaylightDelta);
+                    lastRule.wYear = (ushort)(lastRuleYear + 1);
+                    rules.Add(lastRule);
+                }
+
+                // Outlook will try to find a rule that match the static rule, and will use the last rule that fits
+                
+                // now we will replace a dynamic rule with the appropriate static rule
+
+                // find the index for the rule
+                int effectiveRuleIndex = 0;
+                for (int index = 0; index < rules.Count; index++)
+                {
+                    if (effectiveRuleYear >= rules[index].wYear)
+                    {
+                        effectiveRuleIndex = index;
+                    }
+                }
+
+                // prepare the effective rule structure
+                TimeZoneRuleStructure ruleStructure = new TimeZoneRuleStructure();
+                ruleStructure.wYear = rules[effectiveRuleIndex].wYear;
+                ruleStructure.TZRuleFlags = effectiveRuleFlags;
+
+                if (effectiveRule == null)
+                {
+                    // We should have a no-daylight-savings rule
+                    ruleStructure.SetBias(timezone.BaseUtcOffset, new TimeSpan());
+                }
+                else
+                {
+                    ruleStructure.SetBias(timezone.BaseUtcOffset, effectiveRule.DaylightDelta);
+                    ruleStructure.stStandardDate = AdjustmentRuleHelper.GetStandardDate(effectiveRule);
+                    ruleStructure.stDaylightDate = AdjustmentRuleHelper.GetDaylightDate(effectiveRule);
+                }
+
+                rules[effectiveRuleIndex] = ruleStructure;
+                tzRules = rules.ToArray();
+            }
+
+            TimeZoneDefinitionStructure structure = new TimeZoneDefinitionStructure();
+            structure.KeyName = timezone.Id;
+            structure.TZRules = tzRules;
+            return structure;
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/TimeZoneDefinitionStructure/TimeZoneDefinitionRecurStructure.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/TimeZoneDefinitionStructure/TimeZoneDefinitionRecurStructure.cs
@@ -92,7 +92,13 @@ namespace PSTFileFormat
                 timezoneID = TimeZoneInfo.Local.Id;
             }
             string displayName = RegistryTimeZoneUtils.GetDisplayName(timezoneID, out standardDisplayName, out daylightDisplayName);
-            
+            // [ContinuMail 2026] non-Windows has no registry display names; fall back to the zone id so
+            // CreateCustomTimeZone (which rejects null names) still succeeds. Display-only — offset/DST rule
+            // come from the structure bytes, not the registry.
+            displayName ??= timezoneID;
+            standardDisplayName ??= timezoneID;
+            daylightDisplayName ??= timezoneID;
+
             if (effectiveTimeZoneRule == null)
             {
                 // no daylight savings

--- a/vendor/PSTFileFormat/Messaging/Messages/TimeZoneDefinitionStructure/TimeZoneRuleStructure.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/TimeZoneDefinitionStructure/TimeZoneRuleStructure.cs
@@ -1,0 +1,131 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Utilities;
+
+namespace PSTFileFormat
+{
+    // http://msdn.microsoft.com/en-us/library/ee160657%28v=exchg.80%29
+    public class TimeZoneRuleStructure
+    {
+        public const int Length = 66;
+
+        public byte MajorVersion = 0x02;
+        public byte MinorVersion = 0x01;
+        public ushort Reserved = 0x003E;
+        public TimeZoneRuleFlags TZRuleFlags;
+        public ushort wYear; // Specifies the year in which this rule is scheduled to take effect.
+        // 14 unused bytes
+        public int lBias; // The offset in minutes from UTC, will be -120 for GMT+2:00
+        public int lStandardBias; // The offset in minutes from the value of the lBias field during standard time
+        public int lDaylightBias; // The offset in minutes from the value of the lBias field during daylight saving time.
+        public SystemTime stStandardDate = new SystemTime();
+        public SystemTime stDaylightDate = new SystemTime();
+
+        public TimeZoneRuleStructure()
+        {
+        }
+
+        public TimeZoneRuleStructure(byte[] buffer, int offset)
+        {
+            MajorVersion = ByteReader.ReadByte(buffer, offset + 0);
+            MinorVersion = ByteReader.ReadByte(buffer, offset + 1);
+            Reserved = LittleEndianConverter.ToUInt16(buffer, offset + 2);
+            TZRuleFlags = (TimeZoneRuleFlags)LittleEndianConverter.ToUInt16(buffer, offset + 4);
+            wYear = LittleEndianConverter.ToUInt16(buffer, offset + 6);
+            // 14 unused bytes
+            lBias = LittleEndianConverter.ToInt32(buffer, offset + 22);
+            lStandardBias = LittleEndianConverter.ToInt32(buffer, offset + 26);
+            lDaylightBias = LittleEndianConverter.ToInt32(buffer, offset + 30);
+            stStandardDate = new SystemTime(buffer, offset + 34);
+            stDaylightDate = new SystemTime(buffer, offset + 50);
+        }
+
+        public void WriteBytes(byte[] buffer, int offset)
+        {
+            ByteWriter.WriteByte(buffer, offset + 0, MajorVersion);
+            ByteWriter.WriteByte(buffer, offset + 1, MinorVersion);
+            LittleEndianWriter.WriteUInt16(buffer, offset + 2, Reserved);
+            LittleEndianWriter.WriteUInt16(buffer, offset + 4, (ushort)TZRuleFlags);
+            LittleEndianWriter.WriteUInt16(buffer, offset + 6, wYear);
+            // 14 unused bytes
+            LittleEndianWriter.WriteInt32(buffer, offset + 22, lBias);
+            LittleEndianWriter.WriteInt32(buffer, offset + 26, lStandardBias);
+            LittleEndianWriter.WriteInt32(buffer, offset + 30, lDaylightBias);
+            stStandardDate.WriteBytes(buffer, offset + 34);
+            stDaylightDate.WriteBytes(buffer, offset + 50);
+        }
+
+        public TimeZoneInfo.AdjustmentRule ToAdjustmentRule()
+        { 
+            DateTime startDate = DateTimeUtils.GetYearStart(wYear).Date;
+            DateTime endDate = DateTimeUtils.GetYearEnd(wYear).Date;
+            return AdjustmentRuleUtils.CreateAdjustmentRule(startDate, endDate, lBias, lStandardBias, lDaylightBias, stStandardDate, stDaylightDate);
+        }
+
+        /// <summary>
+        /// Translate this TimeZoneRuleStructure to a static AdjustmentRule,
+        /// Similar to the static rule Windows 2000 \ XP originally used, and Outlook still uses.
+        /// </summary>
+        public TimeZoneInfo.AdjustmentRule ToStaticAdjustmentRule()
+        {
+            // Static rule can either be fixed-date (wYear is not zero) or floating-date (wYear is zero).
+            // Static fixed-date rule can only occur once (single year).
+            if (stStandardDate.wYear != 0)
+            {
+                if (stDaylightDate.wYear == stStandardDate.wYear)
+                {
+                    return AdjustmentRuleUtils.CreateStaticAdjustmentRule(stStandardDate.wYear, lBias, lStandardBias, lDaylightBias, stStandardDate, stDaylightDate);
+                }
+                else // fixed-date rule that spans multiple years
+                {
+                    throw new Exception("Fixed-Date TimeZoneRuleStructure spans more than one year and cannot be converted to static AdjustmentRule");
+                }
+            }
+            else
+            {
+                return AdjustmentRuleUtils.CreateStaticAdjustmentRule(lBias, lStandardBias, lDaylightBias, stStandardDate, stDaylightDate);
+            }
+        }
+
+        public TimeSpan BaseUtcOffset
+        { 
+            get
+            {
+                // baseUtcOffset should be 120 for GMT+2:00
+                return new TimeSpan(0, -(lBias + lStandardBias), 0);
+            }
+        }
+
+        public void SetBias(TimeSpan baseUtcOffset, TimeSpan daylightDelta)
+        {
+            lBias = -(int)baseUtcOffset.TotalMinutes;
+            lStandardBias = 0;
+            lDaylightBias = -(int)daylightDelta.TotalMinutes;
+        }
+
+        public bool IsRecurringTimeZoneRule
+        {
+            get
+            {
+                return (TZRuleFlags & TimeZoneRuleFlags.RecurringTimeZoneRule) > 0;
+            }
+        }
+
+        public bool IsEffectiveTimeZoneRule
+        {
+            get
+            {
+                return (TZRuleFlags & TimeZoneRuleFlags.EffectiveTimeZoneRule) > 0;
+            }
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/TimeZoneStructure/AdjustmentRuleHelper.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/TimeZoneStructure/AdjustmentRuleHelper.cs
@@ -1,0 +1,67 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Utilities;
+
+namespace PSTFileFormat
+{
+    public class AdjustmentRuleHelper
+    {
+        public static SystemTime GetStandardDate(TimeZoneInfo.AdjustmentRule rule)
+        {
+            return FromTransitionTime(rule.DateStart.Year, rule.DateEnd.Year, rule.DaylightTransitionEnd);
+        }
+
+        public static SystemTime GetDaylightDate(TimeZoneInfo.AdjustmentRule rule)
+        {
+            return FromTransitionTime(rule.DateStart.Year, rule.DateEnd.Year, rule.DaylightTransitionStart);
+        }
+
+        // Details about the conversion process:
+        // http://msdn.microsoft.com/en-us/library/windows/desktop/ms725481%28v=vs.85%29.aspx
+        public static SystemTime FromTransitionTime(int startYear, int endYear, TimeZoneInfo.TransitionTime transitionTime)
+        {
+            SystemTime result = new SystemTime();
+            if (transitionTime.IsFixedDateRule)
+            {
+                if (startYear == endYear)
+                {
+                    // If the wYear member is not zero, the transition date is absolute; it will only occur one time.
+                    int year = startYear;
+                    int month = transitionTime.Month;
+                    int day = transitionTime.Day;
+                    // this will calculate DayOfWeek
+                    TimeSpan timeOfDay = transitionTime.TimeOfDay.TimeOfDay;
+                    result.DateTime = new DateTime(year, month, day).Add(timeOfDay);
+                    // When rule is fixed-date, wDayOfWeek (which is redundant) is unused and set to 0
+                    // http://social.msdn.microsoft.com/Forums/en-US/os_binaryfile/thread/d5ebf7d3-f6a9-429d-8f27-7ec2bdec440f
+                    result.wDayOfWeek = 0;
+                }
+                else
+                {
+                    // The SystemTime structure (and registry) do not support this
+                    throw new Exception("Cannot create transition time with absolute date that spans multiple years");
+                }
+            }
+            else
+            {
+                // If the wYear member is zero, it is a relative date that occurs yearly.
+                result.wYear = 0; // Note: TimeZoneRuleStructure have an additional wYear parameter besides the one in stStandardDate / stDaylightDate
+                result.wMonth = (ushort)transitionTime.Month;
+                // the wDay member is set to indicate the occurrence of the day of the week within the month
+                result.wDay = (ushort)transitionTime.Week;
+                result.wDayOfWeek = (ushort)transitionTime.DayOfWeek;
+                result.TimeOfDay = transitionTime.TimeOfDay.TimeOfDay;
+            }
+            return result;
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/TimeZoneStructure/AdjustmentRuleHelper.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/TimeZoneStructure/AdjustmentRuleHelper.cs
@@ -47,8 +47,20 @@ namespace PSTFileFormat
                 }
                 else
                 {
-                    // The SystemTime structure (and registry) do not support this
-                    throw new Exception("Cannot create transition time with absolute date that spans multiple years");
+                    // [ContinuMail 2026] Some non-Windows (ICU) TimeZoneInfo rules express a DST transition
+                    // as a fixed calendar date over a multi-year span, which the one-time SYSTEMTIME absolute
+                    // form (wYear != 0) cannot hold. Rather than throw (which aborts writing any appointment
+                    // in such a zone on Linux/macOS), convert to the equivalent relative-yearly rule — the Nth
+                    // weekday of the month — which the structure CAN hold. Approximate but valid; only reached
+                    // off-Windows (Windows rules are floating already, so Windows byte output is unchanged).
+                    int representativeYear = startYear != 0 ? startYear : DateTime.UtcNow.Year;
+                    int dom = Math.Min(transitionTime.Day, DateTime.DaysInMonth(representativeYear, transitionTime.Month));
+                    DateTime fixedDate = new DateTime(representativeYear, transitionTime.Month, dom);
+                    result.wYear = 0; // relative, occurs yearly
+                    result.wMonth = (ushort)transitionTime.Month;
+                    result.wDay = (ushort)Math.Min(5, (dom + 6) / 7); // occurrence within month (5 = last)
+                    result.wDayOfWeek = (ushort)fixedDate.DayOfWeek;
+                    result.TimeOfDay = transitionTime.TimeOfDay.TimeOfDay;
                 }
             }
             else

--- a/vendor/PSTFileFormat/Messaging/Messages/TimeZoneStructure/TimeZoneStructure.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/TimeZoneStructure/TimeZoneStructure.cs
@@ -1,0 +1,136 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Utilities;
+
+namespace PSTFileFormat
+{
+    // http://msdn.microsoft.com/en-us/library/ee237092%28v=exchg.80%29.aspx
+    public class TimeZoneStructure // PidLidTimeZoneStruct
+    {
+        public const int Length = 48;
+
+        public int lBias;                 // The time zone's offset in minutes from UTC, will be -120 for GMT+2:00
+        public int lStandardBias;         // The offset in minutes from the value of the lBias field during standard time
+        public int lDaylightBias;         // The offset in minutes from the value of the lBias field during daylight saving time.
+        // ushort wStandardYear;          // This field matches the stStandardDate's wYear member.
+        public SystemTime stStandardDate; // This field contains the date and local time that indicate when to begin using the value specified in the lStandardBias field
+        // ushort wDaylightYear;          // This field is equal to the value of the stDaylightDate's wYear field
+        public SystemTime stDaylightDate; // This field contains the date and local time that indicate when to begin using the value specified in the lDaylightBias field
+
+        public TimeZoneStructure()
+        { 
+        }
+
+        public TimeZoneStructure(byte[] buffer)
+        {
+            lBias = LittleEndianConverter.ToInt32(buffer, 0);
+            lStandardBias = LittleEndianConverter.ToInt32(buffer, 4);
+            lDaylightBias = LittleEndianConverter.ToInt32(buffer, 8);
+            ushort wStandardYear = LittleEndianConverter.ToUInt16(buffer, 12);
+            stStandardDate = new SystemTime(buffer, 14);
+            ushort wDaylightYear = LittleEndianConverter.ToUInt16(buffer, 30);
+            stDaylightDate = new SystemTime(buffer, 32);
+
+            if (stStandardDate.wYear != wStandardYear)
+            {
+                throw new InvalidPropertyException("Invalid TimeZoneStructure");
+            }
+
+            if (stDaylightDate.wYear != wDaylightYear)
+            {
+                throw new InvalidPropertyException("Invalid TimeZoneStructure");
+            }
+        }
+
+        public byte[] GetBytes()
+        {
+            byte[] buffer = new byte[Length];
+            LittleEndianWriter.WriteInt32(buffer, 0, lBias);
+            LittleEndianWriter.WriteInt32(buffer, 4, lStandardBias);
+            LittleEndianWriter.WriteInt32(buffer, 8, lDaylightBias);
+            LittleEndianWriter.WriteUInt16(buffer, 12, stStandardDate.wYear);
+            stStandardDate.WriteBytes(buffer, 14);
+            LittleEndianWriter.WriteUInt16(buffer, 30, stDaylightDate.wYear);
+            stDaylightDate.WriteBytes(buffer, 32);
+
+            return buffer;
+        }
+
+        public TimeZoneInfo ToTimeZoneInfo(string timeZoneID)
+        {
+            // baseUtcOffset should be 120 for GMT+2:00
+            TimeSpan baseUtcOffset = new TimeSpan(0, -(lBias + lStandardBias), 0);
+            
+            string standardDisplayName;
+            string daylightDisplayName;
+            string displayName = RegistryTimeZoneUtils.GetDisplayName(timeZoneID, out standardDisplayName, out daylightDisplayName);
+
+            // Note about stStandardDate:
+            // If the time zone does not support daylight saving time, the wMonth member in the SYSTEMTIME structure MUST be zero
+            if (stStandardDate.wMonth == 0)
+            {
+                return TimeZoneInfo.CreateCustomTimeZone(timeZoneID, baseUtcOffset, displayName, standardDisplayName);
+            }
+            else
+            {
+                TimeZoneInfo.AdjustmentRule rule;
+                if (stStandardDate.wYear == 0)
+                {
+                    // If the wYear member is zero, the date is interpreted as a relative date that occurs yearly
+                    rule = AdjustmentRuleUtils.CreateStaticAdjustmentRule(lBias, lStandardBias, lDaylightBias, stStandardDate, stDaylightDate);
+                }
+                else
+                {
+                    // If the wYear member is not zero, the date is interpreted as an absolute date that only occurs once.
+                    DateTime ruleStartDate = DateTimeUtils.GetYearStart(stStandardDate.wYear).Date;
+                    DateTime ruleEndDate = DateTimeUtils.GetYearEnd(stStandardDate.wYear).Date;
+                    rule = AdjustmentRuleUtils.CreateAdjustmentRule(ruleStartDate, ruleEndDate, lBias, lStandardBias, lDaylightBias, stStandardDate, stDaylightDate);
+                }
+                return TimeZoneInfo.CreateCustomTimeZone(timeZoneID, baseUtcOffset, displayName, standardDisplayName, daylightDisplayName, new TimeZoneInfo.AdjustmentRule[] { rule });
+            }
+        }
+
+        public void SetBias(TimeSpan baseUtcOffset, TimeSpan daylightDelta)
+        {
+            lBias = -(int)baseUtcOffset.TotalMinutes;
+            lStandardBias = 0;
+            lDaylightBias = -(int)daylightDelta.TotalMinutes;
+        }
+
+        public static TimeZoneStructure FromTimeZoneInfo(TimeZoneInfo staticTimeZone)
+        {
+            TimeZoneInfo.AdjustmentRule[] rules = staticTimeZone.GetAdjustmentRules();
+            if (rules.Length > 1)
+            {
+                throw new ArgumentException("Cannot create TimeZoneStructure from a time zone with multiple DST rules");
+            }
+            
+            TimeZoneStructure structure = new TimeZoneStructure();
+            if (rules.Length == 0)
+            {
+                // no daylight saving
+                structure.SetBias(staticTimeZone.BaseUtcOffset, new TimeSpan());
+                structure.stStandardDate = new SystemTime();
+                structure.stDaylightDate = new SystemTime();
+            }
+            else
+            {
+                TimeZoneInfo.AdjustmentRule rule = rules[0];
+                structure.SetBias(staticTimeZone.BaseUtcOffset, rule.DaylightDelta);
+                structure.stStandardDate = AdjustmentRuleHelper.GetStandardDate(rule);
+                structure.stDaylightDate = AdjustmentRuleHelper.GetDaylightDate(rule);
+            }
+
+            return structure;
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Messaging/Messages/TimeZoneStructure/TimeZoneStructure.cs
+++ b/vendor/PSTFileFormat/Messaging/Messages/TimeZoneStructure/TimeZoneStructure.cs
@@ -73,6 +73,12 @@ namespace PSTFileFormat
             string standardDisplayName;
             string daylightDisplayName;
             string displayName = RegistryTimeZoneUtils.GetDisplayName(timeZoneID, out standardDisplayName, out daylightDisplayName);
+            // [ContinuMail 2026] On non-Windows the registry has no display names; fall back to the zone id so
+            // CreateCustomTimeZone (which rejects null names) still succeeds. The zone's offset and DST transition
+            // dates are reconstructed from THIS structure's bytes, not from the registry, so this is display-only.
+            displayName ??= timeZoneID;
+            standardDisplayName ??= timeZoneID;
+            daylightDisplayName ??= timeZoneID;
 
             // Note about stStandardDate:
             // If the time zone does not support daylight saving time, the wMonth member in the SYSTEMTIME structure MUST be zero

--- a/vendor/PSTFileFormat/Messaging/NamedProperties/PropertyNames.cs
+++ b/vendor/PSTFileFormat/Messaging/NamedProperties/PropertyNames.cs
@@ -46,5 +46,9 @@ namespace PSTFileFormat
         public static readonly PropertyName PidLidSendMeetingAsIcal = new PropertyName(PropertyLongID.PidLidSendMeetingAsIcal, PropertySetGuid.PSETID_Appointment);
         
         public static readonly PropertyName PidLidIsRecurring = new PropertyName(PropertyLongID.PidLidIsRecurring, PropertySetGuid.PSETID_Meeting);
+
+        // ContinuMail 2026 (PR7b): task recurrence props
+        public static readonly PropertyName PidLidTaskFRecurring = new PropertyName(PropertyLongID.PidLidTaskFRecurring, PropertySetGuid.PSETID_Task);
+        public static readonly PropertyName PidLidTaskRecurrence = new PropertyName(PropertyLongID.PidLidTaskRecurrence, PropertySetGuid.PSETID_Task);
     }
 }

--- a/vendor/PSTFileFormat/Messaging/NamedProperties/PropertyNames.cs
+++ b/vendor/PSTFileFormat/Messaging/NamedProperties/PropertyNames.cs
@@ -33,6 +33,7 @@ namespace PSTFileFormat
         public static readonly PropertyName PidLidBusyStatus = new PropertyName(PropertyLongID.PidLidBusyStatus, PropertySetGuid.PSETID_Appointment);
         public static readonly PropertyName PidLidFInvited = new PropertyName(PropertyLongID.PidLidFInvited, PropertySetGuid.PSETID_Appointment);
         public static readonly PropertyName PidLidAppointmentStateFlags = new PropertyName(PropertyLongID.PidLidAppointmentStateFlags, PropertySetGuid.PSETID_Appointment);
+        public static readonly PropertyName PidLidResponseStatus = new PropertyName(PropertyLongID.PidLidResponseStatus, PropertySetGuid.PSETID_Appointment);
         public static readonly PropertyName PidLidAppointmentRecur = new PropertyName(PropertyLongID.PidLidAppointmentRecur, PropertySetGuid.PSETID_Appointment);
         public static readonly PropertyName PidLidTimeZoneDescription = new PropertyName(PropertyLongID.PidLidTimeZoneDescription, PropertySetGuid.PSETID_Appointment);
         public static readonly PropertyName PidLidTimeZoneStruct = new PropertyName(PropertyLongID.PidLidTimeZoneStruct, PropertySetGuid.PSETID_Appointment);

--- a/vendor/PSTFileFormat/Messaging/Recipients/MessageRecipient.cs
+++ b/vendor/PSTFileFormat/Messaging/Recipients/MessageRecipient.cs
@@ -18,6 +18,7 @@ namespace PSTFileFormat
         public string EmailAddress;
         public bool IsOrganizer;
         public RecipientType RecipientType = RecipientType.To; // default preserves prior behavior
+        public int ResponseStatus = 0; // PidTagRecipientTrackStatus; 0 = none/unknown (default, backward-compat)
 
         public MessageRecipient()
         {

--- a/vendor/PSTFileFormat/Messaging/Recipients/RecipientsTable.cs
+++ b/vendor/PSTFileFormat/Messaging/Recipients/RecipientsTable.cs
@@ -29,12 +29,16 @@ namespace PSTFileFormat
                 RecipientFlags recipientFlags = (RecipientFlags)GetInt32Property(rowIndex, PropertyID.PidTagRecipientFlags);
                 result.IsOrganizer = ((recipientFlags & RecipientFlags.MeetingOrganizer) > 0);
             }
+            if (ContainsPropertyColumn(PropertyID.PidTagRecipientTrackStatus, PropertyTypeName.PtypInteger32))
+            {
+                result.ResponseStatus = GetInt32Property(rowIndex, PropertyID.PidTagRecipientTrackStatus) ?? 0;
+            }
             return result;
         }
 
         public void AddRecipient(PSTFile file, MessageRecipient recipient)
         {
-            AddRecipient(file, recipient.DisplayName, recipient.EmailAddress, recipient.IsOrganizer, recipient.RecipientType);
+            AddRecipient(file, recipient.DisplayName, recipient.EmailAddress, recipient.IsOrganizer, recipient.RecipientType, recipient.ResponseStatus);
         }
 
         public void AddRecipient(PSTFile file, string displayName, string emailAddress, bool isOrganizer)
@@ -43,6 +47,11 @@ namespace PSTFileFormat
         }
 
         public void AddRecipient(PSTFile file, string displayName, string emailAddress, bool isOrganizer, RecipientType recipientType)
+        {
+            AddRecipient(file, displayName, emailAddress, isOrganizer, recipientType, 0);
+        }
+
+        public void AddRecipient(PSTFile file, string displayName, string emailAddress, bool isOrganizer, RecipientType recipientType, int responseStatus)
         {
             // http://social.msdn.microsoft.com/Forums/en-US/os_binaryfile/thread/a5f9c653-40f5-4638-85d3-00c54607d984/
             // dwRowID must be > 0:
@@ -57,14 +66,14 @@ namespace PSTFileFormat
             SetInt32Property(rowIndex, PropertyID.PidTagDisplayType, 0);
 
             SetStringProperty(rowIndex, PropertyID.PidTagRecipientDisplayName, displayName);
-            
+
             int recipientFlags = (int)RecipientFlags.SendableAttendee;
             if (isOrganizer)
             {
                 recipientFlags |= (int)RecipientFlags.MeetingOrganizer;
             }
             SetInt32Property(rowIndex, PropertyID.PidTagRecipientFlags, recipientFlags);
-            SetInt32Property(rowIndex, PropertyID.PidTagRecipientTrackStatus, 0);
+            SetInt32Property(rowIndex, PropertyID.PidTagRecipientTrackStatus, responseStatus);
 
             byte[] recipientEntryID = RecipientEntryID.GetEntryID(displayName, emailAddress).GetBytes();
             SetBytesProperty(rowIndex, PropertyID.PidTagEntryId, recipientEntryID);

--- a/vendor/PSTFileFormat/PSTFileFormat-MODIFICATIONS.md
+++ b/vendor/PSTFileFormat/PSTFileFormat-MODIFICATIONS.md
@@ -1,39 +1,12 @@
 # PSTFileFormat — ContinuMail Modifications
 
-This file tracks all changes made to the vendored `ROM-Knowledgeware/PSTFileFormat` library
-(upstream unmaintained since 2019) by ContinuMail. The upstream code is LGPLv3; all
-modifications remain under LGPLv3 per the license terms.
+The authoritative, consolidated list of local modifications to the vendored
+`ROM-Knowledgeware/PSTFileFormat` library lives one directory up:
 
----
+**➡ `vendor/PSTFileFormat-MODIFICATIONS.md`**
 
-## 2026-07-01 — Bare RecurrencePattern prefix for PidLidTaskRecurrence (PR7b Task 1)
+(This nested file previously duplicated a subset of that log — the PR7b bare-RecurrencePattern
+split for `PidLidTaskRecurrence` — which has been folded into the authoritative file to avoid drift.)
 
-**File:** `Messaging/Messages/RecurrencePatternStructure/AppointmentRecurrencePatternStructure.cs`
-
-**What:** Extracted the RecurrencePattern prefix bytes (ReaderVersion … EndDate, lines 169–197
-of the original `GetBytes`) into a private `WriteRecurrencePattern(MemoryStream)` helper, and
-added a public `byte[] GetRecurrencePatternBytes()` method that emits ONLY that prefix — the
-bare MS-OXOCAL RecurrencePattern with no AppointmentRecurrencePattern tail. `GetBytes` now
-delegates the prefix to `WriteRecurrencePattern` and is byte-identical to the previous
-implementation for all appointment paths.
-
-**Why:** `PidLidTaskRecurrence` (0x8116, PSETID_Task) stores a bare RecurrencePattern (not an
-AppointmentRecurrencePattern), so the existing serializer needed to be splittable. The new
-method is the vendor-side building block for the PR7b recurring-task writer (Task 3).
-
-**Supporting changes:**
-- `Messaging/Enums/PropertyLongID.cs`: added `PidLidTaskRecurrence = 0x00008116`.
-- `Messaging/NamedProperties/PropertyNames.cs`: registered `PidLidTaskFRecurring` and
-  `PidLidTaskRecurrence` under `PSETID_Task`.
-
-**Test gate:** `tests/Mail2Pst.Core.Tests/Vendor/RecurringAppointmentBlobTests.cs` — 4 new tests:
-- `GetRecurrencePatternBytes_is_the_prefix_of_GetBytes` (prefix-equality against full blob).
-- `Bare_pattern_matches_task_GT_oracle` (Theory ×3: weekly 54 B / monthly 54 B / daily 50 B)
-  asserted byte-for-byte against real Outlook-authored `PidLidTaskRecurrence` blobs.
-- All 20 pre-existing appointment byte-gate tests still pass (split is a pure extraction).
-
----
-
-## 2026 (prior to 2026-07-01) — CreateEmptyStore, OccurrenceCount fix, and other reworks
-
-*(Earlier modifications predating this log file — see git history on the `vendor/` subtree.)*
+The component is LGPLv3; all modifications remain under LGPLv3. See the project git history
+(`git log -- vendor/PSTFileFormat`) for full diffs.

--- a/vendor/PSTFileFormat/PSTFileFormat-MODIFICATIONS.md
+++ b/vendor/PSTFileFormat/PSTFileFormat-MODIFICATIONS.md
@@ -1,0 +1,39 @@
+# PSTFileFormat — ContinuMail Modifications
+
+This file tracks all changes made to the vendored `ROM-Knowledgeware/PSTFileFormat` library
+(upstream unmaintained since 2019) by ContinuMail. The upstream code is LGPLv3; all
+modifications remain under LGPLv3 per the license terms.
+
+---
+
+## 2026-07-01 — Bare RecurrencePattern prefix for PidLidTaskRecurrence (PR7b Task 1)
+
+**File:** `Messaging/Messages/RecurrencePatternStructure/AppointmentRecurrencePatternStructure.cs`
+
+**What:** Extracted the RecurrencePattern prefix bytes (ReaderVersion … EndDate, lines 169–197
+of the original `GetBytes`) into a private `WriteRecurrencePattern(MemoryStream)` helper, and
+added a public `byte[] GetRecurrencePatternBytes()` method that emits ONLY that prefix — the
+bare MS-OXOCAL RecurrencePattern with no AppointmentRecurrencePattern tail. `GetBytes` now
+delegates the prefix to `WriteRecurrencePattern` and is byte-identical to the previous
+implementation for all appointment paths.
+
+**Why:** `PidLidTaskRecurrence` (0x8116, PSETID_Task) stores a bare RecurrencePattern (not an
+AppointmentRecurrencePattern), so the existing serializer needed to be splittable. The new
+method is the vendor-side building block for the PR7b recurring-task writer (Task 3).
+
+**Supporting changes:**
+- `Messaging/Enums/PropertyLongID.cs`: added `PidLidTaskRecurrence = 0x00008116`.
+- `Messaging/NamedProperties/PropertyNames.cs`: registered `PidLidTaskFRecurring` and
+  `PidLidTaskRecurrence` under `PSETID_Task`.
+
+**Test gate:** `tests/Mail2Pst.Core.Tests/Vendor/RecurringAppointmentBlobTests.cs` — 4 new tests:
+- `GetRecurrencePatternBytes_is_the_prefix_of_GetBytes` (prefix-equality against full blob).
+- `Bare_pattern_matches_task_GT_oracle` (Theory ×3: weekly 54 B / monthly 54 B / daily 50 B)
+  asserted byte-for-byte against real Outlook-authored `PidLidTaskRecurrence` blobs.
+- All 20 pre-existing appointment byte-gate tests still pass (split is a pure extraction).
+
+---
+
+## 2026 (prior to 2026-07-01) — CreateEmptyStore, OccurrenceCount fix, and other reworks
+
+*(Earlier modifications predating this log file — see git history on the `vendor/` subtree.)*

--- a/vendor/PSTFileFormat/Utils/AdjustmentRuleUtils.Win32.cs
+++ b/vendor/PSTFileFormat/Utils/AdjustmentRuleUtils.Win32.cs
@@ -1,0 +1,48 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Utilities
+{
+    public partial class AdjustmentRuleUtils
+    {
+        /// <summary>
+        /// This will return the static timezone adjustment rule the the OS uses.
+        /// We assume that the static rule is used by one of the dynamic adjustment rules.
+        /// </summary>
+        public static TimeZoneInfo.AdjustmentRule FindSystemStaticAdjustmentRule(string keyName)
+        {
+            RegistryTimeZoneInformation information = RegistryTimeZoneUtils.GetStaticTimeZoneInformation(keyName);
+            if (information == null)
+            {
+                throw new TimeZoneNotFoundException();
+            }
+            else
+            {
+                return GetStaticAdjustmentRule(information);
+            }
+        }
+
+        public static TimeZoneInfo.AdjustmentRule GetStaticAdjustmentRule(RegistryTimeZoneInformation information)
+        {
+            if (RegistryTimeZoneUtils.IsDaylightSavingsEnabled())
+            {
+                return CreateStaticAdjustmentRule(information.Bias, information.StandardBias, information.DaylightBias, information.StandardDate, information.DaylightDate);
+            }
+            else
+            {
+                // We cant have an AdjustmentRule if there is no DST
+                return null;
+            }
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Utils/AdjustmentRuleUtils.Win32.cs
+++ b/vendor/PSTFileFormat/Utils/AdjustmentRuleUtils.Win32.cs
@@ -34,6 +34,10 @@ namespace Utilities
 
         public static TimeZoneInfo.AdjustmentRule GetStaticAdjustmentRule(RegistryTimeZoneInformation information)
         {
+            if (information == null) // [ContinuMail 2026] non-Windows: no registry TZ info, so no static DST rule.
+            {
+                return null;
+            }
             if (RegistryTimeZoneUtils.IsDaylightSavingsEnabled())
             {
                 return CreateStaticAdjustmentRule(information.Bias, information.StandardBias, information.DaylightBias, information.StandardDate, information.DaylightDate);

--- a/vendor/PSTFileFormat/Utils/RegistryTimeZoneUtils.Win32.cs
+++ b/vendor/PSTFileFormat/Utils/RegistryTimeZoneUtils.Win32.cs
@@ -1,0 +1,65 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Win32;
+
+namespace Utilities
+{
+    public partial class RegistryTimeZoneUtils
+    {
+        /// <summary>
+        /// For dynamic DST use TimeZoneInfo
+        /// </summary>
+        /// /// <returns>null if the key does not contain timezone information</returns>
+        public static RegistryTimeZoneInformation GetStaticTimeZoneInformation(string keyName)
+        {
+            RegistryKey timeZonesKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Time Zones");
+            RegistryKey timeZoneKey = timeZonesKey.OpenSubKey(keyName);
+            if (timeZoneKey == null)
+            {
+                return null;
+            }
+
+            byte[] tzi = (byte[])timeZoneKey.GetValue("TZI");
+            if (tzi == null)
+            {
+                return null;
+            }
+
+            return new RegistryTimeZoneInformation(tzi);
+        }
+
+        public static string GetDisplayName(string keyName, out string standardDisplayName, out string daylightDisplayName)
+        {
+            RegistryKey timeZonesKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Time Zones");
+            RegistryKey timeZoneKey = timeZonesKey.OpenSubKey(keyName);
+            if (timeZoneKey == null)
+            {
+                standardDisplayName = null;
+                daylightDisplayName = null;
+                return null;
+            }
+
+            string displayName = (string)timeZoneKey.GetValue("Display");
+            standardDisplayName = (string)timeZoneKey.GetValue("Std");
+            daylightDisplayName = (string)timeZoneKey.GetValue("Dlt");
+
+            return displayName;
+        }
+
+        public static bool IsDaylightSavingsEnabled()
+        {
+            RegistryKey key = Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Control\TimeZoneInformation");
+            int value = (int)key.GetValue("DisableAutoDaylightTimeSet", 0);
+            return (value == 0);
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Utils/RegistryTimeZoneUtils.Win32.cs
+++ b/vendor/PSTFileFormat/Utils/RegistryTimeZoneUtils.Win32.cs
@@ -21,8 +21,10 @@ namespace Utilities
         /// /// <returns>null if the key does not contain timezone information</returns>
         public static RegistryTimeZoneInformation GetStaticTimeZoneInformation(string keyName)
         {
+            // [ContinuMail 2026] Registry.LocalMachine is null off-Windows; short-circuit BEFORE touching it.
+            if (!OperatingSystem.IsWindows()) return null;
             RegistryKey timeZonesKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Time Zones");
-            RegistryKey timeZoneKey = timeZonesKey.OpenSubKey(keyName);
+            RegistryKey timeZoneKey = timeZonesKey?.OpenSubKey(keyName);
             if (timeZoneKey == null)
             {
                 return null;
@@ -39,8 +41,15 @@ namespace Utilities
 
         public static string GetDisplayName(string keyName, out string standardDisplayName, out string daylightDisplayName)
         {
+            // [ContinuMail 2026] Registry.LocalMachine is null off-Windows; short-circuit BEFORE touching it.
+            if (!OperatingSystem.IsWindows())
+            {
+                standardDisplayName = null;
+                daylightDisplayName = null;
+                return null;
+            }
             RegistryKey timeZonesKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Time Zones");
-            RegistryKey timeZoneKey = timeZonesKey.OpenSubKey(keyName);
+            RegistryKey timeZoneKey = timeZonesKey?.OpenSubKey(keyName); // [ContinuMail 2026] null-safe: no registry on non-Windows.
             if (timeZoneKey == null)
             {
                 standardDisplayName = null;
@@ -57,7 +66,13 @@ namespace Utilities
 
         public static bool IsDaylightSavingsEnabled()
         {
+            // [ContinuMail 2026] Registry.LocalMachine is null off-Windows; short-circuit BEFORE touching it.
+            if (!OperatingSystem.IsWindows()) return true;
             RegistryKey key = Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Control\TimeZoneInformation");
+            if (key == null)
+            {
+                return true;
+            }
             int value = (int)key.GetValue("DisableAutoDaylightTimeSet", 0);
             return (value == 0);
         }

--- a/vendor/PSTFileFormat/Utils/TimeZoneInfoUtils.Win32.cs
+++ b/vendor/PSTFileFormat/Utils/TimeZoneInfoUtils.Win32.cs
@@ -1,0 +1,38 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Utilities
+{
+    public partial class TimeZoneInfoUtils
+    {
+        public static TimeZoneInfo GetSystemStaticTimeZone(string keyName)
+        {
+            RegistryTimeZoneInformation information = RegistryTimeZoneUtils.GetStaticTimeZoneInformation(keyName);
+            TimeZoneInfo.AdjustmentRule rule = AdjustmentRuleUtils.GetStaticAdjustmentRule(information);
+            string displayName;
+            string standardDisplayName;
+            string daylightDisplayName;
+            displayName = RegistryTimeZoneUtils.GetDisplayName(keyName, out standardDisplayName, out daylightDisplayName);
+
+            TimeSpan baseUtcOffset = new TimeSpan(0, -(information.Bias + information.StandardBias), 0);
+            if (rule == null)
+            {
+                // null will only be returned if there is no daylight saving
+                return TimeZoneInfo.CreateCustomTimeZone(keyName, baseUtcOffset, displayName, standardDisplayName);
+            }
+            else
+            {
+                return TimeZoneInfo.CreateCustomTimeZone(keyName, baseUtcOffset, displayName, standardDisplayName, daylightDisplayName, new TimeZoneInfo.AdjustmentRule[] { rule });
+            }
+        }
+    }
+}

--- a/vendor/PSTFileFormat/Utils/TimeZoneInfoUtils.Win32.cs
+++ b/vendor/PSTFileFormat/Utils/TimeZoneInfoUtils.Win32.cs
@@ -17,6 +17,13 @@ namespace Utilities
         public static TimeZoneInfo GetSystemStaticTimeZone(string keyName)
         {
             RegistryTimeZoneInformation information = RegistryTimeZoneUtils.GetStaticTimeZoneInformation(keyName);
+            if (information == null)
+            {
+                // [ContinuMail 2026] Registry unavailable (non-Windows). Reconstruct from the runtime's own
+                // zone database (cross-platform via ICU) instead of the Windows registry; UTC if id unknown.
+                try { return TimeZoneInfo.FindSystemTimeZoneById(keyName); }
+                catch { return TimeZoneInfo.Utc; }
+            }
             TimeZoneInfo.AdjustmentRule rule = AdjustmentRuleUtils.GetStaticAdjustmentRule(information);
             string displayName;
             string standardDisplayName;

--- a/vendor/PSTFileFormat/Utils/TimeZoneInfoUtils.cs
+++ b/vendor/PSTFileFormat/Utils/TimeZoneInfoUtils.cs
@@ -1,0 +1,81 @@
+/* Copyright (C) 2012-2016 ROM Knowledgeware. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * 
+ * Maintainer: Tal Aloni <tal@kmrom.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Win32;
+
+namespace Utilities
+{
+    public partial class TimeZoneInfoUtils
+    {
+        public static bool AreEquivalent(TimeZoneInfo a, TimeZoneInfo b)
+        {
+            return (a.BaseUtcOffset == b.BaseUtcOffset && a.HasSameRules(b));
+        }
+
+        public static DateTime SafeConvertToUtc(DateTime dateTime, TimeZoneInfo sourceTimeZone)
+        {
+            // time can be invalid when setting the clock one hour forward
+            if (sourceTimeZone.IsInvalidTime(dateTime))
+            {
+                TimeZoneInfo.AdjustmentRule rule = AdjustmentRuleUtils.GetAdjustmentRuleForTime(sourceTimeZone.GetAdjustmentRules(), dateTime.Date);
+                // rule cannot be null for invalid time
+                return TimeZoneInfo.ConvertTimeToUtc(dateTime.Add(rule.DaylightDelta), sourceTimeZone);
+            }
+            else
+            {
+                return TimeZoneInfo.ConvertTimeToUtc(dateTime, sourceTimeZone);
+            }
+        }
+
+        public static DateTime AdvancedConvertToUtc(DateTime dateTime, TimeZoneInfo sourceTimeZone, bool assumeDaylightTimeForAmbiguousTime)
+        {
+            DateTime result = SafeConvertToUtc(dateTime, sourceTimeZone);
+
+            // time can be ambiguous when setting the clock one hour backward
+            if (sourceTimeZone.IsAmbiguousTime(dateTime) && assumeDaylightTimeForAmbiguousTime)
+            {
+                TimeZoneInfo.AdjustmentRule rule = AdjustmentRuleUtils.GetAdjustmentRuleForTime(sourceTimeZone.GetAdjustmentRules(), dateTime.Date);
+                // ConvertTimeToUtc will assume standard time, we want it to assume daylight time
+                // rule cannot be null for ambiguous time
+                result = result.Add(-rule.DaylightDelta);
+            }
+
+            return result;
+        }
+
+        public static DateTime SetValidTimeOfDay(DateTime dateTime, TimeSpan timeOfDay, TimeZoneInfo timezone)
+        {
+            dateTime = DateTimeUtils.SetTimeOfDay(dateTime, timeOfDay);
+            // time can be invalid when setting the clock one hour forward
+            if (timezone.IsInvalidTime(dateTime))
+            {
+                TimeZoneInfo.AdjustmentRule rule = AdjustmentRuleUtils.GetAdjustmentRuleForTime(timezone.GetAdjustmentRules(), dateTime.Date);
+                // rule cannot be null for invalid time
+                dateTime = dateTime.Add(rule.DaylightDelta);
+            }
+            
+            dateTime = DateTime.SpecifyKind(dateTime, DateTimeKind.Unspecified);
+            return dateTime;
+        }
+
+        public static TimeZoneInfo FindSystemTimeZoneByDisplayName(string displayName)
+        {
+            foreach (TimeZoneInfo timezone in TimeZoneInfo.GetSystemTimeZones())
+            {
+                if (timezone.DisplayName == displayName)
+                {
+                    return timezone;
+                }
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Adds Thunderbird calendar and task conversion to PST.

## Scope
- Calendar events -> `IPM.Appointment`: single + recurring (RRULE/EXDATE/exceptions), timezones (IANA -> Windows, DST rules), all-day, busy/free, reminders, meeting attendees + organizer, categories, attachments (ByValue + link), Teams/Meet online-meeting URL, Exchange `GlobalObjectId`, and `cal_relations`.
- Thunderbird todos -> `IPM.Task`: core fields plus recurring tasks (`PidLidTaskRecurrence`).
- Reads the calendar SQLite side-tables (`local.sqlite` / `cache.sqlite`); iCal parsing via Ical.Net; discovery + config wiring, with `--no-appointments` / `--no-tasks`.

## Robustness
Notable fix: a recurring appointment in any timezone that carries multiple historical DST rules (most US/EU zones) previously threw an uncaught exception that aborted the whole conversion; a zero-DST test matrix had hidden it. That path and the surrounding recurrence/error-containment code are now fixed and covered, including a mutation-testing pass over the recurrence logic.

## Validation
- Engine unit suite 1176/0; independent `pst-validate` (MS-PST reader) gate; byte-gated recurrence blobs against real Outlook output.
- Validated on a real multi-DST calendar spanning UTC / European / Jerusalem / Kolkata (+05:30) / Bangkok: 368 appointments + 7 tasks, 0 skipped, 0 `pst-validate` errors; field-level decode matched the source with zero deviations; confirmed in classic Outlook.

## Merge
Rebased onto `main` (picks up the dependency bumps incl. Microsoft.Data.Sqlite 10). Rebase-merge to keep `main` linear.
