### PR TITLE
Harden output-overwrite safety and mail/folder/PST-name handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A single pathologically large message in an mbox is now skipped (and noted in the conversion
   report) while the rest of the mailbox still converts, instead of aborting the conversion of every
   later message.
+- Converting to a directory that already contains the output PST now stops immediately with a clear
+  message instead of overwriting it, so a cancelled or failed re-run can no longer destroy a
+  previously converted file. Remove the existing file or choose another output directory to proceed.
 
 ## [0.3.2] — 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Converting to a directory that already contains the output PST now stops immediately with a clear
   message instead of overwriting it, so a cancelled or failed re-run can no longer destroy a
   previously converted file. Remove the existing file or choose another output directory to proceed.
+- A Thunderbird mail folder whose name isn't a valid Outlook folder name (for example a leading
+  space or a reserved Windows device name) is now adjusted to a valid name, with a warning, instead
+  of aborting the whole profile at validation.
+- In folder-per-source (mirror) mode, two source files that would map to the same folder name — for
+  example `Project.v1` and `Project.v2` — are now kept as distinct folders (`Project`, `Project (2)`)
+  with a warning, instead of silently merging into one.
+- **Desktop: a per-account PST name that is a reserved Windows device name with an extension** (for
+  example `AUX.2024`) no longer aborts a multi-account conversion; such names are prefixed to a safe,
+  valid file name.
 
 ## [0.3.2] — 2026-07-08
 

