### PR TITLE
fix: hardening slice C/D/H (null sources, size cap, RRULE COUNT, PO-Box ADR, UTF-8 CLI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Desktop: a per-account PST name that is a reserved Windows device name with an extension** (for
   example `AUX.2024`) no longer aborts a multi-account conversion; such names are prefixed to a safe,
   valid file name.
+- A configuration whose output group lists contacts but no mail sources (`sources: null`) now
+  converts normally instead of failing with an opaque "Object reference not set" error.
+- `maxSizeMB` is now capped at 50 GB and validated, so an extreme value can no longer overflow into
+  a negative or garbage size limit (which previously produced one PST per message).
+- A recurring event with an astronomically large `COUNT` (for example 100,000,000) no longer risks
+  exhausting memory; the recurrence is degraded with a warning instead of enumerating the entire
+  series just to find its last instance.
+- A contact address whose only populated part is a PO Box (or a building/suite in the extended
+  address field) is now preserved — folded into the street line — instead of being silently dropped.
 
 ## [0.3.2] — 2026-07-08
 

--- a/src/Mail2Pst.Cli/Program.cs
+++ b/src/Mail2Pst.Cli/Program.cs
@@ -4,7 +4,18 @@
 #nullable enable
 using System;
 using System.Reflection;
+using System.Text;
 using Mail2Pst.Cli;
+
+// Emit UTF-8 on stdout/stderr so non-ASCII folder names, subjects, and outputDirectory
+// survive the JSON-Lines contract (the Rust GUI decodes stdout as UTF-8). Separate guards:
+// a failure setting InputEncoding must not prevent setting OutputEncoding. Guarded for hosts
+// with no console attached (redirected/service), where the setter can throw.
+try { Console.OutputEncoding = new UTF8Encoding(false); }
+catch { /* no console / output unavailable — ignore */ }
+
+try { Console.InputEncoding = new UTF8Encoding(false); }
+catch { /* no console / input unavailable — ignore */ }
 
 if (args.Length == 0)
 {

--- a/src/Mail2Pst.Core/Calendar/RecurrenceMapping.cs
+++ b/src/Mail2Pst.Core/Calendar/RecurrenceMapping.cs
@@ -19,6 +19,11 @@ namespace Mail2Pst.Core.Calendar;
 /// </summary>
 public static class RecurrenceMapping
 {
+    // Outlook/PST recurrence cannot practically benefit from enumerating millions of instances;
+    // past this point materializing the series to find its last instance is pure waste / OOM risk.
+    // Reject COUNT above this BEFORE any enumeration (see FromIcal), degrading to a warning.
+    public const int MaxMaterializedRecurrenceCount = 100_000;
+
     /// <summary>
     /// Attempts to build a <see cref="RecurrenceSpec"/> from the supplied raw iCal lines
     /// and event anchor.
@@ -58,6 +63,11 @@ public static class RecurrenceMapping
         string? degradeReason = ComputeDegradeReason(p, lines);
         if (degradeReason is not null)
             return (null, degradeReason);
+
+        // Reject a COUNT so large that ComputeLastInstanceUtc would materialize + sort the whole series.
+        if (p.Count > MaxMaterializedRecurrenceCount)
+            return (null,
+                $"COUNT={p.Count} exceeds the maximum materialized recurrence count ({MaxMaterializedRecurrenceCount}); recurrence degraded");
 
         // Build the RRULE body for Ical.Net (strip the "RRULE:" prefix).
         string rruleLine = lines.First(l => l.StartsWith("RRULE", StringComparison.OrdinalIgnoreCase));

--- a/src/Mail2Pst.Core/Config/ConfigValidator.cs
+++ b/src/Mail2Pst.Core/Config/ConfigValidator.cs
@@ -16,6 +16,11 @@ namespace Mail2Pst.Core.Config;
 /// </summary>
 public static class ConfigValidator
 {
+    // MB -> bytes must never approach Int64 overflow, and no real PST needs > 50 GB. This is a
+    // product cap that is easier to reason about than "anything below long.MaxValue bytes". The
+    // default (OutputGroupConfig.MaxSizeMB = 20000) sits well under it.
+    public const long MaxSizeMBCap = 51200; // 50 GB
+
     public static void Validate(ConversionConfig config)
     {
         if (config.Outputs is null || config.Outputs.Count == 0)
@@ -35,6 +40,9 @@ public static class ConfigValidator
             if (output.MaxSizeMB <= 0)
                 throw new ConfigValidationException(
                     $"Output '{output.Name}' has maxSizeMB={output.MaxSizeMB}; it must be greater than 0.");
+            if (output.MaxSizeMB > MaxSizeMBCap)
+                throw new ConfigValidationException(
+                    $"Output '{output.Name}' has maxSizeMB={output.MaxSizeMB}; it must not exceed {MaxSizeMBCap} (50 GB).");
 
             bool hasMail = output.Sources is { Count: > 0 };
             bool hasContacts = output.Contacts is { Count: > 0 };

--- a/src/Mail2Pst.Core/Contacts/VCardContactMapper.cs
+++ b/src/Mail2Pst.Core/Contacts/VCardContactMapper.cs
@@ -75,6 +75,9 @@ public class VCardContactMapper
             if (adr is null) continue;
             var pa = ToPostal(adr);
             if (pa.IsEmpty) continue;
+            if (Parts(adr.Value.POBox).Any(s => !string.IsNullOrWhiteSpace(s)) ||
+                Parts(adr.Value.Extended).Any(s => !string.IsNullOrWhiteSpace(s)))
+                warnings.Add($"Contact '{c.DisplayName ?? cardId}': PO-Box/extended-address folded into the street field.");
             if (adr.Parameters.PropertyClass.IsSet(PCl.Work)) c.BusinessAddress ??= pa;
             else                                               c.HomeAddress     ??= pa;
         }
@@ -203,9 +206,20 @@ public class VCardContactMapper
         .OrderBy(e => e!.Parameters.Preference == 0 ? int.MaxValue : e!.Parameters.Preference)
         .Select(e => e!.Value!);
 
+    /// <summary>Null-safe view over an ADR component list — <c>Join</c> tolerates a null list, but
+    /// chaining <c>.Concat</c> on a raw (possibly null) <c>adr.Value.*</c> list throws.</summary>
+    private static IEnumerable<string> Parts(IEnumerable<string>? values) =>
+        values ?? Enumerable.Empty<string>();
+
     private static PostalAddress ToPostal(AddressProperty adr) => new()
     {
-        Street     = NullIfEmpty(Join(adr.Value.Street)),
+        // A non-empty ADR must never vanish. PostalAddress has no PO-Box / extended-address field,
+        // so fold those components into Street in stable order (PO-Box, then Extended, then Street)
+        // — otherwise a box-only or suite-only address maps empty and is dropped (finding #17).
+        Street     = NullIfEmpty(Join(
+                         Parts(adr.Value.POBox)
+                             .Concat(Parts(adr.Value.Extended))
+                             .Concat(Parts(adr.Value.Street)))),
         City       = NullIfEmpty(Join(adr.Value.Locality)),
         State      = NullIfEmpty(Join(adr.Value.Region)),
         PostalCode = NullIfEmpty(Join(adr.Value.PostalCode)),

--- a/src/Mail2Pst.Core/Contacts/VCardContactMapper.cs
+++ b/src/Mail2Pst.Core/Contacts/VCardContactMapper.cs
@@ -75,8 +75,14 @@ public class VCardContactMapper
             if (adr is null) continue;
             var pa = ToPostal(adr);
             if (pa.IsEmpty) continue;
-            if (Parts(adr.Value.POBox).Any(s => !string.IsNullOrWhiteSpace(s)) ||
-                Parts(adr.Value.Extended).Any(s => !string.IsNullOrWhiteSpace(s)))
+            // Warn only when the fold was load-bearing: Street itself was empty, so the
+            // PO-Box/Extended component is what rescued the address from mapping empty.
+            // A populated Street with an Extended component (apartment/suite) is common and
+            // not worth a warning even though it's still folded into Street below.
+            bool hasBoxOrExtended = Parts(adr.Value.POBox).Any(s => !string.IsNullOrWhiteSpace(s))
+                                  || Parts(adr.Value.Extended).Any(s => !string.IsNullOrWhiteSpace(s));
+            bool streetEmpty = !Parts(adr.Value.Street).Any(s => !string.IsNullOrWhiteSpace(s));
+            if (hasBoxOrExtended && streetEmpty)
                 warnings.Add($"Contact '{c.DisplayName ?? cardId}': PO-Box/extended-address folded into the street field.");
             if (adr.Parameters.PropertyClass.IsSet(PCl.Work)) c.BusinessAddress ??= pa;
             else                                               c.HomeAddress     ??= pa;

--- a/src/Mail2Pst.Core/Mapping/MappingEngine.cs
+++ b/src/Mail2Pst.Core/Mapping/MappingEngine.cs
@@ -29,7 +29,7 @@ public static class MappingEngine
             var plan = new PstOutputPlan
             {
                 Name = output.Name,
-                MaxSizeBytes = output.MaxSizeMB * 1024L * 1024L,
+                MaxSizeBytes = checked(output.MaxSizeMB * 1024L * 1024L),
                 IncludeEmptyFolders = output.IncludeEmptyFolders,
             };
 

--- a/src/Mail2Pst.Core/Mapping/MappingEngine.cs
+++ b/src/Mail2Pst.Core/Mapping/MappingEngine.cs
@@ -34,7 +34,7 @@ public static class MappingEngine
             };
 
             var usedMailKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (SourceConfig source in output.Sources)
+            foreach (SourceConfig source in output.Sources ?? new List<SourceConfig>())
             {
                 IReadOnlyList<string> targetPath;
                 bool mirrorDerived = false;

--- a/tests/Mail2Pst.Core.Tests/Calendar/RecurrenceMappingTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Calendar/RecurrenceMappingTests.cs
@@ -83,4 +83,23 @@ public class RecurrenceMappingTests
         Assert.Null(spec);
         Assert.Contains("BYMONTHDAY", reason);
     }
+
+    [Fact]
+    public void FromIcal_CountJustAboveMaterializationCap_DegradesBeforeEnumeration()
+    {
+        // A COUNT just above the cap (100_000) previously enumerated + sorted the whole series just to
+        // read the last instance. The rule must now degrade BEFORE enumeration. We use 100_001 (not
+        // 100_000_000) as the red value on purpose: pre-fix it enumerates only ~100k occurrences (fast,
+        // no OOM) instead of 100 million, so the failing test is safe to run — while still proving the
+        // new cap branch fires exactly one past the ceiling.
+        var anchor = new DateTime(2020, 1, 1, 9, 0, 0, DateTimeKind.Utc);
+
+        var (spec, reason) = RecurrenceMapping.FromIcal(
+            new[] { "RRULE:FREQ=DAILY;COUNT=100001" },
+            anchor, anchor, TimeZoneInfo.Utc, null);
+
+        Assert.Null(spec);
+        Assert.NotNull(reason);
+        Assert.Contains("COUNT", reason);
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Cli/CliEncodingE2ETests.cs
+++ b/tests/Mail2Pst.Core.Tests/Cli/CliEncodingE2ETests.cs
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Cli;
+
+// Spawns the real built CLI and reads RAW stdout bytes (not a decoded TextWriter) to prove a
+// non-ASCII folder name survives intact through the CLI's stdout end to end: Console.OutputEncoding
+// (Program.cs) writes UTF-8 bytes for the process's stdout stream, CliEventSerializer emits the
+// standard \u-escaped JSON (unchanged wire format), and a spec-compliant JSON parser (here,
+// System.Text.Json, mirroring the GUI's serde parser) decodes it back to the original character.
+// This is a round-trip/regression test, not a raw-byte mojibake test: pre-fix (no
+// Console.OutputEncoding set), a lone non-ASCII byte written through a legacy OEM/ANSI console
+// codepage can corrupt the UTF-8 byte stream before JSON parsing ever sees it, which this test
+// would catch via the U+FFFD replacement-char check. Mirrors the spawn/RepoRoot/CliDllPath pattern
+// in DiscoverCommandE2ETests.
+public class CliEncodingE2ETests
+{
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Mail2Pst.sln")))
+            dir = dir.Parent;
+        return dir?.FullName ?? throw new InvalidOperationException("Could not locate repo root (Mail2Pst.sln).");
+    }
+
+    private static string CliDllPath()
+    {
+        string config = AppContext.BaseDirectory.Replace('\\', '/').Contains("/bin/Release/") ? "Release" : "Debug";
+        string dll = Path.Combine(RepoRoot(), "src", "Mail2Pst.Cli", "bin", config, "net8.0", "Mail2Pst.Cli.dll");
+        Assert.True(File.Exists(dll), $"CLI build output not found at {dll}");
+        return dll;
+    }
+
+    // Reads stdout as raw bytes so we observe the exact encoding the process wrote.
+    private static (int exitCode, byte[] stdout, string stderr) RunCliRaw(string args)
+    {
+        var psi = new ProcessStartInfo("dotnet", $"\"{CliDllPath()}\" {args}")
+        {
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, WorkingDirectory = RepoRoot(),
+        };
+        using Process proc = Process.Start(psi)!;
+        using var buffer = new MemoryStream();
+        proc.StandardOutput.BaseStream.CopyTo(buffer);   // raw bytes, no decoding
+        string stderr = proc.StandardError.ReadToEnd();
+        proc.WaitForExit(60_000);
+        return (proc.ExitCode, buffer.ToArray(), stderr);
+    }
+
+    [Fact]
+    public void Cli_EmitsFolderNameWithUmlaut_StdoutBytesDecodeAsUtf8_NoReplacementChar()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "m2p-enc-" + Guid.NewGuid());
+        Directory.CreateDirectory(dir);
+        string mbox = Path.Combine(dir, "Kläranlage.mbox");
+        File.WriteAllText(mbox, "From a@b Mon Jan  1 00:00:00 2020\r\n\r\nx\r\n", new UTF8Encoding(false));
+        try
+        {
+            (int exit, byte[] stdout, string stderr) = RunCliRaw($"scan --input \"{mbox}\"");
+            Assert.True(exit == 0, $"expected exit 0, got {exit}. stderr: {stderr}");
+
+            // UTF-8 decode of the raw bytes with replacement detection: no U+FFFD. Pre-fix
+            // (Windows legacy codepage) the 'ä' is a lone 0xE4 byte, which UTF-8 decoding replaces
+            // with U+FFFD -- corrupting the JSON text before it is even parsed. (Not
+            // throwOnInvalid: we detect the failure via the U+FFFD assertion below rather than an
+            // exception.)
+            string text = new UTF8Encoding(false, throwOnInvalidBytes: false).GetString(stdout);
+            Assert.DoesNotContain('�', text);
+
+            // The wire format itself is unchanged: System.Text.Json's default encoder still
+            // \u-escapes non-ASCII (e.g. "Kläranlage"), so parse the JSON and assert on the
+            // DECODED value -- proving the umlaut round-trips through the CLI's stdout and a
+            // spec-compliant JSON parser, not that raw UTF-8 bytes appear literally on the wire.
+            using JsonDocument doc = JsonDocument.Parse(text);
+            string? displayName = doc.RootElement.GetProperty("sources")[0].GetProperty("displayName").GetString();
+            Assert.Contains("Kläranlage", displayName);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Config/ConfigValidatorTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Config/ConfigValidatorTests.cs
@@ -62,6 +62,18 @@ public class ConfigValidatorTests
         Assert.Throws<ConfigValidationException>(() => ConfigValidator.Validate(config));
     }
 
+    [Theory]
+    [InlineData(51201)]              // one MB above the 50 GB product cap
+    [InlineData(long.MaxValue)]      // would overflow MB -> bytes
+    public void Validate_MaxSizeMBAboveCap_Throws(long maxSizeMb)
+    {
+        var config = ValidConfig();
+        config.Outputs[0].MaxSizeMB = maxSizeMb;
+
+        var ex = Assert.Throws<ConfigValidationException>(() => ConfigValidator.Validate(config));
+        Assert.Contains("maxSizeMB", ex.Message);
+    }
+
     [Fact]
     public void Validate_OutputWithNoSources_Throws()
     {

--- a/tests/Mail2Pst.Core.Tests/Contacts/VCardContactMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Contacts/VCardContactMapperTests.cs
@@ -208,4 +208,37 @@ public class VCardContactMapperTests
         Assert.True(street.IndexOf("PO Box 123", StringComparison.Ordinal) < street.IndexOf("Building 4", StringComparison.Ordinal),
             $"expected PO-Box before Extended, got '{street}'");
     }
+
+    [Fact]
+    public void Map_PoBoxOnlyAdr_EmitsFoldWarning()
+    {
+        // Load-bearing fold: Street is empty, so PO-Box is what rescues the address from
+        // mapping empty. The warning must fire here.
+        string vcf = "BEGIN:VCARD\r\nVERSION:4.0\r\nFN:Boxer\r\nADR;TYPE=HOME:PO Box 123;;;;;;\r\nEND:VCARD\r\n";
+        var v = FolkerKinzel.VCards.Vcf.Parse(vcf).Single();
+
+        var warnings = new List<string>();
+        var c = new VCardContactMapper().Map(v, "c", warnings);
+
+        Assert.NotNull(c.HomeAddress);
+        Assert.Contains(warnings, w => w.Contains("folded into the street field", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Map_StreetWithExtendedAdr_DoesNotEmitFoldWarning()
+    {
+        // Non-load-bearing: Street is already populated, Extended is just an apartment/suite
+        // component. Folding it in is fine but shouldn't warn — this used to fire on any
+        // populated Extended, which is noisy for the very common apartment/suite case.
+        string vcf = "BEGIN:VCARD\r\nVERSION:4.0\r\nFN:Suite\r\nADR;TYPE=HOME:;Apt 4;Main St;City;;;\r\nEND:VCARD\r\n";
+        var v = FolkerKinzel.VCards.Vcf.Parse(vcf).Single();
+
+        var warnings = new List<string>();
+        var c = new VCardContactMapper().Map(v, "c", warnings);
+
+        Assert.NotNull(c.HomeAddress);
+        Assert.Contains("Apt 4", c.HomeAddress!.Street);
+        Assert.Contains("Main St", c.HomeAddress!.Street);
+        Assert.DoesNotContain(warnings, w => w.Contains("folded into the street field", StringComparison.OrdinalIgnoreCase));
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Contacts/VCardContactMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Contacts/VCardContactMapperTests.cs
@@ -174,4 +174,38 @@ public class VCardContactMapperTests
         var c = new VCardContactMapper().Map(v, "c", new System.Collections.Generic.List<string>());
         Assert.Equal("https://untyped.example", c.Webpage);
     }
+
+    [Fact]
+    public void Map_PoBoxOnlyAdr_PreservesAddressInStreet()
+    {
+        // ADR components: POBox;Extended;Street;Locality;Region;PostalCode;Country
+        // Only the PO-Box is populated. Previously ToPostal read only Street/Locality/..., so the
+        // whole address mapped empty and was dropped by the `if (pa.IsEmpty) continue;` guard.
+        string vcf = "BEGIN:VCARD\r\nVERSION:4.0\r\nFN:Boxer\r\nADR;TYPE=HOME:PO Box 123;;;;;;\r\nEND:VCARD\r\n";
+        var v = FolkerKinzel.VCards.Vcf.Parse(vcf).Single();
+
+        var c = new VCardContactMapper().Map(v, "c", new List<string>());
+
+        Assert.NotNull(c.HomeAddress);
+        Assert.Contains("PO Box 123", c.HomeAddress!.Street);
+    }
+
+    [Fact]
+    public void Map_PoBoxAndExtendedAdr_FoldsInStableOrder_PoBoxThenExtended()
+    {
+        // POBox="PO Box 123", Extended="Building 4". Fold order must be PO-Box then Extended then
+        // Street, and the extended-address component must not be lost. ADR has SEVEN components
+        // (POBox;Extended;Street;Locality;Region;PostalCode;Country) = six semicolons.
+        string vcf = "BEGIN:VCARD\r\nVERSION:4.0\r\nFN:Boxer\r\nADR;TYPE=WORK:PO Box 123;Building 4;;;;;\r\nEND:VCARD\r\n";
+        var v = FolkerKinzel.VCards.Vcf.Parse(vcf).Single();
+
+        var c = new VCardContactMapper().Map(v, "c", new List<string>());
+
+        Assert.NotNull(c.BusinessAddress);
+        string street = c.BusinessAddress!.Street!;
+        Assert.Contains("PO Box 123", street);
+        Assert.Contains("Building 4", street);
+        Assert.True(street.IndexOf("PO Box 123", StringComparison.Ordinal) < street.IndexOf("Building 4", StringComparison.Ordinal),
+            $"expected PO-Box before Extended, got '{street}'");
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Mapping/MappingEngineTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mapping/MappingEngineTests.cs
@@ -282,4 +282,25 @@ public class MappingEngineTests
         Assert.Empty(plans[0].SourceMappings);
         Assert.Single(plans[0].ContactMappings);
     }
+
+    [Fact]
+    public void BuildPlan_MaxSizeMBOverflow_DoesNotProduceNegativeMaxSizeBytes()
+    {
+        // Defense-in-depth: even bypassing ConfigValidator, the MB->bytes multiply must not silently
+        // wrap to a negative/garbage cap. With checked{} it surfaces as OverflowException.
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Personal",
+                    MaxSizeMB = long.MaxValue,
+                    Sources = new List<SourceConfig> { new() { Path = "Inbox.mbox", Type = "mbox" } },
+                },
+            },
+        };
+
+        Assert.Throws<OverflowException>(() => MappingEngine.BuildPlan(config));
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Mapping/MappingEngineTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Mapping/MappingEngineTests.cs
@@ -252,4 +252,34 @@ public class MappingEngineTests
         Assert.Equal(new[] { "Shared" }, plan.SourceMappings[1].TargetFolderPath.ToArray());   // NOT "Shared (2)"
         Assert.Empty(plan.PlanningWarnings);
     }
+
+    [Fact]
+    public void BuildPlan_OutputWithNullSourcesAndValidContact_DoesNotThrowNRE()
+    {
+        // A contacts-only config leaves Sources null. ConfigValidator already tolerates a null
+        // Sources list (it iterates `Sources ?? new List<>()`), so this reaches MappingEngine,
+        // which iterated output.Sources directly and threw an opaque NullReferenceException.
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Personal",
+                    MaxSizeMB = 100,
+                    Sources = null,
+                    Contacts = new List<ContactSourceConfig>
+                    {
+                        new() { Path = "abook.sqlite", Format = "thunderbird-sqlite" },
+                    },
+                },
+            },
+        };
+
+        List<PstOutputPlan> plans = MappingEngine.BuildPlan(config);
+
+        Assert.Single(plans);
+        Assert.Empty(plans[0].SourceMappings);
+        Assert.Single(plans[0].ContactMappings);
+    }
 }


