### PR TITLE
feat: calendar/task category colours in the Outlook colour-import plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,9 @@ reviews/
 CLAUDE.md
 todo.md
 /publish-smoke/
+
+# Graphify knowledge-graph output (dev tool; graph.json/report embed repo content incl.
+# private-dir excerpts if misconfigured — never commit) + its local ignore config
+graphify-out/
+.graphifyignore
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   note if a calendar belongs to an account you didn't select), and the results screen breaks the run down
   per type — Mail / Calendar / Tasks / Contacts — with progress shown per phase. Single-PST and combined
   outputs put everything in the one file, unchanged.
+- **Calendar and task category colours now import into Outlook.** The categories used on converted
+  appointments and to-dos join the optional "Import colours" step with the colour Thunderbird shows for
+  them — a user-set colour override from the profile if one exists, otherwise Thunderbird's own computed
+  default (Thunderbird derives default category colours from the category name; the converter reproduces
+  that computation exactly). Where a mail tag and a calendar category share a name, the mail tag's colour
+  wins. Per-calendar *source* colours (the swatch next to each calendar's name) are never mistaken for
+  category colours.
 
 ### Internal
 - Desktop calendar/tasks/contacts wiring: engine `discover` now emits a per-item `accountId` for each

--- a/src/Mail2Pst.Cli/ConvertCommand.cs
+++ b/src/Mail2Pst.Cli/ConvertCommand.cs
@@ -142,7 +142,7 @@ internal static class ConvertCommand
             string reportTxtPath = Path.Combine(outputDir, "conversion-report.txt");
             File.WriteAllText(reportTxtPath, report.ToSummary());
 
-            var colourPlan = BuildColourPlan(config.ProfilePath);
+            var colourPlan = BuildColourPlan(config.ProfilePath, report.CalendarCategoryNames);
 
             CliArgs.WriteJsonLine(new
             {
@@ -189,7 +189,7 @@ internal static class ConvertCommand
         }
     }
 
-    private static object[] BuildColourPlan(string? profilePath)
+    private static object[] BuildColourPlan(string? profilePath, IReadOnlyList<string> calendarCategoryNames)
     {
         if (string.IsNullOrEmpty(profilePath)) return Array.Empty<object>();
         string prefsPath = Path.Combine(profilePath, "prefs.js");
@@ -199,9 +199,14 @@ internal static class ConvertCommand
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         { return Array.Empty<object>(); }
 
+        var calColors = CalendarCategoryColorResolver.Resolve(
+            calendarCategoryNames,
+            CalendarCategoryOverrideReader.ParseText(content));
+
         var plan = CategoryColorPlan.Build(
             PrefsTagReader.ParseText(content),
-            PrefsTagReader.ParseColors(content));
+            PrefsTagReader.ParseColors(content),
+            calColors);
 
         var list = new List<object>();
         foreach (var c in plan)

--- a/src/Mail2Pst.Core/ConversionRunner.cs
+++ b/src/Mail2Pst.Core/ConversionRunner.cs
@@ -210,6 +210,7 @@ public class ConversionRunner
                                     else
                                     {
                                         ApplyCalendarAttachments(mapped, group.Master?.Attachments ?? new List<RawSideText>(), taskAttResolver, report.RecordTaskWarning);
+                                        report.RecordCalendarCategories(mapped.Categories);
                                         plannedTasks.Add(new PlannedTask
                                         {
                                             Task = mapped,
@@ -277,6 +278,7 @@ public class ConversionRunner
                                     else
                                     {
                                         ApplyCalendarAttachments(mapped, group.Master?.Attachments ?? new List<RawSideText>(), apptAttResolver, report.RecordAppointmentWarning);
+                                        report.RecordCalendarCategories(mapped.Categories);
                                         plannedAppointments.Add(new PlannedAppointment
                                         {
                                             Appointment = mapped,

--- a/src/Mail2Pst.Core/OutlookCategories/CalendarCategoryColorResolver.cs
+++ b/src/Mail2Pst.Core/OutlookCategories/CalendarCategoryColorResolver.cs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Mail2Pst.Core.OutlookCategories;
+
+/// <summary>Resolves each calendar/task category name to its Thunderbird colour: a prefs.js override
+/// (keyed by the mangled name) if present, else the computed hashColor default. Insertion-ordered,
+/// case-insensitively de-duplicated (first occurrence casing kept).</summary>
+public static class CalendarCategoryColorResolver
+{
+    public static IReadOnlyDictionary<string, string> Resolve(
+        IEnumerable<string> categoryNames,
+        IReadOnlyDictionary<string, string> overridesByMangledKey)
+    {
+        ArgumentNullException.ThrowIfNull(categoryNames);
+        ArgumentNullException.ThrowIfNull(overridesByMangledKey);
+
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string name in categoryNames)
+        {
+            if (string.IsNullOrEmpty(name) || result.ContainsKey(name)) continue;
+            string key = CategoryColorHasher.FormatStringForCSSRule(name);
+            string hex = overridesByMangledKey.TryGetValue(key, out string? o) ? o
+                : CategoryColorHasher.HashColor(name);
+            result[name] = hex;
+        }
+        return result;
+    }
+}

--- a/src/Mail2Pst.Core/OutlookCategories/CalendarCategoryOverrideReader.cs
+++ b/src/Mail2Pst.Core/OutlookCategories/CalendarCategoryOverrideReader.cs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace Mail2Pst.Core.OutlookCategories;
+
+/// <summary>Reads user-overridden calendar category colours from prefs.js —
+/// <c>calendar.category.color.&lt;mangledKey&gt;</c> with a #RRGGBB value. Line-oriented; does NOT
+/// execute JS. Default category colours are NOT stored (Thunderbird computes them), so this is empty
+/// for a profile that never changed a category colour.</summary>
+public static class CalendarCategoryOverrideReader
+{
+    private static readonly Regex Line = new(
+        "^\\s*user_pref\\s*\\(\\s*\"calendar\\.category\\.color\\.(?<key>[^\"]+)\"\\s*,\\s*\"(?<val>#?[0-9A-Fa-f]{6})\"\\s*\\)\\s*;?\\s*$",
+        RegexOptions.CultureInvariant);
+
+    public static IReadOnlyDictionary<string, string> Read(string prefsJsPath)
+    {
+        try { return ParseText(File.ReadAllText(prefsJsPath)); }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        { return new Dictionary<string, string>(StringComparer.Ordinal); }
+    }
+
+    public static IReadOnlyDictionary<string, string> ParseText(string content)
+    {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (string line in content.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None))
+        {
+            Match m = Line.Match(line);
+            if (!m.Success) continue;
+            string hex = m.Groups["val"].Value;
+            if (hex[0] != '#') hex = "#" + hex;
+            map[m.Groups["key"].Value] = hex; // key is already the mangled token; later duplicate wins
+        }
+        return map;
+    }
+}

--- a/src/Mail2Pst.Core/OutlookCategories/CategoryColorHasher.cs
+++ b/src/Mail2Pst.Core/OutlookCategories/CategoryColorHasher.cs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Globalization;
+using System.Text;
+
+namespace Mail2Pst.Core.OutlookCategories;
+
+/// <summary>Reproduces Thunderbird's category-colour logic so we can compute the colour Thunderbird
+/// shows for a category name (Thunderbird stores no default colours — it derives them).</summary>
+public static class CategoryColorHasher
+{
+    // Palette values observed in Thunderbird 140.12.1 calViewUtils.sys.mjs (hashColor).
+    // Factual compatibility data for category colour mapping; the algorithm is reproduced, not copied.
+    private static readonly string[] Palette =
+    {
+        "#FFFFFF", "#FFCCCC", "#FFCC99", "#FFFF99", "#FFFFCC", "#99FF99", "#99FFFF", "#CCFFFF", "#CCCCFF", "#FFCCFF",
+        "#CCCCCC", "#FF6666", "#FF9966", "#FFFF66", "#FFFF33", "#66FF99", "#33FFFF", "#66FFFF", "#9999FF", "#FF99FF",
+        "#C0C0C0", "#FF0000", "#FF9900", "#FFCC66", "#FFFF00", "#33FF33", "#66CCCC", "#33CCFF", "#6666CC", "#CC66CC",
+        "#999999", "#CC0000", "#FF6600", "#FFCC33", "#FFCC00", "#33CC00", "#00CCCC", "#3366FF", "#6633FF", "#CC33CC",
+        "#666666", "#990000", "#CC6600", "#CC9933", "#999900", "#009900", "#339999", "#3333FF", "#6600CC", "#993399",
+        "#333333", "#660000", "#993300", "#996633", "#666600", "#006600", "#336666", "#000099", "#333399", "#663366",
+        "#000000", "#330000", "#663300", "#663333", "#333300", "#003300", "#003333", "#000066", "#330099", "#330033",
+    };
+
+    /// <summary>Thunderbird hashColor: sum the first UTF-16 code unit of each code point of (name || " "),
+    /// index the 70-colour palette by (sum % 70). Reproduces JS Array.from(str, e =&gt; e.charCodeAt(0)).</summary>
+    public static string HashColor(string? name)
+    {
+        string s = string.IsNullOrEmpty(name) ? " " : name!;
+        int sum = 0;
+        foreach (Rune r in s.EnumerateRunes())
+            sum += char.ConvertFromUtf32(r.Value)[0]; // first UTF-16 unit: char for BMP, high surrogate otherwise
+        return Palette[sum % Palette.Length];
+    }
+
+    /// <summary>Thunderbird formatStringForCSSRule: lowercase, then space -&gt; "_", [a-z0-9] kept,
+    /// else "-ux" + lowercase-hex(charCode) + "-". Used to build the override-pref lookup key.</summary>
+    public static string FormatStringForCSSRule(string? name)
+    {
+        // Exact compatibility is guaranteed for ordinary ASCII/BMP names and the verified fixtures.
+        // ToLowerInvariant may diverge from JS toLowerCase() for rare Unicode case-folding edge cases;
+        // category names in practice do not hit those.
+        if (string.IsNullOrEmpty(name)) return string.Empty;
+        var sb = new StringBuilder(name!.Length);
+        foreach (char c in name!.ToLowerInvariant())
+        {
+            if (c == ' ') sb.Append('_');
+            else if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) sb.Append(c);
+            else sb.Append("-ux").Append(((int)c).ToString("x", CultureInfo.InvariantCulture)).Append('-');
+        }
+        return sb.ToString();
+    }
+}

--- a/src/Mail2Pst.Core/OutlookCategories/CategoryColorPlan.cs
+++ b/src/Mail2Pst.Core/OutlookCategories/CategoryColorPlan.cs
@@ -9,20 +9,31 @@ using Mail2Pst.Core.Msf;
 namespace Mail2Pst.Core.OutlookCategories;
 
 /// <summary>
-/// Builds the colour-import candidate list from a profile's prefs.js tag names + colours. Candidate set =
-/// the five built-in $labelN keys plus every key seen in names/colours. Name resolution matches the E4
-/// resolver (prefs name -> built-in $labelN default -> key). Colour = prefs .color -> built-in default for
-/// $labelN -> none. Names are validated against Outlook rules. Pure; Outlook-free.
+/// Builds the colour-import candidate list from a profile's prefs.js tag names + colours, optionally
+/// merged with calendar category colours. Candidate set = the five built-in $labelN keys plus every key
+/// seen in names/colours. Name resolution matches the E4 resolver (prefs name -> built-in $labelN default
+/// -> key). Colour = prefs .color -> built-in default for $labelN -> none. Names are validated against
+/// Outlook rules. Merge precedence: a coloured mail tag wins; an uncoloured mail tag is upgraded in place
+/// (list position kept) by a coloured calendar category of the same name; a calendar-only name is
+/// appended. Names de-dupe case-insensitively. Pure; Outlook-free.
 /// </summary>
 public static class CategoryColorPlan
 {
+    // Back-compat: mail tags only.
     public static IReadOnlyList<CategoryCandidate> Build(
         IReadOnlyDictionary<string, string> tagNames, IReadOnlyDictionary<string, string> tagColors)
+        => Build(tagNames, tagColors, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+
+    public static IReadOnlyList<CategoryCandidate> Build(
+        IReadOnlyDictionary<string, string> tagNames,
+        IReadOnlyDictionary<string, string> tagColors,
+        IReadOnlyDictionary<string, string> calendarCategoryColors)
     {
         ArgumentNullException.ThrowIfNull(tagNames);
         ArgumentNullException.ThrowIfNull(tagColors);
+        ArgumentNullException.ThrowIfNull(calendarCategoryColors);
 
-        // Deterministic order: the five built-ins first, then any other key (ordinal-sorted), distinct.
+        // Deterministic mail-tag order: the five built-ins first, then any other key (ordinal-sorted).
         var keys = new List<string>();
         var seenKey = new HashSet<string>(StringComparer.Ordinal);
         foreach (string k in MsfTagDefaults.BuiltinLabels.Keys)
@@ -31,27 +42,47 @@ public static class CategoryColorPlan
             if (!MsfTagDefaults.Filtered.Contains(k) && seenKey.Add(k)) keys.Add(k);
 
         var result = new List<CategoryCandidate>();
-        // OrdinalIgnoreCase (not E4's Ordinal): Outlook category names are case-insensitive.
-        var seenName = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var indexByName = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        // Pass 1: mail tags (behaviour identical to the old 2-arg path).
         foreach (string key in keys)
         {
             string name = tagNames.TryGetValue(key, out string? pref) ? pref
                 : MsfTagDefaults.BuiltinLabels.TryGetValue(key, out string? builtin) ? builtin
                 : key;
-            if (!seenName.Add(name)) continue; // ordinal-ignore-case de-dupe across keys
-
+            if (indexByName.ContainsKey(name)) continue;
             string? hex = tagColors.TryGetValue(key, out string? c) ? c
                 : MsfTagDefaults.BuiltinColors.TryGetValue(key, out string? bc) ? bc
                 : null;
+            indexByName[name] = result.Count;
+            result.Add(MakeCandidate(name, hex));
+        }
 
-            if (name.Length == 0 || name.Length > 255 || name.Contains(','))
-            { result.Add(new CategoryCandidate(name, hex, null, "skipped-invalid-name")); continue; }
-
-            if (hex is null || !OlCategoryColorMap.TryNearestIndex(hex, out int color))
-            { result.Add(new CategoryCandidate(name, hex, null, "skipped-no-colour")); continue; }
-
-            result.Add(new CategoryCandidate(name, hex, color, "would-add"));
+        // Pass 2: calendar categories. Coloured mail wins; an uncoloured mail tag is upgraded; new names append.
+        foreach (var kv in calendarCategoryColors)
+        {
+            CategoryCandidate cand = MakeCandidate(kv.Key, kv.Value);
+            if (indexByName.TryGetValue(kv.Key, out int idx))
+            {
+                if (result[idx].Action == "skipped-no-colour" && cand.Action == "would-add")
+                    result[idx] = cand; // upgrade in place, keeping list position
+                // else: coloured / invalid mail candidate wins -> skip the calendar entry
+            }
+            else
+            {
+                indexByName[kv.Key] = result.Count;
+                result.Add(cand);
+            }
         }
         return result;
+    }
+
+    private static CategoryCandidate MakeCandidate(string name, string? hex)
+    {
+        if (name.Length == 0 || name.Length > 255 || name.Contains(','))
+            return new CategoryCandidate(name, hex, null, "skipped-invalid-name");
+        if (hex is null || !OlCategoryColorMap.TryNearestIndex(hex, out int color))
+            return new CategoryCandidate(name, hex, null, "skipped-no-colour");
+        return new CategoryCandidate(name, hex, color, "would-add");
     }
 }

--- a/src/Mail2Pst.Core/Reporting/ConversionReport.cs
+++ b/src/Mail2Pst.Core/Reporting/ConversionReport.cs
@@ -35,6 +35,9 @@ public class ConversionReport
     private int _srcAttempted, _srcEnriched, _srcDegraded;
     private int _enrOrphanDropped, _lofEnabled, _lofDisabled, _lofDuplicates;
 
+    private readonly List<string> _calendarCategoryNames = new();
+    private readonly HashSet<string> _calendarCategorySeen = new(StringComparer.OrdinalIgnoreCase);
+
     public int ConvertedCount => Volatile.Read(ref _convertedCount);
 
     // Contact counters (Task 14 fills the full surface; Task 7 stub kept compatible).
@@ -64,6 +67,7 @@ public class ConversionReport
     public IReadOnlyList<SkippedMessage> Skipped { get { lock (_lock) return _skipped.ToArray(); } }
     public IReadOnlyList<SkippedMessage> Warnings { get { lock (_lock) return _warnings.ToArray(); } }
     public IReadOnlyList<string> OutputFiles { get { lock (_lock) return _outputFiles.ToArray(); } }
+    public IReadOnlyList<string> CalendarCategoryNames { get { lock (_lock) return _calendarCategoryNames.ToArray(); } }
 
     public void AddOutputFiles(IEnumerable<string> files)
     {
@@ -118,6 +122,22 @@ public class ConversionReport
     {
         Interlocked.Increment(ref _taskWarningCount);
         AddWarning(message);
+    }
+
+    /// <summary>Records category names written to appointments/tasks (global for the whole conversion;
+    /// Outlook's Master Category List is global, not per output group). De-dups case-insensitively,
+    /// keeping the first occurrence's casing; empties ignored.</summary>
+    public void RecordCalendarCategories(IEnumerable<string> names)
+    {
+        if (names is null) return;
+        lock (_lock)
+        {
+            foreach (string n in names)
+            {
+                if (string.IsNullOrWhiteSpace(n)) continue; // ignore empty/whitespace-only (would hash to hashColor(" "))
+                if (_calendarCategorySeen.Add(n)) _calendarCategoryNames.Add(n);
+            }
+        }
     }
 
     private void AddWarning(string message)

--- a/tests/Mail2Pst.Core.Tests/ConversionRunnerCalendarAttachmentTests.cs
+++ b/tests/Mail2Pst.Core.Tests/ConversionRunnerCalendarAttachmentTests.cs
@@ -155,6 +155,36 @@ public class ConversionRunnerCalendarAttachmentTests
     }
 
     // -----------------------------------------------------------------------
+    // Categories — the mapped AppointmentRecord.Categories must be accumulated
+    // onto the report (Outlook's Master Category List), not read from raw iCal.
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// An event with a CATEGORIES property must have those category names recorded
+    /// on the report's CalendarCategoryNames.
+    /// </summary>
+    [Fact]
+    public void Event_with_categories_records_category_names_on_report()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), $"m2p-runcat-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        string dbPath = MakeCalStoreWithCategories();
+        try
+        {
+            var report = RunConvertWith(dbPath, "test-cal", dir);
+
+            Assert.Equal(1, report.AppointmentsConverted);
+            Assert.Contains("Meeting", report.CalendarCategoryNames);
+            Assert.Contains("Suppliers", report.CalendarCategoryNames);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // Helpers — synthetic SQLite stores (no real mail/PII, all example.com).
     // -----------------------------------------------------------------------
 
@@ -232,6 +262,33 @@ public class ConversionRunnerCalendarAttachmentTests
         X("INSERT INTO cal_attachments (item_id,cal_id,recurrence_id,recurrence_id_tz,icalString) " +
           "VALUES ('inlineatt-01@example.com','test-cal',NULL,NULL," +
           "'ATTACH;FILENAME=hi.txt;VALUE=BINARY;ENCODING=BASE64;FMTTYPE=text/plain:aGk=');");
+
+        return path;
+    }
+
+    /// <summary>
+    /// A minimal Thunderbird calendar store with one event carrying a CATEGORIES property.
+    /// </summary>
+    private static string MakeCalStoreWithCategories()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"cal-categories-{Guid.NewGuid():N}.sqlite");
+        using var conn = new SqliteConnection($"Data Source={path}");
+        conn.Open();
+        CreateCalSchema(conn);
+
+        void X(string sql)
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = sql;
+            cmd.ExecuteNonQuery();
+        }
+
+        long start = MicrosFor(2026, 7, 9, 9, 0);
+        long end   = MicrosFor(2026, 7, 9, 10, 0);
+        X($"INSERT INTO cal_events (cal_id,id,title,flags,event_start,event_end,event_start_tz) " +
+          $"VALUES ('test-cal','categories-01@example.com','Categorised Event',0,{start},{end},'UTC');");
+        X("INSERT INTO cal_properties (item_id,cal_id,key,value,recurrence_id,recurrence_id_tz) " +
+          "VALUES ('categories-01@example.com','test-cal','CATEGORIES','Meeting,Suppliers',NULL,NULL);");
 
         return path;
     }

--- a/tests/Mail2Pst.Core.Tests/ConversionRunnerTaskTests.cs
+++ b/tests/Mail2Pst.Core.Tests/ConversionRunnerTaskTests.cs
@@ -94,6 +94,31 @@ public class ConversionRunnerTaskTests
         }
     }
 