--- a/desktop/src/lib/accounts.test.ts
+++ b/desktop/src/lib/accounts.test.ts
@@ -46,9 +46,15 @@ describe("sanitizePstName", () => {
   it("falls back to 'Account' when empty after sanitizing", () => {
     expect(sanitizePstName("...")).toBe("Account");
   });
-  it("escapes reserved Windows device names", () => {
-    expect(sanitizePstName("CON")).toBe("CON-mail");
-    expect(sanitizePstName("LPT1.backup")).toBe("LPT1.backup-mail"); // stem LPT1 is reserved
+  it("escapes reserved Windows device names, including with an extension", () => {
+    // Prefix (not suffix) so no "<reserved>.<ext>" form survives the backend regex.
+    expect(sanitizePstName("CON")).toBe("mail-CON");
+    expect(sanitizePstName("LPT1.backup")).toBe("mail-LPT1.backup");
+    expect(sanitizePstName("AUX.2024")).toBe("mail-AUX.2024");   // stem+ext — the backend-abort bug
+    expect(sanitizePstName("con.backup")).toBe("mail-con.backup");
+    expect(sanitizePstName("com1.log")).toBe("mail-com1.log");
+    // A normal name that merely contains a reserved substring is untouched.
+    expect(sanitizePstName("Console")).toBe("Console");
   });
 });
 

--- a/desktop/src/lib/accounts.ts
+++ b/desktop/src/lib/accounts.ts
@@ -12,8 +12,10 @@ export interface AccountGroup {
   defaultPstName: string;
 }
 
-// Windows reserved device names (stem only), mirroring Core OutputNameValidator.
-const RESERVED = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i;
+// Windows reserved device names, optionally with an extension — mirrors Core OutputNameValidator's
+// /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$/i. Testing the WHOLE string (not just the pre-dot
+// stem) is load-bearing: "AUX.2024" is reserved to the backend, so the frontend must catch it too.
+const RESERVED = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$/i;
 
 /** Match the engine's OutputNameValidator policy so a per-account PST name never fails validation. */
 export function sanitizePstName(raw: string): string {
@@ -22,8 +24,9 @@ export function sanitizePstName(raw: string): string {
   s = s.trim();                                // 2. whitespace
   s = s.replace(/^\.+|\.+$/g, "").trim();       // 3. leading/trailing periods
   if (s.length === 0) return "Account";         // 4. empty fallback
-  const stem = s.split(".")[0];                 // 5. reserved device-name stem -> suffix
-  if (RESERVED.test(stem)) s = `${s}-mail`;
+  // 5. Reserved device name (whole string, incl. "<reserved>.<ext>") -> PREFIX a safe token so the
+  //    result no longer starts with the reserved name and passes the backend regex.
+  if (RESERVED.test(s)) s = `mail-${s}`;
   return s;
 }
 

--- a/src/Mail2Pst.Core/ConversionRunner.cs
+++ b/src/Mail2Pst.Core/ConversionRunner.cs
@@ -45,6 +45,13 @@ public class ConversionRunner
         var report = new ConversionReport();
         List<PstOutputPlan> plans = MappingEngine.BuildPlan(config);
 
+        // Mirror-mode planning warnings (folder-name sanitization / collision disambiguation). Recorded
+        // into the report now; the live WarningEvents are emitted after the ScanEvent below so the
+        // documented event order (scan before any warning) is preserved.
+        var planningWarnings = plans.SelectMany(p => p.PlanningWarnings).ToList();
+        foreach (string planningWarning in planningWarnings)
+            report.RecordWarning(new SourceReference { SourcePath = "", Identifier = "(mapping)" }, planningWarning);
+
         var enrichmentOptions = new MsfEnrichmentOptions
         {
             TagResolver = MsfTagResolverFactory.Create(config.ProfilePath),
@@ -90,6 +97,9 @@ public class ConversionRunner
                 }
             }
             onProgress(new ScanEvent(total));
+
+            foreach (string planningWarning in planningWarnings)
+                onProgress(new WarningEvent("", "(mapping)", planningWarning));
         }
 
         // Track whether the "X disabled by --no-X" warning has already been emitted

--- a/src/Mail2Pst.Core/Discovery/MailTreeDiscovery.cs
+++ b/src/Mail2Pst.Core/Discovery/MailTreeDiscovery.cs
@@ -15,7 +15,8 @@ namespace Mail2Pst.Core.Discovery;
 /// Reconstructs a nested mail-folder tree (Thunderbird <name> + sibling <name>.sbd/ layout, or a
 /// flat directory of .mbox files) into a list of sources each carrying an explicit nested
 /// TargetFolderPath. Parse-free: filesystem reads only (a small prefix per file for the content
-/// sniff). Observational: emits raw names + structured warnings, never renames.
+/// sniff). Raw display names are preserved, but synthesized TargetFolderPath segments are sanitized
+/// to valid PST folder names, with a warning emitted when a segment changes.
 /// </summary>
 public static class MailTreeDiscovery
 {
@@ -139,8 +140,13 @@ public static class MailTreeDiscovery
                 if (name.EndsWith(".sbd", StringComparison.OrdinalIgnoreCase))
                 {
                     ctx.SawSbd = true;
-                    string segment = name[..^4]; // strip ".sbd"
+                    string rawSegment = name[..^4]; // strip ".sbd"
+                    string segment = FolderNameValidator.Sanitize(rawSegment, "Folder");
                     var childPrefix = new List<string>(prefix) { segment };
+                    if (!string.Equals(segment, rawSegment, StringComparison.Ordinal))
+                        ctx.Warnings.Add(new DiscoveryWarning("invalid-folder-name", entry,
+                            childPrefix, rawSegment, prefix.Count, null,
+                            $"Folder name '{rawSegment}' is not a valid PST folder name; using '{segment}'."));
                     Walk(entry, childPrefix, ctx);
                 }
                 else
@@ -184,7 +190,12 @@ public static class MailTreeDiscovery
             }
 
             string display = name.EndsWith(".mbox", StringComparison.OrdinalIgnoreCase) ? name[..^5] : name;
-            var targetPath = new List<string>(prefix) { display };
+            string leaf = FolderNameValidator.Sanitize(display, "Folder");
+            var targetPath = new List<string>(prefix) { leaf };
+            if (!string.Equals(leaf, display, StringComparison.Ordinal))
+                ctx.Warnings.Add(new DiscoveryWarning("invalid-folder-name", entry,
+                    targetPath, display, prefix.Count, null,
+                    $"Folder name '{display}' is not a valid PST folder name; using '{leaf}'."));
 
             // Pair this ACCEPTED mbox with its sibling <name>.msf, if present.
             string? msfPath = null;

--- a/src/Mail2Pst.Core/Mapping/MappingEngine.cs
+++ b/src/Mail2Pst.Core/Mapping/MappingEngine.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using Mail2Pst.Core.Config;
 using Mail2Pst.Core.Contacts;
+using Mail2Pst.Core;
 
 namespace Mail2Pst.Core.Mapping;
 
@@ -32,9 +33,11 @@ public static class MappingEngine
                 IncludeEmptyFolders = output.IncludeEmptyFolders,
             };
 