### PR DESCRIPTION
Batched hardening fixes across the Core engine and CLI. Five confirmed defects, one fix plus a regression test each. No `vendor/PSTFileFormat` changes and no change to the CLI JSON-Lines output contract.

## Fixes
- **Mapping:** a config that lists contacts but no mail sources (`sources: null`) previously threw a `NullReferenceException`. `MappingEngine.BuildPlan` now null-coalesces `Sources`, matching the adjacent Contacts loop.
- **Config:** `maxSizeMB` had no upper bound and could overflow `Int64` in the MB→bytes conversion, yielding a negative/garbage size limit (one PST per message). It is now capped at 50 GB in `ConfigValidator`, and the multiply is performed in a `checked` context as defense-in-depth.
- **Calendar:** an unbounded `RRULE COUNT` materialized and sorted the entire occurrence series just to read the last instance (multi-GB allocation / OOM risk). A `COUNT` above 100,000 now degrades with a warning instead of enumerating the whole series.
- **Contacts:** a vCard address whose only populated component was a PO Box or the extended-address field mapped to an empty address and was dropped. Those components are now folded into the street line so the address is preserved; the fold warning is emitted only when it was load-bearing (the street field was otherwise empty).
- **CLI:** the CLI now sets UTF-8 console encoding at startup as a safeguard for non-ASCII output, covered by an end-to-end test asserting a non-ASCII name round-trips intact through the JSON-Lines stdout.

## Verification
- Full solution test suite passes (Core and Integration).