### PR TITLE
Harden parsing/mapping against malformed and pathological inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A corrupt, truncated, or pathologically deep-nested Thunderbird `.mab` (Mork) address book is
+  now recorded as a skipped contact instead of aborting the whole conversion.** Previously a Mork
+  parse failure propagated out of the address-book reader and stopped the run (discarding all other
+  mail, contacts, and calendar output), and a maliciously deep-nested `.mab` could crash the
+  process with a stack overflow. Such a book is now skipped with a recorded reason and the run
+  completes.
+
 ## [0.3.2] — 2026-07-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   completes.
 - A recurring event with two overrides on the same day no longer aborts the conversion — the
   duplicate override is dropped with a warning and the event still converts.
-- A single pathologically large message in an mbox is now skipped with a warning and the rest of
-  the mailbox still converts, instead of aborting the conversion of every later message.
+- A single pathologically large message in an mbox is now skipped (and noted in the conversion
+  report) while the rest of the mailbox still converts, instead of aborting the conversion of every
+  later message.
 
 ## [0.3.2] — 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   completes.
 - A recurring event with two overrides on the same day no longer aborts the conversion — the
   duplicate override is dropped with a warning and the event still converts.
+- A single pathologically large message in an mbox is now skipped with a warning and the rest of
+  the mailbox still converts, instead of aborting the conversion of every later message.
 
 ## [0.3.2] — 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mail, contacts, and calendar output), and a maliciously deep-nested `.mab` could crash the
   process with a stack overflow. Such a book is now skipped with a recorded reason and the run
   completes.
+- A recurring event with two overrides on the same day no longer aborts the conversion — the
+  duplicate override is dropped with a warning and the event still converts.
 
 ## [0.3.2] — 2026-07-08
 

--- a/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
@@ -717,10 +717,31 @@ public static class CalendarEventMapper
         appt.DeletedOccurrences = deleted;
 
         // Map override exceptions (appointment-only; stays here).
-        appt.Exceptions = group.Overrides
+        var mappedExceptions = group.Overrides
             .Select(o => ToException(o, w))
             .Where(e => e is not null)
             .Select(e => e!)
             .ToList();
+
+        // De-duplicate overrides that fall on the same calendar day. MS-OXOCAL stores at most one
+        // exception per day, and the writer collapses DeletedInstanceDates by the appointment-zone-local
+        // original day (AppointmentWriter.AddDeletedDate). Two overrides on one day would make
+        // ModifiedInstanceDates.Count exceed DeletedInstanceDates.Count, which the vendored recurrence
+        // serializer rejects with InvalidRecurrencePatternException — aborting the whole run. Keep the
+        // first override per day (the writer re-sorts) and warn for each dropped collision so the event
+        // still converts. exZone matches the zone the writer resolves for the exception day.
+        TimeZoneInfo exZone = appt.TimeZone ?? TimeZoneInfo.Utc;
+        var seenDays = new HashSet<DateTime>();
+        var dedupedExceptions = new List<AppointmentException>();
+        foreach (AppointmentException e in mappedExceptions)
+        {
+            DateTime day = TimeZoneInfo.ConvertTimeFromUtc(e.OriginalInstance.OriginalStartUtc, exZone).Date;
+            if (seenDays.Add(day))
+                dedupedExceptions.Add(e);
+            else
+                w.Add($"recurrence: multiple overrides for '{appt.Subject}' fall on {day:yyyy-MM-dd}; " +
+                      "kept the first (PST stores at most one exception per day)");
+        }
+        appt.Exceptions = dedupedExceptions;
     }
 }

--- a/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
+++ b/src/Mail2Pst.Core/Calendar/CalendarEventMapper.cs
@@ -729,7 +729,9 @@ public static class CalendarEventMapper
         // ModifiedInstanceDates.Count exceed DeletedInstanceDates.Count, which the vendored recurrence
         // serializer rejects with InvalidRecurrencePatternException — aborting the whole run. Keep the
         // first override per day (the writer re-sorts) and warn for each dropped collision so the event
-        // still converts. exZone matches the zone the writer resolves for the exception day.
+        // still converts. exZone matches the zone the writer resolves for the exception day: both derive
+        // from master.EventStartTz (the mapper sets appt.TimeZone from it; the writer resolves the same
+        // via ResolveWindowsZone), so their .Date keys agree.
         TimeZoneInfo exZone = appt.TimeZone ?? TimeZoneInfo.Utc;
         var seenDays = new HashSet<DateTime>();
         var dedupedExceptions = new List<AppointmentException>();

--- a/src/Mail2Pst.Core/Contacts/MorkAddressBookReader.cs
+++ b/src/Mail2Pst.Core/Contacts/MorkAddressBookReader.cs
@@ -19,7 +19,21 @@ public class MorkAddressBookReader : IAddressBookReader
         var results = new List<ContactReadResult>();
         // MorkReader.Parse(string) -> MorkDocument (verified API). ParseSharedReadWrite also exists
         // for files another process may have open; prefer it if .mab files are locked in practice.