+            var usedMailKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (SourceConfig source in output.Sources)
             {
                 IReadOnlyList<string> targetPath;
+                bool mirrorDerived = false;
                 if (source.TargetFolderPath is not null)
                     // An explicit path (even if empty/invalid) is treated as explicit — never
                     // silently falls back to a mode default. Invalid explicit targets are rejected
@@ -47,9 +50,37 @@ public static class MappingEngine
                     // silently converted into a mirror/flatten default.
                     targetPath = new[] { source.TargetFolder };
                 else if (output.FolderMapping == FolderMappingMode.Mirror)
-                    targetPath = new[] { Path.GetFileNameWithoutExtension(source.Path) };
+                {
+                    // Mirror: one folder per source file. Sanitize the filename stem (may be reserved,
+                    // padded, or empty for "/x/.mbox") so it can't fail ConfigValidator / CreateChildFolder,
+                    // and warn whenever sanitizing changed it — a silent rename must never happen.
+                    string rawStem = Path.GetFileNameWithoutExtension(source.Path);
+                    string sanitizedStem = FolderNameValidator.Sanitize(rawStem, "Folder");
+                    if (!string.Equals(sanitizedStem, rawStem, StringComparison.Ordinal))
+                        plan.PlanningWarnings.Add(
+                            $"Source '{source.Path}' has an invalid mirror folder name '{rawStem}' — using '{sanitizedStem}'.");
+                    targetPath = new[] { sanitizedStem };
+                    mirrorDerived = true;
+                }
                 else
-                    targetPath = new[] { DefaultFlattenFolderName };
+                    targetPath = new[] { DefaultFlattenFolderName };        // flatten — intentional merge
+
+                // Mirror-derived paths can silently collide (Project.v1 and Project.v2 both -> "Project",
+                // or two sources sanitizing to the same fallback). Keep the first, suffix later ones
+                // " (2)", " (3)", … (first free), and record a planning warning. Explicit/flatten targets
+                // are left as-is — their merges are intentional.
+                if (mirrorDerived && usedMailKeys.Contains(FolderPathKey.Join(targetPath)))
+                {
+                    string baseLeaf = targetPath[^1];
+                    int n = 2;
+                    string leaf;
+                    do { leaf = $"{baseLeaf} ({n})"; n++; }
+                    while (usedMailKeys.Contains(FolderPathKey.Join(new[] { leaf })));
+                    plan.PlanningWarnings.Add(
+                        $"Source '{source.Path}' maps to mail folder '{baseLeaf}', already used — using '{leaf}' instead.");
+                    targetPath = new[] { leaf };
+                }
+                usedMailKeys.Add(FolderPathKey.Join(targetPath));
 
                 plan.SourceMappings.Add(new SourceMapping { Source = source, TargetFolderPath = targetPath });
             }

--- a/src/Mail2Pst.Core/Mapping/PstOutputPlan.cs
+++ b/src/Mail2Pst.Core/Mapping/PstOutputPlan.cs
@@ -19,4 +19,8 @@ public class PstOutputPlan
     public List<ContactMapping> ContactMappings { get; set; } = new();
     public List<TaskMapping> TaskMappings { get; set; } = new();
     public List<AppointmentMapping> AppointmentMappings { get; set; } = new();
+
+    /// <summary>Warnings raised while building this plan (e.g. a mirror-mode folder-name collision that
+    /// was disambiguated). Drained into the ConversionReport by ConversionRunner before writing.</summary>
+    public List<string> PlanningWarnings { get; set; } = new();
 }

--- a/src/Mail2Pst.Core/Writing/PstPartManager.cs
+++ b/src/Mail2Pst.Core/Writing/PstPartManager.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 using Mail2Pst.Core;
 using Mail2Pst.Core.Config;
 using Mail2Pst.Core.Models;
