### PR TITLE
ci: run independent PST validation on every PR + structural canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,3 +136,66 @@ jobs:
       - name: Cargo test
         working-directory: desktop/src-tauri
         run: cargo test --locked
+
+  # Preflight: does this push/PR touch anything that could change PST output or the validation
+  # logic? Docs-only / non-code changes skip the validate job below, so documentation and
+  # release-note PRs don't spend CI on the independent-validation build.
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Path filter
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'src/**'
+              - 'tests/**'
+              - 'tools/pst-validate/**'
+              - 'fixtures/**'
+              - 'Mail2Pst.sln'
+              - '.github/workflows/ci.yml'
+
+  # Independent semantic validation: convert real output and re-read it with an INDEPENDENT MS-PST
+  # reader (tools/pst-validate, dev/test-only), then compare folder/message counts to the converter's
+  # own truth model. Breaks the closed-loop round-trip that shares the vendored reader. Advisory,
+  # not a required check (a paths-filtered skip must never block merges). ubuntu-only: PST output is
+  # byte-deterministic across OSes, so one leg validates all.
+  validate:
+    name: Independent PST validation (ubuntu)
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up .NET 8 SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      # Cache the cargo registry + pst-validate target dir so the outlook-pst build is paid once.
+      - name: Cache cargo (pst-validate)
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: tools/pst-validate
+
+      # Build the INDEPENDENT MS-PST reader (dev/test-only; never shipped). --locked pins outlook-pst.
+      - name: Build pst-validate
+        run: cargo build --locked --release --manifest-path tools/pst-validate/Cargo.toml
+
+      # Run ONLY the independent-validation gate, with the validator wired in. These tests skip in
+      # the build-test matrix (env unset there); here they execute against real converter output.
+      - name: Independent-reader gate
+        env:
+          MAIL2PST_PST_VALIDATOR: ${{ github.workspace }}/tools/pst-validate/target/release/pst-validate
+        run: dotnet test tests/Mail2Pst.Integration.Tests -c Release --filter "Category=IndependentValidation"

--- a/tests/Mail2Pst.Integration.Tests/AppointmentIndependentValidationTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/AppointmentIndependentValidationTests.cs
@@ -16,6 +16,7 @@ namespace Mail2Pst.Integration.Tests;
 /// Requires MAIL2PST_PST_VALIDATOR to be set (same env-var as IndependentValidationTests).
 /// Without it the test is skipped so CI (no Rust validator) stays green.
 /// </summary>
+[Trait("Category", "IndependentValidation")]
 public class AppointmentIndependentValidationTests
 {
     // Zero-count folders the independent reader may surface that the converter did not create

--- a/tests/Mail2Pst.Integration.Tests/ContactIndependentValidationTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/ContactIndependentValidationTests.cs
@@ -16,6 +16,7 @@ namespace Mail2Pst.Integration.Tests;
 /// Requires MAIL2PST_PST_VALIDATOR to be set (same env-var as IndependentValidationTests).
 /// Without it the test is skipped so CI (no Rust validator) stays green.
 /// </summary>
+[Trait("Category", "IndependentValidation")]
 public class ContactIndependentValidationTests
 {
     // Zero-count folders the independent reader may surface that the converter did not create

--- a/tests/Mail2Pst.Integration.Tests/IndependentValidationTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/IndependentValidationTests.cs
@@ -6,11 +6,13 @@ using System.IO;
 using System.Linq;
 using Mail2Pst.Core;
 using Mail2Pst.Core.Config;
+using Mail2Pst.TestSupport;
 using PSTFileFormat;
 using Xunit;
 
 namespace Mail2Pst.Integration.Tests;
 
+[Trait("Category", "IndependentValidation")]
 public class IndependentValidationTests
 {
     // Zero-count folders the independent reader may surface that the converter did not create
@@ -34,46 +36,7 @@ public class IndependentValidationTests
 
         // Build a config over the committed sample mbox (mirror mode → one folder per source).
         ConversionConfig config = SampleConfig(out string outDir);
-        try
-        {
-            var (outputs, _) = RoundTripHarness.Convert(config, outDir);
-            Assert.NotEmpty(outputs); // a conversion that produced no PST parts would otherwise pass vacuously
-
-            // Expected path-keyed counts from the converter's own truth model.
-            Dictionary<string, int> expected = RoundTripHarness.BuildTruth(config)
-                .ToDictionary(kv => kv.Key, kv => kv.Value.Count, StringComparer.Ordinal);
-
-            // Actual path-keyed counts, aggregated across all output parts via the INDEPENDENT reader.
-            var actual = new Dictionary<string, long>(StringComparer.Ordinal);
-            foreach (string part in outputs)
-            {
-                ValidatorResult r = PstValidatorRunner.Run(part, Timeout);
-                Assert.True(r.Opened, $"validator could not open {Path.GetFileName(part)}: " +
-                    string.Join("; ", r.Errors.Select(e => $"{e.Stage}:{e.Message}")));
-                Assert.Empty(r.Errors);
-                foreach (ValidatedFolder f in r.Folders)
-                {
-                    string key = FolderPathKey.Join(f.Path);
-                    actual[key] = actual.GetValueOrDefault(key) + f.MessageCount;
-                }
-            }
-
-            // Every expected path must match exactly (includes expected empty folders).
-            foreach ((string key, int count) in expected)
-            {
-                Assert.True(actual.TryGetValue(key, out long got),
-                    $"expected folder '{key}' missing from independent reader output");
-                Assert.Equal(count, got);
-            }
-
-            // Any UNEXPECTED folder with messages is a failure; zero-count surprises must be allowlisted.
-            foreach ((string key, long got) in actual)
-            {
-                if (expected.ContainsKey(key)) continue;
-                if (got == 0 && ZeroCountAllowlist.Contains(key)) continue;
-                Assert.Fail($"unexpected folder '{key}' with {got} message(s) in independent reader output");
-            }
-        }
+        try { ConvertAndAssertIndependentCountsMatchTruth(config, outDir); }
         finally { Directory.Delete(outDir, true); }
     }
 
@@ -98,6 +61,111 @@ public class IndependentValidationTests
         }
         finally { File.Delete(path); }
     }