+    /// <summary>
+    /// A todo with a CATEGORIES property must have those category names recorded
+    /// on the report's CalendarCategoryNames (mapped record, not raw iCal).
+    /// </summary>
+    [Fact]
+    public void Todo_with_categories_records_category_names_on_report()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), $"m2p-runtask-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        string dbPath = MakeTaskStoreWithCategories();
+        try
+        {
+            var report = RunConvertWith(dbPath, "test-cal", dir);
+
+            Assert.Equal(1, report.TasksConverted);
+            Assert.Contains("Meeting", report.CalendarCategoryNames);
+            Assert.Contains("Suppliers", report.CalendarCategoryNames);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------------
@@ -134,6 +159,42 @@ public class ConversionRunnerTaskTests
           $"VALUES ('test-cal','bysetpos-todo-01@example.com','Monthly Task',0,{due});");
         X("INSERT INTO cal_recurrence (item_id,cal_id,icalString) " +
           "VALUES ('bysetpos-todo-01@example.com','test-cal','RRULE:FREQ=MONTHLY;BYDAY=MO;BYSETPOS=-1');");
+
+        return path;
+    }
+
+    /// <summary>
+    /// A minimal Thunderbird calendar store with one todo carrying a CATEGORIES property.
+    /// </summary>
+    private static string MakeTaskStoreWithCategories()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"task-categories-{Guid.NewGuid():N}.sqlite");
+        using var conn = new SqliteConnection($"Data Source={path}");
+        conn.Open();
+
+        void X(string sql)
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = sql;
+            cmd.ExecuteNonQuery();
+        }
+
+        // Schema matching SqliteCalendarReader expectations.
+        X("CREATE TABLE cal_events (cal_id TEXT,id TEXT,time_created INTEGER,last_modified INTEGER,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,event_start INTEGER,event_end INTEGER,event_stamp INTEGER,event_start_tz TEXT,event_end_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,alarm_last_ack INTEGER,offline_journal INTEGER);");
+        X("CREATE TABLE cal_todos (cal_id TEXT,id TEXT,time_created INTEGER,last_modified INTEGER,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,todo_entry INTEGER,todo_due INTEGER,todo_completed INTEGER,todo_complete INTEGER,todo_entry_tz TEXT,todo_due_tz TEXT,todo_completed_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,alarm_last_ack INTEGER,todo_stamp INTEGER,offline_journal INTEGER);");
+        X("CREATE TABLE cal_recurrence (item_id TEXT,cal_id TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_attendees (item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_alarms (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_attachments (item_id TEXT,cal_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_relations (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_properties (item_id TEXT,key TEXT,value BLOB,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT);");
+        X("CREATE TABLE cal_parameters (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,key1 TEXT,key2 TEXT,value TEXT);");
+
+        long due = MicrosFor(2026, 7, 31);
+        X($"INSERT INTO cal_todos (cal_id,id,title,flags,todo_due) " +
+          $"VALUES ('test-cal','categories-todo-01@example.com','Categorised Task',0,{due});");
+        X("INSERT INTO cal_properties (item_id,cal_id,key,value,recurrence_id,recurrence_id_tz) " +
+          "VALUES ('categories-todo-01@example.com','test-cal','CATEGORIES','Meeting,Suppliers',NULL,NULL);");
 
         return path;
     }