@@ -82,6 +83,7 @@ internal sealed class PstPartManager
     public void Begin(IReadOnlyList<FolderToPrecreate> foldersToPrecreate)
     {
         ValidateFolderInventory(foldersToPrecreate);   // fail before touching the filesystem
+        EnsureOutputDoesNotExist();                    // fail before overwriting a pre-existing output PST
 
         _currentPath = StartNewFile(_groupName, null, _outputDirectory);
         _outputFiles.Add(_currentPath);
@@ -145,6 +147,48 @@ internal sealed class PstPartManager
                     $"Folder '{string.Join("/", folder.Path)}' is requested as both {existing} and {folder.Type}.");
             seen[key] = folder.Type;
         }
+    }
+
+    /// <summary>Fail-fast guard: refuse to overwrite a pre-existing output PST. <see cref="Begin"/>
+    /// creates the first part with <c>PSTFile.CreateEmptyStore</c> (which truncates via
+    /// <c>FileMode.Create</c>), and a later cancel/fatal deletes the current part — so silently
+    /// overwriting a prior good PST would destroy it on an aborted re-run. We refuse instead, before
+    /// any file is created. Throws before <see cref="StartNewFile"/>, so <c>_currentPath</c> stays
+    /// empty and the fatal-cleanup <see cref="DeleteCurrentPart"/> is a no-op.
+    /// Checks the single-file name (<c>Name.pst</c>) and — because a prior run may have split into
+    /// <c>Name-1.pst</c>, <c>Name-2.pst</c>, … and we cannot know up front how many parts this run
+    /// makes — any converter-owned split part by pattern.</summary>
+    private void EnsureOutputDoesNotExist()
+    {
+        string singlePath = ResolveOutputPath(_groupName, partNumber: null, _outputDirectory);
+        if (File.Exists(singlePath))
+            throw new ConfigValidationException(
+                $"Output file '{singlePath}' already exists. Remove it or choose a different output " +
+                "directory, then run the conversion again.");
+
+        string dir = Path.GetDirectoryName(singlePath)!;   // = the resolved full output directory
+        string? existingPart = FindExistingSplitPart(dir, _groupName);
+        if (existingPart is not null)
+            throw new ConfigValidationException(
+                $"An output file from a previous run ('{existingPart}') already exists. Remove it or " +
+                "choose a different output directory, then run the conversion again.");
+    }
+
+    /// <summary>Returns the path of the first existing converter-owned split part
+    /// (<c>Name-1.pst</c>, <c>Name-2.pst</c>, …) in <paramref name="dir"/>, or <c>null</c>. Matches
+    /// the exact split-naming pattern (a positive integer with no leading zero — parts are numbered
+    /// from 1), so unrelated files such as <c>Name-old.pst</c> or <c>Name-0.pst</c> are ignored.
+    /// Case-insensitive on Windows, case-sensitive elsewhere (filesystem semantics).</summary>
+    private static string? FindExistingSplitPart(string dir, string groupName)
+    {
+        if (!Directory.Exists(dir))
+            return null;
+        RegexOptions options = OperatingSystem.IsWindows() ? RegexOptions.IgnoreCase : RegexOptions.None;
+        var partPattern = new Regex($"^{Regex.Escape(groupName)}-[1-9][0-9]*\\.pst$", options);
+        foreach (string path in Directory.EnumerateFiles(dir, "*.pst"))
+            if (partPattern.IsMatch(Path.GetFileName(path)))
+                return path;
+        return null;
     }
 
     public bool ShouldSplitBefore(long messageSize) =>

--- a/tests/Mail2Pst.Core.Tests/ConversionRunnerContactTests.cs
+++ b/tests/Mail2Pst.Core.Tests/ConversionRunnerContactTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using Mail2Pst.Core;
 using Mail2Pst.Core.Config;
 using Microsoft.Data.Sqlite;
@@ -86,5 +87,45 @@ public class ConversionRunnerContactTests
                 w.Reason.Contains("Contact skipped [abook]", StringComparison.OrdinalIgnoreCase));
         }
         finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void Convert_OutputPathAlreadyExists_FailsFastWithoutDeletingPriorPst()
