### PR TITLE
feat(desktop): convert calendars, tasks & contacts with per-account PST routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,8 +61,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Item relations are preserved.** Thunderbird `RELATED-TO` links between calendar items — which have no
   native Outlook equivalent — are preserved as a readable note appended to the item body, with a warning,
   rather than being silently dropped.
+- **The desktop app now converts calendars, tasks, and contacts — each routed to the right PST.** The
+  profile Options screen gains an **"Also convert"** group with Calendar events / Tasks / Contacts toggles
+  (default on, with live counts that grey out when a type has nothing to convert). In multi-account (split)
+  mode, each calendar and address book is written into the PST of the **account it belongs to**; local
+  items — a local calendar (e.g. your "Home" calendar), the Personal Address Book — go to a **Local
+  Folders** PST, created automatically even when Local Folders has no mail of its own. The Options
+  **Preview** shows exactly which PST each calendar/contact list will land in *before* you convert (with a
+  note if a calendar belongs to an account you didn't select), and the results screen breaks the run down
+  per type — Mail / Calendar / Tasks / Contacts — with progress shown per phase. Single-PST and combined
+  outputs put everything in the one file, unchanged.
 
 ### Internal
+- Desktop calendar/tasks/contacts wiring: engine `discover` now emits a per-item `accountId` for each
+  calendar and address book, resolved by matching the calendar's `prefs.js` registry URI / an address
+  book's CardDAV URL against the discovered accounts (email-first with a URL-decoded and **boundary-guarded**
+  compare so a shorter local-part can't substring-match a longer one, then a normalized exact/subdomain host
+  match; any ambiguity resolves to "local" rather than guessing). The frontend routes each item by that id
+  through a single shared `routeAlsoConvert` used by **both** the config builder and the Options preview
+  (so the preview can never disagree with what is written), synthesizing a PIM-only "Local Folders" output
+  group when a local item has no existing Local Folders PST. `ConfigValidator` accepts such a
+  sources-empty, calendars/contacts-only output group; the CLI event contract is unchanged (`schemaVersion`
+  stays 1 — `accountId` is additive).
 - New contact pipeline (`ContactRecord` model, SQLite + Mork readers, a shared vCard mapper, and an
   `IPM.Contact` writer) added as a distinct write phase that reuses the existing PST size-split,
   checkpoint, and reporting machinery. Reading is **vCard-first** (modern Thunderbird stores rich contact

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -143,6 +143,8 @@ export default function App() {
             accounts={f.accounts}
             selectedAccountKeys={f.selectedAccountKeys}
             pstNames={f.pstNames}
+            calendars={flow.calendars}
+            addressBooks={flow.addressBooks}
           />
         ) : f.scan && f.outputTarget?.kind === "pstFile" ? (
           <OptionsView

--- a/desktop/src/components/views/ConvertView.tsx
+++ b/desktop/src/components/views/ConvertView.tsx
@@ -11,6 +11,13 @@ import { formatRate, formatDuration } from "@/lib/progressStats";
 import { useSmoothedProgress } from "@/lib/useSmoothedProgress";
 import type { ConvertState } from "@/lib/useConvert";
 
+const PHASE_HEADING: Record<string, string> = {
+  mail: "Converting your mail…",
+  appointments: "Converting appointments…",
+  tasks: "Converting tasks…",
+  contacts: "Converting contacts…",
+};
+
 export function ConvertView({ state }: { state: ConvertState }) {
   const [cancelling, setCancelling] = useState(false);
   const { displayConverted, mbPerSec, etaSec } = useSmoothedProgress(state);
@@ -19,7 +26,7 @@ export function ConvertView({ state }: { state: ConvertState }) {
   const pct = Math.round(ratio * 100);
   return (
     <div className="flex flex-1 flex-col">
-      <h1 className="text-xl font-semibold text-foreground">Converting your mail…</h1>
+      <h1 className="text-xl font-semibold text-foreground">{PHASE_HEADING[state.currentPhase ?? "mail"] ?? "Converting your mail…"}</h1>
       <p className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
         <FolderInput className="size-4 text-primary" />
         {state.currentFolder ? (
@@ -35,6 +42,15 @@ export function ConvertView({ state }: { state: ConvertState }) {
         </span>
         <span className="text-light-gray">{pct}%</span>
       </div>
+      {state.currentPhase && state.currentPhase !== "mail" && (() => {
+        const t = state.currentPhase === "appointments" ? state.appointments
+          : state.currentPhase === "tasks" ? state.tasks : state.contacts;
+        return t.total > 0 ? (
+          <div className="text-sm text-light-gray">
+            {t.converted.toLocaleString()} of {t.total.toLocaleString()}
+          </div>
+        ) : null;
+      })()}
       <div className="mt-1.5">
         <ProgressBar value={ratio} />
       </div>

--- a/desktop/src/components/views/DoneView.tsx
+++ b/desktop/src/components/views/DoneView.tsx
@@ -3,18 +3,20 @@
 
 import { Check, Package, FolderOpen, TriangleAlert } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { StatChip } from "@/components/ui/stat-chip";
 import { openFolder } from "@/lib/engine";
 import { splitPath } from "@/lib/convert";
 import type { ConvertState } from "@/lib/useConvert";
 import { formatElapsed } from "@/lib/progressStats";
 import { shouldShowEnrichment, formatEnrichmentLine } from "@/lib/doneEnrichment";
+import { perTypeRows, anySkipped, doneSubtitle } from "@/lib/perTypeRows";
 import { ColourImportCard } from "@/components/views/ColourImportCard";
 
 export function DoneView({ state, profileRoot, onConvertAnother }: { state: ConvertState; profileRoot?: string | null; onConvertAnother: () => void }) {
   const first = state.outputs[0];
   const folder = first ? splitPath(first).dir : state.outputDir;
   const elapsed = state.elapsedMs != null ? formatElapsed(state.elapsedMs) : "";
+  const rows = perTypeRows(state);
+  const showSkipped = anySkipped(rows);
   const title =
     state.outputs.length <= 1
       ? first
@@ -30,9 +32,7 @@ export function DoneView({ state, profileRoot, onConvertAnother }: { state: Conv
         </div>
         <div>
           <h1 className="text-xl font-semibold text-foreground">Conversion complete</h1>
-          <p className="text-sm text-muted-foreground">
-            {state.converted.toLocaleString()} messages converted{elapsed ? ` in ${elapsed}` : ""}.
-          </p>
+          <p className="text-sm text-muted-foreground">{doneSubtitle(state, elapsed)}</p>
         </div>
       </div>
 
@@ -51,10 +51,21 @@ export function DoneView({ state, profileRoot, onConvertAnother }: { state: Conv
         )}
       </div>
 
-      <div className="mt-4 flex gap-2.5">
-        <StatChip label="Converted" value={state.converted} />
-        <StatChip label="Skipped" value={state.skipped} />
-        <StatChip label="Warnings" value={state.warnings} />
+      <div className="mt-4 overflow-hidden rounded-[10px] border border-border bg-card text-sm">
+        <div className="flex border-b border-border px-3.5 py-1.5 text-[11px] uppercase tracking-wide text-light-gray">
+          <div className="flex-1">Type</div>
+          <div className="w-20 text-right">Converted</div>
+          {showSkipped && <div className="w-20 text-right">Skipped</div>}
+          <div className="w-20 text-right">Warnings</div>
+        </div>
+        {rows.map((r) => (
+          <div key={r.label} className="flex border-t border-border px-3.5 py-2 first:border-t-0 text-foreground">
+            <div className="flex-1 font-medium">{r.label}</div>
+            <div className="w-20 text-right tabular-nums">{r.converted.toLocaleString()}</div>
+            {showSkipped && <div className="w-20 text-right tabular-nums text-light-gray">{r.skipped.toLocaleString()}</div>}
+            <div className="w-20 text-right tabular-nums text-light-gray">{r.warnings.toLocaleString()}</div>
+          </div>
+        ))}
       </div>
 
       {state.enrichment && shouldShowEnrichment(state.enrichment) && (

--- a/desktop/src/components/views/ProfileOptionsView.tsx
+++ b/desktop/src/components/views/ProfileOptionsView.tsx
@@ -12,8 +12,9 @@ import { formatBytes } from "@/lib/format";
 import { openJunkHelp, pickOutputPst } from "@/lib/engine";
 import { groupByAccount, sanitizePstName, accountKeyForRow } from "@/lib/accounts";
 import { buildAccountPreview } from "@/lib/profilePreview";
+import { alsoConvertInfo } from "@/lib/alsoConvert";
 import type { OptionsState } from "@/lib/options";
-import type { ConversionConfig, ProfileSourceRow, OutputTarget, Account } from "@/lib/types";
+import type { ConversionConfig, ProfileSourceRow, OutputTarget, Account, DiscoveredCalendar, DiscoveredAddressBook } from "@/lib/types";
 
 interface ProfileOptionsViewProps {
   rows: ProfileSourceRow[];
@@ -30,11 +31,13 @@ interface ProfileOptionsViewProps {
   accounts?: Account[];
   selectedAccountKeys?: Set<string>;
   pstNames?: Record<string, string>;
+  calendars: DiscoveredCalendar[];
+  addressBooks: DiscoveredAddressBook[];
 }
 
 export function ProfileOptionsView({
   rows, outputTarget, onOutputTargetChange, profileRoot, checkedIds, skipEmpty, options, onSetOptions, onStart, onBack,
-  accounts, selectedAccountKeys, pstNames,
+  accounts, selectedAccountKeys, pstNames, calendars, addressBooks,
 }: ProfileOptionsViewProps) {
   const [startError, setStartError] = useState<string | null>(null);
   const [splitOk, setSplitOk] = useState(true);
@@ -50,6 +53,8 @@ export function ProfileOptionsView({
     () => effectiveRows(rows, checkedIds, skipEmpty) as ProfileSourceRow[],
     [rows, checkedIds, skipEmpty],
   );
+
+  const also = useMemo(() => alsoConvertInfo(calendars, addressBooks), [calendars, addressBooks]);
 
   const outputPath = outputTarget?.kind === "pstFile" ? outputTarget.path : null;
   const folderDir = outputTarget?.kind === "folder" ? outputTarget.dir : null;
@@ -105,7 +110,7 @@ export function ProfileOptionsView({
           // selection-filtered upstream, but don't rely on that here).
           const combineRows = rows.filter((r) => keys.has(accountKeyForRow(r)));
           const path = joinOutputPstPath(folderDir, sanitizedCombineName);
-          const { config, outputDir } = buildProfileConfig(combineRows, checkedIds, skipEmpty, options, path, profileRoot);
+          const { config, outputDir } = buildProfileConfig(combineRows, checkedIds, skipEmpty, options, path, profileRoot, calendars, addressBooks);
           onStart(config, outputDir, expectedTotalMessages(combineRows, checkedIds, skipEmpty));
         } else {
           const accs = accounts ?? [];
@@ -115,6 +120,7 @@ export function ProfileOptionsView({
             .map((g) => ({ key: g.key, pstName: names[g.key] ?? g.defaultPstName, rows: g.rows }));
           const { config, outputDir } = buildProfileConfigMulti({
             groups: selectedGroups, checkedIds, skipEmpty, options, target: outputTarget, profileRoot,
+            calendars, addressBooks,
           });
           const splitRows = selectedGroups.flatMap((g) => g.rows);
           onStart(config, outputDir, expectedTotalMessages(splitRows, checkedIds, skipEmpty));
@@ -130,7 +136,7 @@ export function ProfileOptionsView({
       return;
     }
     try {
-      const { config, outputDir } = buildProfileConfig(rows, checkedIds, skipEmpty, options, outputPath, profileRoot);
+      const { config, outputDir } = buildProfileConfig(rows, checkedIds, skipEmpty, options, outputPath, profileRoot, calendars, addressBooks);
       onStart(config, outputDir, expectedTotalMessages(rows, checkedIds, skipEmpty));
     } catch (e) {
       setStartError(e instanceof ConvertConfigError ? e.message : "Could not start the conversion.");
@@ -159,6 +165,43 @@ export function ProfileOptionsView({
               Flatten into one folder
             </label>
           </div>
+
+          <div>
+            <div className="mb-1 text-sm font-medium text-foreground">Also convert</div>
+            <label className="flex items-center gap-2 text-sm text-foreground">
+              <input type="checkbox" checked={options.includeAppointments && !also.appointments.disabled}
+                disabled={also.appointments.disabled}
+                onChange={(e) => onSetOptions({ includeAppointments: e.target.checked })} />
+              Calendar events
+              <span className="ml-auto text-xs text-light-gray">
+                {also.appointments.disabled ? "none found" : also.appointments.count.toLocaleString()}
+              </span>
+            </label>
+            <label className="mt-1 flex items-center gap-2 text-sm text-foreground">
+              <input type="checkbox" checked={options.includeTasks && !also.tasks.disabled}
+                disabled={also.tasks.disabled}
+                onChange={(e) => onSetOptions({ includeTasks: e.target.checked })} />
+              Tasks
+              <span className="ml-auto text-xs text-light-gray">
+                {also.tasks.disabled ? "none found" : also.tasks.count.toLocaleString()}
+              </span>
+            </label>
+            <label className="mt-1 flex items-center gap-2 text-sm text-foreground">
+              <input type="checkbox" checked={options.includeContacts && !also.contacts.disabled}
+                disabled={also.contacts.disabled}
+                onChange={(e) => onSetOptions({ includeContacts: e.target.checked })} />
+              Contacts
+              <span className="ml-auto text-xs text-light-gray">
+                {also.contacts.disabled ? "none found"
+                  : also.contacts.unknown && also.contacts.count === 0 ? "found"
+                  : `${also.contacts.count.toLocaleString()}${also.contacts.unknown ? "+" : ""}`}
+              </span>
+            </label>
+            {isMultiAccount && !combine && (
+              <p className="mt-1 text-xs text-light-gray">Written to the first PST.</p>
+            )}
+          </div>
+
           <div>
             <div className="mb-1 flex items-center gap-1.5 text-sm font-medium text-foreground">
               Junk handling

--- a/desktop/src/components/views/ProfileOptionsView.tsx
+++ b/desktop/src/components/views/ProfileOptionsView.tsx
@@ -68,13 +68,16 @@ export function ProfileOptionsView({
     try { return deriveOutputTarget(outputPath).pstName; } catch { return "Output"; }
   }, [outputPath]);
 
-  const previewEntries = useMemo(
+  const preview = useMemo(
     () =>
       isMultiAccount
-        ? buildAccountPreview(eff, accounts ?? [], selectedAccountKeys ?? new Set<string>(), pstNames ?? {}, options.folderMapping)
-        : [],
-    [isMultiAccount, eff, accounts, selectedAccountKeys, pstNames, options.folderMapping],
+        ? buildAccountPreview(eff, accounts ?? [], selectedAccountKeys ?? new Set<string>(), pstNames ?? {},
+            options.folderMapping, calendars, addressBooks, options)
+        : { entries: [], warnings: [] },
+    [isMultiAccount, eff, accounts, selectedAccountKeys, pstNames, options, calendars, addressBooks],
   );
+  const previewEntries = preview.entries;
+  const routeWarnings = preview.warnings;
 
   const sanitizedCombineName = sanitizePstName(combineName);
   const combineFilename = `${sanitizedCombineName}.pst`;
@@ -120,7 +123,7 @@ export function ProfileOptionsView({
             .map((g) => ({ key: g.key, pstName: names[g.key] ?? g.defaultPstName, rows: g.rows }));
           const { config, outputDir } = buildProfileConfigMulti({
             groups: selectedGroups, checkedIds, skipEmpty, options, target: outputTarget, profileRoot,
-            calendars, addressBooks,
+            calendars, addressBooks, accounts,
           });
           const splitRows = selectedGroups.flatMap((g) => g.rows);
           onStart(config, outputDir, expectedTotalMessages(splitRows, checkedIds, skipEmpty));
@@ -198,7 +201,9 @@ export function ProfileOptionsView({
               </span>
             </label>
             {isMultiAccount && !combine && (
-              <p className="mt-1 text-xs text-light-gray">Written to the first PST.</p>
+              <p className="mt-1 text-xs text-light-gray">
+                Each list is written to its account's PST; local items go to Local Folders.
+              </p>
             )}
           </div>
 
@@ -275,10 +280,22 @@ export function ProfileOptionsView({
                           <span className="ml-2 text-light-gray">{f.messages.toLocaleString()} · {formatBytes(f.bytes)}</span>
                         </div>
                       ))}
+                      {entry.pim.calendars.map((name, i) => (
+                        <div key={`c${i}`} className="pl-3 text-foreground">🗓 {name}</div>
+                      ))}
+                      {entry.pim.contacts.map((name, i) => (
+                        <div key={`k${i}`} className="pl-3 text-foreground">👤 {name}</div>
+                      ))}
+                      {entry.isSynthetic && (
+                        <div className="pl-3 text-xs text-light-gray">PIM-only PST (no mail).</div>
+                      )}
                     </div>
                   </div>
                 ))}
                 {previewEntries.length === 0 && <div className="pl-3 text-xs text-light-gray">No folders selected.</div>}
+                {routeWarnings.map((w, i) => (
+                  <p key={`w${i}`} className="mt-2 text-xs text-primary">{w}</p>
+                ))}
               </div>
             ) : (
               <>

--- a/desktop/src/lib/alsoConvert.test.ts
+++ b/desktop/src/lib/alsoConvert.test.ts
@@ -5,10 +5,10 @@ import type { DiscoveredCalendar, DiscoveredAddressBook } from "./types";
 const cal = (eventCount: number, taskCount: number): DiscoveredCalendar => ({
   calId: "c", displayName: "d", storeKind: "local", storePath: "/s", calendarType: "both",
   isVisibleInThunderbird: true, eventCount, taskCount,
-  defaultCalendarFolderPath: [], defaultTaskFolderPath: [],
+  defaultCalendarFolderPath: [], defaultTaskFolderPath: [], accountId: null,
 });
 const book = (contactCount: number | null): DiscoveredAddressBook =>
-  ({ displayName: "b", path: `/b${contactCount}`, format: "thunderbird-sqlite", contactCount });
+  ({ displayName: "b", path: `/b${contactCount}`, format: "thunderbird-sqlite", contactCount, accountId: null });
 
 describe("alsoConvertInfo", () => {
   it("sums counts across calendars/books", () => {

--- a/desktop/src/lib/alsoConvert.test.ts
+++ b/desktop/src/lib/alsoConvert.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { alsoConvertInfo } from "./alsoConvert";
+import type { DiscoveredCalendar, DiscoveredAddressBook } from "./types";
+
+const cal = (eventCount: number, taskCount: number): DiscoveredCalendar => ({
+  calId: "c", displayName: "d", storeKind: "local", storePath: "/s", calendarType: "both",
+  isVisibleInThunderbird: true, eventCount, taskCount,
+  defaultCalendarFolderPath: [], defaultTaskFolderPath: [],
+});
+const book = (contactCount: number | null): DiscoveredAddressBook =>
+  ({ displayName: "b", path: `/b${contactCount}`, format: "thunderbird-sqlite", contactCount });
+
+describe("alsoConvertInfo", () => {
+  it("sums counts across calendars/books", () => {
+    const i = alsoConvertInfo([cal(10, 2), cal(0, 5)], [book(4), book(3)]);
+    expect(i.appointments.count).toBe(10);
+    expect(i.tasks.count).toBe(7);
+    expect(i.contacts.count).toBe(7);
+  });
+  it("disables appointments independently of tasks", () => {
+    const i = alsoConvertInfo([cal(0, 7)], []);
+    expect(i.appointments.disabled).toBe(true);
+    expect(i.tasks.disabled).toBe(false);
+  });
+  it("keeps contacts enabled when a count is unknown", () => {
+    const i = alsoConvertInfo([], [book(null)]);
+    expect(i.contacts.disabled).toBe(false);
+    expect(i.contacts.unknown).toBe(true);
+    expect(i.contacts.count).toBe(0);
+  });
+  it("disables contacts only when no books or all known-zero", () => {
+    expect(alsoConvertInfo([], []).contacts.disabled).toBe(true);
+    expect(alsoConvertInfo([], [book(0), book(0)]).contacts.disabled).toBe(true);
+    expect(alsoConvertInfo([], [book(0), book(null)]).contacts.disabled).toBe(false);
+  });
+});

--- a/desktop/src/lib/alsoConvert.ts
+++ b/desktop/src/lib/alsoConvert.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+import type { DiscoveredCalendar, DiscoveredAddressBook } from "./types";
+
+export interface AlsoConvertInfo {
+  appointments: { count: number; disabled: boolean };
+  tasks: { count: number; disabled: boolean };
+  contacts: { count: number; unknown: boolean; disabled: boolean };
+}
+
+/** Counts + per-type disable flags for the "Also convert" toggles.
+ * Appointments/tasks disable independently on their own count. Contacts disable
+ * only when there are no address books or every KNOWN count is 0 — an unknown
+ * (null) count keeps contacts enabled (a count failure must not block conversion). */
+export function alsoConvertInfo(
+  calendars: DiscoveredCalendar[],
+  addressBooks: DiscoveredAddressBook[],
+): AlsoConvertInfo {
+  const appt = calendars.reduce((n, c) => n + c.eventCount, 0);
+  const task = calendars.reduce((n, c) => n + c.taskCount, 0);
+  const known = addressBooks.filter((b) => b.contactCount != null);
+  const contactCount = known.reduce((n, b) => n + (b.contactCount ?? 0), 0);
+  const unknown = addressBooks.some((b) => b.contactCount == null);
+  const contactsDisabled = addressBooks.length === 0 || addressBooks.every((b) => b.contactCount === 0);
+  return {
+    appointments: { count: appt, disabled: appt === 0 },
+    tasks: { count: task, disabled: task === 0 },
+    contacts: { count: contactCount, unknown, disabled: contactsDisabled },
+  };
+}

--- a/desktop/src/lib/discover.test.ts
+++ b/desktop/src/lib/discover.test.ts
@@ -127,4 +127,22 @@ describe("parseDiscover", () => {
     });
     expect(parseDiscover(stdout).addressBooks[0].contactCount).toBeNull();
   });
+
+  it("parses accountId on calendars and address books (present, null, absent)", () => {
+    const stdout = JSON.stringify({
+      type: "discovery", root: "/p", layout: "x", sources: [], warnings: [], skipped: [],
+      pairing: { pairedMsfCount: 0, unpairedMboxCount: 0, orphanMsfCount: 0 }, accounts: [],
+      calendars: [{ calId: "c1", displayName: "Home", storeKind: "local", storePath: "/s",
+        calendarType: "both", isVisibleInThunderbird: true, eventCount: 1, taskCount: 0,
+        defaultCalendarFolderPath: [], defaultTaskFolderPath: [], accountId: "/p/acc" }],
+      addressBooks: [
+        { displayName: "P", path: "/p/abook.sqlite", format: "thunderbird-sqlite", contactCount: 1, accountId: null },
+        { displayName: "G", path: "/p/abook-1.sqlite", format: "thunderbird-sqlite", contactCount: 2 }, // absent
+      ],
+    });
+    const r = parseDiscover(stdout);
+    expect(r.calendars[0].accountId).toBe("/p/acc");
+    expect(r.addressBooks[0].accountId).toBeNull();
+    expect(r.addressBooks[1].accountId).toBeNull(); // absent -> null
+  });
 });

--- a/desktop/src/lib/discover.test.ts
+++ b/desktop/src/lib/discover.test.ts
@@ -89,4 +89,42 @@ describe("parseDiscover", () => {
     });
     expect(parseDiscover(json).accounts[0].addressResolution).toBe("not-found");
   });
+
+  it("parses calendars and addressBooks", () => {
+    const stdout = JSON.stringify({
+      type: "discovery", root: "/p", layout: "thunderbird-profile",
+      sources: [], warnings: [], skipped: [],
+      pairing: { pairedMsfCount: 0, unpairedMboxCount: 0, orphanMsfCount: 0 },
+      accounts: [],
+      calendars: [{ calId: "c1", displayName: "Home", storeKind: "local", storePath: "/p/local.sqlite",
+        calendarType: "both", isVisibleInThunderbird: true, eventCount: 12, taskCount: 3,
+        defaultCalendarFolderPath: ["Calendar"], defaultTaskFolderPath: ["Tasks"] }],
+      addressBooks: [{ displayName: "Personal", path: "/p/abook.sqlite", format: "thunderbird-sqlite", contactCount: 4 },
+        { displayName: "Collected", path: "/p/history.mab", format: "thunderbird-mab", contactCount: null }],
+    });
+    const r = parseDiscover(stdout);
+    expect(r.calendars).toHaveLength(1);
+    expect(r.calendars[0].eventCount).toBe(12);
+    expect(r.addressBooks).toHaveLength(2);
+    expect(r.addressBooks[1].contactCount).toBeNull();
+  });
+
+  it("defaults calendars/addressBooks to [] when absent", () => {
+    const stdout = JSON.stringify({
+      type: "discovery", root: "/p", layout: "x", sources: [], warnings: [], skipped: [],
+      pairing: { pairedMsfCount: 0, unpairedMboxCount: 0, orphanMsfCount: 0 }, accounts: [],
+    });
+    const r = parseDiscover(stdout);
+    expect(r.calendars).toEqual([]);
+    expect(r.addressBooks).toEqual([]);
+  });
+
+  it("coerces a malformed contactCount to null (never NaN)", () => {
+    const stdout = JSON.stringify({
+      type: "discovery", root: "/p", layout: "x", sources: [], warnings: [], skipped: [],
+      pairing: { pairedMsfCount: 0, unpairedMboxCount: 0, orphanMsfCount: 0 }, accounts: [],
+      addressBooks: [{ displayName: "B", path: "/b", format: "thunderbird-sqlite", contactCount: "oops" }],
+    });
+    expect(parseDiscover(stdout).addressBooks[0].contactCount).toBeNull();
+  });
 });

--- a/desktop/src/lib/discover.ts
+++ b/desktop/src/lib/discover.ts
@@ -51,7 +51,7 @@ export function parseDiscover(stdout: string): DiscoverResult {
     };
   });
 
-  const calendars = (Array.isArray(obj.calendars) ? obj.calendars : []).map((c) => {
+  const calendars: DiscoveredCalendar[] = (Array.isArray(obj.calendars) ? obj.calendars : []).map((c) => {
     const cc = c as Record<string, unknown>;
     return {
       calId: String(cc.calId ?? ""),
@@ -66,7 +66,7 @@ export function parseDiscover(stdout: string): DiscoverResult {
       defaultTaskFolderPath: Array.isArray(cc.defaultTaskFolderPath) ? cc.defaultTaskFolderPath.map(String) : [],
     };
   });
-  const addressBooks = (Array.isArray(obj.addressBooks) ? obj.addressBooks : []).map((b) => {
+  const addressBooks: DiscoveredAddressBook[] = (Array.isArray(obj.addressBooks) ? obj.addressBooks : []).map((b) => {
     const bb = b as Record<string, unknown>;
     const rawCount = bb.contactCount == null ? null : Number(bb.contactCount);
     return {

--- a/desktop/src/lib/discover.ts
+++ b/desktop/src/lib/discover.ts
@@ -64,6 +64,7 @@ export function parseDiscover(stdout: string): DiscoverResult {
       taskCount: Number(cc.taskCount ?? 0),
       defaultCalendarFolderPath: Array.isArray(cc.defaultCalendarFolderPath) ? cc.defaultCalendarFolderPath.map(String) : [],
       defaultTaskFolderPath: Array.isArray(cc.defaultTaskFolderPath) ? cc.defaultTaskFolderPath.map(String) : [],
+      accountId: cc.accountId == null ? null : String(cc.accountId),
     };
   });
   const addressBooks: DiscoveredAddressBook[] = (Array.isArray(obj.addressBooks) ? obj.addressBooks : []).map((b) => {
@@ -76,6 +77,7 @@ export function parseDiscover(stdout: string): DiscoverResult {
       // Guard: a malformed count must become unknown (null), never NaN, or it would
       // poison alsoConvertInfo's sums.
       contactCount: rawCount == null || Number.isNaN(rawCount) ? null : rawCount,
+      accountId: bb.accountId == null ? null : String(bb.accountId),
     };
   });
 

--- a/desktop/src/lib/discover.ts
+++ b/desktop/src/lib/discover.ts
@@ -4,7 +4,7 @@
 import { extractJsonObjects, isRecord, EngineParseError } from "./parse";
 import type {
   DiscoverResult, DiscoveredSource, DiscoverWarning, DiscoverSkipped, DiscoverPairing,
-  Account, AddressResolution,
+  Account, AddressResolution, DiscoveredCalendar, DiscoveredAddressBook,
 } from "./types";
 
 /** Parse the engine's single pretty-printed `discovery` object (tolerates dev-build
@@ -51,6 +51,34 @@ export function parseDiscover(stdout: string): DiscoverResult {
     };
   });
 
+  const calendars = (Array.isArray(obj.calendars) ? obj.calendars : []).map((c) => {
+    const cc = c as Record<string, unknown>;
+    return {
+      calId: String(cc.calId ?? ""),
+      displayName: String(cc.displayName ?? ""),
+      storeKind: String(cc.storeKind ?? ""),
+      storePath: String(cc.storePath ?? ""),
+      calendarType: String(cc.calendarType ?? ""),
+      isVisibleInThunderbird: Boolean(cc.isVisibleInThunderbird),
+      eventCount: Number(cc.eventCount ?? 0),
+      taskCount: Number(cc.taskCount ?? 0),
+      defaultCalendarFolderPath: Array.isArray(cc.defaultCalendarFolderPath) ? cc.defaultCalendarFolderPath.map(String) : [],
+      defaultTaskFolderPath: Array.isArray(cc.defaultTaskFolderPath) ? cc.defaultTaskFolderPath.map(String) : [],
+    };
+  });
+  const addressBooks = (Array.isArray(obj.addressBooks) ? obj.addressBooks : []).map((b) => {
+    const bb = b as Record<string, unknown>;
+    const rawCount = bb.contactCount == null ? null : Number(bb.contactCount);
+    return {
+      displayName: String(bb.displayName ?? ""),
+      path: String(bb.path ?? ""),
+      format: String(bb.format ?? ""),
+      // Guard: a malformed count must become unknown (null), never NaN, or it would
+      // poison alsoConvertInfo's sums.
+      contactCount: rawCount == null || Number.isNaN(rawCount) ? null : rawCount,
+    };
+  });
+
   return {
     root: String(obj.root ?? ""),
     layout: String(obj.layout ?? ""),
@@ -59,6 +87,8 @@ export function parseDiscover(stdout: string): DiscoverResult {
     skipped,
     pairing,
     accounts,
+    calendars,
+    addressBooks,
     schemaVersion: obj.schemaVersion as number | undefined,
   };
 }

--- a/desktop/src/lib/options.test.ts
+++ b/desktop/src/lib/options.test.ts
@@ -266,3 +266,12 @@ describe("defaultOptions enrichment defaults", () => {
     expect(o.dropExpunged).toBe(false);
   });
 });
+
+describe("defaultOptions", () => {
+  it("defaults the three data-type toggles ON", () => {
+    const o = defaultOptions();
+    expect(o.includeAppointments).toBe(true);
+    expect(o.includeTasks).toBe(true);
+    expect(o.includeContacts).toBe(true);
+  });
+});

--- a/desktop/src/lib/options.ts
+++ b/desktop/src/lib/options.ts
@@ -19,6 +19,9 @@ export interface OptionsState {
   flattenFolderName: string;
   junkHandling: "Off" | "Category" | "Folder";
   dropExpunged: boolean;
+  includeAppointments: boolean;
+  includeTasks: boolean;
+  includeContacts: boolean;
 }
 
 /** Fresh default options (factory, so callers never share a mutable object). */
@@ -31,6 +34,9 @@ export function defaultOptions(): OptionsState {
     flattenFolderName: FLATTEN_DEFAULT_NAME,
     junkHandling: "Off",
     dropExpunged: false,
+    includeAppointments: true,
+    includeTasks: true,
+    includeContacts: true,
   };
 }
 

--- a/desktop/src/lib/perTypeRows.test.ts
+++ b/desktop/src/lib/perTypeRows.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { perTypeRows, anySkipped, totalItems, mailWarnings, doneSubtitle } from "./perTypeRows";
+import { initialConvertState } from "./useConvert";
+
+// Real numbers from a full run: done.warnings=40 is the GRAND TOTAL (mail 1 + appt 38 + task 1).
+const base = {
+  ...initialConvertState, converted: 16330, skipped: 0, warnings: 40,
+  appointments: { converted: 368, total: 0, skipped: 0, warnings: 38 },
+  tasks: { converted: 7, total: 0, skipped: 0, warnings: 1 },
+  contacts: { converted: 4, total: 0, skipped: 0, warnings: 0 },
+};
+
+describe("perTypeRows", () => {
+  it("emits a row per non-zero type", () => {
+    const rows = perTypeRows(base);
+    expect(rows.map((r) => r.label)).toEqual(["Mail", "Calendar", "Tasks", "Contacts"]);
+  });
+  it("mail row shows MAIL-ONLY warnings, not the grand total", () => {
+    expect(mailWarnings(base)).toBe(1); // 40 - 38 - 1 - 0
+    const rows = perTypeRows(base);
+    expect(rows.find((r) => r.label === "Mail")!.warnings).toBe(1);
+    expect(rows.find((r) => r.label === "Calendar")!.warnings).toBe(38);
+  });
+  it("subtracts per-type skips from the grand total too", () => {
+    // total warnings list includes per-type skips (RecordAppointmentSkipped -> AddWarning)
+    const s = { ...base, warnings: 42, tasks: { converted: 7, total: 0, skipped: 2, warnings: 1 } };
+    expect(mailWarnings(s)).toBe(1); // 42 - 38 - 1 - 0(appt skip) - 2(task skip) - 0
+  });
+  it("clamps to zero on an inconsistent event", () => {
+    expect(mailWarnings({ ...base, warnings: 1 })).toBe(0); // 1 - 39 -> clamped
+  });
+  it("omits zero-total types", () => {
+    const rows = perTypeRows({ ...base, appointments: { converted: 0, total: 0, skipped: 0, warnings: 0 } });
+    expect(rows.map((r) => r.label)).toEqual(["Mail", "Tasks", "Contacts"]);
+  });
+  it("totalItems sums all types", () => {
+    expect(totalItems(base)).toBe(16709);
+  });
+  it("anySkipped reflects any type skipped>0", () => {
+    expect(anySkipped(perTypeRows(base))).toBe(false);
+    expect(anySkipped(perTypeRows({ ...base, tasks: { converted: 7, total: 0, skipped: 2, warnings: 0 } }))).toBe(true);
+  });
+  it("doneSubtitle: 'messages' for mail-only, 'items' for mixed", () => {
+    const mailOnly = { ...initialConvertState, converted: 100 };
+    expect(doneSubtitle(mailOnly, "")).toBe("100 messages converted.");
+    // Locale-agnostic: build the expected count the same way the impl does, so the
+    // thousands separator matches whatever locale the test host uses.
+    expect(doneSubtitle(base, "29s")).toBe(`${(16709).toLocaleString()} items converted in 29s.`);
+  });
+});

--- a/desktop/src/lib/perTypeRows.ts
+++ b/desktop/src/lib/perTypeRows.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+import type { ConvertState } from "./useConvert";
+
+export interface PerTypeRow { label: string; converted: number; skipped: number; warnings: number; }
+
+/** Mail-only warning count. The engine's top-level `warnings` is a GRAND TOTAL —
+ * its warning list also receives every per-type warning AND every per-type skip
+ * (see ConversionReport.AddWarning). So mail-only warnings = total minus the
+ * per-type warning and skip counts, clamped >= 0. `converted` and `skipped` are
+ * already mail-only on the wire, so only warnings needs this correction. */
+export function mailWarnings(s: ConvertState): number {
+  const perType =
+    s.appointments.warnings + s.tasks.warnings + s.contacts.warnings +
+    s.appointments.skipped + s.tasks.skipped + s.contacts.skipped;
+  return Math.max(0, s.warnings - perType);
+}
+
+/** One row per data type that produced anything (non-zero converted/skipped/warnings).
+ * Mail uses top-level converted/skipped but the DERIVED mail-only warning count; the
+ * other three use their own per-type slices. */
+export function perTypeRows(s: ConvertState): PerTypeRow[] {
+  const all: PerTypeRow[] = [
+    { label: "Mail", converted: s.converted, skipped: s.skipped, warnings: mailWarnings(s) },
+    { label: "Calendar", converted: s.appointments.converted, skipped: s.appointments.skipped, warnings: s.appointments.warnings },
+    { label: "Tasks", converted: s.tasks.converted, skipped: s.tasks.skipped, warnings: s.tasks.warnings },
+    { label: "Contacts", converted: s.contacts.converted, skipped: s.contacts.skipped, warnings: s.contacts.warnings },
+  ];
+  return all.filter((r) => r.converted > 0 || r.skipped > 0 || r.warnings > 0);
+}
+
+export function anySkipped(rows: PerTypeRow[]): boolean {
+  return rows.some((r) => r.skipped > 0);
+}
+
+export function totalItems(s: ConvertState): number {
+  return s.converted + s.appointments.converted + s.tasks.converted + s.contacts.converted;
+}
+
+/** DoneView subtitle. A run with more than the Mail row reads "N items converted";
+ * a mail-only run keeps the historical "N messages converted" wording. `elapsed` is
+ * the already-formatted duration (e.g. "29s") or "" for none. */
+export function doneSubtitle(s: ConvertState, elapsed: string): string {
+  const mixed = perTypeRows(s).length > 1;
+  const n = mixed ? totalItems(s) : s.converted;
+  const noun = mixed ? "items" : "messages";
+  return `${n.toLocaleString()} ${noun} converted${elapsed ? ` in ${elapsed}` : ""}.`;
+}

--- a/desktop/src/lib/profileConfig.test.ts
+++ b/desktop/src/lib/profileConfig.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, it, expect } from "vitest";
 import { mergeProfileSources, buildProfileConfig, buildProfileConfigMulti } from "./profileConfig";
-import type { DiscoveredSource, ProfileSourceRow, DiscoveredCalendar, DiscoveredAddressBook } from "./types";
+import type { DiscoveredSource, ProfileSourceRow, DiscoveredCalendar, DiscoveredAddressBook, Account } from "./types";
 import type { OutputTarget } from "./types";
 import type { ScanResult } from "./parse";
 import { ConvertConfigError } from "./convert";
@@ -345,7 +345,7 @@ describe("buildProfileConfig calendars/contacts", () => {
 });
 
 describe("buildProfileConfigMulti calendars/contacts", () => {
-  it("split mode: calendars/contacts only on the FIRST group", () => {
+  it("split mode: calendars/contacts route to the matching account's group only", () => {
     // Account-prefixed paths so mirror-stripping leaves a folder (real multi-account shape).
     const r1: ProfileSourceRow = { ...calRow(), id: "/p/A/Inbox", path: "/p/A/Inbox", targetFolderPath: ["A", "Inbox"] };
     const r2: ProfileSourceRow = { ...calRow(), id: "/p/B/Inbox", path: "/p/B/Inbox", targetFolderPath: ["B", "Inbox"] };
@@ -354,11 +354,62 @@ describe("buildProfileConfigMulti calendars/contacts", () => {
     const { config } = buildProfileConfigMulti({
       groups: [g1, g2], checkedIds: new Set(["/p/A/Inbox", "/p/B/Inbox"]), skipEmpty: false,
       options: defaultOptions(), target: { kind: "folder", dir: "C:/out" }, profileRoot: "/p",
-      calendars: [cal], addressBooks: [bk],
+      calendars: [{ ...cal, accountId: "a" }], addressBooks: [{ ...bk, accountId: "a" }],
     });
     expect(config.outputs[0].calendars).toHaveLength(1);
     expect(config.outputs[0].contacts).toHaveLength(1);
     expect(config.outputs[1].calendars).toBeUndefined();
     expect(config.outputs[1].contacts).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// per-account routing + synthetic Local Folders PST (Task 8)
+// ---------------------------------------------------------------------------
+
+const acc = (id: string, resolution: Account["addressResolution"]): Account => ({
+  id, folderSegment: id, accountPath: id, store: null, email: null, host: null, addressResolution: resolution,
+});
+// Rows carry accountId so groupByAccount keys == account ids.
+const rowFor = (accountId: string, leaf: string): ProfileSourceRow => ({
+  ...calRow(), id: `${accountId}/${leaf}`, path: `${accountId}/${leaf}`,
+  targetFolderPath: [accountId, leaf], accountId,
+});
+
+describe("buildProfileConfigMulti routing", () => {
+  it("routes matched calendar/book to their account groups; local to Local Folders group", () => {
+    const gmail = rowFor("/acc/gmail", "Inbox");
+    const lf = rowFor("/acc/lf", "Inbox");
+    const groups = [
+      { key: "/acc/gmail", pstName: "Gmail", rows: [gmail] },
+      { key: "/acc/lf", pstName: "Local Folders", rows: [lf] },
+    ];
+    const accounts = [acc("/acc/gmail", "server"), acc("/acc/lf", "local-folders")];
+    const { config } = buildProfileConfigMulti({
+      groups, checkedIds: new Set([gmail.id, lf.id]), skipEmpty: false, options: defaultOptions(),
+      target: { kind: "folder", dir: "C:/out" }, profileRoot: "/p", accounts,
+      calendars: [{ ...cal, accountId: "/acc/gmail" }, { ...cal, calId: "c2", accountId: null }],
+      addressBooks: [{ ...bk, accountId: "/acc/gmail" }],
+    });
+    const gmailOut = config.outputs.find((o) => o.name === "Gmail")!;
+    const lfOut = config.outputs.find((o) => o.name === "Local Folders")!;
+    expect(gmailOut.calendars).toHaveLength(1);
+    expect(gmailOut.contacts).toHaveLength(1);
+    expect(lfOut.calendars).toHaveLength(1);   // the accountId:null calendar
+  });
+
+  it("synthesizes a Local Folders PST when local PIM exists and no LF group is present", () => {
+    const gmail = rowFor("/acc/gmail", "Inbox");
+    const groups = [{ key: "/acc/gmail", pstName: "Gmail", rows: [gmail] }];
+    const accounts = [acc("/acc/gmail", "server")];
+    const { config } = buildProfileConfigMulti({
+      groups, checkedIds: new Set([gmail.id]), skipEmpty: false, options: defaultOptions(),
+      target: { kind: "folder", dir: "C:/out" }, profileRoot: "/p", accounts,
+      calendars: [{ ...cal, accountId: null }], addressBooks: [],
+    });
+    const lf = config.outputs.find((o) => o.name === "Local Folders");
+    expect(lf).toBeDefined();
+    expect(lf!.sources).toEqual([]);
+    expect(lf!.calendars).toHaveLength(1);
   });
 });

--- a/desktop/src/lib/profileConfig.test.ts
+++ b/desktop/src/lib/profileConfig.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, it, expect } from "vitest";
 import { mergeProfileSources, buildProfileConfig, buildProfileConfigMulti } from "./profileConfig";
-import type { DiscoveredSource, ProfileSourceRow } from "./types";
+import type { DiscoveredSource, ProfileSourceRow, DiscoveredCalendar, DiscoveredAddressBook } from "./types";
 import type { OutputTarget } from "./types";
 import type { ScanResult } from "./parse";
 import { ConvertConfigError } from "./convert";
@@ -261,5 +261,104 @@ describe("buildProfileConfigMulti", () => {
       groups: [{ key: "A", pstName: "A", rows: [srcRow("a", "A", ["x", "Empty"], null, 0)] }],
       mapping: "mirror", target: { kind: "folder", dir: "/out" }, skipEmpty: true,
     })).toThrow(/at least one folder/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// calendars / contacts population (Task 5)
+// ---------------------------------------------------------------------------
+
+const calRow = (): ProfileSourceRow => ({
+  id: "/p/Inbox", path: "/p/Inbox", displayName: "Inbox", messages: 5, bytes: 100, sourceBytes: 100,
+  dateFrom: null, dateTo: null, warnings: 0, skipped: 0, targetFolderPath: ["Inbox"], msfPath: null, accountId: null,
+});
+const cal: DiscoveredCalendar = {
+  calId: "c1", displayName: "Home", storeKind: "local", storePath: "/p/local.sqlite", calendarType: "both",
+  isVisibleInThunderbird: true, eventCount: 3, taskCount: 2,
+  defaultCalendarFolderPath: ["Calendar"], defaultTaskFolderPath: ["Tasks"],
+};
+const bk: DiscoveredAddressBook = { displayName: "Personal", path: "/p/abook.sqlite", format: "thunderbird-sqlite", contactCount: 4 };
+const calChecked = new Set(["/p/Inbox"]);
+
+function buildCal(over: Partial<ReturnType<typeof defaultOptions>>) {
+  return buildProfileConfig([calRow()], calChecked, false,
+    { ...defaultOptions(), ...over }, "C:/out/Mail.pst", "/p", [cal], [bk]).config.outputs[0];
+}
+
+describe("buildProfileConfig calendars/contacts", () => {
+  it("appointments on, tasks off -> IncludeTasks=false explicitly", () => {
+    const g = buildCal({ includeAppointments: true, includeTasks: false });
+    expect(g.calendars).toHaveLength(1);
+    expect(g.calendars![0].includeAppointments).toBe(true);
+    expect(g.calendars![0].includeTasks).toBe(false);
+  });
+  it("appointments off, tasks on -> IncludeAppointments=false explicitly", () => {
+    const g = buildCal({ includeAppointments: false, includeTasks: true });
+    expect(g.calendars![0].includeAppointments).toBe(false);
+    expect(g.calendars![0].includeTasks).toBe(true);
+  });
+  it("both off -> calendars omitted", () => {
+    const g = buildCal({ includeAppointments: false, includeTasks: false });
+    expect(g.calendars).toBeUndefined();
+  });
+  it("contacts off -> contacts omitted", () => {
+    const g = buildCal({ includeContacts: false });
+    expect(g.contacts).toBeUndefined();
+  });
+  it("contacts on -> one entry per address book", () => {
+    const g = buildCal({ includeContacts: true });
+    expect(g.contacts).toEqual([{ path: "/p/abook.sqlite", format: "thunderbird-sqlite" }]);
+  });
+
+  // Effective-disable: a zero-count type never emits config even though options.* default ON.
+  it("0 appointments, 7 tasks, defaults ON -> includeAppointments=false, includeTasks=true", () => {
+    const cal0 = { ...cal, eventCount: 0, taskCount: 7 };
+    const g = buildProfileConfig([calRow()], calChecked, false, defaultOptions(), "C:/out/Mail.pst", "/p", [cal0], [bk]).config.outputs[0];
+    expect(g.calendars).toHaveLength(1);
+    expect(g.calendars![0].includeAppointments).toBe(false);
+    expect(g.calendars![0].includeTasks).toBe(true);
+  });
+  it("0 appointments and 0 tasks -> calendars omitted (defaults ON)", () => {
+    const cal0 = { ...cal, eventCount: 0, taskCount: 0 };
+    const g = buildProfileConfig([calRow()], calChecked, false, defaultOptions(), "C:/out/Mail.pst", "/p", [cal0], [bk]).config.outputs[0];
+    expect(g.calendars).toBeUndefined();
+  });
+  it("0 known contacts -> contacts omitted even with toggle ON", () => {
+    const g = buildProfileConfig([calRow()], calChecked, false, defaultOptions(), "C:/out/Mail.pst", "/p", [cal], [{ ...bk, contactCount: 0 }]).config.outputs[0];
+    expect(g.contacts).toBeUndefined();
+  });
+  it("unknown contact count -> contacts still included", () => {
+    const g = buildProfileConfig([calRow()], calChecked, false, defaultOptions(), "C:/out/Mail.pst", "/p", [cal], [{ ...bk, contactCount: null }]).config.outputs[0];
+    expect(g.contacts).toHaveLength(1);
+  });
+  it("mixed books -> emits unknown + non-empty, skips known-empty", () => {
+    const known = { displayName: "Personal", path: "/p/abook.sqlite", format: "thunderbird-sqlite", contactCount: 4 };
+    const empty = { displayName: "Empty", path: "/p/empty.sqlite", format: "thunderbird-sqlite", contactCount: 0 };
+    const unknown = { displayName: "Old", path: "/p/old.mab", format: "thunderbird-mab", contactCount: null };
+    const g = buildProfileConfig([calRow()], calChecked, false, defaultOptions(), "C:/out/Mail.pst", "/p", [cal], [known, empty, unknown]).config.outputs[0];
+    expect(g.contacts!.map((c) => c.path)).toEqual(["/p/abook.sqlite", "/p/old.mab"]);
+  });
+  it("no calendars discovered -> calendars omitted", () => {
+    const g = buildProfileConfig([calRow()], calChecked, false, defaultOptions(), "C:/out/Mail.pst", "/p", [], [bk]).config.outputs[0];
+    expect(g.calendars).toBeUndefined();
+  });
+});
+
+describe("buildProfileConfigMulti calendars/contacts", () => {
+  it("split mode: calendars/contacts only on the FIRST group", () => {
+    // Account-prefixed paths so mirror-stripping leaves a folder (real multi-account shape).
+    const r1: ProfileSourceRow = { ...calRow(), id: "/p/A/Inbox", path: "/p/A/Inbox", targetFolderPath: ["A", "Inbox"] };
+    const r2: ProfileSourceRow = { ...calRow(), id: "/p/B/Inbox", path: "/p/B/Inbox", targetFolderPath: ["B", "Inbox"] };
+    const g1 = { key: "a", pstName: "A", rows: [r1] };
+    const g2 = { key: "b", pstName: "B", rows: [r2] };
+    const { config } = buildProfileConfigMulti({
+      groups: [g1, g2], checkedIds: new Set(["/p/A/Inbox", "/p/B/Inbox"]), skipEmpty: false,
+      options: defaultOptions(), target: { kind: "folder", dir: "C:/out" }, profileRoot: "/p",
+      calendars: [cal], addressBooks: [bk],
+    });
+    expect(config.outputs[0].calendars).toHaveLength(1);
+    expect(config.outputs[0].contacts).toHaveLength(1);
+    expect(config.outputs[1].calendars).toBeUndefined();
+    expect(config.outputs[1].contacts).toBeUndefined();
   });
 });

--- a/desktop/src/lib/profileConfig.test.ts
+++ b/desktop/src/lib/profileConfig.test.ts
@@ -275,9 +275,9 @@ const calRow = (): ProfileSourceRow => ({
 const cal: DiscoveredCalendar = {
   calId: "c1", displayName: "Home", storeKind: "local", storePath: "/p/local.sqlite", calendarType: "both",
   isVisibleInThunderbird: true, eventCount: 3, taskCount: 2,
-  defaultCalendarFolderPath: ["Calendar"], defaultTaskFolderPath: ["Tasks"],
+  defaultCalendarFolderPath: ["Calendar"], defaultTaskFolderPath: ["Tasks"], accountId: null,
 };
-const bk: DiscoveredAddressBook = { displayName: "Personal", path: "/p/abook.sqlite", format: "thunderbird-sqlite", contactCount: 4 };
+const bk: DiscoveredAddressBook = { displayName: "Personal", path: "/p/abook.sqlite", format: "thunderbird-sqlite", contactCount: 4, accountId: null };
 const calChecked = new Set(["/p/Inbox"]);
 
 function buildCal(over: Partial<ReturnType<typeof defaultOptions>>) {
@@ -332,9 +332,9 @@ describe("buildProfileConfig calendars/contacts", () => {
     expect(g.contacts).toHaveLength(1);
   });
   it("mixed books -> emits unknown + non-empty, skips known-empty", () => {
-    const known = { displayName: "Personal", path: "/p/abook.sqlite", format: "thunderbird-sqlite", contactCount: 4 };
-    const empty = { displayName: "Empty", path: "/p/empty.sqlite", format: "thunderbird-sqlite", contactCount: 0 };
-    const unknown = { displayName: "Old", path: "/p/old.mab", format: "thunderbird-mab", contactCount: null };
+    const known = { displayName: "Personal", path: "/p/abook.sqlite", format: "thunderbird-sqlite", contactCount: 4, accountId: null };
+    const empty = { displayName: "Empty", path: "/p/empty.sqlite", format: "thunderbird-sqlite", contactCount: 0, accountId: null };
+    const unknown = { displayName: "Old", path: "/p/old.mab", format: "thunderbird-mab", contactCount: null, accountId: null };
     const g = buildProfileConfig([calRow()], calChecked, false, defaultOptions(), "C:/out/Mail.pst", "/p", [cal], [known, empty, unknown]).config.outputs[0];
     expect(g.contacts!.map((c) => c.path)).toEqual(["/p/abook.sqlite", "/p/old.mab"]);
   });

--- a/desktop/src/lib/profileConfig.ts
+++ b/desktop/src/lib/profileConfig.ts
@@ -1,12 +1,56 @@
 // SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import type { DiscoveredSource, ProfileSourceRow, ConversionConfig, SourceConfigEntry, OutputTarget, OutputGroupConfig } from "./types";
+import type {
+  DiscoveredSource, ProfileSourceRow, ConversionConfig, SourceConfigEntry, OutputTarget, OutputGroupConfig,
+  DiscoveredCalendar, DiscoveredAddressBook, CalendarSourceConfigTS, ContactSourceConfigTS,
+} from "./types";
 import type { ScanResult } from "./parse";
 import type { OptionsState } from "./options";
 import { effectiveRows } from "./review";
 import { deriveOutputTarget, ConvertConfigError } from "./convert";
 import { sanitizePstName, dedupePstNames } from "./accounts";
+import { alsoConvertInfo } from "./alsoConvert";
+
+/** Build the calendars[]/contacts[] arrays for the PRIMARY output group from the
+ * discovered data + toggles. Applies the SAME disable logic the UI uses, so a
+ * zero-count type (which the UI shows disabled/unchecked) never emits config even
+ * though options.* defaults ON. Both include flags are always set explicitly; an
+ * array is omitted entirely (undefined) when its type is effectively off OR the
+ * discovered list is empty. */
+export function buildAlsoConvert(
+  calendars: DiscoveredCalendar[],
+  addressBooks: DiscoveredAddressBook[],
+  options: OptionsState,
+): { calendars?: CalendarSourceConfigTS[]; contacts?: ContactSourceConfigTS[] } {
+  const info = alsoConvertInfo(calendars, addressBooks);
+  // "Effective" = the user's toggle AND the type is not UI-disabled (zero count).
+  const effAppointments = options.includeAppointments && !info.appointments.disabled;
+  const effTasks = options.includeTasks && !info.tasks.disabled;
+  const effContacts = options.includeContacts && !info.contacts.disabled;
+
+  const out: { calendars?: CalendarSourceConfigTS[]; contacts?: ContactSourceConfigTS[] } = {};
+  if ((effAppointments || effTasks) && calendars.length > 0) {
+    out.calendars = calendars.map((c) => {
+      const entry: CalendarSourceConfigTS = {
+        storePath: c.storePath, calId: c.calId,
+        includeAppointments: effAppointments,
+        includeTasks: effTasks,
+      };
+      if (c.defaultCalendarFolderPath.length > 0) entry.appointmentFolderPath = c.defaultCalendarFolderPath;
+      if (c.defaultTaskFolderPath.length > 0) entry.taskFolderPath = c.defaultTaskFolderPath;
+      return entry;
+    });
+  }
+  if (effContacts) {
+    // Skip books we KNOW are empty; keep unknown-count books (they may hold contacts).
+    const booksToInclude = addressBooks.filter((b) => b.contactCount == null || b.contactCount > 0);
+    if (booksToInclude.length > 0) {
+      out.contacts = booksToInclude.map((b) => ({ path: b.path, format: b.format }));
+    }
+  }
+  return out;
+}
 
 /** Merge discovery sources with scan counts. Identity = discovered `path`; the
  * scan row's id is ignored (it is scan-local). displayName = joined nested path. */
@@ -47,6 +91,8 @@ export function buildProfileConfig(
   options: OptionsState,
   outputPstPath: string,
   profileRoot: string,
+  calendars: DiscoveredCalendar[] = [],
+  addressBooks: DiscoveredAddressBook[] = [],
 ): { config: ConversionConfig; outputDir: string; pstName: string } {
   const { outputDir, pstName } = deriveOutputTarget(outputPstPath);
   const folderMapping = options.folderMapping;
@@ -75,6 +121,7 @@ export function buildProfileConfig(
         folderMapping,
         includeEmptyFolders: !skipEmpty,
         sources,
+        ...buildAlsoConvert(calendars, addressBooks, options),
       }],
     },
   };
@@ -100,6 +147,8 @@ export function buildProfileConfigMulti({
   options,
   target,
   profileRoot,
+  calendars,
+  addressBooks,
 }: {
   groups: MultiAccountGroup[];
   checkedIds: Set<string>;
@@ -107,8 +156,12 @@ export function buildProfileConfigMulti({
   options: OptionsState;
   target: OutputTarget;
   profileRoot: string;
+  calendars?: DiscoveredCalendar[];
+  addressBooks?: DiscoveredAddressBook[];
 }): { config: ConversionConfig; outputDir: string } {
   const folderMapping = options.folderMapping;
+  const cals = calendars ?? [];
+  const books = addressBooks ?? [];
   const outputDir = target.kind === "folder" ? target.dir : deriveOutputTarget(target.path).outputDir;
 
   // Build surviving output groups
@@ -148,6 +201,13 @@ export function buildProfileConfigMulti({
   // De-duplicate names (shared helper — keeps parity with the Options preview).
   const dedup = dedupePstNames(outputGroups.map((g) => g.name));
   outputGroups.forEach((g, i) => { g.name = dedup[i]; });
+
+  // Profile-global calendar/contacts attach to the FIRST (primary) group only.
+  // outputGroups is guaranteed non-empty here (the `length === 0` throw above ran
+  // first), but guard explicitly so a future refactor can't index into nothing.
+  if (outputGroups.length > 0) {
+    Object.assign(outputGroups[0], buildAlsoConvert(cals, books, options));
+  }
 
   return {
     outputDir,

--- a/desktop/src/lib/profileConfig.ts
+++ b/desktop/src/lib/profileConfig.ts
@@ -3,7 +3,7 @@
 
 import type {
   DiscoveredSource, ProfileSourceRow, ConversionConfig, SourceConfigEntry, OutputTarget, OutputGroupConfig,
-  DiscoveredCalendar, DiscoveredAddressBook, CalendarSourceConfigTS, ContactSourceConfigTS,
+  DiscoveredCalendar, DiscoveredAddressBook, CalendarSourceConfigTS, ContactSourceConfigTS, Account,
 } from "./types";
 import type { ScanResult } from "./parse";
 import type { OptionsState } from "./options";
@@ -11,6 +11,7 @@ import { effectiveRows } from "./review";
 import { deriveOutputTarget, ConvertConfigError } from "./convert";
 import { sanitizePstName, dedupePstNames } from "./accounts";
 import { alsoConvertInfo } from "./alsoConvert";
+import { routeAlsoConvert, SYNTHETIC_LOCAL_FOLDERS_KEY } from "./routeAlsoConvert";
 
 /** Build the calendars[]/contacts[] arrays for the PRIMARY output group from the
  * discovered data + toggles. Applies the SAME disable logic the UI uses, so a
@@ -149,6 +150,7 @@ export function buildProfileConfigMulti({
   profileRoot,
   calendars,
   addressBooks,
+  accounts,
 }: {
   groups: MultiAccountGroup[];
   checkedIds: Set<string>;
@@ -158,14 +160,17 @@ export function buildProfileConfigMulti({
   profileRoot: string;
   calendars?: DiscoveredCalendar[];
   addressBooks?: DiscoveredAddressBook[];
+  accounts?: Account[];
 }): { config: ConversionConfig; outputDir: string } {
   const folderMapping = options.folderMapping;
   const cals = calendars ?? [];
   const books = addressBooks ?? [];
+  const accts = accounts ?? [];
   const outputDir = target.kind === "folder" ? target.dir : deriveOutputTarget(target.path).outputDir;
 
   // Build surviving output groups
   const outputGroups: OutputGroupConfig[] = [];
+  const keptKeys: string[] = [];
   for (const group of groups) {
     const eff = effectiveRows(group.rows, checkedIds, skipEmpty) as ProfileSourceRow[];
     if (eff.length === 0) continue; // drop group with no effective sources
@@ -192,6 +197,7 @@ export function buildProfileConfigMulti({
       includeEmptyFolders: !skipEmpty,
       sources,
     });
+    keptKeys.push(group.key);
   }
 
   if (outputGroups.length === 0) {
@@ -202,11 +208,30 @@ export function buildProfileConfigMulti({
   const dedup = dedupePstNames(outputGroups.map((g) => g.name));
   outputGroups.forEach((g, i) => { g.name = dedup[i]; });
 
-  // Profile-global calendar/contacts attach to the FIRST (primary) group only.
-  // outputGroups is guaranteed non-empty here (the `length === 0` throw above ran
-  // first), but guard explicitly so a future refactor can't index into nothing.
-  if (outputGroups.length > 0) {
-    Object.assign(outputGroups[0], buildAlsoConvert(cals, books, options));
+  // Route each calendar/address book into its account's group (split mode).
+  const isLocalFolders = (key: string): boolean =>
+    accts.find((a) => a.id === key)?.addressResolution === "local-folders";
+  const routeGroups = keptKeys.map((key) => ({ key, accountId: key, isLocalFolders: isLocalFolders(key) }));
+  const routed = routeAlsoConvert(cals, books, routeGroups, options);
+
+  keptKeys.forEach((key, i) => {
+    const pim = routed.perGroup.get(key);
+    if (pim?.calendars) outputGroups[i].calendars = pim.calendars;
+    if (pim?.contacts) outputGroups[i].contacts = pim.contacts;
+  });
+
+  if (routed.needsLocalFoldersGroup) {
+    const synthetic = routed.perGroup.get(SYNTHETIC_LOCAL_FOLDERS_KEY);
+    const names = dedupePstNames([...outputGroups.map((g) => g.name), sanitizePstName("Local Folders")]);
+    outputGroups.push({
+      name: names[names.length - 1],
+      maxSizeMB: options.maxSizeMB,
+      folderMapping,
+      includeEmptyFolders: !skipEmpty,
+      sources: [],
+      ...(synthetic?.calendars ? { calendars: synthetic.calendars } : {}),
+      ...(synthetic?.contacts ? { contacts: synthetic.contacts } : {}),
+    });
   }
 
   return {

--- a/desktop/src/lib/profilePreview.test.ts
+++ b/desktop/src/lib/profilePreview.test.ts
@@ -3,7 +3,8 @@
 
 import { describe, it, expect } from "vitest";
 import { buildAccountPreview } from "./profilePreview";
-import type { Account, ProfileSourceRow } from "./types";
+import { defaultOptions } from "./options";
+import type { Account, ProfileSourceRow, DiscoveredCalendar, DiscoveredAddressBook } from "./types";
 
 const acct = (id: string, email: string | null, seg: string): Account => ({
   id, folderSegment: seg, accountPath: id, store: "ImapMail", email, host: seg,
@@ -24,7 +25,7 @@ const all = new Set(["a", "b"]);
 
 describe("buildAccountPreview", () => {
   it("one entry per selected account; mirror shows the account-stripped folder path", () => {
-    const out = buildAccountPreview(rows, accounts, all, {}, "mirror");
+    const { entries: out } = buildAccountPreview(rows, accounts, all, {}, "mirror");
     expect(out.map((e) => e.pstName)).toEqual(["alice@example.com", "bob@example.test"]);
     // account segment "a" is stripped (it becomes the PST), matching buildProfileConfigMulti
     expect(out[0].folders.map((f) => f.displayName)).toEqual(["Inbox", "Sent"]);
@@ -32,24 +33,86 @@ describe("buildAccountPreview", () => {
   });
 
   it("flatten aggregates each account into one Imported Mail row", () => {
-    const out = buildAccountPreview(rows, accounts, all, {}, "flatten");
+    const { entries: out } = buildAccountPreview(rows, accounts, all, {}, "flatten");
     expect(out[0].folders).toEqual([{ displayName: "Imported Mail", messages: 15, bytes: 1500 }]);
     expect(out[1].folders).toEqual([{ displayName: "Imported Mail", messages: 3, bytes: 300 }]);
   });
 
   it("uses edited pstNames (sanitized) and falls back to the account default", () => {
-    const out = buildAccountPreview(rows, accounts, all, { a: "My Mail" }, "mirror");
+    const { entries: out } = buildAccountPreview(rows, accounts, all, { a: "My Mail" }, "mirror");
     expect(out[0].pstName).toBe("My Mail");
     expect(out[1].pstName).toBe("bob@example.test");
   });
 
   it("de-duplicates colliding pst names with -2, matching the builder", () => {
-    const out = buildAccountPreview(rows, accounts, all, { a: "Same", b: "Same" }, "mirror");
+    const { entries: out } = buildAccountPreview(rows, accounts, all, { a: "Same", b: "Same" }, "mirror");
     expect(out.map((e) => e.pstName)).toEqual(["Same", "Same-2"]);
   });
 
   it("omits accounts with no effective rows and respects selection", () => {
-    const out = buildAccountPreview(rows, accounts, new Set(["a"]), {}, "mirror");
+    const { entries: out } = buildAccountPreview(rows, accounts, new Set(["a"]), {}, "mirror");
     expect(out.map((e) => e.key)).toEqual(["a"]);
+  });
+});
+
+const acc = (id: string, r: Account["addressResolution"]): Account =>
+  ({ id, folderSegment: id, accountPath: id, store: null, email: null, host: null, addressResolution: r });
+const row2 = (accountId: string, leaf: string): ProfileSourceRow => ({
+  id: `${accountId}/${leaf}`, path: `${accountId}/${leaf}`, displayName: leaf, messages: 1, bytes: 10,
+  sourceBytes: 10, dateFrom: null, dateTo: null, warnings: 0, skipped: 0,
+  targetFolderPath: [accountId, leaf], msfPath: null, accountId,
+});
+const cal = (accountId: string | null): DiscoveredCalendar => ({
+  calId: "c" + accountId, displayName: "Home", storeKind: "local", storePath: "/s", calendarType: "both",
+  isVisibleInThunderbird: true, eventCount: 2, taskCount: 0,
+  defaultCalendarFolderPath: ["Calendars", "Home"], defaultTaskFolderPath: [], accountId,
+});
+const book = (accountId: string | null): DiscoveredAddressBook =>
+  ({ displayName: "Personal", path: "/p/abook.sqlite", format: "thunderbird-sqlite", contactCount: 3, accountId });
+
+describe("buildAccountPreview routing", () => {
+  it("shows calendars/contacts under their account and a synthetic Local Folders entry", () => {
+    const gmail = row2("/acc/gmail", "Inbox");
+    const { entries, warnings } = buildAccountPreview(
+      [gmail], [acc("/acc/gmail", "server")], new Set(["/acc/gmail"]), {},
+      "mirror", [cal("/acc/gmail"), cal(null)], [book(null)], defaultOptions(),
+    );
+    const gmailEntry = entries.find((e) => e.key === "/acc/gmail")!;
+    expect(gmailEntry.pim.calendars.length).toBe(1);
+    const synthetic = entries.find((e) => e.pstName === "Local Folders")!;
+    expect(synthetic.pim.calendars.length).toBe(1);
+    expect(synthetic.pim.contacts.length).toBe(1);
+    expect(synthetic.isSynthetic).toBe(true);
+    expect(warnings).toEqual([]);
+  });
+
+  it("uses the discovered display names as labels (not raw filenames)", () => {
+    const gmail = row2("/acc/gmail", "Inbox");
+    const { entries } = buildAccountPreview(
+      [gmail], [acc("/acc/gmail", "server")], new Set(["/acc/gmail"]), {},
+      "mirror", [], [book(null)], defaultOptions(),
+    );
+    const synthetic = entries.find((e) => e.isSynthetic)!;
+    expect(synthetic.pim.contacts).toEqual(["Personal"]); // displayName, not "abook.sqlite"
+  });
+
+  it("synthetic Local Folders name matches buildProfileConfigMulti", async () => {
+    const { buildProfileConfigMulti } = await import("./profileConfig");
+    const gmail = row2("/acc/gmail", "Inbox");
+    const args = {
+      accounts: [acc("/acc/gmail", "server")], selectedKeys: new Set(["/acc/gmail"]),
+      calendars: [cal(null)], addressBooks: [book(null)], options: defaultOptions(),
+    };
+    const { entries } = buildAccountPreview([gmail], args.accounts, args.selectedKeys, {},
+      "mirror", args.calendars, args.addressBooks, args.options);
+    const { config } = buildProfileConfigMulti({
+      groups: [{ key: "/acc/gmail", pstName: "Gmail", rows: [gmail] }],
+      checkedIds: new Set([gmail.id]), skipEmpty: false, options: args.options,
+      target: { kind: "folder", dir: "C:/out" }, profileRoot: "/p", accounts: args.accounts,
+      calendars: args.calendars, addressBooks: args.addressBooks,
+    });
+    const previewSynthetic = entries.find((e) => e.isSynthetic)!.pstName;
+    const configSynthetic = config.outputs.find((o) => o.sources.length === 0)!.name;
+    expect(previewSynthetic).toBe(configSynthetic);
   });
 });

--- a/desktop/src/lib/profilePreview.ts
+++ b/desktop/src/lib/profilePreview.ts
@@ -2,23 +2,40 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { groupByAccount, sanitizePstName, dedupePstNames } from "./accounts";
-import type { Account, ProfileSourceRow } from "./types";
+import { routeAlsoConvert, SYNTHETIC_LOCAL_FOLDERS_KEY } from "./routeAlsoConvert";
+import type { Account, ProfileSourceRow, DiscoveredCalendar, DiscoveredAddressBook } from "./types";
+import type { OptionsState } from "./options";
 
 export interface AccountPreviewFolder { displayName: string; messages: number; bytes: number }
-export interface AccountPreviewEntry { key: string; pstName: string; folders: AccountPreviewFolder[] }
+export interface AccountPreviewPim { calendars: string[]; contacts: string[] }
+export interface AccountPreviewEntry {
+  key: string;
+  pstName: string;
+  folders: AccountPreviewFolder[];
+  pim: AccountPreviewPim;
+  isSynthetic?: boolean;
+}
+export interface AccountPreviewResult { entries: AccountPreviewEntry[]; warnings: string[] }
 
-/** One preview entry per selected, non-empty account. `effRows` must already be
- * effectiveRows(...)-filtered so the preview matches what Start converts. Mirror
- * strips the account segment from each folder path (matching buildProfileConfigMulti);
- * flatten aggregates to one "Imported Mail" row per account. PST names are sanitized
- * and de-duplicated exactly like the builder via the shared dedupePstNames. */
+/** One preview entry per selected, non-empty account (+ a synthetic "Local Folders"
+ * entry when routing needs one). `effRows` must already be effectiveRows(...)-filtered
+ * so the preview matches what Start converts. Mirror strips the account segment from
+ * each folder path (matching buildProfileConfigMulti); flatten aggregates to one
+ * "Imported Mail" row per account. PST names are sanitized and de-duplicated exactly
+ * like the builder via the shared dedupePstNames. When `calendars`/`addressBooks`/
+ * `options` are supplied, PIM routing is driven through the SAME `routeAlsoConvert`
+ * used by `buildProfileConfigMulti`, so the preview and the actual conversion always
+ * agree on where each calendar/address book lands. */
 export function buildAccountPreview(
   effRows: ProfileSourceRow[],
   accounts: Account[],
   selectedKeys: Set<string>,
   pstNames: Record<string, string>,
   folderMapping: "mirror" | "flatten",
-): AccountPreviewEntry[] {
+  calendars: DiscoveredCalendar[] = [],
+  addressBooks: DiscoveredAddressBook[] = [],
+  options?: OptionsState,
+): AccountPreviewResult {
   const groups = groupByAccount(effRows, accounts).filter(
     (g) => selectedKeys.has(g.key) && g.rows.length > 0,
   );
@@ -37,10 +54,49 @@ export function buildAccountPreview(
             const displayName = stripped.length > 0 ? stripped.join(" / ") : r.displayName;
             return { displayName, messages: r.messages, bytes: r.bytes };
           });
-    return { key: g.key, pstName, folders };
+    return { key: g.key, pstName, folders, pim: { calendars: [], contacts: [] } };
   });
 
   const deduped = dedupePstNames(entries.map((e) => e.pstName));
   entries.forEach((e, i) => { e.pstName = deduped[i]; });
-  return entries;
+
+  let warnings: string[] = [];
+  if (options) {
+    const isLF = (key: string) => accounts.find((a) => a.id === key)?.addressResolution === "local-folders";
+    const routeGroups = groups.map((g) => ({ key: g.key, accountId: g.key, isLocalFolders: isLF(g.key) }));
+    const routed = routeAlsoConvert(calendars, addressBooks, routeGroups, options);
+    warnings = routed.warnings;
+
+    // Friendly labels: map the routed config entries back to the ORIGINAL discovered items
+    // (which carry displayName) by calId / path — the config shapes drop displayName.
+    const calName = new Map(calendars.map((c) => [c.calId, c.displayName]));
+    const bookName = new Map(addressBooks.map((b) => [b.path, b.displayName]));
+    const calLabels = (pim: { calendars?: { calId: string }[] } | undefined) =>
+      (pim?.calendars ?? []).map((c) => calName.get(c.calId) ?? c.calId);
+    const bookLabels = (pim: { contacts?: { path: string }[] } | undefined) =>
+      (pim?.contacts ?? []).map((c) => bookName.get(c.path) ?? (c.path.split(/[\\/]/).pop() ?? c.path));
+
+    const byKey = new Map(entries.map((e) => [e.key, e]));
+    for (const [key, pim] of routed.perGroup) {
+      if (key === SYNTHETIC_LOCAL_FOLDERS_KEY) continue;
+      const e = byKey.get(key);
+      if (!e) continue;
+      e.pim.calendars = calLabels(pim);
+      e.pim.contacts = bookLabels(pim);
+    }
+
+    if (routed.needsLocalFoldersGroup) {
+      const synthetic = routed.perGroup.get(SYNTHETIC_LOCAL_FOLDERS_KEY);
+      const names = dedupePstNames([...entries.map((e) => e.pstName), sanitizePstName("Local Folders")]);
+      entries.push({
+        key: SYNTHETIC_LOCAL_FOLDERS_KEY,
+        pstName: names[names.length - 1],
+        folders: [],
+        isSynthetic: true,
+        pim: { calendars: calLabels(synthetic), contacts: bookLabels(synthetic) },
+      });
+    }
+  }
+
+  return { entries, warnings };
 }

--- a/desktop/src/lib/routeAlsoConvert.test.ts
+++ b/desktop/src/lib/routeAlsoConvert.test.ts
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+import { describe, it, expect } from "vitest";
+import { routeAlsoConvert, SYNTHETIC_LOCAL_FOLDERS_KEY } from "./routeAlsoConvert";
+import { defaultOptions } from "./options";
+import type { DiscoveredCalendar, DiscoveredAddressBook } from "./types";
+
+const cal = (accountId: string | null, ev = 2, tk = 1): DiscoveredCalendar => ({
+  calId: "c" + accountId, displayName: "d", storeKind: "local", storePath: "/s" + accountId,
+  calendarType: "both", isVisibleInThunderbird: true, eventCount: ev, taskCount: tk,
+  defaultCalendarFolderPath: ["Calendars", "d"], defaultTaskFolderPath: ["Tasks", "d"], accountId,
+});
+const book = (accountId: string | null, count: number | null = 3): DiscoveredAddressBook =>
+  ({ displayName: "b", path: "/b" + accountId, format: "thunderbird-sqlite", contactCount: count, accountId });
+
+const G = (key: string, isLocalFolders = false) => ({ key, accountId: key, isLocalFolders });
+const opts = defaultOptions();
+
+describe("routeAlsoConvert", () => {
+  it("routes a matched calendar/book to its account group", () => {
+    const r = routeAlsoConvert([cal("/acc/gmail")], [book("/acc/gmail")], [G("/acc/gmail"), G("/acc/lf", true)], opts);
+    expect(r.perGroup.get("/acc/gmail")!.calendars).toHaveLength(1);
+    expect(r.perGroup.get("/acc/gmail")!.contacts).toHaveLength(1);
+    expect(r.perGroup.has("/acc/lf")).toBe(false);
+    expect(r.needsLocalFoldersGroup).toBe(false);
+    expect(r.warnings).toEqual([]);
+  });
+
+  it("routes a local item to an existing Local Folders group (no synthetic)", () => {
+    const r = routeAlsoConvert([cal(null)], [book(null)], [G("/acc/gmail"), G("/acc/lf", true)], opts);
+    expect(r.perGroup.get("/acc/lf")!.calendars).toHaveLength(1);
+    expect(r.perGroup.get("/acc/lf")!.contacts).toHaveLength(1);
+    expect(r.needsLocalFoldersGroup).toBe(false);
+  });
+
+  it("creates a synthetic LF bucket when no LF group exists", () => {
+    const r = routeAlsoConvert([cal(null)], [book(null)], [G("/acc/gmail")], opts);
+    expect(r.perGroup.get(SYNTHETIC_LOCAL_FOLDERS_KEY)!.calendars).toHaveLength(1);
+    expect(r.needsLocalFoldersGroup).toBe(true);
+  });
+
+  it("deselected/unmatched account falls back to LF and warns", () => {
+    const r = routeAlsoConvert([cal("/acc/deleted")], [], [G("/acc/gmail"), G("/acc/lf", true)], opts);
+    expect(r.perGroup.get("/acc/lf")!.calendars).toHaveLength(1);
+    expect(r.warnings.length).toBe(1);
+    expect(r.warnings[0]).toMatch(/isn't part of this split|Local Folders/i);
+  });
+
+  it("respects effective-enable: zero-count calendar emits nothing", () => {
+    const r = routeAlsoConvert([cal("/acc/gmail", 0, 0)], [], [G("/acc/gmail")], opts);
+    expect(r.perGroup.get("/acc/gmail")).toBeUndefined();
+  });
+
+  it("appointments off, tasks on -> includeAppointments=false, includeTasks=true", () => {
+    const r = routeAlsoConvert([cal("/acc/gmail")], [], [G("/acc/gmail")],
+      { ...opts, includeAppointments: false, includeTasks: true });
+    const c = r.perGroup.get("/acc/gmail")!.calendars![0];
+    expect(c.includeAppointments).toBe(false);
+    expect(c.includeTasks).toBe(true);
+  });
+
+  it("unknown contact count still routes; .mab-style null count is included", () => {
+    const r = routeAlsoConvert([], [book(null, null)], [G("/acc/lf", true)], opts);
+    expect(r.perGroup.get("/acc/lf")!.contacts).toHaveLength(1);
+  });
+
+  it("contacts toggled off emits no contacts", () => {
+    const r = routeAlsoConvert([], [book("/acc/gmail")], [G("/acc/gmail")], { ...opts, includeContacts: false });
+    expect(r.perGroup.get("/acc/gmail")).toBeUndefined();
+  });
+});

--- a/desktop/src/lib/routeAlsoConvert.ts
+++ b/desktop/src/lib/routeAlsoConvert.ts
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+import type {
+  DiscoveredCalendar, DiscoveredAddressBook, CalendarSourceConfigTS, ContactSourceConfigTS,
+} from "./types";
+import type { OptionsState } from "./options";
+import { alsoConvertInfo } from "./alsoConvert";
+
+export const SYNTHETIC_LOCAL_FOLDERS_KEY = "__synthetic_local_folders__";
+
+export interface RouteGroup { key: string; accountId: string | null; isLocalFolders: boolean }
+export interface RoutedPim { calendars?: CalendarSourceConfigTS[]; contacts?: ContactSourceConfigTS[] }
+export interface RouteResult {
+  perGroup: Map<string, RoutedPim>;
+  needsLocalFoldersGroup: boolean;
+  warnings: string[];
+}
+
+/** Split-mode routing: each calendar/book → its account group; local/fallback → Local Folders
+ * (existing group, else the synthetic key). Applies the same effective-enable logic as
+ * alsoConvertInfo (zero-count type omitted; unknown contact count kept). Single source of truth
+ * for both buildProfileConfigMulti and the Preview. */
+export function routeAlsoConvert(
+  calendars: DiscoveredCalendar[],
+  addressBooks: DiscoveredAddressBook[],
+  groups: RouteGroup[],
+  options: OptionsState,
+): RouteResult {
+  const info = alsoConvertInfo(calendars, addressBooks);
+  const effAppointments = options.includeAppointments && !info.appointments.disabled;
+  const effTasks = options.includeTasks && !info.tasks.disabled;
+  const effContacts = options.includeContacts && !info.contacts.disabled;
+
+  const perGroup = new Map<string, RoutedPim>();
+  const warnings: string[] = [];
+  let needsLocalFoldersGroup = false;
+
+  const lfGroup = groups.find((g) => g.isLocalFolders) ?? null;
+  // Route by the group's own accountId (not by assuming key === accountId), so a future preview
+  // whose group key differs from the account id still routes correctly.
+  const byAccountId = new Map(
+    groups.filter((g) => g.accountId != null).map((g) => [g.accountId as string, g]),
+  );
+
+  const bucket = (key: string): RoutedPim => {
+    let b = perGroup.get(key);
+    if (!b) { b = {}; perGroup.set(key, b); }
+    return b;
+  };
+
+  // Resolve where an item with this accountId goes; may push a warning / flag synthetic need.
+  const targetKey = (accountId: string | null, label: string): string => {
+    if (accountId != null) {
+      const g = byAccountId.get(accountId);
+      if (g) return g.key;                                               // matched, selected
+      warnings.push(`${label} belongs to an account that isn't part of this split; it will be written to Local Folders.`);
+    }
+    if (lfGroup) return lfGroup.key;                                     // local → existing LF
+    needsLocalFoldersGroup = true;
+    return SYNTHETIC_LOCAL_FOLDERS_KEY;                                  // local/fallback → synthetic LF
+  };
+
+  if (effAppointments || effTasks) {
+    for (const c of calendars) {
+      // A zero-appt calendar with tasks still routes; a wholly-empty calendar contributes nothing.
+      const wantsAppt = effAppointments && c.eventCount > 0;
+      const wantsTask = effTasks && c.taskCount > 0;
+      if (!wantsAppt && !wantsTask) continue;
+      const entry: CalendarSourceConfigTS = {
+        storePath: c.storePath, calId: c.calId,
+        includeAppointments: wantsAppt,
+        includeTasks: wantsTask,
+      };
+      if (c.defaultCalendarFolderPath.length > 0) entry.appointmentFolderPath = c.defaultCalendarFolderPath;
+      if (c.defaultTaskFolderPath.length > 0) entry.taskFolderPath = c.defaultTaskFolderPath;
+      const key = targetKey(c.accountId, `Calendar "${c.displayName}"`);
+      (bucket(key).calendars ??= []).push(entry);
+    }
+  }
+
+  if (effContacts) {
+    for (const b of addressBooks) {
+      if (!(b.contactCount == null || b.contactCount > 0)) continue;      // skip known-empty
+      const key = targetKey(b.accountId, `Address book "${b.displayName}"`);
+      (bucket(key).contacts ??= []).push({ path: b.path, format: b.format });
+    }
+  }
+
+  return { perGroup, needsLocalFoldersGroup, warnings };
+}

--- a/desktop/src/lib/types.ts
+++ b/desktop/src/lib/types.ts
@@ -145,6 +145,26 @@ export interface DiscoverPairing {
   orphanMsfCount: number;
 }
 
+export interface DiscoveredCalendar {
+  calId: string;
+  displayName: string;
+  storeKind: string;
+  storePath: string;
+  calendarType: string; // "calendar" | "task" | "both"
+  isVisibleInThunderbird: boolean;
+  eventCount: number;
+  taskCount: number;
+  defaultCalendarFolderPath: string[];
+  defaultTaskFolderPath: string[];
+}
+
+export interface DiscoveredAddressBook {
+  displayName: string;
+  path: string;
+  format: string; // "thunderbird-sqlite" | "thunderbird-mab"
+  contactCount: number | null; // null = unknown
+}
+
 export interface DiscoverResult {
   root: string;
   layout: string;
@@ -153,6 +173,8 @@ export interface DiscoverResult {
   skipped: DiscoverSkipped[];
   pairing: DiscoverPairing;
   accounts: Account[];
+  calendars: DiscoveredCalendar[];
+  addressBooks: DiscoveredAddressBook[];
   schemaVersion?: number;
 }
 

--- a/desktop/src/lib/types.ts
+++ b/desktop/src/lib/types.ts
@@ -92,6 +92,10 @@ export type ConvertEvent = (
       bytes: number;
       currentSource?: string | null;
       currentFolder?: string | null;
+      phase?: string;
+      appointmentsConverted?: number; appointmentsTotal?: number;
+      tasksConverted?: number; tasksTotal?: number;
+      contactsConverted?: number; contactsTotal?: number;
     }
   | { type: "warning"; source: string; identifier: string; reason: string }
   | {
@@ -105,6 +109,9 @@ export type ConvertEvent = (
       elapsedMs: number;
       enrichment?: EnrichmentSummary;
       colourPlan?: ColourPlanEntry[];
+      appointmentsConverted?: number; appointmentsSkipped?: number; appointmentWarnings?: number;
+      tasksConverted?: number; tasksSkipped?: number; taskWarnings?: number;
+      contactsConverted?: number; contactsSkipped?: number; contactWarnings?: number;
     }
   | { type: "error"; stage?: string; message: string; fatal: boolean }
   | {

--- a/desktop/src/lib/types.ts
+++ b/desktop/src/lib/types.ts
@@ -29,12 +29,29 @@ export interface SourceConfigEntry {
   msfPath?: string;
 }
 
+export interface CalendarSourceConfigTS {
+  storePath: string;
+  calId: string;
+  includeAppointments: boolean;
+  includeTasks: boolean;
+  appointmentFolderPath?: string[];
+  taskFolderPath?: string[];
+}
+
+export interface ContactSourceConfigTS {
+  path: string;
+  format: string;
+  targetFolderPath?: string[];
+}
+
 export interface OutputGroupConfig {
   name: string;
   maxSizeMB: number;
   folderMapping: "mirror" | "flatten";
   includeEmptyFolders: boolean;
   sources: SourceConfigEntry[];
+  calendars?: CalendarSourceConfigTS[];
+  contacts?: ContactSourceConfigTS[];
 }
 
 export interface ConversionConfig {

--- a/desktop/src/lib/types.ts
+++ b/desktop/src/lib/types.ts
@@ -180,6 +180,7 @@ export interface DiscoveredCalendar {
   taskCount: number;
   defaultCalendarFolderPath: string[];
   defaultTaskFolderPath: string[];
+  accountId: string | null;
 }
 
 export interface DiscoveredAddressBook {
@@ -187,6 +188,7 @@ export interface DiscoveredAddressBook {
   path: string;
   format: string; // "thunderbird-sqlite" | "thunderbird-mab"
   contactCount: number | null; // null = unknown
+  accountId: string | null;
 }
 
 export interface DiscoverResult {

--- a/desktop/src/lib/useConvert.test.ts
+++ b/desktop/src/lib/useConvert.test.ts
@@ -47,3 +47,24 @@ describe("reduceConvert colourPlan capture", () => {
     expect(initialConvertState.colourPlan).toBeNull();
   });
 });
+
+describe("reduceConvert per-type", () => {
+  it("copies progress per-type counts + currentPhase", () => {
+    const ev = { type: "progress", converted: 10, total: 20, warnings: 0, skipped: 0, bytes: 0,
+      phase: "contacts", contactsConverted: 3, contactsTotal: 4 } as ConvertEvent;
+    const s = reduceConvert(running, ev);
+    expect(s.currentPhase).toBe("contacts");
+    expect(s.contacts.converted).toBe(3);
+    expect(s.contacts.total).toBe(4);
+  });
+  it("copies done per-type counts under exact wire names", () => {
+    const ev = { type: "done", converted: 100, skipped: 0, warnings: 40, outputs: [], elapsedMs: 1,
+      appointmentsConverted: 368, appointmentsSkipped: 0, appointmentWarnings: 38,
+      tasksConverted: 7, tasksSkipped: 0, taskWarnings: 1,
+      contactsConverted: 4, contactsSkipped: 0, contactWarnings: 0 } as ConvertEvent;
+    const s = reduceConvert(running, ev);
+    expect(s.appointments).toEqual({ converted: 368, total: 0, skipped: 0, warnings: 38 });
+    expect(s.tasks.warnings).toBe(1);
+    expect(s.contacts.converted).toBe(4);
+  });
+});

--- a/desktop/src/lib/useConvert.ts
+++ b/desktop/src/lib/useConvert.ts
@@ -10,6 +10,9 @@ import type { ConversionConfig, ConvertEvent, EnrichmentSummary, ColourPlanEntry
 
 export type ConvertPhase = "idle" | "running" | "done" | "error" | "cancelled";
 
+export interface TypeCounts { converted: number; total: number; skipped: number; warnings: number; }
+const emptyCounts: TypeCounts = { converted: 0, total: 0, skipped: 0, warnings: 0 };
+
 export interface ConvertState {
   phase: ConvertPhase;
   total: number;
@@ -27,6 +30,10 @@ export interface ConvertState {
   elapsedMs: number | null;
   enrichment: EnrichmentSummary | null;
   colourPlan: ColourPlanEntry[] | null;
+  currentPhase: string | null;
+  appointments: TypeCounts;
+  tasks: TypeCounts;
+  contacts: TypeCounts;
 }
 
 export const initialConvertState: ConvertState = {
@@ -46,6 +53,10 @@ export const initialConvertState: ConvertState = {
   elapsedMs: null,
   enrichment: null,
   colourPlan: null,
+  currentPhase: null,
+  appointments: { ...emptyCounts },
+  tasks: { ...emptyCounts },
+  contacts: { ...emptyCounts },
 };
 
 export function reduceConvert(state: ConvertState, ev: ConvertEvent): ConvertState {
@@ -71,6 +82,16 @@ export function reduceConvert(state: ConvertState, ev: ConvertEvent): ConvertSta
         skipped: ev.skipped,
         bytes,
         currentFolder: ev.currentFolder ?? state.currentFolder,
+        currentPhase: ev.phase ?? state.currentPhase,
+        appointments: { ...state.appointments,
+          converted: ev.appointmentsConverted ?? state.appointments.converted,
+          total: ev.appointmentsTotal ?? state.appointments.total },
+        tasks: { ...state.tasks,
+          converted: ev.tasksConverted ?? state.tasks.converted,
+          total: ev.tasksTotal ?? state.tasks.total },
+        contacts: { ...state.contacts,
+          converted: ev.contactsConverted ?? state.contacts.converted,
+          total: ev.contactsTotal ?? state.contacts.total },
       };
     }
     case "warning":
@@ -93,6 +114,12 @@ export function reduceConvert(state: ConvertState, ev: ConvertEvent): ConvertSta
         elapsedMs: ev.elapsedMs,
         enrichment: ev.enrichment ?? null,
         colourPlan: ev.colourPlan ?? null,
+        appointments: { total: state.appointments.total,
+          converted: ev.appointmentsConverted ?? 0, skipped: ev.appointmentsSkipped ?? 0, warnings: ev.appointmentWarnings ?? 0 },
+        tasks: { total: state.tasks.total,
+          converted: ev.tasksConverted ?? 0, skipped: ev.tasksSkipped ?? 0, warnings: ev.taskWarnings ?? 0 },
+        contacts: { total: state.contacts.total,
+          converted: ev.contactsConverted ?? 0, skipped: ev.contactsSkipped ?? 0, warnings: ev.contactWarnings ?? 0 },
       };
     case "error":
       return { ...state, phase: "error", errorMessage: ev.message };

--- a/desktop/src/lib/useScan.ts
+++ b/desktop/src/lib/useScan.ts
@@ -8,7 +8,7 @@ import { checkSchemaVersion } from "./schema";
 import { defaultOptions, type OptionsState, FLATTEN_SOURCE_ID } from "./options";
 import { sortSources, type SortField, type SortDir } from "./review";
 import { groupByAccount, accountKeyForRow } from "./accounts";
-import type { FileStat, SourceRow, ProfileSourceRow, DiscoverWarning, DiscoverResult, OutputTarget, Account } from "./types";
+import type { FileStat, SourceRow, ProfileSourceRow, DiscoverWarning, DiscoverResult, OutputTarget, Account, DiscoveredCalendar, DiscoveredAddressBook } from "./types";
 import type { ScanResult } from "./parse";
 
 export type FlowStage = "select" | "scanning" | "review" | "options" | "scanError" | "accounts";
@@ -74,6 +74,8 @@ export interface PreConvertState {
   accounts: Account[];
   selectedAccountKeys: Set<string>;
   pstNames: Record<string, string>; // per-account edited PST name, keyed by account key
+  calendars: DiscoveredCalendar[];
+  addressBooks: DiscoveredAddressBook[];
 }
 
 function initialState(): PreConvertState {
@@ -98,6 +100,8 @@ function initialState(): PreConvertState {
     accounts: [],
     selectedAccountKeys: new Set(),
     pstNames: {},
+    calendars: [],
+    addressBooks: [],
   };
 }
 
@@ -172,6 +176,8 @@ export function useScan() {
           accounts: disc.accounts,
           selectedAccountKeys,
           pstNames,
+          calendars: disc.calendars,
+          addressBooks: disc.addressBooks,
         }));
       } catch (e) {
         const errorMessage = e instanceof Error ? e.message : String(e);
@@ -208,6 +214,8 @@ export function useScan() {
         scanProgress: null,
         sortBy: "default",
         sortDir: "desc",
+        calendars: [],
+        addressBooks: [],
       }));
     } catch (e) {
       const errorMessage = e instanceof Error ? e.message : String(e);
@@ -269,7 +277,7 @@ export function useScan() {
   }, []);
 
   const back = useCallback(
-    () => setState((s) => ({ ...s, stage: "select", scan: null, profileRows: [], discoverWarnings: [], errorMessage: null, sourceError: null, scanProgress: null })),
+    () => setState((s) => ({ ...s, stage: "select", scan: null, profileRows: [], discoverWarnings: [], errorMessage: null, sourceError: null, scanProgress: null, calendars: [], addressBooks: [] })),
     [],
   );
   const resetFlow = useCallback(() => setState(initialState()), []);
@@ -310,6 +318,8 @@ export function useScan() {
     toggleAccount,
     setPstName,
     discoveredAccountCount,
+    calendars: state.calendars,
+    addressBooks: state.addressBooks,
     back,
     resetFlow,
   };

--- a/src/Mail2Pst.Cli/DiscoverCommand.cs
+++ b/src/Mail2Pst.Cli/DiscoverCommand.cs
@@ -68,11 +68,13 @@ internal static class DiscoverCommand
                     eventCount = c.EventCount, taskCount = c.TaskCount,
                     defaultCalendarFolderPath = c.DefaultCalendarFolderPath,
                     defaultTaskFolderPath = c.DefaultTaskFolderPath,
+                    accountId = c.AccountId,
                 }),
                 addressBooks = r.AddressBooks.Select(b => new
                 {
                     displayName = b.DisplayName, path = b.Path, format = b.Format,
                     contactCount = b.ContactCount, // int? -> JSON number or null
+                    accountId = b.AccountId,
                 }),
             };
             Console.WriteLine(CliEventSerializer.Serialize(output, indented: true));

--- a/src/Mail2Pst.Cli/DiscoverCommand.cs
+++ b/src/Mail2Pst.Cli/DiscoverCommand.cs
@@ -69,6 +69,11 @@ internal static class DiscoverCommand
                     defaultCalendarFolderPath = c.DefaultCalendarFolderPath,
                     defaultTaskFolderPath = c.DefaultTaskFolderPath,
                 }),
+                addressBooks = r.AddressBooks.Select(b => new
+                {
+                    displayName = b.DisplayName, path = b.Path, format = b.Format,
+                    contactCount = b.ContactCount, // int? -> JSON number or null
+                }),
             };
             Console.WriteLine(CliEventSerializer.Serialize(output, indented: true));
             return 0;

--- a/src/Mail2Pst.Core/Contacts/AddressBookContactCounter.cs
+++ b/src/Mail2Pst.Core/Contacts/AddressBookContactCounter.cs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using Mail2Pst.Core.Discovery;
+using Mail2Pst.Core.Storage;
+
+namespace Mail2Pst.Core.Contacts;
+
+/// <summary>Best-effort, non-throwing contact count for a discovered address book.
+/// null = unknown (count failed, or a format we don't cheaply count, e.g. .mab).</summary>
+public static class AddressBookContactCounter
+{
+    public static int? TryCount(DiscoveredAddressBook book)
+    {
+        try
+        {
+            return book.Format switch
+            {
+                "thunderbird-sqlite" => CountSqlite(book.Path),
+                _ => null, // .mab count deferred — shown as unknown, still convertible
+            };
+        }
+        catch
+        {
+            return null; // never fail discovery over a contact count
+        }
+    }
+
+    private static int? CountSqlite(string path)
+    {
+        using SqliteSnapshot snap = SqliteSnapshot.Open(path);
+        using var cmd = snap.Connection.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(DISTINCT card) FROM properties";
+        object? result = cmd.ExecuteScalar();
+        return result is long l ? (int)l : null;
+    }
+}

--- a/src/Mail2Pst.Core/Contacts/AddressBookRegistryReader.cs
+++ b/src/Mail2Pst.Core/Contacts/AddressBookRegistryReader.cs
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using Mail2Pst.Core.Msf;   // PrefsJsEscape
+
+namespace Mail2Pst.Core.Contacts;
+
+/// <summary>Reads <c>ldap_2.servers.&lt;key&gt;.{filename,carddav.url}</c> from prefs.js and
+/// returns basename(filename) → carddav.url, only for server entries that have BOTH. Modern
+/// Thunderbird (102+) CardDAV address-book layout. Line-oriented (does NOT execute JS); mirrors
+/// CalendarRegistryReader and reuses PrefsJsEscape. Missing file → empty map.</summary>
+public static class AddressBookRegistryReader
+{
+    private static readonly Regex Line = new(
+        "^\\s*user_pref\\s*\\(\\s*\"ldap_2\\.servers\\.(?<key>[^.\"]+)\\.(?<sub>[^\"]+)\"\\s*,\\s*\"(?<val>(?:\\\\.|[^\"\\\\])*)\"\\s*\\)\\s*;?\\s*$",
+        RegexOptions.CultureInvariant);
+
+    public static IReadOnlyDictionary<string, string> ReadFilenameToCardDavUrl(string prefsJsPath)
+    {
+        try { return ParseText(File.ReadAllText(prefsJsPath)); }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        { return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase); }
+    }
+
+    public static IReadOnlyDictionary<string, string> ParseText(string content)
+    {
+        var fileName = new Dictionary<string, string>(StringComparer.Ordinal);
+        var cardDav = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (string raw in content.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None))
+        {
+            Match m = Line.Match(raw);
+            if (!m.Success) continue;
+            string key = m.Groups["key"].Value, sub = m.Groups["sub"].Value;
+            if (!PrefsJsEscape.TryUnescape(m.Groups["val"].Value, out string val)) continue;
+            if (sub == "filename") fileName[key] = Path.GetFileName(val);
+            else if (sub == "carddav.url") cardDav[key] = val;
+        }
+
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (key, fn) in fileName)
+            if (fn.Length > 0 && cardDav.TryGetValue(key, out string? url) && url.Length > 0)
+                map[fn] = url;
+        return map;
+    }
+}

--- a/src/Mail2Pst.Core/Discovery/DiscoveryResult.cs
+++ b/src/Mail2Pst.Core/Discovery/DiscoveryResult.cs
@@ -28,6 +28,7 @@ public sealed class DiscoveredAddressBook
     public string DisplayName { get; set; } = string.Empty;
     public string Path { get; set; } = string.Empty;
     public string Format { get; set; } = string.Empty; // "thunderbird-sqlite" | "thunderbird-mab"
+    public int? ContactCount { get; set; }              // null = unknown/count-failed
 }
 
 public sealed class DiscoveredCalendarSource

--- a/src/Mail2Pst.Core/Discovery/DiscoveryResult.cs
+++ b/src/Mail2Pst.Core/Discovery/DiscoveryResult.cs
@@ -29,6 +29,7 @@ public sealed class DiscoveredAddressBook
     public string Path { get; set; } = string.Empty;
     public string Format { get; set; } = string.Empty; // "thunderbird-sqlite" | "thunderbird-mab"
     public int? ContactCount { get; set; }              // null = unknown/count-failed
+    public string? AccountId { get; set; }               // null = local / unmatched
 }
 
 public sealed class DiscoveredCalendarSource
@@ -43,6 +44,7 @@ public sealed class DiscoveredCalendarSource
     public int TaskCount { get; init; }
     public IReadOnlyList<string> DefaultCalendarFolderPath { get; init; } = System.Array.Empty<string>();
     public IReadOnlyList<string> DefaultTaskFolderPath { get; init; } = System.Array.Empty<string>();
+    public string? AccountId { get; init; }              // null = local / unmatched
 }
 
 public sealed class CalendarDiscoveryResult

--- a/src/Mail2Pst.Core/Discovery/MailProfileDiscovery.cs
+++ b/src/Mail2Pst.Core/Discovery/MailProfileDiscovery.cs
@@ -141,7 +141,7 @@ public static class MailProfileDiscovery
 
         var addressBooks = DiscoverAddressBooks(prefsRoot ?? root).ToList();
 
-        var calendarResult = DiscoverCalendars(prefsRoot ?? root);
+        var calendarResult = DiscoverCalendars(prefsRoot ?? root, accounts);
         warnings.AddRange(calendarResult.Warnings);
 
         return new DiscoveryResult(root, layout, sources, warnings, skipped,
@@ -160,8 +160,10 @@ public static class MailProfileDiscovery
     /// cal_ids that have rows get a synthesized display name and a warning.  Skips
     /// <c>deleted.sqlite</c>.
     /// </summary>
-    public static CalendarDiscoveryResult DiscoverCalendars(string profileDir)
+    public static CalendarDiscoveryResult DiscoverCalendars(string profileDir,
+        IReadOnlyList<Account>? accounts = null)
     {
+        accounts ??= Array.Empty<Account>();
         var result = new CalendarDiscoveryResult();
 
         // Registry: cal_id -> entry (name, type, visibility). Missing file -> empty.
@@ -271,6 +273,13 @@ public static class MailProfileDiscovery
             string folderLeaf = FolderNameValidator.Sanitize(
                 displayName, "Calendar " + calId[..Math.Min(8, calId.Length)]);
 
+            string? calUri = registry.TryGetValue(calId, out CalendarRegistryEntry? uriEntry) ? uriEntry.Uri : null;
+            AccountMatch match = PimAccountMatcher.Match(calUri, accounts);
+            if (match.Ambiguous)
+                result.Warnings.Add(new DiscoveryWarning("calendar-ambiguous-account", chosenPath,
+                    null, null, null, null,
+                    $"Calendar {displayName} matched more than one account; treated as local (Local Folders)."));
+
             result.Calendars.Add(new DiscoveredCalendarSource
             {
                 CalId                    = calId,
@@ -285,6 +294,7 @@ public static class MailProfileDiscovery
                 DefaultTaskFolderPath    = taskCount > 0
                     ? new[] { "Tasks", folderLeaf }
                     : Array.Empty<string>(),
+                AccountId                = match.AccountId,
             });
         }
 

--- a/src/Mail2Pst.Core/Discovery/MailProfileDiscovery.cs
+++ b/src/Mail2Pst.Core/Discovery/MailProfileDiscovery.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using Mail2Pst.Core.Calendar;
 using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Contacts;
 using Mail2Pst.Core.Msf;
 
 namespace Mail2Pst.Core.Discovery;
@@ -297,16 +298,24 @@ public static class MailProfileDiscovery
         {
             string name = Path.GetFileName(sqlite);
             if (name is "abook.sqlite" or "history.sqlite" || name.StartsWith("abook", StringComparison.OrdinalIgnoreCase))
-                yield return new DiscoveredAddressBook
+            {
+                var book = new DiscoveredAddressBook
                 {
                     DisplayName = FriendlyBookName(name), Path = sqlite, Format = "thunderbird-sqlite",
                 };
+                book.ContactCount = AddressBookContactCounter.TryCount(book);
+                yield return book;
+            }
         }
         foreach (string mab in Directory.EnumerateFiles(profileDir, "*.mab"))
-            yield return new DiscoveredAddressBook
+        {
+            var book = new DiscoveredAddressBook
             {
                 DisplayName = FriendlyBookName(Path.GetFileName(mab)), Path = mab, Format = "thunderbird-mab",
             };
+            book.ContactCount = AddressBookContactCounter.TryCount(book); // null for mab
+            yield return book;
+        }
     }
 
     private static string FriendlyBookName(string fileName) => fileName switch

--- a/src/Mail2Pst.Core/Discovery/MailProfileDiscovery.cs
+++ b/src/Mail2Pst.Core/Discovery/MailProfileDiscovery.cs
@@ -139,7 +139,12 @@ public static class MailProfileDiscovery
             })
             .ToList();
 
-        var addressBooks = DiscoverAddressBooks(prefsRoot ?? root).ToList();
+        var cardDavByFile = string.IsNullOrEmpty(prefsRoot)
+            ? new Dictionary<string, string>()
+            : (IReadOnlyDictionary<string, string>)AddressBookRegistryReader
+                .ReadFilenameToCardDavUrl(Path.Combine(prefsRoot, "prefs.js"));
+        var addressBooks = DiscoverAddressBooks(prefsRoot ?? root, accounts, cardDavByFile, out var abWarnings);
+        warnings.AddRange(abWarnings);
 
         var calendarResult = DiscoverCalendars(prefsRoot ?? root, accounts);
         warnings.AddRange(calendarResult.Warnings);
@@ -299,6 +304,31 @@ public static class MailProfileDiscovery
         }
 
         return result;
+    }
+
+    public static List<DiscoveredAddressBook> DiscoverAddressBooks(
+        string profileDir,
+        IReadOnlyList<Account> accounts,
+        IReadOnlyDictionary<string, string> cardDavByFile,
+        out List<DiscoveryWarning> warnings)
+    {
+        warnings = new List<DiscoveryWarning>();
+        var books = new List<DiscoveredAddressBook>();
+        foreach (DiscoveredAddressBook book in DiscoverAddressBooks(profileDir)) // existing enumerator
+        {
+            string file = Path.GetFileName(book.Path);
+            if (cardDavByFile.TryGetValue(file, out string? url))
+            {
+                AccountMatch m = PimAccountMatcher.Match(url, accounts);
+                book.AccountId = m.AccountId;
+                if (m.Ambiguous)
+                    warnings.Add(new DiscoveryWarning("addressbook-ambiguous-account", book.Path,
+                        null, null, null, null,
+                        $"Address book {book.DisplayName} matched more than one account; treated as local (Local Folders)."));
+            }
+            books.Add(book);
+        }
+        return books;
     }
 
     public static IEnumerable<DiscoveredAddressBook> DiscoverAddressBooks(string profileDir)

--- a/src/Mail2Pst.Core/Discovery/PimAccountMatcher.cs
+++ b/src/Mail2Pst.Core/Discovery/PimAccountMatcher.cs
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Mail2Pst.Core.Discovery;
+
+/// <summary>Result of resolving a calendar URI / CardDAV URL to a mail account.
+/// AccountId==null &amp; Ambiguous==false = genuinely local / no candidate (silent).
+/// AccountId==null &amp; Ambiguous==true  = ≥2 host candidates; caller emits a warning.</summary>
+public readonly record struct AccountMatch(string? AccountId, bool Ambiguous);
+
+/// <summary>Resolves a Thunderbird calendar/CardDAV URI to a discovered account.
+/// Safety-by-default: email match (raw or %40-encoded) first, then normalized host
+/// (exact or subdomain — never bare substring); ≥2 host candidates → null+Ambiguous.</summary>
+public static class PimAccountMatcher
+{
+    public static AccountMatch Match(string? uriOrUrl, IReadOnlyList<Account> accounts)
+    {
+        if (string.IsNullOrEmpty(uriOrUrl)) return new AccountMatch(null, false);
+
+        string candidate = uriOrUrl!;
+        string decoded = SafeUnescape(candidate);
+
+        // 1. Email match (raw OR url-encoded), case-insensitive. Ambiguity -> null.
+        string? emailMatchId = null;
+        bool emailAmbiguous = false;
+        foreach (Account a in accounts)
+        {
+            if (string.IsNullOrEmpty(a.Email)) continue;
+            string enc = SafeEscape(a.Email!);   // aksel@x -> aksel%40x
+            bool hit = decoded.IndexOf(a.Email!, StringComparison.OrdinalIgnoreCase) >= 0 ||
+                       candidate.IndexOf(a.Email!, StringComparison.OrdinalIgnoreCase) >= 0 ||
+                       candidate.IndexOf(enc, StringComparison.OrdinalIgnoreCase) >= 0;
+            if (!hit) continue;
+            if (emailMatchId is null) emailMatchId = a.Id;
+            else if (!string.Equals(emailMatchId, a.Id, StringComparison.Ordinal)) emailAmbiguous = true;
+        }
+        if (emailAmbiguous) return new AccountMatch(null, true);   // never guess between two emails
+        if (emailMatchId is not null) return new AccountMatch(emailMatchId, false);
+
+        // 2. Host match (exact or subdomain). Ambiguity -> null+Ambiguous.
+        string? host = TryGetHost(candidate);
+        if (host is not null)
+        {
+            string? matchedId = null;
+            bool ambiguous = false;
+            foreach (Account a in accounts)
+            {
+                string? ah = NormalizeHost(a.Host);
+                if (ah is null) continue;
+                bool hit = string.Equals(host, ah, StringComparison.OrdinalIgnoreCase) ||
+                           host.EndsWith("." + ah, StringComparison.OrdinalIgnoreCase);
+                if (!hit) continue;
+                if (matchedId is null) matchedId = a.Id;
+                else if (!string.Equals(matchedId, a.Id, StringComparison.Ordinal)) ambiguous = true;
+            }
+            if (ambiguous) return new AccountMatch(null, true);
+            if (matchedId is not null) return new AccountMatch(matchedId, false);
+        }
+
+        return new AccountMatch(null, false);
+    }
+
+    private static string SafeUnescape(string s)
+    {
+        try { return Uri.UnescapeDataString(s); } catch { return s; }
+    }
+
+    private static string SafeEscape(string s)
+    {
+        try { return Uri.EscapeDataString(s); } catch { return s; }
+    }
+
+    private static string? TryGetHost(string s)
+    {
+        if (Uri.TryCreate(s, UriKind.Absolute, out Uri? u) && !string.IsNullOrEmpty(u.Host))
+            return u.Host;
+        return null;
+    }
+
+    private static string? NormalizeHost(string? host)
+    {
+        if (string.IsNullOrWhiteSpace(host)) return null;
+        string h = host!.Trim();
+        int scheme = h.IndexOf("://", StringComparison.Ordinal);
+        if (scheme >= 0) h = h[(scheme + 3)..];
+        int slash = h.IndexOf('/');
+        if (slash >= 0) h = h[..slash];
+        int colon = h.IndexOf(':');
+        if (colon >= 0) h = h[..colon];
+        return h.Length == 0 ? null : h;
+    }
+}

--- a/src/Mail2Pst.Core/Discovery/PimAccountMatcher.cs
+++ b/src/Mail2Pst.Core/Discovery/PimAccountMatcher.cs
@@ -30,9 +30,11 @@ public static class PimAccountMatcher
         {
             if (string.IsNullOrEmpty(a.Email)) continue;
             string enc = SafeEscape(a.Email!);   // aksel@x -> aksel%40x
-            bool hit = decoded.IndexOf(a.Email!, StringComparison.OrdinalIgnoreCase) >= 0 ||
-                       candidate.IndexOf(a.Email!, StringComparison.OrdinalIgnoreCase) >= 0 ||
-                       candidate.IndexOf(enc, StringComparison.OrdinalIgnoreCase) >= 0;
+            // Boundary-guarded: an email only matches at token boundaries, so
+            // "myinfo@x" does NOT match account "info@x" (substring mis-route).
+            bool hit = ContainsBounded(decoded, a.Email!) ||
+                       ContainsBounded(candidate, a.Email!) ||
+                       ContainsBounded(candidate, enc);
             if (!hit) continue;
             if (emailMatchId is null) emailMatchId = a.Id;
             else if (!string.Equals(emailMatchId, a.Id, StringComparison.Ordinal)) emailAmbiguous = true;
@@ -62,6 +64,26 @@ public static class PimAccountMatcher
 
         return new AccountMatch(null, false);
     }
+
+    /// <summary>True iff <paramref name="needle"/> occurs in <paramref name="haystack"/> at a
+    /// position bounded on both sides by a non-email-token char (or string end) — so an account
+    /// email is not accidentally matched as a substring of a longer local-part/domain.</summary>
+    private static bool ContainsBounded(string haystack, string needle)
+    {
+        if (needle.Length == 0) return false;
+        int i = 0;
+        while ((i = haystack.IndexOf(needle, i, StringComparison.OrdinalIgnoreCase)) >= 0)
+        {
+            bool left  = i == 0 || !IsEmailTokenChar(haystack[i - 1]);
+            bool right = i + needle.Length == haystack.Length || !IsEmailTokenChar(haystack[i + needle.Length]);
+            if (left && right) return true;
+            i += 1;
+        }
+        return false;
+    }
+
+    private static bool IsEmailTokenChar(char c) =>
+        char.IsLetterOrDigit(c) || c == '.' || c == '_' || c == '%' || c == '+' || c == '-' || c == '@';
 
     private static string SafeUnescape(string s)
     {

--- a/tests/Mail2Pst.Core.Tests/Cli/DiscoverCommandE2ETests.cs
+++ b/tests/Mail2Pst.Core.Tests/Cli/DiscoverCommandE2ETests.cs
@@ -201,6 +201,143 @@ public class DiscoverCommandE2ETests
         }
     }
 
+    [Fact]
+    public void Discover_Profile_EmitsCalendarAccountId_ForMatchedAndLocalCalendar()
+    {
+        // Two calendars: CAL1's registry uri resolves (via PimAccountMatcher) to the account
+        // directory "Mail/imap.example.com" (prefs.js wires host+identity email for that account);
+        // CAL2 has no uri at all, so it stays local (accountId == null).
+        string profile = Path.Combine(Path.GetTempPath(), "m2p-cal-acct-e2e-" + Guid.NewGuid());
+        string accountDir = Path.Combine(profile, "Mail", "imap.example.com");
+        Directory.CreateDirectory(accountDir);
+        Directory.CreateDirectory(Path.Combine(profile, "calendar-data"));
+        try
+        {
+            // Accounts are only registered from directories that yield >=1 mail source
+            // (MailProfileDiscovery.DiscoverStores derives `accounts` from indexed sources'
+            // origin keys) — an account directory with no mail sources never appears in
+            // `Accounts`, so PimAccountMatcher would have nothing to match against.
+            WriteMbox(Path.Combine(accountDir, "Inbox"));
+
+            File.WriteAllText(Path.Combine(profile, "prefs.js"),
+                "user_pref(\"calendar.registry.CAL1.name\", \"Work\");\n" +
+                "user_pref(\"calendar.registry.CAL1.type\", \"caldav\");\n" +
+                "user_pref(\"calendar.registry.CAL1.uri\", \"https://imap.example.com/dav/calendars/user/work\");\n" +
+                "user_pref(\"calendar.registry.CAL1.calendar-main-in-composite\", true);\n" +
+                "user_pref(\"calendar.registry.CAL2.name\", \"Personal\");\n" +
+                "user_pref(\"calendar.registry.CAL2.type\", \"storage\");\n" +
+                "user_pref(\"calendar.registry.CAL2.calendar-main-in-composite\", true);\n" +
+                "user_pref(\"mail.server.server1.directory-rel\", \"[ProfD]Mail/imap.example.com\");\n" +
+                "user_pref(\"mail.server.server1.hostname\", \"imap.example.com\");\n" +
+                "user_pref(\"mail.account.account1.server\", \"server1\");\n" +
+                "user_pref(\"mail.account.account1.identities\", \"id1\");\n" +
+                "user_pref(\"mail.identity.id1.useremail\", \"user@example.com\");\n",
+                new UTF8Encoding(false));
+
+            string calPath = Path.Combine(profile, "calendar-data", "local.sqlite");
+            MakeCalStore(calPath, "CAL1", addEvent: true);
+            using (var conn = new SqliteConnection($"Data Source={calPath}"))
+            {
+                conn.Open();
+                using var cmd = conn.CreateCommand();
+                cmd.CommandText = "INSERT INTO cal_events (cal_id,id,title,flags,event_start,event_end,recurrence_id) " +
+                    "VALUES ('CAL2','ev2','Personal Event',0,1782810000000000,1782811800000000,NULL);";
+                cmd.ExecuteNonQuery();
+            }
+
+            (int exit, string stdout, string stderr) = RunCli($"discover --input \"{profile}\"");
+            Assert.True(exit == 0, $"expected exit 0, got {exit}. stderr: {stderr}");
+
+            using JsonDocument doc = JsonDocument.Parse(stdout);
+            JsonElement root = doc.RootElement;
+            JsonElement calendars = root.GetProperty("calendars");
+            Assert.Equal(2, calendars.GetArrayLength());
+
+            JsonElement work = calendars.EnumerateArray().Single(c => c.GetProperty("calId").GetString() == "CAL1");
+            Assert.Equal(accountDir, work.GetProperty("accountId").GetString());
+
+            JsonElement personal = calendars.EnumerateArray().Single(c => c.GetProperty("calId").GetString() == "CAL2");
+            Assert.Equal(JsonValueKind.Null, personal.GetProperty("accountId").ValueKind);
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            Directory.Delete(profile, true);
+        }
+    }
+
+    [Fact]
+    public void Discover_Profile_EmitsAddressBookAccountId_ForMatchedAndLocalBook()
+    {
+        // abook.sqlite's carddav.url registry entry resolves (via PimAccountMatcher) to the account
+        // directory "Mail/imap.example.com"; abook-secondary.sqlite has no registry entry, so it
+        // stays local (accountId == null).
+        string profile = Path.Combine(Path.GetTempPath(), "m2p-abook-acct-e2e-" + Guid.NewGuid());
+        string accountDir = Path.Combine(profile, "Mail", "imap.example.com");
+        Directory.CreateDirectory(accountDir);
+        try
+        {
+            // Accounts are only registered from directories that yield >=1 mail source
+            // (MailProfileDiscovery.DiscoverStores derives `accounts` from indexed sources'
+            // origin keys) — an account directory with no mail sources never appears in
+            // `Accounts`, so PimAccountMatcher would have nothing to match against.
+            WriteMbox(Path.Combine(accountDir, "Inbox"));
+
+            File.WriteAllText(Path.Combine(profile, "prefs.js"),
+                "user_pref(\"ldap_2.servers.abook1.filename\", \"abook.sqlite\");\n" +
+                "user_pref(\"ldap_2.servers.abook1.carddav.url\", \"https://imap.example.com/dav/addressbooks/user/default/\");\n" +
+                "user_pref(\"mail.server.server1.directory-rel\", \"[ProfD]Mail/imap.example.com\");\n" +
+                "user_pref(\"mail.server.server1.hostname\", \"imap.example.com\");\n" +
+                "user_pref(\"mail.account.account1.server\", \"server1\");\n" +
+                "user_pref(\"mail.account.account1.identities\", \"id1\");\n" +
+                "user_pref(\"mail.identity.id1.useremail\", \"user@example.com\");\n",
+                new UTF8Encoding(false));
+
+            string abookPath = Path.Combine(profile, "abook.sqlite");
+            using (var conn = new SqliteConnection($"Data Source={abookPath}"))
+            {
+                conn.Open();
+                using var cmd = conn.CreateCommand();
+                cmd.CommandText =
+                    "CREATE TABLE properties (card TEXT, name TEXT, value TEXT);" +
+                    "INSERT INTO properties VALUES ('c1','DisplayName','A');";
+                cmd.ExecuteNonQuery();
+            }
+
+            string secondaryPath = Path.Combine(profile, "abook-secondary.sqlite");
+            using (var conn = new SqliteConnection($"Data Source={secondaryPath}"))
+            {
+                conn.Open();
+                using var cmd = conn.CreateCommand();
+                cmd.CommandText =
+                    "CREATE TABLE properties (card TEXT, name TEXT, value TEXT);" +
+                    "INSERT INTO properties VALUES ('c1','DisplayName','B');";
+                cmd.ExecuteNonQuery();
+            }
+
+            (int exit, string stdout, string stderr) = RunCli($"discover --input \"{profile}\"");
+            Assert.True(exit == 0, $"expected exit 0, got {exit}. stderr: {stderr}");
+
+            using JsonDocument doc = JsonDocument.Parse(stdout);
+            JsonElement root = doc.RootElement;
+            JsonElement addressBooks = root.GetProperty("addressBooks");
+            Assert.Equal(2, addressBooks.GetArrayLength());
+
+            JsonElement matched = addressBooks.EnumerateArray()
+                .Single(b => b.GetProperty("path").GetString()!.EndsWith("abook.sqlite"));
+            Assert.Equal(accountDir, matched.GetProperty("accountId").GetString());
+
+            JsonElement local = addressBooks.EnumerateArray()
+                .Single(b => b.GetProperty("path").GetString()!.EndsWith("abook-secondary.sqlite"));
+            Assert.Equal(JsonValueKind.Null, local.GetProperty("accountId").ValueKind);
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            Directory.Delete(profile, true);
+        }
+    }
+
     // Minimal cal store (mirrors DiscoverCalendarsTests.MakeCalStore).
     private static void MakeCalStore(string path, string calId, bool addEvent = true)
     {

--- a/tests/Mail2Pst.Core.Tests/Cli/DiscoverCommandE2ETests.cs
+++ b/tests/Mail2Pst.Core.Tests/Cli/DiscoverCommandE2ETests.cs
@@ -157,6 +157,50 @@ public class DiscoverCommandE2ETests
         }
     }
 
+    [Fact]
+    public void Discover_Profile_EmitsAddressBooksArray_WithContactCount()
+    {
+        // Build a minimal Thunderbird profile: Mail/LocalFolders triggers "thunderbird-profile"
+        // layout which calls DiscoverAddressBooks. An abook.sqlite with two distinct cards should
+        // surface as one address book with contactCount == 2 in the emitted JSON.
+        string profile = Path.Combine(Path.GetTempPath(), "m2p-abook-e2e-" + Guid.NewGuid());
+        Directory.CreateDirectory(Path.Combine(profile, "Mail", "Local Folders"));
+        try
+        {
+            string abookPath = Path.Combine(profile, "abook.sqlite");
+            using (var conn = new SqliteConnection($"Data Source={abookPath}"))
+            {
+                conn.Open();
+                using var cmd = conn.CreateCommand();
+                cmd.CommandText =
+                    "CREATE TABLE properties (card TEXT, name TEXT, value TEXT);" +
+                    "INSERT INTO properties VALUES ('c1','DisplayName','A'),('c1','PrimaryEmail','a@example.test')," +
+                    "('c2','DisplayName','B');";
+                cmd.ExecuteNonQuery();
+            }
+
+            (int exit, string stdout, string stderr) = RunCli($"discover --input \"{profile}\"");
+            Assert.True(exit == 0, $"expected exit 0, got {exit}. stderr: {stderr}");
+
+            using JsonDocument doc = JsonDocument.Parse(stdout);
+            JsonElement root = doc.RootElement;
+            Assert.Equal("discovery", root.GetProperty("type").GetString());
+            Assert.Equal(1, root.GetProperty("schemaVersion").GetInt32());
+
+            JsonElement addressBooks = root.GetProperty("addressBooks");
+            Assert.Equal(1, addressBooks.GetArrayLength());
+            JsonElement book = addressBooks.EnumerateArray().Single();
+            Assert.EndsWith("abook.sqlite", book.GetProperty("path").GetString());
+            Assert.Equal("thunderbird-sqlite", book.GetProperty("format").GetString());
+            Assert.Equal(2, book.GetProperty("contactCount").GetInt32());
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            Directory.Delete(profile, true);
+        }
+    }
+
     // Minimal cal store (mirrors DiscoverCalendarsTests.MakeCalStore).
     private static void MakeCalStore(string path, string calId, bool addEvent = true)
     {

--- a/tests/Mail2Pst.Core.Tests/Config/ConfigValidatorPimOnlyTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Config/ConfigValidatorPimOnlyTests.cs
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#nullable enable
+using System.Collections.Generic;
+using Mail2Pst.Core.Config;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Config;
+
+// Regression guard: an output group made entirely of PIM data (contacts/calendars, no mail
+// Sources) must be accepted by ConfigValidator — and a group with none of sources/contacts/
+// calendars must still be rejected. Pins the "!hasMail && !hasContacts && !hasTasks &&
+// !hasAppointments" guard in ConfigValidator.Validate.
+public class ConfigValidatorPimOnlyTests
+{
+    private static ConversionConfig With(OutputGroupConfig g) =>
+        new() { Outputs = new List<OutputGroupConfig> { g } };
+
+    [Fact]
+    public void Accepts_group_with_contacts_and_no_mail()
+    {
+        var g = new OutputGroupConfig
+        {
+            Name = "Local Folders", MaxSizeMB = 5120, FolderMapping = FolderMappingMode.Mirror,
+            IncludeEmptyFolders = true, Sources = new List<SourceConfig>(),
+            Contacts = new List<ContactSourceConfig>
+            {
+                new() { Path = "/p/abook.sqlite", Format = "thunderbird-sqlite" },
+            },
+        };
+
+        ConfigValidator.Validate(With(g)); // must not throw
+    }
+
+    [Fact]
+    public void Rejects_group_with_nothing()
+    {
+        var g = new OutputGroupConfig
+        {
+            Name = "Empty", MaxSizeMB = 5120, FolderMapping = FolderMappingMode.Mirror,
+            IncludeEmptyFolders = true, Sources = new List<SourceConfig>(),
+        };
+
+        Assert.Throws<ConfigValidationException>(() => ConfigValidator.Validate(With(g)));
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Contacts/AddressBookContactCounterTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Contacts/AddressBookContactCounterTests.cs
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Data.Sqlite;
+using Mail2Pst.Core.Contacts;
+using Mail2Pst.Core.Discovery;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Contacts;
+
+public class AddressBookContactCounterTests
+{
+    [Fact]
+    public void Sqlite_book_counts_distinct_cards()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"abook-{Guid.NewGuid():N}.sqlite");
+        using (var c = new SqliteConnection($"Data Source={path}"))
+        {
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText =
+                "CREATE TABLE properties (card TEXT, name TEXT, value TEXT);" +
+                "INSERT INTO properties VALUES ('c1','DisplayName','A'),('c1','PrimaryEmail','a@example.test')," +
+                "('c2','DisplayName','B');";
+            cmd.ExecuteNonQuery();
+        }
+        var book = new DiscoveredAddressBook { Path = path, Format = "thunderbird-sqlite" };
+        Assert.Equal(2, AddressBookContactCounter.TryCount(book));
+        File.Delete(path);
+    }
+
+    [Fact]
+    public void Unreadable_book_returns_null_not_throw()
+    {
+        var book = new DiscoveredAddressBook { Path = "Z:/does/not/exist.sqlite", Format = "thunderbird-sqlite" };
+        Assert.Null(AddressBookContactCounter.TryCount(book));
+    }
+
+    [Fact]
+    public void Mab_format_returns_null_unknown()
+    {
+        var book = new DiscoveredAddressBook { Path = "whatever.mab", Format = "thunderbird-mab" };
+        Assert.Null(AddressBookContactCounter.TryCount(book));
+    }
+
+    // Proves the COUNT(DISTINCT card) figure matches what the real converter reads,
+    // so the UI count never overstates. Thunderbird stores mailing lists in separate
+    // tables (not `properties`), so every distinct card is a real contact.
+    [Fact]
+    public void Count_matches_the_reader_output()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"abook-{Guid.NewGuid():N}.sqlite");
+        using (var c = new SqliteConnection($"Data Source={path}"))
+        {
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText =
+                "CREATE TABLE properties (card TEXT, name TEXT, value TEXT);" +
+                "INSERT INTO properties VALUES ('c1','DisplayName','A'),('c2','DisplayName','B'),('c3','DisplayName','C');";
+            cmd.ExecuteNonQuery();
+        }
+        int readerCount = new SqliteAddressBookReader()
+            .Read(new AddressBook { Path = path, Format = AddressBookFormat.ThunderbirdSqlite })
+            .Count(r => r.Success);
+        int? counted = AddressBookContactCounter.TryCount(
+            new DiscoveredAddressBook { Path = path, Format = "thunderbird-sqlite" });
+        Assert.Equal(readerCount, counted);
+        File.Delete(path);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Contacts/AddressBookRegistryReaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Contacts/AddressBookRegistryReaderTests.cs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using Mail2Pst.Core.Contacts;
+using Xunit;
+
+public class AddressBookRegistryReaderTests
+{
+    [Fact]
+    public void Maps_filename_to_carddav_url()
+    {
+        string prefs =
+            "user_pref(\"ldap_2.servers.foo.filename\", \"abook-1.sqlite\");\n" +
+            "user_pref(\"ldap_2.servers.foo.carddav.url\", \"https://dav/aksel%40example.com/\");\n";
+        var map = AddressBookRegistryReader.ParseText(prefs);
+        Assert.Equal("https://dav/aksel%40example.com/", map["abook-1.sqlite"]);
+    }
+
+    [Fact]
+    public void Server_without_carddav_url_is_not_mapped()
+    {
+        string prefs = "user_pref(\"ldap_2.servers.pab.filename\", \"abook.sqlite\");\n";
+        var map = AddressBookRegistryReader.ParseText(prefs);
+        Assert.False(map.ContainsKey("abook.sqlite"));
+    }
+
+    [Fact]
+    public void Tolerates_whitespace_and_ignores_unrelated_keys()
+    {
+        string prefs =
+            "  user_pref( \"ldap_2.servers.bar.filename\" , \"abook-2.sqlite\" ) ;\n" +
+            "user_pref(\"ldap_2.servers.bar.carddav.url\",\"https://dav/x/\");\n" +
+            "user_pref(\"ldap_2.servers.bar.description\", \"Work\");\n" +
+            "user_pref(\"mail.something.else\", \"nope\");\n";
+        var map = AddressBookRegistryReader.ParseText(prefs);
+        Assert.Single(map);
+        Assert.Equal("https://dav/x/", map["abook-2.sqlite"]);
+    }
+
+    [Fact]
+    public void Filename_is_reduced_to_basename()
+    {
+        string prefs =
+            "user_pref(\"ldap_2.servers.baz.filename\", \"sub/dir/abook-3.sqlite\");\n" +
+            "user_pref(\"ldap_2.servers.baz.carddav.url\", \"https://dav/y/\");\n";
+        var map = AddressBookRegistryReader.ParseText(prefs);
+        Assert.Equal("https://dav/y/", map["abook-3.sqlite"]);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Discovery/AddressBookAccountResolutionTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Discovery/AddressBookAccountResolutionTests.cs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Data.Sqlite;
+using Mail2Pst.Core.Discovery;
+using Mail2Pst.Core.Msf;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Discovery;
+
+public class AddressBookAccountResolutionTests
+{
+    private static Account Acct(string id, string email, string host) =>
+        new(id, id, id, null, email, host, AddressResolution.NotFound);
+
+    private static string WriteBook(string dir, string file)
+    {
+        string path = Path.Combine(dir, file);
+        using var c = new SqliteConnection($"Data Source={path}");
+        c.Open();
+        using var cmd = c.CreateCommand();
+        cmd.CommandText = "CREATE TABLE properties (card TEXT, name TEXT, value TEXT);" +
+                          "INSERT INTO properties VALUES ('c1','DisplayName','A');";
+        cmd.ExecuteNonQuery();
+        return path;
+    }
+
+    [Fact]
+    public void Carddav_book_resolves_to_account_local_book_is_null()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "ab-" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        WriteBook(dir, "abook.sqlite");        // local Personal Address Book
+        WriteBook(dir, "abook-1.sqlite");      // CardDAV-synced
+        var accounts = new List<Account> { Acct("/p/ImapMail/imap.example.com", "user@example.com", "imap.example.com") };
+        var cardDav = new Dictionary<string, string> { ["abook-1.sqlite"] = "https://dav.example.com/user%40example.com/" };
+
+        var books = MailProfileDiscovery.DiscoverAddressBooks(dir, accounts, cardDav, out var warnings);
+
+        Assert.Null(books.Find(b => Path.GetFileName(b.Path) == "abook.sqlite")!.AccountId);
+        Assert.Equal("/p/ImapMail/imap.example.com",
+            books.Find(b => Path.GetFileName(b.Path) == "abook-1.sqlite")!.AccountId);
+        Assert.Empty(warnings);
+        Directory.Delete(dir, true);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Discovery/CalendarAccountResolutionTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Discovery/CalendarAccountResolutionTests.cs
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Data.Sqlite;
+using Mail2Pst.Core.Discovery;
+using Mail2Pst.Core.Msf;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Discovery;
+
+public class CalendarAccountResolutionTests
+{
+    private static Account Acct(string id, string email, string host) =>
+        new(id, id, id, null, email, host, AddressResolution.NotFound);
+
+    // Minimal calendar SQLite store schema, copied verbatim from DiscoverCalendarsTests.MakeCalStore
+    // (do not invent columns — cal_events/cal_todos have specific required columns).
+    private static void MakeCalStore(string path, string calId)
+    {
+        using var c = new SqliteConnection($"Data Source={path}"); c.Open();
+        void X(string sql) { using var cmd = c.CreateCommand(); cmd.CommandText = sql; cmd.ExecuteNonQuery(); }
+        X("CREATE TABLE cal_events (cal_id TEXT,id TEXT,time_created INTEGER,last_modified INTEGER,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,event_start INTEGER,event_end INTEGER,event_stamp INTEGER,event_start_tz TEXT,event_end_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,alarm_last_ack INTEGER,offline_journal INTEGER);");
+        X("CREATE TABLE cal_todos (cal_id TEXT,id TEXT,time_created INTEGER,last_modified INTEGER,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,todo_entry INTEGER,todo_due INTEGER,todo_completed INTEGER,todo_complete INTEGER,todo_entry_tz TEXT,todo_due_tz TEXT,todo_completed_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,alarm_last_ack INTEGER,todo_stamp INTEGER,offline_journal INTEGER);");
+        X("CREATE TABLE cal_recurrence (item_id TEXT,cal_id TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_attendees (item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_alarms (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_attachments (item_id TEXT,cal_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_relations (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_properties (item_id TEXT,key TEXT,value BLOB,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT);");
+        X("CREATE TABLE cal_parameters (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,key1 TEXT,key2 TEXT,value TEXT);");
+        X($"INSERT INTO cal_events (cal_id,id,title,flags,event_start,event_end,recurrence_id) " +
+          $"VALUES ('{calId}','ev1','Test Event',0,1782810000000000,1782811800000000,NULL);");
+    }
+
+    // Builds a minimal profile dir with a prefs.js registry + a local.sqlite so a calendar is
+    // discovered with a known URI.
+    private static string WriteProfile(string calId, string uri, string calName)
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "prof-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(dir, "calendar-data"));
+        File.WriteAllText(Path.Combine(dir, "prefs.js"),
+            $"user_pref(\"calendar.registry.{calId}.name\", \"{calName}\");\n" +
+            $"user_pref(\"calendar.registry.{calId}.type\", \"caldav\");\n" +
+            $"user_pref(\"calendar.registry.{calId}.uri\", \"{uri}\");\n");
+        MakeCalStore(Path.Combine(dir, "calendar-data", "local.sqlite"), calId);
+        return dir;
+    }
+
+    [Fact]
+    public void Caldav_calendar_resolves_to_matching_account()
+    {
+        string dir = WriteProfile("cal1", "https://dav/user%40example.com/", "Work");
+        var accounts = new List<Account> { Acct("/p/ImapMail/imap.example.com", "user@example.com", "imap.example.com") };
+        var res = MailProfileDiscovery.DiscoverCalendars(dir, accounts);
+        var cal = Assert.Single(res.Calendars);
+        Assert.Equal("/p/ImapMail/imap.example.com", cal.AccountId);
+        Directory.Delete(dir, true);
+    }
+
+    [Fact]
+    public void Local_storage_calendar_resolves_to_null()
+    {
+        string dir = WriteProfile("cal2", "moz-storage-calendar://", "Home");
+        var res = MailProfileDiscovery.DiscoverCalendars(dir, new List<Account>());
+        Assert.Null(Assert.Single(res.Calendars).AccountId);
+        Directory.Delete(dir, true);
+    }
+
+    [Fact]
+    public void Ambiguous_host_emits_warning_and_null_account()
+    {
+        string dir = WriteProfile("cal3", "https://caldav.example.com/dav", "Shared");
+        var accounts = new List<Account>
+        {
+            Acct("/p/A", null!, "example.com"),
+            Acct("/p/B", null!, "example.com"),
+        };
+        var res = MailProfileDiscovery.DiscoverCalendars(dir, accounts);
+        Assert.Null(Assert.Single(res.Calendars).AccountId);
+        Assert.Contains(res.Warnings, w => w.Code == "calendar-ambiguous-account");
+        Directory.Delete(dir, true);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Discovery/PimAccountMatcherTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Discovery/PimAccountMatcherTests.cs
@@ -88,4 +88,25 @@ public class PimAccountMatcherTests
         Assert.Null(PimAccountMatcher.Match(null, Accounts).AccountId);
         Assert.Null(PimAccountMatcher.Match("", Accounts).AccountId);
     }
+
+    [Fact]
+    public void Email_substring_of_longer_localpart_does_not_match()
+    {
+        var accounts = new[] { Acct("/p/info", "info@example.com", "imap.example.com") };
+        var m = PimAccountMatcher.Match("https://dav/myinfo@example.com/cal", accounts);
+        Assert.Null(m.AccountId);          // "myinfo@example.com" is NOT account "info@example.com"
+        Assert.False(m.Ambiguous);
+    }
+
+    [Fact]
+    public void Email_bounded_match_still_works_encoded_and_raw()
+    {
+        var accounts = new[] { Acct("/p/info", "info@example.com", "imap.example.com") };
+        var raw = PimAccountMatcher.Match("https://dav/info@example.com/cal", accounts);
+        Assert.Equal("/p/info", raw.AccountId);
+        Assert.False(raw.Ambiguous);
+        var encoded = PimAccountMatcher.Match("https://dav/info%40example.com/cal", accounts);
+        Assert.Equal("/p/info", encoded.AccountId);
+        Assert.False(encoded.Ambiguous);
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Discovery/PimAccountMatcherTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Discovery/PimAccountMatcherTests.cs
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Collections.Generic;
+using Mail2Pst.Core.Discovery;
+using Mail2Pst.Core.Msf;
+using Xunit;
+
+public class PimAccountMatcherTests
+{
+    private static Account Acct(string id, string? email, string? host) =>
+        new(id, id, id, null, email, host, AddressResolution.NotFound);
+
+    private static readonly IReadOnlyList<Account> Accounts = new[]
+    {
+        Acct("/p/ImapMail/imap.example.com", "aksel@example.com", "imap.example.com"),
+        Acct("/p/ImapMail/mail.example.org", "aksel@example.org", "mail.example.org"),
+    };
+
+    [Fact]
+    public void Email_literal_in_url_matches()
+    {
+        var m = PimAccountMatcher.Match("https://caldav.example/aksel@example.org/cal", Accounts);
+        Assert.Equal("/p/ImapMail/mail.example.org", m.AccountId);
+        Assert.False(m.Ambiguous);
+    }
+
+    [Fact]
+    public void Email_url_encoded_matches()
+    {
+        var m = PimAccountMatcher.Match("https://apidata.example.com/caldav/v2/aksel%40example.com/events", Accounts);
+        Assert.Equal("/p/ImapMail/imap.example.com", m.AccountId);
+    }
+
+    [Fact]
+    public void Host_exact_matches_when_no_email()
+    {
+        var noEmail = new[] { Acct("/p/A", null, "cloud.acme.test") };
+        var m = PimAccountMatcher.Match("https://cloud.acme.test/dav/cal", noEmail);
+        Assert.Equal("/p/A", m.AccountId);
+    }
+
+    [Fact]
+    public void Host_subdomain_matches()
+    {
+        var noEmail = new[] { Acct("/p/A", null, "acme.test") };
+        var m = PimAccountMatcher.Match("https://dav.acme.test/cal", noEmail);
+        Assert.Equal("/p/A", m.AccountId);
+    }
+
+    [Fact]
+    public void Host_substring_does_not_match()
+    {
+        var noEmail = new[] { Acct("/p/A", null, "acme.test") };
+        var m = PimAccountMatcher.Match("https://acme.test.evil.example/cal", noEmail);
+        Assert.Null(m.AccountId);          // "acme.test.evil.example" is NOT a subdomain of "acme.test"
+        Assert.False(m.Ambiguous);
+    }
+
+    [Fact]
+    public void Ambiguous_host_returns_null_and_flags()
+    {
+        var two = new[] { Acct("/p/A", null, "example.net"), Acct("/p/B", null, "example.net") };
+        var m = PimAccountMatcher.Match("https://caldav.example.net/dav", two);
+        Assert.Null(m.AccountId);
+        Assert.True(m.Ambiguous);
+    }
+
+    [Fact]
+    public void Ambiguous_email_returns_null_and_flags()
+    {
+        var two = new[] { Acct("/p/A", "shared@example.net", "a.example.net"), Acct("/p/B", "shared@example.net", "b.example.net") };
+        var m = PimAccountMatcher.Match("https://dav/shared@example.net/cal", two);
+        Assert.Null(m.AccountId);
+        Assert.True(m.Ambiguous);
+    }
+
+    [Fact]
+    public void Local_storage_uri_returns_null_not_ambiguous()
+    {
+        var m = PimAccountMatcher.Match("moz-storage-calendar://", Accounts);
+        Assert.Null(m.AccountId);
+        Assert.False(m.Ambiguous);
+    }
+
+    [Fact]
+    public void Null_or_empty_returns_null()
+    {
+        Assert.Null(PimAccountMatcher.Match(null, Accounts).AccountId);
+        Assert.Null(PimAccountMatcher.Match("", Accounts).AccountId);
+    }
+}


### PR DESCRIPTION
## Problem
The desktop app converted mail only — Thunderbird calendars, tasks, and contacts had no GUI path. An initial build attached all discovered calendars/contacts to the *first* PST in multi-account (split) mode, mis-routing a local "Home" calendar and the Personal Address Book into the wrong account's file, with no way to see the routing before converting.

## Fix
- **"Also convert" toggles** (Calendar events / Tasks / Contacts, default on, live counts) on the profile Options screen; per-phase progress heading and a per-type results breakdown (Mail / Calendar / Tasks / Contacts).
- **Per-account routing.** Each calendar/address book is written into the PST of the account it belongs to; local/account-less items go to a **Local Folders** PST, synthesized (sources-empty, PIM-only) when Local Folders has no mail. Resolution is engine-side: `discover` emits a per-item `accountId`, matched from the calendar registry URI / an address book's CardDAV `prefs.js` URL against the discovered accounts — email-first (URL-decoded, boundary-guarded so a shorter local-part can't substring-match a longer one), then normalized exact/subdomain host; any ambiguity resolves to "local" rather than guessing.
- One shared `routeAlsoConvert` drives **both** the config builder and the Options **Preview**, so the preview cannot disagree with what is written; it shows which PST each list lands in (and warns when a calendar belongs to a deselected account).

## Effect
In split mode each account's calendar/contacts land in its own PST; the local Home calendar + Personal Address Book land in Local Folders. Single-PST and combined outputs are unchanged. Owner-validated end-to-end in classic Outlook.

## Tests
Engine Core 1206/0, Integration 87/0 (11 env-gated skips); Desktop Vitest 266/266; Rust sidecar 15/0; `npm run build` clean; leak-check clean. `schemaVersion` unchanged (`accountId` additive).