+
+    // [Tier 1] Structural canary: a tiny profile with shapes sample.mbox lacks — a multi-folder
+    // tree, a non-ASCII (Danish) folder display name, and an empty folder with
+    // IncludeEmptyFolders=true — converted through the real ConversionRunner and validated by the
+    // INDEPENDENT MS-PST reader. Uniquely detects: multi-folder enumeration drift, PT_UNICODE
+    // folder-name corruption, and whether the independent reader enumerates converter-created
+    // empty folders.
+    [SkippableFact]
+    [Trait("Tier", "1")]
+    public void GeneratedProfile_NastyShapes_ValidatesWithIndependentReader()
+    {
+        Skip.If(PstValidatorRunner.ValidatorPath is null,
+            "Set MAIL2PST_PST_VALIDATOR to the built pst-validate exe to run the independent-reader gate.");
+
+        using var profile = new ThunderbirdProfileBuilder()
+            .WithAccount("alice@example.com", "imap.example.com")
+            .WithFolder("Inbox", messageCount: 3)                 // ASCII, multi-message
+            .WithFolder("Færdige opgaver", messageCount: 2)       // Danish PT_UNICODE folder name
+            .WithFolder("Kladder", messageCount: 0)               // empty folder (C5 output side)
+            .Build();
+
+        // Guard against generator API drift: prove the profile really has the three intended shapes.
+        Assert.Equal(3, profile.Folders.Count);
+        Assert.Contains(profile.Folders, f => Path.GetFileName(f.FilePath) == "Færdige opgaver");
+        Assert.Contains(profile.Folders, f => Path.GetFileName(f.FilePath) == "Kladder");
+
+        string outDir = Path.Combine(Path.GetTempPath(), "mail2pst-canary-" + Guid.NewGuid());
+        Directory.CreateDirectory(outDir);
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Archive",
+                    MaxSizeMB = 50_000,
+                    FolderMapping = FolderMappingMode.Mirror,
+                    IncludeEmptyFolders = true, // exercises empty-folder enumeration through both truth and reader
+                    Sources = profile.Folders
+                        .Select(f => new SourceConfig { Type = "mbox", Path = f.FilePath })
+                        .ToList(),
+                },
+            },
+        };
+
+        // C5 GUARD: prove this canary is actually exercising the empty-folder branch. If BuildTruth
+        // itself dropped the empty folder, the expected model would silently stop testing C5 while
+        // the test still passed — assert the expected model includes it, count 0.
+        Dictionary<string, int> expected = RoundTripHarness.BuildTruth(config)
+            .ToDictionary(kv => kv.Key, kv => kv.Value.Count, StringComparer.Ordinal);
+        Assert.True(expected.ContainsKey("Kladder"),
+            "Canary is intended to exercise IncludeEmptyFolders=true, but BuildTruth did not include the empty folder.");
+        Assert.Equal(0, expected["Kladder"]);
+
+        try { ConvertAndAssertIndependentCountsMatchTruth(config, outDir); }
+        finally { Directory.Delete(outDir, true); }
+    }
+
+    // Converts `config` into `outDir`, validates every produced PST part with the INDEPENDENT
+    // reader, and asserts the independent per-folder counts exactly match the converter's own
+    // BuildTruth. Shared by the sample-mbox gate and the generated-profile canary.
+    private static void ConvertAndAssertIndependentCountsMatchTruth(ConversionConfig config, string outDir)
+    {
+        var (outputs, _) = RoundTripHarness.Convert(config, outDir);
+        Assert.NotEmpty(outputs); // a conversion that produced no PST parts would otherwise pass vacuously
+
+        // Expected path-keyed counts from the converter's own truth model.
+        Dictionary<string, int> expected = RoundTripHarness.BuildTruth(config)
+            .ToDictionary(kv => kv.Key, kv => kv.Value.Count, StringComparer.Ordinal);
+
+        // Actual path-keyed counts, aggregated across all output parts via the INDEPENDENT reader.
+        var actual = new Dictionary<string, long>(StringComparer.Ordinal);
+        foreach (string part in outputs)
+        {
+            ValidatorResult r = PstValidatorRunner.Run(part, Timeout);
+            Assert.True(r.Opened, $"validator could not open {Path.GetFileName(part)}: " +
+                string.Join("; ", r.Errors.Select(e => $"{e.Stage}:{e.Message}")));
+            Assert.Empty(r.Errors);
+            foreach (ValidatedFolder f in r.Folders)
+            {
+                string key = FolderPathKey.Join(f.Path);
+                actual[key] = actual.GetValueOrDefault(key) + f.MessageCount;
+            }
+        }
+
+        // Every expected path must match exactly (includes expected empty folders).
+        foreach ((string key, int count) in expected)
+        {
+            Assert.True(actual.TryGetValue(key, out long got),
+                $"expected folder '{key}' [{CodePoints(key)}] missing from independent reader output. " +
+                $"actual keys: {string.Join(" | ", actual.Keys.Select(k => $"'{k}' [{CodePoints(k)}]"))}");
+            Assert.Equal(count, got);
+        }
+
+        // Any unexpected folder is a failure unless it is a known zero-count implementation folder.
+        foreach ((string key, long got) in actual)
+        {
+            if (expected.ContainsKey(key)) continue;
+            if (got == 0 && ZeroCountAllowlist.Contains(key)) continue;
+            Assert.Fail($"unexpected folder '{key}' with {got} message(s) in independent reader output");
+        }
+    }
+
+    // Diagnostic: render a string's UTF-16 code units as hex so NFC/NFD or encoding drift is visible.
+    private static string CodePoints(string s) => string.Join("+", s.Select(c => ((int)c).ToString("X4")));
 
     private static ConversionConfig SampleConfig(out string outDir)
     {

--- a/tests/Mail2Pst.Integration.Tests/PstValidatorRunner.cs
+++ b/tests/Mail2Pst.Integration.Tests/PstValidatorRunner.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -41,6 +42,11 @@ public static class PstValidatorRunner
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true,
+                // pst-validate emits UTF-8 JSON. Without pinning the read encoding, .NET decodes the
+                // child's stdout using the console's OEM code page on Windows, turning any non-ASCII
+                // folder/message name into mojibake (e.g. UTF-8 'æ' C3 A6 read as CP437 '├ª'). Pin UTF-8.
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
             },
         };
         proc.StartInfo.ArgumentList.Add(pstPath);