-        MorkDocument doc = MorkReader.Parse(book.Path);
+        MorkDocument doc;
+        try
+        {
+            doc = MorkReader.Parse(book.Path);
+        }
+        catch (MorkFormatException ex)
+        {
+            // A corrupt/truncated .mab is a whole-book format failure. The reader owns this
+            // boundary: degrade the entire book to one skipped result (ConversionRunner routes
+            // it to RecordContactSkipped) rather than letting the format error abort the run.
+            // Only MorkFormatException is caught — any other exception is a real bug and propagates.
+            results.Add(ContactReadResult.Failed(book.DisplayName, ex.Message));
+            return results;
+        }
+
         foreach (MorkRow row in EnumerateContactRows(doc))
         {
             string cardId = string.IsNullOrEmpty(row.Id) ? Guid.NewGuid().ToString("N") : row.Id;

--- a/src/Mail2Pst.Core/Mork/MorkReader.cs
+++ b/src/Mail2Pst.Core/Mork/MorkReader.cs
@@ -86,6 +86,13 @@ internal sealed class MorkAssembler
     private readonly IReadOnlyList<MorkToken> _tokens;
     private int _pos;
 
+    // Recursion ceiling for ReadDict. Real Thunderbird .msf/.mab nest ~2 levels; 64 is far
+    // above any legitimate file. Corrupt/hostile input can nest arbitrarily deep, and ReadDict
+    // recurses per level, so without this ceiling that is an UNCATCHABLE StackOverflowException
+    // that kills the process. Throwing the ordinary MorkFormatException instead routes into the
+    // callers' existing graceful format-error handling.
+    private const int MaxDictNestDepth = 64;
+
     // ---- atom dictionaries: hex-id string -> decoded string -----------------
     // Column atoms: populated from dicts whose first sub-dict is <(a=c)>.
     // Value atoms:  populated from all other dicts.
@@ -197,6 +204,10 @@ internal sealed class MorkAssembler
     /// </summary>
     private void ReadDict(int nestDepth, bool parentIsColumn)
     {
+        if (nestDepth > MaxDictNestDepth)
+            throw new MorkFormatException(
+                $"Mork dict nesting exceeded the maximum of {MaxDictNestDepth} levels at token index {_pos}");
+
         Expect(MorkTokenKind.DictOpen); // consume '<'
 
         // Nested dicts (nestDepth > 0) save and restore the charset so an inner

--- a/src/Mail2Pst.Core/Parsing/Mbox/MessageChunk.cs
+++ b/src/Mail2Pst.Core/Parsing/Mbox/MessageChunk.cs
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+
+namespace Mail2Pst.Core.Parsing.Mbox;
+
+/// <summary>One result from the mbox boundary engine: either a materialized message buffer
+/// (or <c>null</c> in count/offset mode) OR an "oversized" marker for a message that exceeded the
+/// max-message-size cap and was skipped without being fully buffered.</summary>
+internal readonly struct MessageChunk
+{
+    public SpillableMessageBuffer? Buffer { get; }
+    public bool IsOversized { get; }
+    /// <summary>Approximate content bytes seen before the message was cut off (for the skip message).</summary>
+    public long OversizedBytes { get; }
+
+    private MessageChunk(SpillableMessageBuffer? buffer, bool oversized, long bytes)
+    {
+        Buffer = buffer;
+        IsOversized = oversized;
+        OversizedBytes = bytes;
+    }
+
+    public static MessageChunk Ok(SpillableMessageBuffer? buffer) => new(buffer, false, 0);
+    public static MessageChunk Oversized(long bytes) => new(null, true, bytes);
+}

--- a/src/Mail2Pst.Core/Parsing/MboxParser.cs
+++ b/src/Mail2Pst.Core/Parsing/MboxParser.cs
@@ -24,12 +24,27 @@ public class MboxParser : IMailSourceParser
     private readonly MimeMessageMapper _mapper;
     private readonly long _rawSpillThreshold;
 
+    /// <summary>Largest a single message may be before it is skipped. 1900 MiB — safely under
+    /// Array.MaxLength (~2 GiB) with headroom for MemoryStream capacity-doubling, so neither the
+    /// per-line MemoryStream nor the per-message buffer can reach the ~2 GiB overflow point.</summary>
+    public const long DefaultMaxMessageBytes = 1900L * 1024 * 1024;
+
+    /// <summary>Convert-path raw-message spill threshold (64 MiB): a message larger than this spills to
+    /// a temp file during conversion so parse-side peak RAM stays bounded. Used by the convert parser in
+    /// <see cref="ParserRegistry"/>; scan uses its own tighter 4 MiB threshold.</summary>
+    public const long DefaultRawSpillThreshold = 64L * 1024 * 1024;
+
+    private readonly long _maxMessageBytes;
+
     public MboxParser(long tempFileThresholdBytes = 4L * 1024 * 1024, bool measureOnly = false,
-                      long rawSpillThreshold = long.MaxValue)
+                      long rawSpillThreshold = long.MaxValue, long maxMessageBytes = DefaultMaxMessageBytes)
     {
         if (tempFileThresholdBytes < 0)
             throw new ArgumentOutOfRangeException(nameof(tempFileThresholdBytes), tempFileThresholdBytes, "Temp-file threshold must be non-negative.");
+        if (maxMessageBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxMessageBytes), maxMessageBytes, "Max message size must be positive.");
         _rawSpillThreshold = rawSpillThreshold;
+        _maxMessageBytes = maxMessageBytes;
         _mapper = new MimeMessageMapper(tempFileThresholdBytes, measureOnly);
     }
 
@@ -39,7 +54,8 @@ public class MboxParser : IMailSourceParser
 
         int index = 0;
         foreach (MessageChunk chunk in EnumerateMessageChunks(
-                     stream, materialize: true, _rawSpillThreshold, onBytesRead, onMessageStart: null))
+                     rawStream: stream, materialize: true, rawSpillThreshold: _rawSpillThreshold,
+                     maxMessageBytes: _maxMessageBytes, onBytesRead: onBytesRead, onMessageStart: null))
         {
             index++;
             var sourceRef = new SourceReference
@@ -47,7 +63,16 @@ public class MboxParser : IMailSourceParser
                 SourcePath = path,
                 Identifier = $"message #{index}",
             };
-            SpillableMessageBuffer raw = chunk.Buffer!;   // materialize mode never yields a null buffer (Task 2 adds oversized)
+
+            if (chunk.IsOversized)
+            {
+                yield return ParseResult.Failed(sourceRef,
+                    $"message exceeds the maximum size of {_maxMessageBytes} bytes and was skipped " +
+                    $"(read ~{chunk.OversizedBytes} bytes)");
+                continue;
+            }
+
+            SpillableMessageBuffer raw = chunk.Buffer!;   // materialize mode never yields a null buffer (except oversized, handled above)
 
             MimeMessage? mime = null;
             string? error = null;
@@ -105,13 +130,24 @@ public class MboxParser : IMailSourceParser
 
         var messages = new List<RangeMessage>();
         foreach (MessageChunk chunk in EnumerateMessageChunks(
-                     stream, materialize: true, _rawSpillThreshold, onBytesRead,
-                     onMessageStart: null, startAbsolute: startOffset, endOffset: endOffset))
+                     rawStream: stream, materialize: true, rawSpillThreshold: _rawSpillThreshold,
+                     maxMessageBytes: _maxMessageBytes, onBytesRead: onBytesRead, onMessageStart: null,
+                     startAbsolute: startOffset, endOffset: endOffset))
         {
-            SpillableMessageBuffer raw = chunk.Buffer!;   // Task 2 adds the oversized branch
             // Same sourceRef shape as Parse, minus the rendered "message #N" identifier
             // (assigned only at merge in the range-merge step).
             var sourceRef = new SourceReference { SourcePath = path };
+
+            if (chunk.IsOversized)
+            {
+                messages.Add(new RangeMessage(0, null,
+                    $"message exceeds the maximum size of {_maxMessageBytes} bytes and was skipped " +
+                    $"(read ~{chunk.OversizedBytes} bytes)",
+                    Array.Empty<string>()));
+                continue;
+            }
+
+            SpillableMessageBuffer raw = chunk.Buffer!;
 
             MimeMessage? mime = null;
             string? error = null;
@@ -174,7 +210,8 @@ public class MboxParser : IMailSourceParser
         // drifts from the messages Parse yields. (ConversionRunner reads the file twice:
         // count here, then Parse during conversion; external mutation of the file between
         // the two passes can still diverge — an accepted, out-of-scope limitation.)
-        return EnumerateMessageChunks(stream, materialize: false, rawSpillThreshold: 0, onBytesRead: null, onMessageStart: null).Count();
+        return EnumerateMessageChunks(rawStream: stream, materialize: false, rawSpillThreshold: 0,
+            maxMessageBytes: _maxMessageBytes, onBytesRead: null, onMessageStart: null).Count();
     }
 
     /// <summary>
