### PR TITLE
test(cli): input-list contract pins + transport stress ladder; dedupe duplicate scan inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
 
       - name: Test (Release)
         run: dotnet test Mail2Pst.sln -c Release --no-build
+        # Tier-2 (heavy generated-profile) tests run on pushes to main only — PR CI stays
+        # inside the fast-tier budget.
+        env:
+          MAIL2PST_RUN_TIER2: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && '1' || '' }}
 
       # Prove the actual published CLI runs end-to-end on this OS, not just unit tests.
       # Use the SAME single-file self-contained packaging shape as the desktop sidecar

--- a/src/Mail2Pst.Cli/ScanCommand.cs
+++ b/src/Mail2Pst.Cli/ScanCommand.cs
@@ -52,6 +52,29 @@ internal static class ScanCommand
             }
         }
 
+        // C3: the same source given twice (across --input and --input-list) is almost
+        // certainly accidental — scan it once and say so. Dedupe key = canonical full path
+        // (Path.GetFullPath; symlinks/hardlinks are NOT resolved); case-insensitive on
+        // Windows/macOS (deliberate simplification matching the common platform default),
+        // case-sensitive on Linux.
+        StringComparer pathComparer = OperatingSystem.IsLinux()
+            ? StringComparer.Ordinal
+            : StringComparer.OrdinalIgnoreCase;
+        var seen = new HashSet<string>(pathComparer);
+        var deduped = new List<string>(inputPaths.Count);
+        foreach (string inputPath in inputPaths)
+        {
+            string canonical;
+            try { canonical = Path.GetFullPath(inputPath); }
+            catch (Exception ex) when (ex is ArgumentException or PathTooLongException or NotSupportedException)
+            {
+                canonical = inputPath; // let the existing not-found validation surface it
+            }
+            if (seen.Add(canonical)) deduped.Add(inputPath);
+            else Console.Error.WriteLine($"Warning: duplicate input ignored: {inputPath}");
+        }
+        inputPaths = deduped;
+
         if (inputPaths.Count == 0)
         {
             Console.Error.WriteLine("Usage: continumail-convert scan --input <path> [--input <path> ...] [--input-list <file>] [--type mbox]");

--- a/tests/Mail2Pst.Core.Tests/Cli/ScanTransportE2ETests.cs
+++ b/tests/Mail2Pst.Core.Tests/Cli/ScanTransportE2ETests.cs
@@ -1,0 +1,193 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Mail2Pst.TestSupport;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Cli;
+
+/// <summary>
+/// Process-level stress ladder for the scan --input-list transport: spawns the REAL built
+/// CLI (same boundary the desktop sidecar crosses) against generated profiles at increasing
+/// scale and with hostile-but-legal path shapes. Companion to the in-process contract tests
+/// in Integration.Tests and the permanent #66 regression.
+/// </summary>
+public class ScanTransportE2ETests
+{
+    // Async reads + real timeout: sequential ReadToEnd() before WaitForExit() can deadlock
+    // (child blocks writing a full stderr pipe while we block reading stdout), and would
+    // let a hung child block the test forever before any timeout fires.
+    private static async Task<(int exit, string stdout, string stderr)> RunScanProcessAsync(IEnumerable<string> inputPaths)
+    {
+        string listPath = Path.Combine(Path.GetTempPath(), "m2p-e2e-list-" + Guid.NewGuid() + ".txt");
+        File.WriteAllLines(listPath, inputPaths);
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            psi.ArgumentList.Add(CliE2EProcess.CliDllPath());
+            psi.ArgumentList.Add("scan");
+            psi.ArgumentList.Add("--input-list");
+            psi.ArgumentList.Add(listPath);
+
+            using Process proc = Process.Start(psi)!;
+            Task<string> stdoutTask = proc.StandardOutput.ReadToEndAsync();
+            Task<string> stderrTask = proc.StandardError.ReadToEndAsync();
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+            try
+            {
+                await proc.WaitForExitAsync(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                try { proc.Kill(entireProcessTree: true); } catch { }
+                Assert.Fail("scan process hung past 120s");
+            }
+
+            return (proc.ExitCode, await stdoutTask, await stderrTask);
+        }
+        finally
+        {
+            File.Delete(listPath);
+        }
+    }
+
+    private static int SourcesOf(string stdout)
+    {
+        using JsonDocument doc = JsonDocument.Parse(stdout);
+        return doc.RootElement.GetProperty("totals").GetProperty("sources").GetInt32();
+    }
+
+    // Tier 1 — scale rungs that fit PR CI.
+    [Theory]
+    [InlineData(1)]
+    [InlineData(50)]
+    [InlineData(250)]
+    public async Task Scan_ScaleLadder_ReturnsOneSourcePerInput(int count)
+    {
+        using GeneratedProfile profile = new ThunderbirdProfileBuilder()
+            .WithAccount("alice@example.com", "imap.example.com")
+            .WithFolders(count, "Ladder-{0:D4}", messagesEach: 1)
+            .Build();
+
+        (int exit, string stdout, string stderr) = await RunScanProcessAsync(profile.MailFilePaths);
+
+        Assert.True(exit == 0, $"exit {exit}; stderr: {stderr}");
+        Assert.Equal(count, SourcesOf(stdout));
+    }
+
+    // Tier 2 — heavy rung; pushes to main only (MAIL2PST_RUN_TIER2=1).
+    [Fact]
+    public async Task Scan_1000Inputs_ReturnsOneSourcePerInput()
+    {
+        if (Environment.GetEnvironmentVariable("MAIL2PST_RUN_TIER2") != "1") return;
+
+        using GeneratedProfile profile = new ThunderbirdProfileBuilder()
+            .WithDeepRoot(approximatePrefixChars: 100)
+            .WithAccount("alice@example.com", "imap.example.com")
+            .WithFolders(1000, "Heavy-Ladder-Folder-With-A-Long-Name-{0:D4}", messagesEach: 1)
+            .Build();
+
+        (int exit, string stdout, string stderr) = await RunScanProcessAsync(profile.MailFilePaths);
+
+        Assert.True(exit == 0, $"exit {exit}; stderr: {stderr}");
+        Assert.Equal(1000, SourcesOf(stdout));
+    }
+
+    // Tier 1 — hostile-but-legal folder names travel the whole pipe: generator → list file
+    // → process argv-free transport → JSON result.
+    [Fact]
+    public async Task Scan_HostilePathShapes_AllScanCleanly()
+    {
+        using GeneratedProfile profile = new ThunderbirdProfileBuilder()
+            .WithAccount("alice@example.com", "imap.example.com")
+            .WithFolder("has space", 1)
+            .WithFolder("hash#tag", 1)
+            .WithFolder("amp&ersand", 1)
+            .WithFolder("paren(these)s", 1)
+            .WithFolder("Færdige opgaver", 1)     // Danish
+            .WithFolder("งานที่เสร็จแล้ว", 1)        // Thai
+            .Build();
+
+        (int exit, string stdout, string stderr) = await RunScanProcessAsync(profile.MailFilePaths);
+
+        Assert.True(exit == 0, $"exit {exit}; stderr: {stderr}");
+        Assert.Equal(6, SourcesOf(stdout));
+    }
+
+    // Tier 1 — C4(a): a deep-but-legal path (each segment normal, total comfortably below
+    // classic MAX_PATH) must scan like any other. Prefix length is DERIVED from the actual
+    // temp root so the total lands ~220-240 on every machine/runner, never "add N and hope".
+    [Fact]
+    public async Task Scan_DeepPathBelowClassicMaxPath_Succeeds()
+    {
+        int prefixChars = Math.Max(0, 200 - Path.GetTempPath().Length);
+        using GeneratedProfile profile = new ThunderbirdProfileBuilder()
+            .WithDeepRoot(approximatePrefixChars: prefixChars)
+            .WithAccount("alice@example.com", "imap.example.com")
+            .WithFolder("INBOX", 1)
+            .Build();
+        Assert.All(profile.MailFilePaths, p => Assert.InRange(p.Length, 0, 259));
+
+        (int exit, string stdout, string stderr) = await RunScanProcessAsync(profile.MailFilePaths);
+
+        Assert.True(exit == 0, $"exit {exit}; stderr: {stderr}");
+        Assert.Equal(1, SourcesOf(stdout));
+    }
+
+    // Tier 1 — C4(b): a path above 260 chars. Contract: if this environment can create and
+    // read it, scan succeeds; if the OS/runtime refuses, the CLI fails CLEANLY — nonzero
+    // exit, a one-line error that NAMES the offending path — never an unhandled-exception
+    // dump, never a hang.
+    [Fact]
+    public async Task Scan_PathAboveClassicMaxPath_SucceedsOrFailsCleanly()
+    {
+        GeneratedProfile profile;
+        try
+        {
+            profile = new ThunderbirdProfileBuilder()
+                .WithDeepRoot(approximatePrefixChars: 300)
+                .WithAccount("alice@example.com", "imap.example.com")
+                .WithFolder("INBOX", 1)
+                .Build();
+        }
+        catch (IOException)
+        {
+            return; // environment can't even express the path — nothing to contract-test
+        }
+        using (profile)
+        {
+            Assert.Contains(profile.MailFilePaths, p => p.Length > 260);
+
+            (int exit, string stdout, string stderr) = await RunScanProcessAsync(profile.MailFilePaths);
+
+            if (exit == 0)
+            {
+                Assert.Equal(1, SourcesOf(stdout));
+            }
+            else
+            {
+                Assert.Equal(1, exit);
+                // The error must name the offending path (the folder file is "INBOX"),
+                // not be a vague "failed" — and must not be a crash dump.
+                Assert.Contains("INBOX", stderr);
+                Assert.DoesNotContain("Unhandled exception", stderr);
+                Assert.DoesNotContain("   at ", stderr); // no stack trace
+            }
+        }
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/ScanCommandInputListTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/ScanCommandInputListTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 using System;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using Mail2Pst.Cli;
 using Xunit;
@@ -139,6 +140,89 @@ public class ScanCommandInputListTests
         finally
         {
             File.Delete(listPath);
+        }
+    }
+
+    [Fact]
+    public void Scan_InputListWithUtf8Bom_IsTolerated()
+    {
+        // Tier 0 — C3: BOM tolerated. Pins BCL behavior so a future reader swap can't regress it.
+        string root = Path.Combine(Path.GetTempPath(), "m2p-scan-inputlist-" + Guid.NewGuid());
+        Directory.CreateDirectory(root);
+        try
+        {
+            string a = WriteMbox(root, "a.mbox");
+            string listPath = Path.Combine(root, "inputs.txt");
+            // Explicit UTF-8 BOM followed by the path.
+            File.WriteAllBytes(listPath, new byte[] { 0xEF, 0xBB, 0xBF }
+                .Concat(System.Text.Encoding.UTF8.GetBytes(a + "\n")).ToArray());
+
+            (int exit, string stdout, _) = RunScan("--input-list", listPath);
+
+            Assert.Equal(0, exit);
+            using JsonDocument doc = JsonDocument.Parse(stdout);
+            Assert.Equal(1, doc.RootElement.GetProperty("totals").GetProperty("sources").GetInt32());
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Scan_InputListLinesAreNotUnquoted()
+    {
+        // Tier 0 — C3: no quoting syntax; quotes are ordinary path characters. A quoted line
+        // must be treated as a path that CONTAINS quotes (and thus not found), never unquoted
+        // into a valid path.
+        string root = Path.Combine(Path.GetTempPath(), "m2p-scan-inputlist-" + Guid.NewGuid());
+        Directory.CreateDirectory(root);
+        try
+        {
+            string a = WriteMbox(root, "a.mbox");
+            string listPath = Path.Combine(root, "inputs.txt");
+            File.WriteAllLines(listPath, new[] { "\"" + a + "\"" });
+
+            (int exit, _, string stderr) = RunScan("--input-list", listPath);
+
+            Assert.Equal(1, exit);
+            // The load-bearing contract is that the quotes were NOT stripped — assert the
+            // quoted string survives in the error, without pinning exact message phrasing.
+            Assert.Contains("Input file not found", stderr);
+            Assert.Contains("\"" + a + "\"", stderr);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Scan_InputListPreservesLineEdgeWhitespaceNames()
+    {
+        // Tier 0 — C3: only line endings are trimmed. Filenames with line-edge whitespace are
+        // legal on Linux/macOS; Windows can't create them, so this runs on the Unix CI legs.
+        if (OperatingSystem.IsWindows()) return;
+
+        string root = Path.Combine(Path.GetTempPath(), "m2p-scan-inputlist-" + Guid.NewGuid());
+        Directory.CreateDirectory(root);
+        try
+        {
+            string leading = WriteMbox(root, " leading");
+            string trailing = WriteMbox(root, "trailing ");
+            string both = WriteMbox(root, " both ");
+            string listPath = Path.Combine(root, "inputs.txt");
+            File.WriteAllLines(listPath, new[] { leading, trailing, both });
+
+            (int exit, string stdout, _) = RunScan("--input-list", listPath);
+
+            Assert.Equal(0, exit);
+            using JsonDocument doc = JsonDocument.Parse(stdout);
+            Assert.Equal(3, doc.RootElement.GetProperty("totals").GetProperty("sources").GetInt32());
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
         }
     }
 

--- a/tests/Mail2Pst.Integration.Tests/ScanCommandInputListTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/ScanCommandInputListTests.cs
@@ -100,6 +100,74 @@ public class ScanCommandInputListTests
     }
 
     [Fact]
+    public void Scan_DuplicateInputs_AreScannedOnceWithWarning()
+    {
+        // Tier 0 — C3: duplicates dedupe on the same CANONICAL FULL PATH (Path.GetFullPath —
+        // symlinks/hardlinks are NOT resolved); giving one file twice is almost certainly
+        // accidental and produces confusing reports.
+        string root = Path.Combine(Path.GetTempPath(), "m2p-scan-inputlist-" + Guid.NewGuid());
+        Directory.CreateDirectory(root);
+        try
+        {
+            string a = WriteMbox(root, "a.mbox");
+            string listPath = Path.Combine(root, "inputs.txt");
+            // Same file three ways: verbatim in the list, again via a redundant "..\<dir>"
+            // segment (different string, same canonical path), and once via --input.
+            string redundant = Path.Combine(root, "..", Path.GetFileName(root), "a.mbox");
+            File.WriteAllLines(listPath, new[] { a, redundant });
+
+            (int exit, string stdout, string stderr) = RunScan("--input", a, "--input-list", listPath);
+
+            Assert.Equal(0, exit);
+            using JsonDocument doc = JsonDocument.Parse(stdout);
+            JsonElement totals = doc.RootElement.GetProperty("totals");
+            Assert.Equal(1, totals.GetProperty("sources").GetInt32());
+            Assert.Equal(1, totals.GetProperty("messages").GetInt32());
+            // Contract: EACH ignored duplicate warns once — three references, one kept → 2 warnings.
+            int warningCount = stderr.Split("Warning: duplicate input ignored:").Length - 1;
+            Assert.Equal(2, warningCount);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Scan_CaseDifferingDuplicates_FollowConfiguredPlatformComparer()
+    {
+        // Tier 0 — C3: dedupe comparison is case-insensitive on Windows/macOS (deliberate
+        // simplification matching the common platform default), case-sensitive on Linux.
+        string root = Path.Combine(Path.GetTempPath(), "m2p-scan-inputlist-" + Guid.NewGuid());
+        Directory.CreateDirectory(root);
+        try
+        {
+            string a = WriteMbox(root, "a.mbox");
+            string upper = Path.Combine(Path.GetDirectoryName(a)!, "A.MBOX");
+            string listPath = Path.Combine(root, "inputs.txt");
+            File.WriteAllLines(listPath, new[] { a, upper });
+
+            (int exit, string stdout, _) = RunScan("--input-list", listPath);
+
+            if (OperatingSystem.IsLinux())
+            {
+                // Case-sensitive: A.MBOX is a distinct (and nonexistent) file → clean failure.
+                Assert.Equal(1, exit);
+            }
+            else
+            {
+                Assert.Equal(0, exit);
+                using JsonDocument doc = JsonDocument.Parse(stdout);
+                Assert.Equal(1, doc.RootElement.GetProperty("totals").GetProperty("sources").GetInt32());
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void Scan_MissingInputListFile_FailsWithMessage()
     {
         string listPath = Path.Combine(Path.GetTempPath(), "m2p-missing-" + Guid.NewGuid() + ".txt");


### PR DESCRIPTION
## What

- **Contract pins for the `scan --input-list` file format:** UTF-8 BOM tolerance, no quote stripping (quotes are ordinary path characters), and line-edge-whitespace preservation in paths (runs on the Linux/macOS CI legs, where such filenames are legal).
- **Behavior fix — duplicate inputs now scan once:** the same source given twice (repeated `--input` and/or `--input-list` lines) was scanned twice, double-counting its messages in the report. Inputs dedupe on canonical full path (case-insensitive on Windows/macOS, case-sensitive on Linux); each ignored duplicate emits a stderr warning.
- **Process-level transport stress ladder:** spawns the real built CLI against generated profiles — 1/50/250 inputs on every run, 1000 inputs env-gated to pushes to main (`MAIL2PST_RUN_TIER2`), hostile-but-legal path shapes (spaces, `#`, `&`, parentheses, Danish, Thai), and a long-path pair: below classic MAX_PATH must succeed; above 260 chars succeeds where the OS/runtime supports it and otherwise must fail with a clean one-line error naming the path — never a crash or hang.

## Verification

Full solution green locally (Core 1255/0, Integration 111 incl. 5 new contract tests, frontend 256/256). New Tier-1 E2E suite: 7 tests in ~1 s; the env-gated 1000-input rung passes in ~1 s locally.