--- a/tests/Mail2Pst.Integration.Tests/TaskIndependentValidationTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/TaskIndependentValidationTests.cs
@@ -16,6 +16,7 @@ namespace Mail2Pst.Integration.Tests;
 /// Requires MAIL2PST_PST_VALIDATOR to be set (same env-var as IndependentValidationTests).
 /// Without it the test is skipped so CI (no Rust validator) stays green.
 /// </summary>
+[Trait("Category", "IndependentValidation")]
 public class TaskIndependentValidationTests
 {
     // Zero-count folders the independent reader may surface that the converter did not create


### PR DESCRIPTION
Wires the independent PST validator (`tools/pst-validate`, a dev/test-only MS-PST reader that is never shipped) into CI so converter output is re-read by an independent reader on every PR, breaking the closed-loop round-trip that otherwise shares the vendored reader.

## What this adds
- A new ubuntu `validate` job that builds `pst-validate` and runs the independent-reader gate against freshly-converted output, comparing folder/message counts to the converter's own truth model. A paths-filter preflight skips the job on docs-only changes. Advisory (not a required check) — a filtered skip must not block merges. ubuntu-only, since PST output is byte-deterministic across OSes.
- A `Category` trait on the independent-validation tests so the job selects exactly that gate. Coverage spans mail, calendar, contacts, and tasks.
- A structural canary: a generated profile with a multi-folder tree, a non-ASCII (Danish) folder name, and an empty folder, converted through the real pipeline and validated independently. Confirms the independent reader enumerates converter-created empty folders.

## Fix included
The independent-reader test runner redirected the child process's streams without pinning the read encoding, so on Windows it decoded `pst-validate`'s UTF-8 JSON with the console OEM code page — corrupting non-ASCII folder/message names before comparison. Pinned `StandardOutput`/`StandardErrorEncoding` to UTF-8; ASCII output is unaffected. The canary is the regression test.

All selected independent-validation tests pass with the validator built and skip cleanly without it.