@@ -186,7 +223,8 @@ public class MboxParser : IMailSourceParser
     {
         using FileStream stream = File.OpenRead(path);
         var offsets = new List<long>();
-        foreach (var _ in EnumerateMessageChunks(stream, materialize: false, rawSpillThreshold: 0, onBytesRead: null, onMessageStart: offsets.Add))
+        foreach (var _ in EnumerateMessageChunks(rawStream: stream, materialize: false, rawSpillThreshold: 0,
+                     maxMessageBytes: _maxMessageBytes, onBytesRead: null, onMessageStart: offsets.Add))
         { /* enumerate to drive the callback */ }
         return offsets;
     }
@@ -218,16 +256,20 @@ public class MboxParser : IMailSourceParser
     /// behave exactly as before.
     /// </summary>
     private static IEnumerable<MessageChunk> EnumerateMessageChunks(
-        Stream rawStream, bool materialize, long rawSpillThreshold, Action<long>? onBytesRead,
-        Action<long>? onMessageStart = null, long startAbsolute = 0, long endOffset = long.MaxValue)
+        Stream rawStream, bool materialize, long rawSpillThreshold, long maxMessageBytes,
+        Action<long>? onBytesRead, Action<long>? onMessageStart = null,
+        long startAbsolute = 0, long endOffset = long.MaxValue)
     {
         var buffer = new byte[BufferSize];
         using var line = new MemoryStream(256);
         SpillableMessageBuffer? current = materialize ? new SpillableMessageBuffer(rawSpillThreshold) : null;
         bool previousLineWasBlank = true;
         bool currentHasContent = false;
-        long consumed = 0;      // total bytes of completed lines (independent of rawStream.Position)
-        long currentStart = 0;  // byte offset of the current message's From_ boundary line
+        long consumed = 0;       // logical byte offset of line starts (drives boundary offsets)
+        long currentStart = 0;   // byte offset of the current message's From_ boundary line
+        long messageBytes = 0;   // content bytes accumulated for the current message (for the cap)
+        bool currentOversized = false;
+        bool skipToNewline = false;   // draining the tail of a single over-cap line
 
         int bytesRead;
         while ((bytesRead = rawStream.Read(buffer, 0, buffer.Length)) > 0)
@@ -235,30 +277,80 @@ public class MboxParser : IMailSourceParser
             int offset = 0;
             while (offset < bytesRead)
             {
+                if (skipToNewline)
+                {
+                    // Discard bytes (advancing `consumed`) until this over-cap line's newline.
+                    int nlIdx = Array.IndexOf(buffer, (byte)'\n', offset, bytesRead - offset);
+                    int take = (nlIdx == -1 ? bytesRead : nlIdx + 1) - offset;
+                    consumed += take;
+                    messageBytes += take;        // drained bytes still count toward OversizedBytes (report only)
+                    offset += take;
+                    if (nlIdx == -1)
+                        break;                        // whole remaining buffer was mid-line; read more
+                    skipToNewline = false;
+                    previousLineWasBlank = false;     // an over-cap line is never a blank line
+                    line.SetLength(0);
+                    continue;
+                }
+
                 int newlineIndex = Array.IndexOf(buffer, (byte)'\n', offset, bytesRead - offset);
                 if (newlineIndex == -1)
                 {
-                    // Partial line — carry it across to the next read.
-                    line.Write(buffer, offset, bytesRead - offset);
-                    break;
+                    int chunk = bytesRead - offset;
+                    // Per-line cap: a single line whose accumulation would exceed the cap makes the
+                    // message oversized; account the bytes already in `line`, drop them, and drain the
+                    // rest of the line rather than growing `line` toward the ~2 GiB MemoryStream limit.
+                    if (!currentOversized && messageBytes + line.Length + chunk > maxMessageBytes)
+                    {
+                        MarkOversized(ref currentOversized, ref currentHasContent, ref current);
+                        messageBytes += line.Length;  // count the accumulated partial toward OversizedBytes
+                        consumed += line.Length;      // partial bytes already accumulated for this line
+                        line.SetLength(0);
+                        skipToNewline = true;
+                        continue;                     // re-enter into the skip branch (offset unchanged)
+                    }
+                    line.Write(buffer, offset, chunk);
+                    break;                            // partial line — carry to next read
                 }
 
                 int lineLength = newlineIndex - offset + 1;
+
+                // Completed-line cap check BEFORE writing into the per-line buffer, so `line` never grows
+                // past the cap even when the segment that crosses the cap also contains the newline (the
+                // partial-line branch above handles the no-newline-in-this-buffer case). This keeps
+                // `line.Length <= maxMessageBytes` for ANY cap value — the default 1900 MiB already has
+                // headroom below Array.MaxLength for one 80 KiB segment, but a caller may set a larger cap.
+                if (!currentOversized && messageBytes + line.Length + lineLength > maxMessageBytes)
+                {
+                    long fullLine = line.Length + lineLength;   // accumulated partial + this final segment
+                    MarkOversized(ref currentOversized, ref currentHasContent, ref current);
+                    messageBytes += fullLine;                   // honest OversizedBytes
+                    consumed += fullLine;                       // the whole line's bytes, counted once
+                    line.SetLength(0);
+                    offset = newlineIndex + 1;
+                    previousLineWasBlank = false;               // an over-cap line is content, never a boundary/blank
+                    continue;
+                }
+
                 line.Write(buffer, offset, lineLength);
                 offset = newlineIndex + 1;
 
-                // Process the fully-assembled line. Derive all span-based values (booleans
-                // and any content writes) BEFORE clearing `line` or crossing a yield point —
-                // ReadOnlySpan<byte> is a ref struct and cannot survive a yield boundary.
                 int lineLen = (int)line.Length;
                 bool isBoundary = IsMessageBoundary(line.GetBuffer().AsSpan(0, lineLen), previousLineWasBlank);
                 bool isBlank    = IsBlankLine(line.GetBuffer().AsSpan(0, lineLen));
-                if (!isBoundary && materialize)
-                    WriteUnescapedFromLine(line.GetBuffer().AsSpan(0, lineLen), current!);
 
-                long lineStart = consumed;  // byte offset of this line's first byte
-                consumed += lineLen;        // advance AFTER capturing lineStart
+                if (!isBoundary)
+                {
+                    // Under the cap here (enforced above). The content write is still gated on
+                    // !currentOversized so a message already made oversized by an EARLIER line keeps
+                    // parsing lines for boundary detection without buffering any more content.
+                    if (!currentOversized && materialize)
+                        WriteUnescapedFromLine(line.GetBuffer().AsSpan(0, lineLen), current!);
+                    messageBytes += lineLen;
+                }
 
+                long lineStart = consumed;
+                consumed += lineLen;
                 line.SetLength(0);
 
                 if (isBoundary)
@@ -267,17 +359,17 @@ public class MboxParser : IMailSourceParser
                     {
                         onBytesRead?.Invoke(rawStream.Position);
                         onMessageStart?.Invoke(currentStart);
-                        yield return MessageChunk.Ok(materialize ? current : null);
-                        if (materialize) current = new SpillableMessageBuffer(rawSpillThreshold);
+                        yield return currentOversized
+                            ? MessageChunk.Oversized(messageBytes)
+                            : MessageChunk.Ok(materialize ? current : null);
+                        current = materialize ? new SpillableMessageBuffer(rawSpillThreshold) : null;
                         currentHasContent = false;
+                        messageBytes = 0;
+                        currentOversized = false;
                     }
-                    // A boundary at or beyond endOffset begins the NEXT window's first message:
-                    // the message just yielded above is the last one this window owns, so stop
-                    // here without starting (or parsing) the out-of-window message.
                     if (startAbsolute + lineStart >= endOffset)
                         yield break;
-                    currentStart = lineStart;  // this boundary begins the next message
-                    // The marker line is not written into the message.
+                    currentStart = lineStart;
                 }
                 else
                 {
@@ -288,24 +380,46 @@ public class MboxParser : IMailSourceParser
             }
         }
 
