### PR TITLE
fix: scan large Thunderbird profiles — pass inputs via file, not argv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.1] — 2026-07-08
 
 ### Fixed
+- **Scanning a large Thunderbird profile no longer fails with "The filename or extension is too
+  long. (os error 206)"** ([#66]). The desktop app passed every discovered mail folder to the
+  engine as a command-line argument, so profiles with roughly 250+ folders exceeded Windows'
+  32,767-character command-line limit and the scan could not even start. The app now hands the
+  folder list to the engine through a temporary file, via a new additive `scan --input-list <file>`
+  CLI flag (one path per line; combines with the existing repeatable `--input`).
+
+[#66]: https://github.com/ContinuMail/continumail-converter/issues/66
 - **Converted PSTs now pass `scanpst.exe` (Microsoft's Inbox Repair Tool) with zero findings.**
   Previously every written message tripped scanpst's contents-table cross-check
   ("row doesn't match sub-object" → *errors were found, repair*), because the writer stored a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Scanning a large Thunderbird profile no longer fails with "The filename or extension is too
+  long. (os error 206)"**
+  ([#66](https://github.com/ContinuMail/continumail-converter/issues/66)). The desktop app passed
+  every discovered mail folder to the engine as a command-line argument, so profiles with roughly
+  250+ folders exceeded Windows' 32,767-character command-line limit and the scan could not even
+  start. The app now hands the folder list to the engine through a temporary file, via a new
+  additive `scan --input-list <file>` CLI flag (one path per line; combines with the existing
+  repeatable `--input`).
+
 ## [0.3.1] — 2026-07-08
 
 ### Fixed
-- **Scanning a large Thunderbird profile no longer fails with "The filename or extension is too
-  long. (os error 206)"** ([#66]). The desktop app passed every discovered mail folder to the
-  engine as a command-line argument, so profiles with roughly 250+ folders exceeded Windows'
-  32,767-character command-line limit and the scan could not even start. The app now hands the
-  folder list to the engine through a temporary file, via a new additive `scan --input-list <file>`
-  CLI flag (one path per line; combines with the existing repeatable `--input`).
-
-[#66]: https://github.com/ContinuMail/continumail-converter/issues/66
 - **Converted PSTs now pass `scanpst.exe` (Microsoft's Inbox Repair Tool) with zero findings.**
   Previously every written message tripped scanpst's contents-table cross-check
   ("row doesn't match sub-object" → *errors were found, repair*), because the writer stored a

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -39,14 +39,25 @@ fn drain_lines(buf: &mut String) -> Vec<String> {
 // `--progress` (the Rust reader consumes the advisory `scanProgress` lines plus
 // the final authoritative `scan` object). Pure + unit-tested so the contract the
 // sidecar is invoked with can't drift silently.
-fn scan_args(paths: &[String]) -> Vec<String> {
-    let mut args: Vec<String> = vec!["scan".into()];
-    for p in paths {
-        args.push("--input".into());
-        args.push(p.clone());
-    }
-    args.push("--progress".into());
-    args
+// Scan inputs are handed to the engine via a temp file (--input-list) rather than
+// one --input argument per path: a Thunderbird profile can hold hundreds of mail
+// folders, and per-path args blew past the Windows 32,767-char CreateProcess limit
+// ("os error 206", GitHub issue #66).
+fn scan_args(input_list_path: &str) -> Vec<String> {
+    vec![
+        "scan".into(),
+        "--input-list".into(),
+        input_list_path.into(),
+        "--progress".into(),
+    ]
+}
+
+/// The --input-list file body: one path per line (paths cannot contain newlines
+/// on any supported filesystem).
+fn scan_input_list_content(paths: &[String]) -> String {
+    let mut content = paths.join("\n");
+    content.push('\n');
+    content
 }
 
 // The exact CLI argument vector for a conversion run. `expected_total`, when present,
@@ -162,15 +173,36 @@ async fn start_scan(
         return Err("A scan is already running.".into());
     }
 
-    let args = scan_args(&paths);
+    // Write the input paths to a UNIQUE temp file the sidecar will read (per-run
+    // name avoids collisions with stale files / a second app instance).
+    let unique = format!(
+        "{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    );
+    let list_path = std::env::temp_dir().join(format!("continumail-scan-inputs-{unique}.txt"));
+    std::fs::write(&list_path, scan_input_list_content(&paths))
+        .map_err(|e| format!("cannot write input list: {e}"))?;
+    let list_path_str = list_path.to_string_lossy().to_string();
 
+    // On any failure to launch the sidecar, remove the temp list we just wrote — the
+    // async reader task (which owns cleanup on normal exit) never starts in that case.
     let (mut rx, child) = app
         .shell()
         .sidecar("mail2pst-cli")
-        .map_err(|e| format!("sidecar not found: {e}"))?
-        .args(args)
+        .map_err(|e| {
+            let _ = std::fs::remove_file(&list_path);
+            format!("sidecar not found: {e}")
+        })?
+        .args(scan_args(&list_path_str))
         .spawn()
-        .map_err(|e| format!("failed to start engine: {e}"))?;
+        .map_err(|e| {
+            let _ = std::fs::remove_file(&list_path);
+            format!("failed to start engine: {e}")
+        })?;
 
     // Store the child BEFORE the reader task starts.
     *state.0.lock().unwrap() = Some(child);
@@ -202,6 +234,7 @@ async fn start_scan(
                     }
                     buf.clear();
                     *app_for_task.state::<ScanState>().0.lock().unwrap() = None;
+                    let _ = std::fs::remove_file(&list_path);
                     let _ = app_for_task.emit("scan://exit", payload.code);
                 }
                 _ => {}
@@ -209,13 +242,14 @@ async fn start_scan(
         }
         // Defensive: if the stream ended WITHOUT a Terminated event, no exit was
         // emitted and the frontend Promise would hang forever. Flush any partial
-        // line, clear the slot, and emit a synthetic failure so it rejects.
+        // line, clear the slot + temp file, and emit a synthetic failure so it rejects.
         if !terminated {
             let rest = buf.trim_end_matches(|c| c == '\r' || c == '\n').to_string();
             if !rest.is_empty() {
                 let _ = app_for_task.emit("scan://line", rest);
             }
             *app_for_task.state::<ScanState>().0.lock().unwrap() = None;
+            let _ = std::fs::remove_file(&list_path);
             let _ = app_for_task.emit(
                 "scan://stderr",
                 "Scan process ended without a termination event.".to_string(),
@@ -656,21 +690,25 @@ Path=Profiles/xyz.dev\n";
 
 #[cfg(test)]
 mod tests {
-    use super::{convert_args, drain_lines, scan_args};
+    use super::{convert_args, drain_lines, scan_args, scan_input_list_content};
 
+    // Scan inputs travel via a temp file (--input-list), NOT as one command-line
+    // argument per path: a Thunderbird profile can hold hundreds of mail folders,
+    // and repeated --input args blew past the Windows 32,767-char CreateProcess
+    // limit ("os error 206", GitHub issue #66).
     #[test]
-    fn scan_args_one_input_passes_progress_flag() {
+    fn scan_args_passes_input_list_file_and_progress_flag() {
         assert_eq!(
-            scan_args(&["a.mbox".to_string()]),
-            vec!["scan", "--input", "a.mbox", "--progress"]
+            scan_args("C:/tmp/inputs.txt"),
+            vec!["scan", "--input-list", "C:/tmp/inputs.txt", "--progress"]
         );
     }
 
     #[test]
-    fn scan_args_repeats_input_flag_per_path_in_order() {
+    fn scan_input_list_content_is_one_path_per_line() {
         assert_eq!(
-            scan_args(&["a.mbox".to_string(), "b.mbox".to_string()]),
-            vec!["scan", "--input", "a.mbox", "--input", "b.mbox", "--progress"]
+            scan_input_list_content(&["a.mbox".to_string(), "b.mbox".to_string()]),
+            "a.mbox\nb.mbox\n"
         );
     }
 
@@ -734,7 +772,7 @@ mod tests {
 // `cargo test` — not currently wired into CI (see roadmap: add a cargo-test job).
 #[cfg(test)]
 mod sidecar_integration_tests {
-    use super::{drain_lines, scan_args};
+    use super::{drain_lines, scan_args, scan_input_list_content};
     use std::path::PathBuf;
     use std::process::Command;
 
@@ -805,8 +843,21 @@ mod sidecar_integration_tests {
             return;
         }
 
-        let args = scan_args(&[sample.to_string_lossy().to_string()]);
+        // Exercise the REAL contract: paths go via a temp --input-list file,
+        // exactly as start_scan hands them to the sidecar.
+        let list_path = std::env::temp_dir().join(format!(
+            "continumail-scan-inputs-test-{}.txt",
+            std::process::id()
+        ));
+        std::fs::write(
+            &list_path,
+            scan_input_list_content(&[sample.to_string_lossy().to_string()]),
+        )
+        .expect("write input list");
+
+        let args = scan_args(&list_path.to_string_lossy());
         let (code, lines) = run(&prog, &lead, &args);
+        let _ = std::fs::remove_file(&list_path);
         assert_eq!(code, 0, "scan should exit 0");
         assert!(!lines.is_empty(), "scan --progress emits at least the final scan line");
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -52,12 +52,28 @@ fn scan_args(input_list_path: &str) -> Vec<String> {
     ]
 }
 
-/// The --input-list file body: one path per line (paths cannot contain newlines
-/// on any supported filesystem).
+/// The --input-list file body: one path per line, read verbatim by the CLI. The
+/// line-based format cannot represent a path containing a newline — fine here
+/// because Windows (the only GUI platform) forbids newlines in file names.
 fn scan_input_list_content(paths: &[String]) -> String {
     let mut content = paths.join("\n");
     content.push('\n');
     content
+}
+
+// A unique temp-file path (`continumail-<kind>-<pid>-<nanos><ext>`): the per-run
+// name avoids collisions with stale files / a second app instance. Shared by
+// start_scan (input list) and start_convert (config).
+fn unique_temp_path(kind: &str, ext: &str) -> std::path::PathBuf {
+    let unique = format!(
+        "{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    );
+    std::env::temp_dir().join(format!("continumail-{kind}-{unique}{ext}"))
 }
 
 // The exact CLI argument vector for a conversion run. `expected_total`, when present,
@@ -173,17 +189,8 @@ async fn start_scan(
         return Err("A scan is already running.".into());
     }
 
-    // Write the input paths to a UNIQUE temp file the sidecar will read (per-run
-    // name avoids collisions with stale files / a second app instance).
-    let unique = format!(
-        "{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
-    );
-    let list_path = std::env::temp_dir().join(format!("continumail-scan-inputs-{unique}.txt"));
+    // Write the input paths to a unique temp file the sidecar will read.
+    let list_path = unique_temp_path("scan-inputs", ".txt");
     std::fs::write(&list_path, scan_input_list_content(&paths))
         .map_err(|e| format!("cannot write input list: {e}"))?;
     let list_path_str = list_path.to_string_lossy().to_string();
@@ -274,17 +281,8 @@ async fn start_convert(
         return Err("A conversion is already running.".into());
     }
 
-    // Write the config to a UNIQUE temp file the sidecar will read (per-run name
-    // avoids collisions with stale files / a second app instance).
-    let unique = format!(
-        "{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
-    );
-    let config_path = std::env::temp_dir().join(format!("continumail-convert-config-{unique}.json"));
+    // Write the config to a unique temp file the sidecar will read.
+    let config_path = unique_temp_path("convert-config", ".json");
     let config_text = serde_json::to_string(&config).map_err(|e| e.to_string())?;
     std::fs::write(&config_path, config_text).map_err(|e| format!("cannot write config: {e}"))?;
     let config_path_str = config_path.to_string_lossy().to_string();

--- a/src/Mail2Pst.Cli/Program.cs
+++ b/src/Mail2Pst.Cli/Program.cs
@@ -11,7 +11,7 @@ if (args.Length == 0)
     Console.Error.WriteLine("Usage:");
     Console.Error.WriteLine("  continumail-convert convert  --config <config.json> --output <dir>");
     Console.Error.WriteLine("  continumail-convert convert  --profile <dir> [--config <options.json>] --output <dir>");
-    Console.Error.WriteLine("  continumail-convert scan     --input <path> [--input <path> ...] [--type mbox]");
+    Console.Error.WriteLine("  continumail-convert scan     --input <path> [--input <path> ...] [--input-list <file>] [--type mbox]");
     Console.Error.WriteLine("  continumail-convert discover --input <dir>");
     return 1;
 }

--- a/src/Mail2Pst.Cli/ScanCommand.cs
+++ b/src/Mail2Pst.Cli/ScanCommand.cs
@@ -21,8 +21,14 @@ internal static class ScanCommand
         string sourceType = CliArgs.Flag(args, "--type") ?? "mbox";
         bool streaming = CliArgs.HasFlag(args, "--progress");
 
-        // --input-list: one path per line (blank lines ignored). Lets callers with
-        // hundreds of sources stay under the Windows 32,767-char command-line limit.
+        // --input-list: one path per line, used verbatim (blank lines ignored). Lets
+        // callers with hundreds of sources stay under the Windows 32,767-char
+        // command-line limit.
+        if (CliArgs.HasFlag(args, "--input-list") && inputListPath is null)
+        {
+            Console.Error.WriteLine("--input-list requires a file path.");
+            return 1;
+        }
         if (inputListPath is not null)
         {
             if (!File.Exists(inputListPath))
@@ -30,9 +36,19 @@ internal static class ScanCommand
                 Console.Error.WriteLine($"Input list file not found: {inputListPath}");
                 return 1;
             }
-            foreach (string line in File.ReadAllLines(inputListPath))
+            string[] listLines;
+            try
             {
-                if (!string.IsNullOrWhiteSpace(line)) inputPaths.Add(line.Trim());
+                listLines = File.ReadAllLines(inputListPath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                Console.Error.WriteLine($"Cannot read input list file: {ex.Message}");
+                return 1;
+            }
+            foreach (string line in listLines)
+            {
+                if (!string.IsNullOrWhiteSpace(line)) inputPaths.Add(line);
             }
         }
 

--- a/src/Mail2Pst.Cli/ScanCommand.cs
+++ b/src/Mail2Pst.Cli/ScanCommand.cs
@@ -17,12 +17,28 @@ internal static class ScanCommand
     internal static int Run(string[] args)
     {
         List<string> inputPaths = CliArgs.Flags(args, "--input");
+        string? inputListPath = CliArgs.Flag(args, "--input-list");
         string sourceType = CliArgs.Flag(args, "--type") ?? "mbox";
         bool streaming = CliArgs.HasFlag(args, "--progress");
 
+        // --input-list: one path per line (blank lines ignored). Lets callers with
+        // hundreds of sources stay under the Windows 32,767-char command-line limit.
+        if (inputListPath is not null)
+        {
+            if (!File.Exists(inputListPath))
+            {
+                Console.Error.WriteLine($"Input list file not found: {inputListPath}");
+                return 1;
+            }
+            foreach (string line in File.ReadAllLines(inputListPath))
+            {
+                if (!string.IsNullOrWhiteSpace(line)) inputPaths.Add(line.Trim());
+            }
+        }
+
         if (inputPaths.Count == 0)
         {
-            Console.Error.WriteLine("Usage: continumail-convert scan --input <path> [--input <path> ...] [--type mbox]");
+            Console.Error.WriteLine("Usage: continumail-convert scan --input <path> [--input <path> ...] [--input-list <file>] [--type mbox]");
             return 1;
         }
 

--- a/tests/Mail2Pst.Integration.Tests/ScanCommandInputListTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/ScanCommandInputListTests.cs
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.IO;
+using System.Text.Json;
+using Mail2Pst.Cli;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests;
+
+/// <summary>
+/// `scan --input-list &lt;file&gt;` reads input paths (one per line) from a file, so
+/// callers with hundreds of sources stay under the Windows 32,767-char command-line
+/// limit (GitHub issue #66). The flag is additive and combines with repeated --input.
+/// </summary>
+[Collection("ConsoleCapture")]
+public class ScanCommandInputListTests
+{
+    private const string MboxMessage =
+        "From sender@example.com Mon Jan 01 00:00:00 2024\r\n" +
+        "Message-ID: <input-list-test@example.com>\r\n" +
+        "Subject: Test\r\n" +
+        "\r\n" +
+        "Body.\r\n";
+
+    private static string WriteMbox(string dir, string name)
+    {
+        string path = Path.Combine(dir, name);
+        File.WriteAllText(path, MboxMessage);
+        return path;
+    }
+
+    private static (int exit, string stdout, string stderr) RunScan(params string[] args)
+    {
+        var outWriter = new StringWriter();
+        var errWriter = new StringWriter();
+        TextWriter originalOut = Console.Out;
+        TextWriter originalErr = Console.Error;
+        Console.SetOut(outWriter);
+        Console.SetError(errWriter);
+        try
+        {
+            int exit = ScanCommand.Run(args);
+            return (exit, outWriter.ToString(), errWriter.ToString());
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalErr);
+        }
+    }
+
+    [Fact]
+    public void Scan_InputListFile_ScansAllListedPaths_IgnoringBlankLines()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "m2p-scan-inputlist-" + Guid.NewGuid());
+        Directory.CreateDirectory(root);
+        try
+        {
+            string a = WriteMbox(root, "a.mbox");
+            string b = WriteMbox(root, "b.mbox");
+            string listPath = Path.Combine(root, "inputs.txt");
+            File.WriteAllLines(listPath, new[] { a, "", "   ", b });
+
+            (int exit, string stdout, _) = RunScan("scan", "--input-list", listPath);
+
+            Assert.Equal(0, exit);
+            using JsonDocument doc = JsonDocument.Parse(stdout);
+            Assert.Equal(2, doc.RootElement.GetProperty("totals").GetProperty("sources").GetInt32());
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Scan_InputListCombinesWithRepeatedInputFlags()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "m2p-scan-inputlist-" + Guid.NewGuid());
+        Directory.CreateDirectory(root);
+        try
+        {
+            string a = WriteMbox(root, "a.mbox");
+            string b = WriteMbox(root, "b.mbox");
+            string listPath = Path.Combine(root, "inputs.txt");
+            File.WriteAllLines(listPath, new[] { b });
+
+            (int exit, string stdout, _) = RunScan("scan", "--input", a, "--input-list", listPath);
+
+            Assert.Equal(0, exit);
+            using JsonDocument doc = JsonDocument.Parse(stdout);
+            Assert.Equal(2, doc.RootElement.GetProperty("totals").GetProperty("sources").GetInt32());
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Scan_MissingInputListFile_FailsWithMessage()
+    {
+        string listPath = Path.Combine(Path.GetTempPath(), "m2p-missing-" + Guid.NewGuid() + ".txt");
+
+        (int exit, _, string stderr) = RunScan("scan", "--input-list", listPath);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("Input list file not found", stderr);
+    }
+
+    [Fact]
+    public void Scan_EmptyInputListAndNoInputs_FailsWithUsage()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "m2p-scan-inputlist-" + Guid.NewGuid());
+        Directory.CreateDirectory(root);
+        try
+        {
+            string listPath = Path.Combine(root, "inputs.txt");
+            File.WriteAllText(listPath, "\n");
+
+            (int exit, _, string stderr) = RunScan("scan", "--input-list", listPath);
+
+            Assert.Equal(1, exit);
+            Assert.Contains("Usage:", stderr);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/ScanCommandInputListTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/ScanCommandInputListTests.cs
@@ -62,7 +62,7 @@ public class ScanCommandInputListTests
             string listPath = Path.Combine(root, "inputs.txt");
             File.WriteAllLines(listPath, new[] { a, "", "   ", b });
 
-            (int exit, string stdout, _) = RunScan("scan", "--input-list", listPath);
+            (int exit, string stdout, _) = RunScan("--input-list", listPath);
 
             Assert.Equal(0, exit);
             using JsonDocument doc = JsonDocument.Parse(stdout);
@@ -86,7 +86,7 @@ public class ScanCommandInputListTests
             string listPath = Path.Combine(root, "inputs.txt");
             File.WriteAllLines(listPath, new[] { b });
 
-            (int exit, string stdout, _) = RunScan("scan", "--input", a, "--input-list", listPath);
+            (int exit, string stdout, _) = RunScan("--input", a, "--input-list", listPath);
 
             Assert.Equal(0, exit);
             using JsonDocument doc = JsonDocument.Parse(stdout);
@@ -103,10 +103,69 @@ public class ScanCommandInputListTests
     {
         string listPath = Path.Combine(Path.GetTempPath(), "m2p-missing-" + Guid.NewGuid() + ".txt");
 
-        (int exit, _, string stderr) = RunScan("scan", "--input-list", listPath);
+        (int exit, _, string stderr) = RunScan("--input-list", listPath);
 
         Assert.Equal(1, exit);
         Assert.Contains("Input list file not found", stderr);
+    }
+
+    [Fact]
+    public void Scan_DanglingInputListFlagWithoutValue_FailsWithMessage()
+    {
+        (int exit, _, string stderr) = RunScan("--input-list");
+
+        Assert.Equal(1, exit);
+        Assert.Contains("--input-list requires a file path", stderr);
+    }
+
+    [Fact]
+    public void Scan_UnreadableInputListFile_FailsCleanlyNotWithStackTrace()
+    {
+        // FileShare.None only enforces a mandatory lock on Windows; CI also runs
+        // this suite on Linux/macOS where the second open would succeed.
+        if (!OperatingSystem.IsWindows()) return;
+
+        string listPath = Path.Combine(Path.GetTempPath(), "m2p-locked-" + Guid.NewGuid() + ".txt");
+        File.WriteAllText(listPath, "whatever\n");
+        try
+        {
+            using var _lock = new FileStream(listPath, FileMode.Open, FileAccess.Read, FileShare.None);
+
+            (int exit, _, string stderr) = RunScan("--input-list", listPath);
+
+            Assert.Equal(1, exit);
+            Assert.Contains("Cannot read input list file", stderr);
+        }
+        finally
+        {
+            File.Delete(listPath);
+        }
+    }
+
+    [Fact]
+    public void Scan_InputListPathsAreNotTrimmed()
+    {
+        // Filenames with line-edge whitespace are legal on Linux/macOS (the CLI is
+        // cross-platform), so each list line must be used verbatim. Windows can't
+        // create such a file, so pin the behaviour via the not-found message: it
+        // must echo the path exactly as listed, trailing space intact.
+        string root = Path.Combine(Path.GetTempPath(), "m2p-scan-inputlist-" + Guid.NewGuid());
+        Directory.CreateDirectory(root);
+        try
+        {
+            string spaced = Path.Combine(root, "nonexistent.mbox ");
+            string listPath = Path.Combine(root, "inputs.txt");
+            File.WriteAllLines(listPath, new[] { spaced });
+
+            (int exit, _, string stderr) = RunScan("--input-list", listPath);
+
+            Assert.Equal(1, exit);
+            Assert.Contains("Input file not found: " + spaced + Environment.NewLine, stderr);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
     }
 
     [Fact]
@@ -119,7 +178,7 @@ public class ScanCommandInputListTests
             string listPath = Path.Combine(root, "inputs.txt");
             File.WriteAllText(listPath, "\n");
 
-            (int exit, _, string stderr) = RunScan("scan", "--input-list", listPath);
+            (int exit, _, string stderr) = RunScan("--input-list", listPath);
 
             Assert.Equal(1, exit);
             Assert.Contains("Usage:", stderr);


### PR DESCRIPTION
## Problem

Scanning a Thunderbird profile with roughly 250+ mail folders fails immediately with
`failed to start engine: The filename or extension is too long. (os error 206)` (#66).
The desktop app passed every discovered mail folder to the engine as a repeated
`--input` argument; with enough folders the combined command line exceeds Windows'
32,767-character `CreateProcess` limit, so the sidecar can't even start. Shortening
the profile path (as the reporter tried) doesn't help — the limit is on total argv
length, and the folder count dominates.

## Fix

- **CLI:** additive `scan --input-list <file>` flag — one path per line, used
  verbatim, blank lines ignored, combines with the existing repeatable `--input`.
  Non-breaking; direct CLI users are unaffected.
- **Desktop:** `start_scan` writes the discovered paths to a unique temp file and
  passes only `--input-list <path> --progress`, mirroring `start_convert`'s
  temp-config lifecycle (removed on spawn failure and on process exit).

Hardening from code review: the list-file read is guarded (locked/ACL-blocked file
exits 1 with a one-line error instead of an unhandled exception), a dangling
`--input-list` with no value is rejected instead of silently narrowing the scan,
and the shared `unique_temp_path()` helper replaces duplicated temp-file scaffolding.

## Verification

- 7 new CLI tests (`ScanCommandInputListTests`), 2 new Rust unit tests; the existing
  Rust→CLI E2E test now exercises the real `--input-list` transport.
- Full suites green: Core 1243/0, Integration 88/0, cargo 15/15, Vitest 256/256.
- **A/B repro on a synthetic 400-folder profile** (old-style argv would be ~105,600
  chars, 3.2× the limit): installed 0.3.1 reproduces the reporter's exact error 206;
  this build scans and converts it cleanly (800 messages), with the temp input-list
  file verified created and cleaned up.

Fixes #66