--- a/tests/Mail2Pst.Core.Tests/OutlookCategories/CalendarCategoryColorResolverTests.cs
+++ b/tests/Mail2Pst.Core.Tests/OutlookCategories/CalendarCategoryColorResolverTests.cs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Collections.Generic;
+using Mail2Pst.Core.OutlookCategories;
+using Xunit;
+
+public class CalendarCategoryColorResolverTests
+{
+    private static readonly Dictionary<string, string> NoOverrides = new();
+
+    [Fact]
+    public void Uses_hashColor_when_no_override()
+    {
+        var r = CalendarCategoryColorResolver.Resolve(new[] { "Meeting", "Suppliers" }, NoOverrides);
+        Assert.Equal("#FFFF66", r["Meeting"]);
+        Assert.Equal("#000099", r["Suppliers"]);
+    }
+
+    [Fact]
+    public void Override_wins_over_hashColor()
+    {
+        var overrides = new Dictionary<string, string> { ["meeting"] = "#010203" }; // key = mangled "Meeting"
+        var r = CalendarCategoryColorResolver.Resolve(new[] { "Meeting" }, overrides);
+        Assert.Equal("#010203", r["Meeting"]);
+    }
+
+    [Fact]
+    public void Case_insensitive_dedup_first_occurrence_wins()
+    {
+        var r = CalendarCategoryColorResolver.Resolve(new[] { "Vacation", "vacation" }, NoOverrides);
+        Assert.Single(r);
+        Assert.True(r.ContainsKey("Vacation")); // first occurrence casing kept
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/OutlookCategories/CalendarCategoryOverrideReaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/OutlookCategories/CalendarCategoryOverrideReaderTests.cs
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using Mail2Pst.Core.OutlookCategories;
+using Xunit;
+
+public class CalendarCategoryOverrideReaderTests
+{
+    [Fact]
+    public void Reads_category_color_overrides()
+    {
+        string prefs =
+            "user_pref(\"calendar.category.color.meeting\", \"#123456\");\n" +
+            "user_pref(\"calendar.category.color.follow_up\", \"AABBCC\");\n"; // no leading # -> normalised
+        var map = CalendarCategoryOverrideReader.ParseText(prefs);
+        Assert.Equal("#123456", map["meeting"]);
+        Assert.Equal("#AABBCC", map["follow_up"]);
+    }
+
+    [Fact]
+    public void Ignores_per_calendar_source_colours_and_unrelated_prefs()
+    {
+        // The owner's real shape: per-calendar source colours + mail-tag colours, NO category colours.
+        string prefs =
+            "user_pref(\"calendar.registry.94e695bc.color\", \"#ff0080\");\n" +
+            "user_pref(\"mailnews.tags.$label1.color\", \"#FF0000\");\n";
+        Assert.Empty(CalendarCategoryOverrideReader.ParseText(prefs));
+    }
+
+    [Fact]
+    public void Tolerates_whitespace_and_optional_semicolon()
+    {
+        string prefs = "  user_pref( \"calendar.category.color.follow_up\" , \"#AABBCC\" ) ;  \n";
+        Assert.Equal("#AABBCC", CalendarCategoryOverrideReader.ParseText(prefs)["follow_up"]);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/OutlookCategories/CategoryColorHasherTests.cs
+++ b/tests/Mail2Pst.Core.Tests/OutlookCategories/CategoryColorHasherTests.cs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using Mail2Pst.Core.OutlookCategories;
+using Xunit;
+
+public class CategoryColorHasherTests
+{
+    [Theory]
+    [InlineData("Meeting", "#FFFF66")]    // verified against Thunderbird UI (yellow)
+    [InlineData("Suppliers", "#000099")]  // verified against Thunderbird UI (dark blue)
+    [InlineData("", "#FF6600")]           // empty -> " " (code 32) -> idx 32
+    public void HashColor_matches_thunderbird(string name, string expected)
+    {
+        Assert.Equal(expected, CategoryColorHasher.HashColor(name));
+    }
+
+    [Fact]
+    public void HashColor_nonBMP_sums_only_high_surrogate_per_codepoint()
+    {
+        // "🎂" (U+1F382) -> one code point -> its first UTF-16 unit is the high surrogate 0xD83C (55356).
+        // 55356 % 70 == 56 -> palette[56] == "#336666". (Summing BOTH surrogates would give a different index.)
+        Assert.Equal("#336666", CategoryColorHasher.HashColor("🎂"));
+    }
+
+    [Theory]
+    [InlineData("Meeting", "meeting")]
+    [InlineData("Follow up", "follow_up")]
+    [InlineData("Grab E-Receipt", "grab_e-ux2d-receipt")]
+    [InlineData("Café", "caf-uxe9-")]
+    public void FormatStringForCSSRule_matches_thunderbird(string name, string expected)
+    {
+        Assert.Equal(expected, CategoryColorHasher.FormatStringForCSSRule(name));
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/OutlookCategories/CategoryColorPlanTests.cs
+++ b/tests/Mail2Pst.Core.Tests/OutlookCategories/CategoryColorPlanTests.cs
@@ -74,3 +74,60 @@ public class CategoryColorPlanTests
         Assert.DoesNotContain(plan, c => c.Name == "NonJunk");
     }
 }
+
+public class CategoryColorPlanCalendarMergeTests
+{
+    private static readonly Dictionary<string, string> NoMailNames = new();
+    private static readonly Dictionary<string, string> NoMailColors = new();
+
+    [Fact]
+    public void Calendar_only_category_is_added_would_add()
+    {
+        var cal = new Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase) { ["Meeting"] = "#FFFF66" };
+        var plan = CategoryColorPlan.Build(NoMailNames, NoMailColors, cal);
+        var m = System.Linq.Enumerable.Single(plan, c => c.Name == "Meeting");
+        Assert.Equal("would-add", m.Action);
+        Assert.NotNull(m.OutlookColor);
+    }
+
+    [Fact]
+    public void Coloured_mail_tag_wins_over_calendar_same_name()
+    {
+        var mailNames = new Dictionary<string, string> { ["$label1"] = "Work" };
+        var mailColors = new Dictionary<string, string> { ["$label1"] = "#FF0000" };
+        var cal = new Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase) { ["Work"] = "#00FF00" };
+        var plan = CategoryColorPlan.Build(mailNames, mailColors, cal);
+        var work = System.Linq.Enumerable.Single(plan, c => c.Name == "Work");
+        Assert.Equal("#FF0000", work.Hex); // mail colour kept
+    }
+
+    [Fact]
+    public void Uncoloured_mail_tag_is_upgraded_by_calendar_colour()
+    {
+        var mailNames = new Dictionary<string, string> { ["custom1"] = "Trips" };
+        var mailColors = new Dictionary<string, string>(); // no colour for "Trips"
+        var cal = new Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase) { ["Trips"] = "#3333FF" };
+        var plan = CategoryColorPlan.Build(mailNames, mailColors, cal);
+        var trips = System.Linq.Enumerable.Single(plan, c => c.Name == "Trips");
+        Assert.Equal("would-add", trips.Action);
+        Assert.Equal("#3333FF", trips.Hex); // upgraded in place
+    }
+
+    [Fact]
+    public void Two_arg_and_empty_calendar_three_arg_are_identical_builtins_and_custom()
+    {
+        // No-regression: a realistic mail-tag set (a renamed built-in label + a custom tag) must produce
+        // an IDENTICAL plan via the 2-arg path and the 3-arg path with an empty calendar map.
+        var mailNames = new Dictionary<string, string> { ["$label2"] = "Work", ["custom_a"] = "Receipts" };
+        var mailColors = new Dictionary<string, string> { ["$label2"] = "#FF0000", ["custom_a"] = "#00FF00" };
+        var viaTwo = CategoryColorPlan.Build(mailNames, mailColors);
+        var viaThree = CategoryColorPlan.Build(mailNames, mailColors,
+            new Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase));
+        Assert.Equal(
+            System.Linq.Enumerable.Select(viaTwo, c => (c.Name, c.Hex, c.OutlookColor, c.Action)),
+            System.Linq.Enumerable.Select(viaThree, c => (c.Name, c.Hex, c.OutlookColor, c.Action)));
+        // And it is non-trivial: the built-in $labelN set plus the custom tag all appear.
+        Assert.Contains(viaTwo, c => c.Name == "Work");
+        Assert.Contains(viaTwo, c => c.Name == "Receipts");
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Reporting/ConversionReportCategoriesTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Reporting/ConversionReportCategoriesTests.cs
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using Mail2Pst.Core.Reporting;
+using Xunit;
+
+public class ConversionReportCategoriesTests
+{
+    [Fact]
+    public void Accumulates_distinct_first_casing_preserved()
+    {
+        var r = new ConversionReport();
+        r.RecordCalendarCategories(new[] { "Meeting", "Suppliers" });
+        r.RecordCalendarCategories(new[] { "meeting", "", "   " }); // dup (case-insensitive) + empty + whitespace-only ignored
+        Assert.Equal(new[] { "Meeting", "Suppliers" }, r.CalendarCategoryNames);
+    }
+
+    [Fact]
+    public void Empty_by_default()
+    {
+        Assert.Empty(new ConversionReport().CalendarCategoryNames);
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/ConvertCommandColourPlanTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/ConvertCommandColourPlanTests.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using Mail2Pst.Cli;
+using Microsoft.Data.Sqlite;
 using Xunit;
 
 namespace Mail2Pst.Integration.Tests;
@@ -30,6 +31,120 @@ public class ConvertCommandColourPlanTests
             JsonSerializer.Serialize(mbox) + ",\"type\":\"mbox\"}]}]" +
             profilePart + "}");
         return cfg;
+    }
+
+    // -----------------------------------------------------------------------
+    // Calendar-only config (no mail source) — a synthetic Thunderbird calendar
+    // SQLite store, mirroring ConversionRunnerCalendarAttachmentTests' schema.
+    // -----------------------------------------------------------------------
+
+    private static string CreateCalendarConfig(string dir, string storePath, string? profilePath)
+    {
+        string cfg = Path.Combine(dir, "config.json");
+        string profilePart = profilePath is not null
+            ? ",\"profilePath\":" + JsonSerializer.Serialize(profilePath)
+            : "";
+        File.WriteAllText(cfg,
+            "{\"outputs\":[{\"name\":\"Out\",\"sources\":[],\"calendars\":[{" +
+            "\"storePath\":" + JsonSerializer.Serialize(storePath) + "," +
+            "\"calId\":\"test-cal\"," +
+            "\"includeAppointments\":true," +
+            "\"includeTasks\":false" +
+            "}]}]" + profilePart + "}");
+        return cfg;
+    }
+
+    private static void CreateCalSchema(SqliteConnection conn)
+    {
+        void X(string sql)
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = sql;
+            cmd.ExecuteNonQuery();
+        }
+
+        X("CREATE TABLE cal_events (cal_id TEXT,id TEXT,time_created INTEGER,last_modified INTEGER,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,event_start INTEGER,event_end INTEGER,event_stamp INTEGER,event_start_tz TEXT,event_end_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,alarm_last_ack INTEGER,offline_journal INTEGER);");
+        X("CREATE TABLE cal_todos (cal_id TEXT,id TEXT,time_created INTEGER,last_modified INTEGER,title TEXT,priority INTEGER,privacy TEXT,ical_status TEXT,flags INTEGER,todo_entry INTEGER,todo_due INTEGER,todo_completed INTEGER,todo_complete INTEGER,todo_entry_tz TEXT,todo_due_tz TEXT,todo_completed_tz TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,alarm_last_ack INTEGER,todo_stamp INTEGER,offline_journal INTEGER);");
+        X("CREATE TABLE cal_recurrence (item_id TEXT,cal_id TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_attendees (item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_alarms (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_attachments (item_id TEXT,cal_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_relations (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,icalString TEXT);");
+        X("CREATE TABLE cal_properties (item_id TEXT,key TEXT,value BLOB,recurrence_id INTEGER,recurrence_id_tz TEXT,cal_id TEXT);");
+        X("CREATE TABLE cal_parameters (cal_id TEXT,item_id TEXT,recurrence_id INTEGER,recurrence_id_tz TEXT,key1 TEXT,key2 TEXT,value TEXT);");
+    }
+
+    /// <summary>A calendar store with one event carrying CATEGORIES "Meeting,Suppliers".</summary>
+    private static string CreateCalStoreWithCategories(string dir)
+    {
+        string path = Path.Combine(dir, "cal-categories.sqlite");
+        using var conn = new SqliteConnection($"Data Source={path}");
+        conn.Open();
+        CreateCalSchema(conn);
+
+        void X(string sql)
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = sql;
+            cmd.ExecuteNonQuery();
+        }
+
+        // 2026-07-09 09:00-10:00 UTC as PRTime microseconds.
+        const long Start = 1752051600000000L;
+        const long End = 1752055200000000L;
+        X($"INSERT INTO cal_events (cal_id,id,title,flags,event_start,event_end,event_start_tz) " +
+          $"VALUES ('test-cal','categories-01@example.com','Categorised Event',0,{Start},{End},'UTC');");
+        X("INSERT INTO cal_properties (item_id,cal_id,key,value,recurrence_id,recurrence_id_tz) " +
+          "VALUES ('categories-01@example.com','test-cal','CATEGORIES','Meeting,Suppliers',NULL,NULL);");
+
+        return path;
+    }
+
+    /// <summary>A calendar store with one event that has NO categories.</summary>
+    private static string CreateCalStoreWithoutCategories(string dir)
+    {
+        string path = Path.Combine(dir, "cal-nocategories.sqlite");
+        using var conn = new SqliteConnection($"Data Source={path}");
+        conn.Open();
+        CreateCalSchema(conn);
+
+        void X(string sql)
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = sql;
+            cmd.ExecuteNonQuery();
+        }
+
+        const long Start = 1752051600000000L;
+        const long End = 1752055200000000L;
+        X($"INSERT INTO cal_events (cal_id,id,title,flags,event_start,event_end,event_start_tz) " +
+          $"VALUES ('test-cal','plain-01@example.com','Plain Event',0,{Start},{End},'UTC');");
+
+        return path;
+    }
+
+    private static JsonElement RunConvertAndGetColourPlan(string cfg, string outDir)
+    {
+        var sw = new StringWriter();
+        TextWriter original = Console.Out;
+        Console.SetOut(sw);
+        try
+        {
+            int exit = ConvertCommand.Run(new[] { "--config", cfg, "--output", outDir });
+            Assert.Equal(0, exit);
+
+            string done = sw.ToString().Split('\n').First(l => l.Contains("\"type\":\"done\""));
+            using var doc = JsonDocument.Parse(done);
+            var root = doc.RootElement;
+
+            Assert.True(root.TryGetProperty("colourPlan", out JsonElement plan), "done must have colourPlan");
+            Assert.Equal(JsonValueKind.Array, plan.ValueKind);
+            return plan.Clone();
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
     }
 
     [Fact]
@@ -107,6 +222,124 @@ public class ConvertCommandColourPlanTests
         finally
         {
             Console.SetOut(original);
+            Directory.Delete(dir, true);
+        }
+    }
+
+    /// <summary>
+    /// Converted calendar events carrying CATEGORIES "Meeting"/"Suppliers" must surface as
+    /// colour-plan candidates (Thunderbird's computed hash colours, since no override is set).
+    /// </summary>
+    [Fact]
+    public void Convert_WithCalendarCategories_ColourPlanContainsCalendarCategoryColours()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "mail2pst-colour-cal-" + Guid.NewGuid());
+        Directory.CreateDirectory(dir);
+        string profileDir = Path.Combine(dir, "profile");
+        Directory.CreateDirectory(profileDir);
+
+        // No overrides — resolver falls back to Thunderbird's computed hash colours.
+        File.WriteAllText(Path.Combine(profileDir, "prefs.js"), "");
+
+        string dbPath = CreateCalStoreWithCategories(dir);
+        string cfg = CreateCalendarConfig(dir, dbPath, profileDir);
+        string outDir = Path.Combine(dir, "out");
+
+        try
+        {
+            JsonElement plan = RunConvertAndGetColourPlan(cfg, outDir);
+
+            var meeting = plan.EnumerateArray().FirstOrDefault(e =>
+                e.TryGetProperty("name", out var n) && n.GetString() == "Meeting");
+            Assert.NotEqual(default, meeting);
+            Assert.Equal("#FFFF66", meeting.GetProperty("hex").GetString());
+            Assert.Equal("would-add", meeting.GetProperty("action").GetString());
+
+            var suppliers = plan.EnumerateArray().FirstOrDefault(e =>
+                e.TryGetProperty("name", out var n) && n.GetString() == "Suppliers");
+            Assert.NotEqual(default, suppliers);
+            Assert.Equal("#000099", suppliers.GetProperty("hex").GetString());
+            Assert.Equal("would-add", suppliers.GetProperty("action").GetString());
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    /// <summary>
+    /// No-regression case: a profile with mail tags but NO calendar/task categories must
+    /// produce the same colourPlan as the pre-change (mail-tags-only) code path.
+    /// </summary>
+    [Fact]
+    public void Convert_WithMailTagsButNoCalendarCategories_ColourPlanUnchanged()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "mail2pst-colour-noregr-" + Guid.NewGuid());
+        Directory.CreateDirectory(dir);
+        string profileDir = Path.Combine(dir, "profile");
+        Directory.CreateDirectory(profileDir);
+
+        File.WriteAllText(Path.Combine(profileDir, "prefs.js"),
+            "user_pref(\"mailnews.tags.$label1.tag\", \"Important\");\n" +
+            "user_pref(\"mailnews.tags.$label1.color\", \"#FF0000\");\n");
+
+        string mbox = CreateMinimalMbox(dir);
+        string cfg = CreateConfig(dir, mbox, profileDir);
+        string outDir = Path.Combine(dir, "out");
+
+        try
+        {
+            JsonElement plan = RunConvertAndGetColourPlan(cfg, outDir);
+
+            // Mail-only conversion (no calendar sources) -> report.CalendarCategoryNames is empty,
+            // so the merge in CategoryColorPlan.Build's 3-arg overload contributes nothing: the
+            // plan must be identical in shape/content to the mail-tags-only (2-arg) behaviour.
+            var entries = plan.EnumerateArray().ToList();
+            var important = Assert.Single(entries, e =>
+                e.TryGetProperty("name", out var n) && n.GetString() == "Important");
+            Assert.Equal("#FF0000", important.GetProperty("hex").GetString());
+            Assert.Equal("would-add", important.GetProperty("action").GetString());
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    /// <summary>
+    /// Source-colour guard: a prefs.js with a per-calendar source colour
+    /// (calendar.registry.&lt;uuid&gt;.color) must never surface as a colour-plan candidate —
+    /// that pref is a calendar *source* colour, not a category colour, and the converted
+    /// item carries no categories either.
+    /// </summary>
+    [Fact]
+    public void Convert_WithCalendarRegistrySourceColourButNoCategories_NeverAppearsInColourPlan()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "mail2pst-colour-guard-" + Guid.NewGuid());
+        Directory.CreateDirectory(dir);
+        string profileDir = Path.Combine(dir, "profile");
+        Directory.CreateDirectory(profileDir);
+
+        // A per-calendar source colour (NOT a category colour) — must be ignored entirely.
+        const string SourceColour = "#FF0080";
+        File.WriteAllText(Path.Combine(profileDir, "prefs.js"),
+            "user_pref(\"calendar.registry.94e695bc.color\", \"" + SourceColour + "\");\n");
+
+        string dbPath = CreateCalStoreWithoutCategories(dir);
+        string cfg = CreateCalendarConfig(dir, dbPath, profileDir);
+        string outDir = Path.Combine(dir, "out");
+
+        try
+        {
+            JsonElement plan = RunConvertAndGetColourPlan(cfg, outDir);
+
+            // The store's per-calendar source colour must never leak into the colour plan
+            // (built-in mail-tag candidates with no colour are allowed; that colour specifically must not appear).
+            Assert.DoesNotContain(plan.EnumerateArray(), e =>
+                e.TryGetProperty("hex", out var h) && h.GetString() == SourceColour);
+        }
+        finally
+        {
             Directory.Delete(dir, true);
         }
     }