-        // Flush the final line if the file doesn't end with '\n'.
-        if (line.Length > 0)
+        // Flush a final line with no trailing '\n' (unless we're still draining an over-cap line).
+        if (line.Length > 0 && !skipToNewline)
         {
             int finalLen = (int)line.Length;
             if (!IsMessageBoundary(line.GetBuffer().AsSpan(0, finalLen), previousLineWasBlank))
             {
-                if (materialize) WriteUnescapedFromLine(line.GetBuffer().AsSpan(0, finalLen), current!);
+                if (!currentOversized && messageBytes + finalLen > maxMessageBytes)
+                    MarkOversized(ref currentOversized, ref currentHasContent, ref current);
+                if (!currentOversized && materialize)
+                    WriteUnescapedFromLine(line.GetBuffer().AsSpan(0, finalLen), current!);
+                messageBytes += finalLen;
                 currentHasContent = true;
             }
-            // A bare trailing boundary line yields nothing (no content) — matches splitting.
         }
 
         if (currentHasContent)
         {
             onBytesRead?.Invoke(rawStream.Position);
             onMessageStart?.Invoke(currentStart);
-            yield return MessageChunk.Ok(materialize ? current : null);
+            yield return currentOversized
+                ? MessageChunk.Oversized(messageBytes)
+                : MessageChunk.Ok(materialize ? current : null);
         }
+    }
+
+    /// <summary>Marks the current message oversized and releases its partial buffer (deletes any temp
+    /// file), so a message past the cap consumes no further memory/disk. Content writes stop; the engine
+    /// keeps parsing lines for boundary detection and yields a <see cref="MessageChunk.Oversized"/>.
+    /// <para>Also sets <paramref name="currentHasContent"/>: a message big enough to trip the cap always
+    /// has content, so it MUST still be yielded (as oversized) even when the cap trips on the FIRST
+    /// content line via the partial-line path — where the normal <c>currentHasContent = true</c> in the
+    /// completed-line <c>else</c> branch never runs. Without this, a bare <c>From </c> boundary followed
+    /// by one huge no-newline line at EOF would be silently dropped — the exact tail-drop this fix
+    /// prevents.</para></summary>
+    private static void MarkOversized(ref bool oversized, ref bool currentHasContent, ref SpillableMessageBuffer? current)
+    {
+        oversized = true;
+        currentHasContent = true;
+        current?.Dispose();
+        current = null;
     }
 
     /// <summary>Back-seek window for <see cref="FindBoundaryAtOrAfter"/>'s context bootstrap.</summary>

--- a/src/Mail2Pst.Core/Parsing/MboxParser.cs
+++ b/src/Mail2Pst.Core/Parsing/MboxParser.cs
@@ -38,7 +38,8 @@ public class MboxParser : IMailSourceParser
         using FileStream stream = File.OpenRead(path);
 
         int index = 0;
-        foreach (SpillableMessageBuffer raw in SplitMessages(stream, onBytesRead))
+        foreach (MessageChunk chunk in EnumerateMessageChunks(
+                     stream, materialize: true, _rawSpillThreshold, onBytesRead, onMessageStart: null))
         {
             index++;
             var sourceRef = new SourceReference
@@ -46,6 +47,7 @@ public class MboxParser : IMailSourceParser
                 SourcePath = path,
                 Identifier = $"message #{index}",
             };
+            SpillableMessageBuffer raw = chunk.Buffer!;   // materialize mode never yields a null buffer (Task 2 adds oversized)
 
             MimeMessage? mime = null;
             string? error = null;
@@ -102,11 +104,11 @@ public class MboxParser : IMailSourceParser
         stream.Seek(startOffset, SeekOrigin.Begin);
 
         var messages = new List<RangeMessage>();
