### PR TITLE
fix(parsing): Allow export of folders starting/ending with dots

### DIFF
--- a/desktop/src/lib/options.test.ts
+++ b/desktop/src/lib/options.test.ts
@@ -34,9 +34,9 @@ describe("validateFolderName", () => {
     expect(validateFolderName(" Inbox")).toMatch(/space/);
     expect(validateFolderName("Inbox ")).toMatch(/space/);
   });
-  it("rejects leading/trailing dots", () => {
-    expect(validateFolderName(".Inbox")).toMatch(/dot/);
-    expect(validateFolderName("Inbox.")).toMatch(/dot/);
+  it("accepts leading/trailing dots (folder names are MAPI-internal, not filesystem names)", () => {
+    expect(validateFolderName(".Inbox")).toBeNull();
+    expect(validateFolderName("Inbox.")).toBeNull();
   });
   it("rejects reserved Windows device names (with or without an extension)", () => {
     expect(validateFolderName("CON")).toMatch(/reserved/i);
@@ -248,8 +248,8 @@ describe("validateFolderName parity table (mirror of FolderNameValidatorTests.cs
   // Keep these two arrays identical (case-for-case) to the C# parity table in
   // tests/Mail2Pst.Core.Tests/Config/FolderNameValidatorTests.cs. The engine validator
   // (src/Mail2Pst.Core/Config/FolderNameValidator.cs) must agree on every case.
-  const valid = ["Imported Mail", "Work", "2024 Archive", "a.b", "Folder.name.with.dots", "café"];
-  const invalid = ["", "   ", "a/b", "a\\b", "tab\there", " leading", "trailing ", ".hidden", "trailing.", "CON", "con.txt", "COM1", "LPT9.log"];
+  const valid = ["Imported Mail", "Work", "2024 Archive", "a.b", "Folder.name.with.dots", "café", ".hidden", "trailing."];
+  const invalid = ["", "   ", "a/b", "a\\b", "tab\there", " leading", "trailing ", "CON", "con.txt", "COM1", "LPT9.log"];
 
   it.each(valid)("accepts %j", (name) => {
     expect(validateFolderName(name)).toBeNull();

--- a/desktop/src/lib/options.ts
+++ b/desktop/src/lib/options.ts
@@ -68,9 +68,6 @@ export function validateFolderName(name: string): string | null {
     return "Folder name can't contain control characters.";
   }
   if (name !== trimmed) return "Folder name can't start or end with a space.";
-  if (trimmed.startsWith(".") || trimmed.endsWith(".")) {
-    return "Folder name can't start or end with a dot.";
-  }
   if (/^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$/i.test(trimmed)) {
     return "Folder name is reserved on Windows.";
   }

--- a/src/Mail2Pst.Core/Config/FolderNameValidator.cs
+++ b/src/Mail2Pst.Core/Config/FolderNameValidator.cs
@@ -44,9 +44,6 @@ public static class FolderNameValidator
         if (value != trimmed)
             throw new ConfigValidationException("Folder name can't start or end with a space.");
 
-        if (trimmed.StartsWith('.') || trimmed.EndsWith('.'))
-            throw new ConfigValidationException("Folder name can't start or end with a dot.");
-
         if (ReservedName.IsMatch(trimmed))
             throw new ConfigValidationException("Folder name is reserved on Windows.");
     }

--- a/tests/Mail2Pst.Core.Tests/Config/FolderNameValidatorTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Config/FolderNameValidatorTests.cs
@@ -19,6 +19,8 @@ public class FolderNameValidatorTests
     [InlineData("a.b")]
     [InlineData("Folder.name.with.dots")]
     [InlineData("café")]
+    [InlineData(".hidden")]   // leading dot: a PST folder display name, not a filesystem name
+    [InlineData("trailing.")] // trailing dot: MAPI-internal, never written to disk
     public void Validate_AcceptsValidNames(string name)
     {
         FolderNameValidator.Validate(name); // must not throw
@@ -32,8 +34,6 @@ public class FolderNameValidatorTests
     [InlineData("tab\there")]
     [InlineData(" leading")]
     [InlineData("trailing ")]
-    [InlineData(".hidden")]
-    [InlineData("trailing.")]
     [InlineData("CON")]
     [InlineData("con.txt")]
     [InlineData("COM1")]


### PR DESCRIPTION
I came across a Thunderbird profile that had some folders start with a dot. With this commit, the export of the profile was successful, import in Outlook was a success as well.