### PR TITLE
chore(release): v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] — 2026-07-08
+
 ### Fixed
 - **Converted PSTs now pass `scanpst.exe` (Microsoft's Inbox Repair Tool) with zero findings.**
   Previously every written message tripped scanpst's contents-table cross-check
@@ -23,6 +25,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   message list — the same behaviour Outlook itself exhibits for mail received with inline images.
   (Previously the flag was cleared to avoid the paperclip, which made every such message a
   scanpst repair-required finding.)
+- **Converted PSTs larger than ~2 GB now also pass `scanpst.exe` cleanly.** The Free Page Map
+  (FPMap) allocation page — which only exists once a store grows past ~2 GB — was written at the
+  wrong slot of its allocation interval, which orphaned it and let a message block overwrite the
+  location `scanpst` validates it in; the header free-space counter (`cbAMapFree`) also drifted at
+  that scale. The FPMap is now placed correctly and `cbAMapFree` is recomputed from the allocation
+  bitmaps at close, so a real 3.8 GB profile conversion scans with zero findings. (Smaller PSTs
+  were already clean — this only surfaced at multi-gigabyte scale.)
+- **Converting a Thunderbird/IMAP account whose folder is named "Deleted Items" no longer aborts
+  the run.** A source folder matching a name the blank store already seeds was rejected mid-
+  conversion; those folders are now adopted, so the account's deleted mail lands in the PST's
+  Deleted Items folder.
+- **Desktop: the conversion progress bar now tracks the percentage accurately.** During large
+  conversions the bar lagged far behind the number; it now advances in step with it.
+
+### Changed
+- **Desktop: the Review step lists the largest folders first**, so big inboxes are at the top and
+  empty or skipped folders sink to the bottom.
 
 ## [0.3.0] — 2026-07-07
 

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.2.2",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.2.2",
+      "version": "0.3.1",
       "dependencies": {
         "@radix-ui/react-slot": "^1.3.0",
         "@tauri-apps/api": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.3.0"
+version = "0.3.1"
 description = "ContinuMail Converter — convert mbox mail archives to Outlook PST"
 authors = ["Aksel Visby <aksel@visby.it>"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ContinuMail Converter",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "com.continumail.converter",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/Mail2Pst.Cli/Mail2Pst.Cli.csproj
+++ b/src/Mail2Pst.Cli/Mail2Pst.Cli.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Mail2Pst.Cli</RootNamespace>
-    <Version>0.3.0</Version>
+    <Version>0.3.1</Version>
     <!-- Server GC: measured win on the parallel byte-range scan (4.5 GB gmail corpus:
          ~19s -> ~13.5s wall-clock, ~30% faster). Peak working set rises 163 -> 314 MB,
          still size-independent and modest. See docs/pst-engine-benchmarks.md. -->


### PR DESCRIPTION
Bug-fix release. Version bump `0.3.0 → 0.3.1` (package.json, tauri.conf.json, Cargo.toml, Cargo.lock, CLI csproj; also fixes package-lock.json, left at 0.2.2 by the 0.3.0 cut) + changelog roll.

Rolls up everything on `main` since 0.3.0:
- **scanpst-clean writer arc** — `PidTagMessageSize` on-disk size + 5 real-corpus findings; inline-CID `MSGFLAG_HASATTACH` (already staged in Unreleased).
- **Large-PST allocation fix (PR #61)** — FPMap page placement + `cbAMapFree` reconciliation; converted PSTs > 2 GB now scan scanpst-clean (verified on a real 3.8 GB conversion).
- **Deleted Items** folder adoption — no more mid-run abort.
- **Desktop** — progress bar ↔ percentage sync; Review step sorts largest folders first.

No functional code changes in this PR — version + changelog only; the fixes already merged via PR #61 and the scanpst arc.