-        foreach (SpillableMessageBuffer raw in EnumerateMessageChunks(
+        foreach (MessageChunk chunk in EnumerateMessageChunks(
                      stream, materialize: true, _rawSpillThreshold, onBytesRead,
-                     onMessageStart: null, startAbsolute: startOffset, endOffset: endOffset)
-                 .Select(b => b!))
+                     onMessageStart: null, startAbsolute: startOffset, endOffset: endOffset))
         {
+            SpillableMessageBuffer raw = chunk.Buffer!;   // Task 2 adds the oversized branch
             // Same sourceRef shape as Parse, minus the rendered "message #N" identifier
             // (assigned only at merge in the range-merge step).
             var sourceRef = new SourceReference { SourcePath = path };
@@ -168,7 +170,7 @@ public class MboxParser : IMailSourceParser
     public int CountMessages(string path)
     {
         using FileStream stream = File.OpenRead(path);
-        // Same boundary engine as SplitMessages — for a given file state the count never
+        // Same boundary engine as Parse — for a given file state the count never
         // drifts from the messages Parse yields. (ConversionRunner reads the file twice:
         // count here, then Parse during conversion; external mutation of the file between
         // the two passes can still diverge — an accepted, out-of-scope limitation.)
@@ -188,15 +190,6 @@ public class MboxParser : IMailSourceParser
         { /* enumerate to drive the callback */ }
         return offsets;
     }
-
-    /// <summary>
-    /// Splits an mbox file into a <see cref="SpillableMessageBuffer"/> per message. Thin adapter over
-    /// the shared <see cref="EnumerateMessageChunks"/> engine (materialize mode). See that
-    /// method for the boundary rule and why we avoid MimeKit's <see cref="MimeFormat.Mbox"/>
-    /// parser. The `!` is sound: materialize mode never yields a null chunk.
-    /// </summary>
-    private IEnumerable<SpillableMessageBuffer> SplitMessages(Stream rawStream, Action<long>? onBytesRead = null) =>
-        EnumerateMessageChunks(rawStream, materialize: true, _rawSpillThreshold, onBytesRead, onMessageStart: null).Select(b => b!);
 
     /// <summary>
     /// THE single source of truth for "where do messages begin and end" in an mbox stream.
@@ -221,10 +214,10 @@ public class MboxParser : IMailSourceParser
     /// the engine yields the just-completed message (which is owned by this window) and stops —
     /// it does not begin/parse the out-of-window message. The defaults
     /// (<c>startAbsolute = 0</c>, <c>endOffset = long.MaxValue</c>) make whole-file callers
-    /// (<see cref="SplitMessages"/>, <see cref="CountMessages"/>, <see cref="ScanMessageStartOffsets"/>)
+    /// (<see cref="Parse"/>, <see cref="CountMessages"/>, <see cref="ScanMessageStartOffsets"/>)
     /// behave exactly as before.
     /// </summary>
-    private static IEnumerable<SpillableMessageBuffer?> EnumerateMessageChunks(
+    private static IEnumerable<MessageChunk> EnumerateMessageChunks(
         Stream rawStream, bool materialize, long rawSpillThreshold, Action<long>? onBytesRead,
         Action<long>? onMessageStart = null, long startAbsolute = 0, long endOffset = long.MaxValue)
     {
@@ -274,7 +267,7 @@ public class MboxParser : IMailSourceParser
                     {
                         onBytesRead?.Invoke(rawStream.Position);
                         onMessageStart?.Invoke(currentStart);
-                        yield return materialize ? current : null;
+                        yield return MessageChunk.Ok(materialize ? current : null);
                         if (materialize) current = new SpillableMessageBuffer(rawSpillThreshold);
                         currentHasContent = false;
                     }
@@ -311,7 +304,7 @@ public class MboxParser : IMailSourceParser
         {
             onBytesRead?.Invoke(rawStream.Position);
             onMessageStart?.Invoke(currentStart);
-            yield return materialize ? current : null;
+            yield return MessageChunk.Ok(materialize ? current : null);
         }
     }
 

--- a/src/Mail2Pst.Core/Parsing/ParserRegistry.cs
+++ b/src/Mail2Pst.Core/Parsing/ParserRegistry.cs
@@ -12,7 +12,7 @@ public static class ParserRegistry
     private static readonly Dictionary<string, IMailSourceParser> Parsers =
         new(StringComparer.OrdinalIgnoreCase)
         {
-            ["mbox"] = new MboxParser(),
+            ["mbox"] = new MboxParser(rawSpillThreshold: MboxParser.DefaultRawSpillThreshold),
         };
 
     private static readonly Dictionary<string, IMailSourceParser> ScanParsers =

--- a/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
+++ b/src/Mail2Pst.Core/Writing/AppointmentWriter.cs
@@ -310,9 +310,20 @@ public sealed class AppointmentWriter
     private static void ApplyExceptions(RecurringAppointment ra, AppointmentRecord master,
         int masterDurationMinutes, BusyStatus masterBusy, TimeZoneInfo zone, HashSet<DateTime> deletedDates)
     {
+        // MS-OXOCAL stores at most one exception per calendar day: ModifiedInstanceDates is keyed by day,
+        // and DeletedInstanceDates below collapses by the same zone-local original day. Two exceptions on
+        // one original day would make ModifiedInstanceDates.Count exceed DeletedInstanceDates.Count, which
+        // the vendored recurrence serializer rejects with InvalidRecurrencePatternException — aborting the
+        // run. The mapper already de-dups+warns (CalendarEventMapper.ApplyRecurrence); this is the
+        // defensive backstop for any direct caller, keeping the first exception per original day.
+        var exceptionDays = new HashSet<DateTime>();
         foreach (var ex in master.Exceptions)
         {
             DateTime origStartUtc = ex.OriginalInstance.OriginalStartUtc;
+            DateTime origDay = TimeZoneInfo.ConvertTimeFromUtc(origStartUtc, zone).Date;
+            if (!exceptionDays.Add(origDay))
+                continue;   // duplicate original day — one exception already emitted for it
+
             DateTime newStartUtc = ex.NewStartUtc ?? origStartUtc;
             DateTime newEndUtc   = ex.NewEndUtc   ?? newStartUtc.AddMinutes(masterDurationMinutes);
             int newDuration = (int)Math.Max(0, Math.Round((newEndUtc - newStartUtc).TotalMinutes));
@@ -330,7 +341,7 @@ public sealed class AppointmentWriter
             ra.ExceptionList.Add(info);
 
             // Original date must also be a deleted instance (count-equality; de-dups shared set vs EXDATE).
-            AddDeletedDate(ra, deletedDates, TimeZoneInfo.ConvertTimeFromUtc(origStartUtc, zone).Date);
+            AddDeletedDate(ra, deletedDates, origDay);
         }
     }
 

--- a/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/CalendarEventMapperTests.cs
@@ -1268,6 +1268,43 @@ public class CalendarEventMapperTests
         Assert.Null(appt.TimeZone);
         Assert.Contains(warnings, w => w.Contains("Mars/Phobos", StringComparison.OrdinalIgnoreCase));
     }
+
+    [Fact]
+    public void Map_TwoOverridesSameOriginalDay_KeepsOneWithWarning_NoInvalidRecurrenceException()
+    {
+        // A DAILY master with TWO overrides whose RECURRENCE-ID lands on the SAME day (2026-07-11).
+        // MS-OXOCAL stores at most one exception per day; two would trip the vendored recurrence
+        // invariant (ModifiedInstanceDates.Count <= DeletedInstanceDates.Count) and abort the whole
+        // run. The mapper must keep one exception and warn.
+        var group = SimpleGroup(e =>
+        {
+            e.Title = "Daily Standup";
+            e.Recurrence.Add(new RawSideText("RRULE:FREQ=DAILY"));
+        });
+        group.Overrides.Add(new RawEvent
+        {
+            Id = "ovr-1@example.com", Title = "Standup moved (a)",
+            RecurrenceId = MicrosFor(2026, 7, 11, 14, 0), RecurrenceIdTz = "UTC",
+            EventStart = MicrosFor(2026, 7, 11, 15, 0), EventStartTz = "UTC",
+            EventEnd = MicrosFor(2026, 7, 11, 16, 0), EventEndTz = "UTC",
+        });
+        group.Overrides.Add(new RawEvent
+        {
+            Id = "ovr-2@example.com", Title = "Standup moved (b)",
+            RecurrenceId = MicrosFor(2026, 7, 11, 14, 0), RecurrenceIdTz = "UTC",
+            EventStart = MicrosFor(2026, 7, 11, 17, 0), EventStartTz = "UTC",
+            EventEnd = MicrosFor(2026, 7, 11, 18, 0), EventEndTz = "UTC",
+        });
+
+        var result = CalendarEventMapper.Map(group, out var warnings);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result!.Recurrence);
+        Assert.Single(result.Exceptions);   // the second same-day override was dropped
+        // Prove the policy is "keep FIRST", not just "some one survived".
+        Assert.Equal("Standup moved (a)", result.Exceptions[0].Subject);
+        Assert.Contains(warnings, x => x.Contains("2026-07-11") && x.Contains("kept the first"));
+    }
 }
 
 /// <summary>

--- a/tests/Mail2Pst.Core.Tests/Contacts/MorkAddressBookReaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Contacts/MorkAddressBookReaderTests.cs
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
 // SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.IO;
 using System.Linq;
 using Mail2Pst.Core.Contacts;
 using Xunit;
@@ -20,5 +22,33 @@ public class MorkAddressBookReaderTests
         var results = new MorkAddressBookReader().Read(book).ToList();
         Assert.True(results.Count >= 2);
         Assert.Contains(results, r => r.Success && r.Contact!.Emails.Count > 0);