+    {
+        // #11 end-to-end: a re-run to a directory that already holds the output must fail fast and
+        // leave the prior PST byte-for-byte intact (never truncated, never deleted by the cancel path).
+        string dir = Path.Combine(Path.GetTempPath(), $"m2p-runner-exists-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        byte[] prior = Encoding.UTF8.GetBytes("PRIOR GOOD OUTPUT — must survive the aborted re-run");
+        string outPst = Path.Combine(dir, "Out.pst");
+        File.WriteAllBytes(outPst, prior);
+
+        string db = Path.Combine(dir, "abook.sqlite");
+        using (var conn = new SqliteConnection($"Data Source={db}"))
+        {
+            conn.Open();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"CREATE TABLE properties(card TEXT,name TEXT,value TEXT);
+                INSERT INTO properties VALUES('c1','DisplayName','Alice');";
+            cmd.ExecuteNonQuery();
+        }
+        SqliteConnection.ClearAllPools();
+        try
+        {
+            var config = new ConversionConfig
+            {
+                Outputs = new List<OutputGroupConfig>
+                {
+                    new() { Name = "Out", Sources = new List<SourceConfig>(),
+                        Contacts = new List<ContactSourceConfig>
+                        { new() { Path = db, Format = "thunderbird-sqlite" } } },
+                },
+            };
+
+            Assert.Throws<ConfigValidationException>(() => new ConversionRunner().Run(config, dir));
+            // The prior output is untouched — fail-fast happened before any write.
+            Assert.Equal(prior, File.ReadAllBytes(outPst));
+        }
+        finally { SqliteConnection.ClearAllPools(); Directory.Delete(dir, true); }
     }
 }