### PR DESCRIPTION
## Problem

Converted calendar events and tasks carry their Thunderbird categories into the PST, but the optional "Import colours" step only knew about mail-tag colours — calendar/task categories landed in Outlook uncoloured. Thunderbird stores no default category colours at all: it derives them from the category name at render time, so there is nothing on the items to read.

## Fix

Reproduce Thunderbird's colour derivation in the engine and merge the results into the existing colour plan:

- `CategoryColorHasher` — exact reproduction of Thunderbird's `hashColor` (70-colour palette indexed by a per-code-point char-code sum) and `formatStringForCSSRule` key-mangling, verified against TB 140.12.1 fixtures (`Meeting` -> `#FFFF66`, `Suppliers` -> `#000099`) including non-BMP input.
- `CalendarCategoryOverrideReader` — reads user-set `calendar.category.color.<mangled>` overrides from prefs.js; per-calendar `calendar.registry.<uuid>.color` source colours are never read.
- `CalendarCategoryColorResolver` — override ?? computed default, case-insensitive de-dup.
- `ConversionReport.RecordCalendarCategories` + `ConversionRunner` wiring — accumulates the categories actually written to converted appointments/tasks (global, since Outlook's master list is global).
- `CategoryColorPlan.Build` 3-arg overload — merges calendar categories into the mail-tag plan: a coloured mail tag wins, an uncoloured mail tag is upgraded in place, calendar-only names append. The 2-arg path is behaviour-identical (locked by a full-tuple equality regression test).
- `ConvertCommand.BuildColourPlan` — emits the merged plan after the run completes.

No CLI-contract/schemaVersion change (colourPlan just carries more entries), no writer change, no GUI change; the standalone `import-colours --profile` stays mail-tags-only. Also rides along: `.gitignore` entries for local graphify/dev artifacts.

## Verification

- Full solution green: Core 1226 passed / Integration 90 passed / 0 failed; desktop 266/266 + build clean; leak-check clean over the branch.
- E2E on a real profile with a 29-item synthetic iCalendar corpus: emitted colourPlan matched every predicted value exactly (computed defaults, override precedence, mail-tag-wins on name collisions, comma-in-name category correctly `skipped-invalid-name`); colours verified rendering in classic Outlook.
- Field-level fidelity audit of the corpus (ICS -> Thunderbird sqlite -> PST) found no regressions from this branch.