+    }
+
+    [Fact]
+    public void Read_TruncatedMabThrowingMorkFormatException_ReturnsSingleFailedBook_DoesNotThrow()
+    {
+        // A .mab truncated mid-construct: the tokenizer throws MorkFormatException
+        // ("Unterminated '<' construct at end of input"). Before the fix this escaped
+        // Read() and aborted the whole conversion; now it must degrade to one failed book.
+        string path = Path.Combine(Path.GetTempPath(), $"m2p-trunc-{Guid.NewGuid():N}.mab");
+        File.WriteAllText(path, "< (80=ns:msg:db:row:scope:cards:all)(81=DisplayName");
+        try
+        {
+            var book = new AddressBook
+            {
+                DisplayName = "abook.mab",
+                Path = path,
+                Format = AddressBookFormat.ThunderbirdMab,
+            };
+
+            var results = new MorkAddressBookReader().Read(book).ToList();
+
+            var failed = Assert.Single(results);
+            Assert.False(failed.Success);
+            Assert.Contains("abook.mab", failed.Source);
+            // A degraded book must carry a usable reason, not a blank error.
+            Assert.False(string.IsNullOrWhiteSpace(failed.Error));
+        }
+        finally { File.Delete(path); }
     }
 }

--- a/tests/Mail2Pst.Core.Tests/Contacts/MorkAddressBookReaderTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Contacts/MorkAddressBookReaderTests.cs
@@ -51,4 +51,31 @@ public class MorkAddressBookReaderTests
         }
         finally { File.Delete(path); }
     }
+
+    [Fact]
+    public void Read_DeeplyNestedMab_ReturnsFailedBook_NotStackOverflow()
+    {
+        // Composition of #1 (reader catch) + #5 (depth ceiling): a pathologically deep .mab must
+        // degrade to a single skipped book, never crash the process. 128 levels is past the
+        // ceiling but will not actually overflow the stack on the red path.
+        string path = Path.Combine(Path.GetTempPath(), $"m2p-deep-{Guid.NewGuid():N}.mab");
+        File.WriteAllText(path, new string('<', 128) + new string('>', 128));
+        try
+        {
+            var book = new AddressBook
+            {
+                DisplayName = "deep.mab",
+                Path = path,
+                Format = AddressBookFormat.ThunderbirdMab,
+            };
+
+            var results = new MorkAddressBookReader().Read(book).ToList();
+
+            var failed = Assert.Single(results);
+            Assert.False(failed.Success);
+            Assert.Contains("deep.mab", failed.Source);
+            Assert.False(string.IsNullOrWhiteSpace(failed.Error));
+        }
+        finally { File.Delete(path); }
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/ConversionRunnerContactTests.cs
+++ b/tests/Mail2Pst.Core.Tests/ConversionRunnerContactTests.cs
@@ -45,4 +45,46 @@ public class ConversionRunnerContactTests
         }
         finally { SqliteConnection.ClearAllPools(); Directory.Delete(dir, true); }
     }