--- a/tests/Mail2Pst.Core.Tests/ConversionRunnerMirrorWarningTests.cs
+++ b/tests/Mail2Pst.Core.Tests/ConversionRunnerMirrorWarningTests.cs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Mail2Pst.Core;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Progress;
+using Mail2Pst.Core.Reporting;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests;
+
+public class ConversionRunnerMirrorWarningTests
+{
+    [Fact]
+    public void Run_MirrorCollision_RecordsPlanningWarning_InReportAndAsEventAfterScan()
+    {
+        // Two real mbox files whose stems collapse to the same mirror folder ("Project"). The
+        // disambiguation warning must reach report.Warnings AND be emitted as a WarningEvent — and,
+        // per the CLI contract, the WarningEvent must come AFTER the ScanEvent.
+        const string Msg = "From a@b Mon Jan  1 00:00:00 2020\r\nSubject: x\r\n\r\nbody\r\n";
+        string dir = Path.Combine(Path.GetTempPath(), $"m2p-mirror-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        string v1 = Path.Combine(dir, "Project.v1");
+        string v2 = Path.Combine(dir, "Project.v2");
+        File.WriteAllText(v1, Msg, new UTF8Encoding(false));
+        File.WriteAllText(v2, Msg, new UTF8Encoding(false));
+        try
+        {
+            var config = new ConversionConfig
+            {
+                Outputs = new List<OutputGroupConfig>
+                {
+                    new() { Name = "Out", FolderMapping = FolderMappingMode.Mirror,
+                        Sources = new List<SourceConfig>
+                        {
+                            new() { Path = v1, Type = "mbox" },
+                            new() { Path = v2, Type = "mbox" },
+                        } },
+                },
+            };
+            var events = new List<ConversionProgressEvent>();
+            ConversionReport report = new ConversionRunner().Run(config, dir, events.Add);
+
+            Assert.Contains(report.Warnings, w => w.Reason.Contains("Project (2)", StringComparison.OrdinalIgnoreCase));
+            int scanIdx = events.FindIndex(e => e is ScanEvent);
+            int warnIdx = events.FindIndex(e => e is WarningEvent we && we.Reason.Contains("Project (2)", StringComparison.OrdinalIgnoreCase));
+            Assert.True(scanIdx >= 0 && warnIdx > scanIdx, "the mapping WarningEvent must come after the ScanEvent");
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Discovery/MailTreeDiscoveryTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Discovery/MailTreeDiscoveryTests.cs
@@ -121,11 +121,12 @@ public class MailTreeDiscoveryTests : IDisposable
     }
 
     [Fact]
-    public void InvalidSegmentFromSbdDir_SourceEmitted_PlusWarning()
+    public void InvalidSegmentFromSbdDir_SourceSanitized_PlusWarning()
     {
         File_("CON.sbd/Child", Msg);   // "CON" is a reserved Windows name
         var r = MailTreeDiscovery.Discover(_root);
-        Assert.True(HasSource(r, "CON", "Child"));
+        Assert.True(HasSource(r, "Folder", "Child"));   // reserved name coerced via the fallback
+        Assert.False(HasSource(r, "CON", "Child"));
         Assert.Contains(r.Warnings, w => w.Code == "invalid-folder-name" && w.Segment == "CON" && w.SegmentIndex == 0);
     }
 
@@ -221,5 +222,28 @@ public class MailTreeDiscoveryTests : IDisposable
         Assert.Contains(r.Skipped, s => s.Code == "symlink-skipped");
         // The link's target children must NOT be discovered via the link (no "Link" segment).
         Assert.DoesNotContain(r.Sources, s => s.TargetFolderPath.Count > 0 && s.TargetFolderPath[0] == "Link");
+    }
+
+    // Leading spaces are the one PST-invalid folder-name form that is portably creatable on disk
+    // (Windows preserves leading — not trailing — spaces; Linux preserves both). FolderNameValidator
+    // rejects leading/trailing whitespace, so this exercises the sanitize path on any CI OS.
+    [Fact]
+    public void LeadingSpaceLeafFolderName_IsSanitized_AndWarned_ButDisplayNameStaysRaw()
+    {
+        File_(" To Read", Msg);   // leaf " To Read" -> "To Read"
+        var r = MailTreeDiscovery.Discover(_root);
+        DiscoveredSource s = Assert.Single(r.Sources);
+        Assert.Equal(new[] { "To Read" }, s.TargetFolderPath.ToArray());   // trimmed, valid path
+        Assert.Equal(" To Read", s.DisplayName);                          // raw name kept for the UI
+        Assert.Contains(r.Warnings, w => w.Code == "invalid-folder-name");
+    }
+
+    [Fact]
+    public void LeadingSpaceSbdParentSegment_IsSanitized_InChildPath_AndWarned()
+    {
+        File_(" Parent.sbd/Child", Msg);   // parent segment " Parent" -> "Parent"
+        var r = MailTreeDiscovery.Discover(_root);
+        Assert.True(HasSource(r, "Parent", "Child"));
+        Assert.Contains(r.Warnings, w => w.Code == "invalid-folder-name");
     }
 }

--- a/tests/Mail2Pst.Core.Tests/Mapping/MappingEngineTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mapping/MappingEngineTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using System.Collections.Generic;
+using System.Linq;
 using Mail2Pst.Core.Config;
 using Mail2Pst.Core.Mapping;
 using Xunit;
@@ -177,4 +178,78 @@ public class MappingEngineTests
             new() { Name = "Out", MaxSizeMB = 100, FolderMapping = mode, Sources = new List<SourceConfig>(sources) },
         },
     };