+
+    [Fact]
+    public void Run_ContactSourceWithCorruptMab_SkipsBookAndCompletes_DoesNotAbort()
+    {
+        // #1 end-to-end: a corrupt .mab must NOT abort the whole conversion. The run completes and
+        // the book is recorded as a skipped contact (ContactsSkipped), not thrown as a fatal.
+        string dir = Path.Combine(Path.GetTempPath(), $"m2p-runner-mab-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        string mab = Path.Combine(dir, "abook.mab");
+        File.WriteAllText(mab, "< (80=ns:msg:db:row:scope:cards:all)(81=DisplayName");
+        try
+        {
+            var config = new ConversionConfig
+            {
+                Outputs = new List<OutputGroupConfig>
+                {
+                    new()
+                    {
+                        Name = "Out",
+                        Sources = new List<SourceConfig>(),
+                        Contacts = new List<ContactSourceConfig>
+                        {
+                            new() { Path = mab, Format = "thunderbird-mab" },
+                        },
+                    },
+                },
+            };
+
+            // var (not an explicit type) to match the existing test's style — ConversionReport
+            // lives in Mail2Pst.Core.Reporting, which this file does not import.
+            var report = new ConversionRunner().Run(config, dir);
+
+            Assert.Equal(1, report.ContactsSkipped);
+            Assert.Equal(0, report.ContactsConverted);
+            // §3.1: the dropped book must be VISIBLE in the report surface, naming what was skipped.
+            // RecordContactSkipped adds a warning entry "Contact skipped [<book>]: <error>"; the
+            // derived book name is Path.GetFileNameWithoutExtension("abook.mab") == "abook".
+            Assert.Contains(report.Warnings, w =>
+                w.Reason.Contains("Contact skipped [abook]", StringComparison.OrdinalIgnoreCase));
+        }
+        finally { Directory.Delete(dir, true); }
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Mork/MorkDepthLimitTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mork/MorkDepthLimitTests.cs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using Mail2Pst.Core.Mork;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Mork;
+
+public class MorkDepthLimitTests
+{
+    [Fact]
+    public void Parse_DeeplyNestedDicts_ThrowsMorkFormatException_NotStackOverflow()
+    {
+        // 128 balanced-nested empty dicts (<<<...>>>). This is past the 64-level ceiling but
+        // shallow enough that the PRE-fix parser recurses without a real StackOverflowException
+        // (which would be uncatchable and kill the test host). The fixed parser must throw the
+        // ordinary catchable MorkFormatException at the ceiling.
+        string deep = new string('<', 128) + new string('>', 128);
+
+        Assert.Throws<MorkFormatException>(() => MorkReader.ParseString(deep));
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Parsing/MboxParserOversizedTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Parsing/MboxParserOversizedTests.cs
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Mail2Pst.Core.Parsing;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Parsing;
+
+public class MboxParserOversizedTests
+{
+    private static string WriteTempMbox(string content)
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"m2p-oversized-{Guid.NewGuid():N}.mbox");
+        File.WriteAllText(path, content, new UTF8Encoding(false));
+        return path;
+    }
+
+    // One valid, MimeKit-parseable message body (headers + blank + body).
+    private static string Msg(string subject, string body) =>
+        $"From sender@example.com Mon Jan  1 00:00:00 2020\r\nSubject: {subject}\r\n\r\n{body}\r\n\r\n";
+
+    [Fact]
+    public void Parse_OversizedMessageFollowedByNormalMessages_SkipsOnlyTheOversized_KeepsRest()
+    {
+        // Message #1 is built from many short lines whose total exceeds a tiny injected cap (200 bytes),
+        // so it is oversized. Messages #2..#4 are normal and must still be parsed.
+        var big = new StringBuilder("From sender@example.com Mon Jan  1 00:00:00 2020\r\nSubject: Huge\r\n\r\n");
+        for (int i = 0; i < 100; i++) big.Append("padding-line-x\r\n");   // >200 bytes of content
+        big.Append("\r\n");
+        string content = big.ToString() + Msg("Two", "body two") + Msg("Three", "body three") + Msg("Four", "body four");
+        string path = WriteTempMbox(content);
+        try
+        {
+            var results = new MboxParser(maxMessageBytes: 200).Parse(path).ToList();
+
+            Assert.Equal(4, results.Count);
+            Assert.False(results[0].Success);                                  // #1 oversized -> skip
+            Assert.Contains("maximum size", results[0].Error, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("message #1", results[0].Source.Identifier);
+            Assert.True(results[1].Success && results[2].Success && results[3].Success);   // rest kept
+            Assert.Equal("Two",   results[1].Message!.Subject);
+            Assert.Equal("Three", results[2].Message!.Subject);
+            Assert.Equal("Four",  results[3].Message!.Subject);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void Parse_SingleLineExceedingCap_SkipsThatMessage_KeepsRest_NoOverflow()
+    {
+        // A single line longer than the buffer (80 KiB) with no newline, exceeding the cap, exercises
+        // the per-line drain path (skipToNewline). It must skip that message, not overflow.
+        string monster = new string('x', 200_000);   // one 200 KB line, no interior newline
+        string content =
+            "From sender@example.com Mon Jan  1 00:00:00 2020\r\nSubject: Monster\r\n\r\n" + monster + "\r\n\r\n"
+            + Msg("After", "body after");
+        string path = WriteTempMbox(content);
+        try
+        {
+            var results = new MboxParser(maxMessageBytes: 50_000).Parse(path).ToList();
+
+            Assert.Equal(2, results.Count);
+            Assert.False(results[0].Success);
+            Assert.Contains("maximum size", results[0].Error, StringComparison.OrdinalIgnoreCase);
+            Assert.True(results[1].Success);
+            Assert.Equal("After", results[1].Message!.Subject);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void CountMessages_CountsOversizedMessage()
+    {
+        var big = new StringBuilder("From sender@example.com Mon Jan  1 00:00:00 2020\r\nSubject: Huge\r\n\r\n");
+        for (int i = 0; i < 100; i++) big.Append("padding-line-x\r\n");
+        big.Append("\r\n");
+        string content = big.ToString() + Msg("Two", "body two");
+        string path = WriteTempMbox(content);
+        try
+        {
+            // Oversized message still counts as one message (real boundary), so total == 2.
+            Assert.Equal(2, new MboxParser(maxMessageBytes: 200).CountMessages(path));
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void Parse_HugeFirstLineNoNewlineAtEof_StillYieldsOversizedSkip_NotDropped()
+    {
+        // The ONLY content is one huge no-newline line at EOF, right after the From boundary — so NO
+        // completed non-boundary line ever runs (a following blank line or message would set
+        // currentHasContent via the else branch and mask the bug). Without MarkOversized setting
+        // currentHasContent, the oversized message is silently DROPPED (0 results). With the fix it is
+        // yielded as a single-message skip (1 result). This is the review-fix-1 regression lock.
+        string monster = new string('y', 200_000);   // 200 KB, no interior newline, no trailing newline
+        string content = "From sender@example.com Mon Jan  1 00:00:00 2020\r\n" + monster;
+        string path = WriteTempMbox(content);
+        try
+        {
+            var results = new MboxParser(maxMessageBytes: 50_000).Parse(path).ToList();
+
+            var failed = Assert.Single(results);   // dropped -> 0 results WITHOUT the fix
+            Assert.False(failed.Success);
+            Assert.Contains("maximum size", failed.Error, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ScanRange_OversizedMessage_EmitsSkippedRangeMessage_AndKeepsFollowing()
+    {
+        var big = new StringBuilder("From sender@example.com Mon Jan  1 00:00:00 2020\r\nSubject: Huge\r\n\r\n");
+        for (int i = 0; i < 100; i++) big.Append("padding-line-x\r\n");
+        big.Append("\r\n");
+        string content = big.ToString() + Msg("Two", "body two");
+        string path = WriteTempMbox(content);
+        try
+        {
+            var result = new MboxParser(maxMessageBytes: 200)
+                .ScanRange(path, 0, long.MaxValue, onBytesRead: null);
+
+            Assert.Equal(2, result.Messages.Count);
+            Assert.True(result.Messages[0].IsSkipped);
+            Assert.Contains("maximum size", result.Messages[0].SkipReason!, StringComparison.OrdinalIgnoreCase);
+            Assert.False(result.Messages[1].IsSkipped);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ScanMessageStartOffsets_IncludesOversizedAndFollowingMessages()
+    {
+        // Byte-identity lock: even after draining the oversized message, the NEXT message's boundary
+        // offset must be correct (consumed accounting stays accurate through the drain path).
+        var big = new StringBuilder("From sender@example.com Mon Jan  1 00:00:00 2020\r\nSubject: Huge\r\n\r\n");
+        for (int i = 0; i < 100; i++) big.Append("padding-line-x\r\n");
+        big.Append("\r\n");
+        string content = big.ToString() + Msg("Two", "body two");
+        string path = WriteTempMbox(content);
+        try
+        {
+            var offsets = new MboxParser(maxMessageBytes: 200).ScanMessageStartOffsets(path);
+
+            Assert.Equal(2, offsets.Count);
+            Assert.Equal(0, offsets[0]);
+            Assert.True(offsets[1] > offsets[0]);
+        }
+        finally { File.Delete(path); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Parsing/MboxParserOversizedTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Parsing/MboxParserOversizedTests.cs
@@ -134,12 +134,15 @@ public class MboxParserOversizedTests
     [Fact]
     public void ScanMessageStartOffsets_IncludesOversizedAndFollowingMessages()
     {
-        // Byte-identity lock: even after draining the oversized message, the NEXT message's boundary
-        // offset must be correct (consumed accounting stays accurate through the drain path).
+        // Byte-identity lock (tightened): the SECOND message's start offset must equal the EXACT byte
+        // length of the first (oversized) message's region — even a 1-byte drift in the oversized-drain
+        // consumed accounting fails this. offsets[0] is the first From at 0; offsets[1] is where the
+        // second From begins, which is exactly the byte length of `big` (content == big + 2nd message).
         var big = new StringBuilder("From sender@example.com Mon Jan  1 00:00:00 2020\r\nSubject: Huge\r\n\r\n");
         for (int i = 0; i < 100; i++) big.Append("padding-line-x\r\n");
         big.Append("\r\n");
-        string content = big.ToString() + Msg("Two", "body two");
+        string bigStr = big.ToString();
+        string content = bigStr + Msg("Two", "body two");
         string path = WriteTempMbox(content);
         try
         {
@@ -147,7 +150,7 @@ public class MboxParserOversizedTests
 
             Assert.Equal(2, offsets.Count);
             Assert.Equal(0, offsets[0]);
-            Assert.True(offsets[1] > offsets[0]);
+            Assert.Equal((long)Encoding.UTF8.GetByteCount(bigStr), offsets[1]);   // exact offset, not just monotonic
         }
         finally { File.Delete(path); }
     }

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
@@ -565,6 +565,42 @@ public class AppointmentWriterRecurrenceTests
         Assert.Equal(UnicodeSubject, attachSubject);
     }
 
+    /// <summary>
+    /// Defensive backstop for #3: two exceptions whose ORIGINAL instance is the same day collapse to
+    /// one DeletedInstanceDate, which would trip the vendored ModifiedInstanceDates.Count &lt;=
+    /// DeletedInstanceDates.Count invariant (InvalidRecurrencePatternException, aborting the run). The
+    /// writer must keep one exception per original day so the appointment still writes. Both target the
+    /// 2026-07-08 instance of the Mon+Wed weekly series.
+    /// </summary>
+    [Fact]
+    public void Two_overrides_same_original_day_write_one_exception_without_invalid_recurrence()
+    {
+        var rec = WeeklyRecord();
+        rec.Exceptions = new[]
+        {
+            new AppointmentException {
+                OriginalInstance = new RecurrenceInstanceId(new DateTime(2026,7,8,1,0,0,DateTimeKind.Utc),
+                    new DateTime(2026,7,8,1,0,0,DateTimeKind.Unspecified), "UTC", false),
+                NewStartUtc = new(2026,7,8,7,0,0,DateTimeKind.Utc), NewEndUtc = new(2026,7,8,7,30,0,DateTimeKind.Utc),
+                Subject = "First move", ChangeFlags = AppointmentExceptionChangeFlags.Subject | AppointmentExceptionChangeFlags.StartEnd },
+            new AppointmentException {
+                OriginalInstance = new RecurrenceInstanceId(new DateTime(2026,7,8,1,0,0,DateTimeKind.Utc),
+                    new DateTime(2026,7,8,1,0,0,DateTimeKind.Unspecified), "UTC", false),
+                NewStartUtc = new(2026,7,8,9,0,0,DateTimeKind.Utc), NewEndUtc = new(2026,7,8,9,30,0,DateTimeKind.Utc),
+                Subject = "Second move (same original day)", ChangeFlags = AppointmentExceptionChangeFlags.Subject | AppointmentExceptionChangeFlags.StartEnd },
+        };
+
+        var (_, blob, _) = WriteAndReadAppointment(rec);   // must NOT throw InvalidRecurrencePatternException
+        var s = AppointmentRecurrencePatternStructure.GetRecurrencePatternStructure(blob!);
+
+        Assert.Single(s.ExceptionList);
+        Assert.Single(s.ModifiedInstanceDates);
+        Assert.True(s.DeletedInstanceDates.Count >= s.ModifiedInstanceDates.Count);  // vendored GetBytes invariant holds
+        // The guard skips before AddModifiedInstanceAttachment, so only ONE embedded method=5
+        // exception attachment is written — not two with a de-duped blob.
+        Assert.Equal(1, ReopenAttachmentCount(rec));
+    }
+
     // -----------------------------------------------------------------------
     // Task 6: recurring MEETING preserves PR6 attendees + meeting state + recur blob
     // -----------------------------------------------------------------------

--- a/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/AppointmentWriterRecurrenceTests.cs
@@ -791,4 +791,34 @@ public class AppointmentWriterRecurrenceTests
         Assert.NotNull(blob);   // PidLidAppointmentRecur must be present
         Assert.True(isAllDayEvent, "PidLidAppointmentSubType must be true for an all-day recurring appointment");
     }
+
+    /// <summary>
+    /// Regression lock for #3: an EXDATE (deleted occurrence) and a single override on the SAME original
+    /// day must NOT collide — the override must survive. The EXDATE flows through DeletedInstanceDates
+    /// (ApplyDeletions) while the writer's same-day exception guard uses a SEPARATE set (exceptionDays),
+    /// so the EXDATE must never cause the override to be skipped. Both share the one deleted day, so the
+    /// vendored invariant (ModifiedInstanceDates.Count &lt;= DeletedInstanceDates.Count) still holds.
+    /// </summary>
+    [Fact]
+    public void Exdate_and_override_on_same_original_day_keep_the_override()
+    {
+        var rec = WeeklyRecord();
+        rec.DeletedOccurrences = new[] { new RecurrenceInstanceId(
+            new DateTime(2026,7,8,1,0,0,DateTimeKind.Utc),
+            new DateTime(2026,7,8,1,0,0,DateTimeKind.Unspecified), "UTC", false) };
+        rec.Exceptions = new[] { new AppointmentException {
+            OriginalInstance = new RecurrenceInstanceId(new DateTime(2026,7,8,1,0,0,DateTimeKind.Utc),
+                new DateTime(2026,7,8,1,0,0,DateTimeKind.Unspecified), "UTC", false),
+            NewStartUtc = new(2026,7,8,7,0,0,DateTimeKind.Utc), NewEndUtc = new(2026,7,8,7,30,0,DateTimeKind.Utc),
+            Subject = "Moved despite EXDATE", ChangeFlags = AppointmentExceptionChangeFlags.Subject | AppointmentExceptionChangeFlags.StartEnd } };
+
+        var (_, blob, _) = WriteAndReadAppointment(rec);
+        var s = AppointmentRecurrencePatternStructure.GetRecurrencePatternStructure(blob!);
+
+        Assert.Single(s.ExceptionList);            // the override survived (EXDATE did not block it)
+        Assert.Single(s.ModifiedInstanceDates);
+        Assert.Single(s.DeletedInstanceDates);     // EXDATE + override original day collapse to one deleted day
+        Assert.True(s.DeletedInstanceDates.Count >= s.ModifiedInstanceDates.Count);  // vendored invariant holds
+        Assert.Equal(1, ReopenAttachmentCount(rec));
+    }
 }


### PR DESCRIPTION
## Summary

A pass over the parsing and mapping paths to make a single malformed or pathological input degrade gracefully — skipped and recorded — instead of aborting the entire conversion. Four independent fixes, each with a regression test that names the exact failure mode.

## Fixes

**Corrupt, truncated, or deeply-nested Thunderbird `.mab` address book.** Previously a Mork parse failure propagated out of the address-book reader and stopped the whole run — discarding all other mail, contacts, and calendar output — and a maliciously deep-nested `.mab` could crash the process with a stack overflow. The reader now converts a Mork format failure into a skipped address book (recorded in the conversion report), and the Mork parser caps its dictionary-nesting depth so deep nesting raises a normal, catchable error. The run completes.

**Recurring event with two overrides on the same day.** Two `RECURRENCE-ID` overrides that fall on the same calendar day exceeded a PST recurrence-pattern invariant and aborted the conversion. The mapper now keeps one override per day and records a warning; the appointment writer carries a defensive guard for the same invariant. The event still converts.

**A single oversized message in an mbox.** A single pathologically large message overflowed an in-memory buffer; the resulting error was mislabelled as a file-read failure, so every later message in that mailbox was silently dropped. The parser now caps per-message size — an oversized message is skipped as a distinct single-message failure and the rest of the mailbox converts. The conversion parser also spills large messages to a temporary file to bound memory during parsing.

## Testing

Each fix ships with a regression test. Full solution green locally: Core 1264 passing, Integration 111 passing (env-gated validators skipped locally; the independent PST-validation gate runs in CI). No changes to the CLI event contract, the vendored PST library, or the desktop app.