+
+    [Fact]
+    public void BuildPlan_MirrorDottedExtensionlessNames_DoNotSilentlyMerge()
+    {
+        // "Project.v1" and "Project.v2" both reduce to stem "Project" via GetFileNameWithoutExtension.
+        // Mirror mode must keep them distinct (Project / Project (2)) with a planning warning, not merge.
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Out",
+                    FolderMapping = FolderMappingMode.Mirror,
+                    Sources = new List<SourceConfig>
+                    {
+                        new() { Path = "/mail/Project.v1", Type = "mbox" },
+                        new() { Path = "/mail/Project.v2", Type = "mbox" },
+                    },
+                },
+            },
+        };
+
+        List<PstOutputPlan> plans = MappingEngine.BuildPlan(config);
+
+        PstOutputPlan plan = Assert.Single(plans);
+        Assert.Equal(new[] { "Project" },     plan.SourceMappings[0].TargetFolderPath.ToArray());
+        Assert.Equal(new[] { "Project (2)" }, plan.SourceMappings[1].TargetFolderPath.ToArray());
+        Assert.Single(plan.PlanningWarnings);
+        Assert.Contains("Project (2)", plan.PlanningWarnings[0]);
+    }
+
+    [Fact]
+    public void BuildPlan_MirrorEmptyStem_FallsBackToValidName_AndWarns()
+    {
+        // "/mail/.mbox" -> GetFileNameWithoutExtension -> "" -> must not become an empty folder segment;
+        // it falls back to "Folder" AND records a planning warning (no silent rename).
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new() { Name = "Out", FolderMapping = FolderMappingMode.Mirror,
+                    Sources = new List<SourceConfig> { new() { Path = "/mail/.mbox", Type = "mbox" } } },
+            },
+        };
+
+        PstOutputPlan plan = Assert.Single(MappingEngine.BuildPlan(config));
+        Assert.Equal(new[] { "Folder" }, plan.SourceMappings[0].TargetFolderPath.ToArray());
+        Assert.Single(plan.PlanningWarnings);
+    }
+
+    [Fact]
+    public void BuildPlan_ExplicitTargetFolderCollisions_AreNotDisambiguated()
+    {
+        // Two sources explicitly targeting the same folder is the user's choice — keep both as-is
+        // (an intentional merge), no disambiguation, no planning warning. Guards the "mirror-only" rule.
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new() { Name = "Out", FolderMapping = FolderMappingMode.Mirror,
+                    Sources = new List<SourceConfig>
+                    {
+                        new() { Path = "/a/x", Type = "mbox", TargetFolder = "Shared" },
+                        new() { Path = "/b/y", Type = "mbox", TargetFolder = "Shared" },
+                    } },
+            },
+        };
+
+        PstOutputPlan plan = Assert.Single(MappingEngine.BuildPlan(config));
+        Assert.Equal(new[] { "Shared" }, plan.SourceMappings[0].TargetFolderPath.ToArray());
+        Assert.Equal(new[] { "Shared" }, plan.SourceMappings[1].TargetFolderPath.ToArray());   // NOT "Shared (2)"
+        Assert.Empty(plan.PlanningWarnings);
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Writing/PstPartManagerOutputExistsTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Writing/PstPartManagerOutputExistsTests.cs
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.IO;
+using System.Text;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Writing;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Writing;
+
+public class PstPartManagerOutputExistsTests
+{
+    private static readonly byte[] PriorBytes =
+        Encoding.UTF8.GetBytes("PRIOR GOOD PST DATA — this run must not truncate or delete it");
+
+    private static PstPartManager NewManager(string groupName, string dir) =>
+        new PstPartManager(groupName, dir, long.MaxValue, 500,
+            writeMessage: (f, fo, m) => { }, writeContact: (f, fo, c) => { });
+
+    [Fact]
+    public void Begin_OutputPstAlreadyExists_ThrowsAndLeavesItByteForByteIntact()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), $"m2p-exists-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        string existing = Path.Combine(dir, "Archive.pst");
+        File.WriteAllBytes(existing, PriorBytes);
+        try
+        {
+            var mgr = NewManager("Archive", dir);
+            var ex = Assert.Throws<ConfigValidationException>(() => mgr.Begin(Array.Empty<FolderToPrecreate>()));
+            Assert.Contains("already exists", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Archive.pst", ex.Message);
+            // The pre-existing PST must be byte-for-byte intact — never truncated by CreateEmptyStore.
+            Assert.Equal(PriorBytes, File.ReadAllBytes(existing));
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void Begin_ExistingSplitPartFromPriorRun_ThrowsAndLeavesItIntact()
+    {
+        // A prior run split into Archive-1.pst (no bare Archive.pst). A re-run must still fail fast.
+        string dir = Path.Combine(Path.GetTempPath(), $"m2p-exists-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        string part1 = Path.Combine(dir, "Archive-1.pst");
+        File.WriteAllBytes(part1, PriorBytes);
+        try
+        {
+            var mgr = NewManager("Archive", dir);
+            var ex = Assert.Throws<ConfigValidationException>(() => mgr.Begin(Array.Empty<FolderToPrecreate>()));
+            Assert.Contains("Archive-1.pst", ex.Message);
+            Assert.Equal(PriorBytes, File.ReadAllBytes(part1));
+            Assert.False(File.Exists(Path.Combine(dir, "Archive.pst")));   // nothing created
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void Begin_UnrelatedDashPstName_DoesNotBlock_AndCreatesOutput()
+    {
+        // "Archive-old.pst" is NOT a converter-owned split part (non-numeric suffix) — must not block.
+        string dir = Path.Combine(Path.GetTempPath(), $"m2p-exists-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        File.WriteAllBytes(Path.Combine(dir, "Archive-old.pst"), PriorBytes);
+        try
+        {
+            var mgr = NewManager("Archive", dir);
+            mgr.Begin(Array.Empty<FolderToPrecreate>());   // must NOT throw
+            mgr.Finish();
+            mgr.Close();
+            Assert.True(File.Exists(Path.Combine(dir, "Archive.pst")));           // created cleanly
+            Assert.Equal(PriorBytes, File.ReadAllBytes(Path.Combine(dir, "Archive-old.pst")));  // untouched
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    // Locks the numeric edge of the split pattern: parts are Name-[1-9][0-9]*.pst (numbered from 1,
+    // no leading zero). A leading-zero name is NOT a converter-owned part and must not block. Guards
+    // against a future loosening of the regex to \d+ (which would be a user-visible behaviour change).
+    [Theory]
+    [InlineData("Archive-0.pst")]
+    [InlineData("Archive-01.pst")]
+    public void Begin_LeadingZeroNumericLikePstName_DoesNotBlock(string fileName)
+    {
+        string dir = Path.Combine(Path.GetTempPath(), $"m2p-exists-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        File.WriteAllBytes(Path.Combine(dir, fileName), PriorBytes);
+        try
+        {
+            var mgr = NewManager("Archive", dir);
+            mgr.Begin(Array.Empty<FolderToPrecreate>());   // must NOT throw
+            mgr.Finish();
+            mgr.Close();
+            Assert.True(File.Exists(Path.Combine(dir, "Archive.pst")));           // created cleanly
+            Assert.Equal(PriorBytes, File.ReadAllBytes(Path.Combine(dir, fileName)));  // untouched
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+}


### PR DESCRIPTION
## Summary

Two independent hardening features that make the converter fail safely and degrade gracefully on edge-case inputs rather than aborting the run, overwriting a good file, or silently merging folders. Each fix ships with regression tests.

## Output-overwrite safety

**Converting to a directory that already holds the output PST now fails fast** instead of truncating it. Previously the writer created the first PST part with `FileMode.Create` (truncating any existing file at the target path) before any success, and a cancelled or failed re-run then deleted that part — so re-running a conversion into a directory that already contained a good PST could destroy it. The conversion now stops immediately, *before touching any file*, with a clear message naming the existing file and the remedy (remove it or choose another output directory). It refuses when either the single output name (`Name.pst`) or a split part from a previous run (`Name-1.pst`, `Name-2.pst`, …) already exists.

## Name handling

Three name-derivers that could produce names the engine rejects — aborting the run or silently merging folders — are now routed through the existing validation instead of a new one:

- **Invalid Thunderbird mail-folder names** (for example a leading space or a reserved Windows device name) are sanitized to valid folder names during discovery, with a warning, instead of flowing through raw and risking a config-validation abort of the whole profile. The original name is kept for display.
- **Mirror-mode (folder-per-source) folder-name collisions** — two source files whose names reduce to the same folder (e.g. `Project.v1` and `Project.v2`), or a name that sanitizes to an empty/fallback value — are now disambiguated (`Project`, `Project (2)`) with a warning, instead of silently merging into one folder. Flatten mode and explicit folder targets (intentional merges) are unchanged.
- **Desktop:** a per-account PST name that is a reserved Windows device name with an extension (for example `AUX.2024`) no longer aborts a multi-account conversion. Such names are prefixed to a safe file name that the engine's output-name validation accepts, matching the engine's own reserved-name policy.

## Testing

Regression tests cover each fix on both the engine and the desktop. Full solution green locally: Core 1270 passing, Integration 111 passing (env-gated validators skipped locally; the independent PST-validation gate runs in CI); desktop Vitest 256 passing. No changes to the CLI event contract, the vendored PST library, or the event `schemaVersion`.
