### PR TITLE
Add parser fuzzing harness and graceful-degradation regression tests

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -106,3 +106,8 @@ The developer/test-only tool tools/pst-validate depends on the "outlook-pst" cra
 licensed MIT. The tool's own source is GPL-3.0-or-later (ContinuMail project code). It is used
 solely to independently validate converter output during testing, is not linked into the engine,
 CLI, or desktop app, and is NOT shipped in ContinuMail Converter release artifacts.
+
+The developer/test-only tool tools/Mail2Pst.Fuzz depends on "SharpFuzz" (Metalnem), licensed MIT.
+The tool's own source is GPL-3.0-or-later (ContinuMail project code). It is used solely to fuzz
+the parsers during testing, is not linked into the engine, CLI, or desktop app, and is NOT shipped
+in ContinuMail Converter release artifacts.

--- a/tests/Mail2Pst.Core.Tests/Fuzzing/FuzzGracefulDegradationTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Fuzzing/FuzzGracefulDegradationTests.cs
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Mork;
+using Mail2Pst.Core.Parsing;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Fuzzing;
+
+/// <summary>
+/// Regression home for crashes surfaced by tools/Mail2Pst.Fuzz. Each test feeds a synthetic,
+/// PII-free input and asserts GRACEFUL degradation (a whitelisted outcome), never an un-whitelisted
+/// throw. New fuzzer finds are added here as minimized synthetic repros.
+/// </summary>
+public class FuzzGracefulDegradationTests
+{
+    // Lock: arbitrary non-mbox garbage bytes must enumerate to completion without an unexpected
+    // throw out of Parse. NOTE: garbage with no `From ` boundary is simply not an mbox message, so
+    // this may yield ZERO results — the invariant is "enumeration completes, no un-whitelisted
+    // exception", NOT "produces failed skips". This is the exact contract the mbox fuzz target checks.
+    [Fact]
+    public void MboxParser_GarbageBytes_EnumeratesToCompletion_NoUnexpectedThrow()
+    {
+        byte[] garbage = Enumerable.Range(0, 4096).Select(i => (byte)((i * 37) ^ 0xA5)).ToArray();
+        string path = Path.Combine(Path.GetTempPath(), $"m2p-fuzzreg-{Guid.NewGuid():N}.mbox");
+        File.WriteAllBytes(path, garbage);
+        try
+        {
+            var results = new MboxParser().Parse(path).ToList();   // must not throw; may be empty
+            Assert.All(results, r => Assert.True(r.Success || r.Error is not null));
+        }
+        finally { File.Delete(path); }
+    }
+
+    // Lock: a truncated Mork header must NOT produce an un-whitelisted exception. The fuzz contract
+    // is "parse OK, or throw only the whitelisted MorkFormatException" — some malformed streams may
+    // legitimately parse as an empty document, so we do NOT require a throw. (The StackOverflow fix
+    // is already locked separately by the deep-nest MorkDepthLimitTests.)
+    [Fact]
+    public void MorkReader_TruncatedHeader_NoUnexpectedException()
+    {
+        byte[] truncated = System.Text.Encoding.ASCII.GetBytes("// <!-- <mdb:mork:z v=\"1.4\"/> -->\n< (");
+        using var ms = new MemoryStream(truncated);
+        try
+        {
+            _ = MorkReader.Parse(ms);
+        }
+        catch (Exception ex)
+        {
+            Assert.IsType<MorkFormatException>(ex);   // only the whitelisted type is acceptable
+        }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Fuzzing/FuzzGracefulDegradationTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Fuzzing/FuzzGracefulDegradationTests.cs
@@ -29,8 +29,11 @@ public class FuzzGracefulDegradationTests
         File.WriteAllBytes(path, garbage);
         try
         {
+            // Primary guarantee: enumerating to completion does not throw an un-whitelisted
+            // exception. Garbage with no `From ` boundary may legitimately yield ZERO results.
             var results = new MboxParser().Parse(path).ToList();   // must not throw; may be empty
-            Assert.All(results, r => Assert.True(r.Success || r.Error is not null));
+            // Real (non-tautological) shape invariant: a successful result always carries a Message.
+            Assert.All(results, r => Assert.True(!r.Success || r.Message is not null));
         }
         finally { File.Delete(path); }
     }

--- a/tools/Mail2Pst.Fuzz/FuzzTargets.cs
+++ b/tools/Mail2Pst.Fuzz/FuzzTargets.cs
@@ -22,6 +22,11 @@ public static class FuzzTargets
     private static bool IsGraceful(Exception ex) =>
         ex is MorkFormatException or FormatException or IOException;
 
+    // Owned scratch subdir under the OS temp root, so per-iteration mbox files don't scatter
+    // directly into the shared temp folder. Created once.
+    private static readonly string TempDir =
+        Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "mail2pst-fuzz")).FullName;
+
     public static void RunMork(ReadOnlySpan<byte> data)
     {
         // MorkReader is byte-friendly via Parse(Stream); no temp file needed.
@@ -36,7 +41,7 @@ public static class FuzzTargets
     public static void RunMbox(ReadOnlySpan<byte> data)
     {
         // MboxParser.Parse is path-based, so spill the input to a scratch file per iteration.
-        string path = Path.Combine(Path.GetTempPath(), $"m2p-fuzz-{Guid.NewGuid():N}.mbox");
+        string path = Path.Combine(TempDir, $"{Guid.NewGuid():N}.mbox");
         try
         {
             // The temp-file WRITE is inside the try on purpose: an IOException from a full/locked

--- a/tools/Mail2Pst.Fuzz/FuzzTargets.cs
+++ b/tools/Mail2Pst.Fuzz/FuzzTargets.cs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Mork;
+using Mail2Pst.Core.Parsing;
+
+namespace Mail2Pst.Fuzz;
+
+/// <summary>
+/// One target per fuzzed parser. Each runs the parser over the input bytes and swallows ONLY the
+/// whitelisted graceful exceptions (MorkFormatException / FormatException / IOException) — the
+/// documented "degrade to a skip" contract. Any other exception type escapes, so libFuzzer (or the
+/// replay driver) records it as a crash: that is the bug class we are hunting.
+/// </summary>
+public static class FuzzTargets
+{
+    // The single whitelist: these three types are the documented "degrade to a skip" outcomes.
+    // Anything else escaping the target is a finding. Both targets use the SAME filter.
+    private static bool IsGraceful(Exception ex) =>
+        ex is MorkFormatException or FormatException or IOException;
+
+    public static void RunMork(ReadOnlySpan<byte> data)
+    {
+        // MorkReader is byte-friendly via Parse(Stream); no temp file needed.
+        using var ms = new MemoryStream(data.ToArray());
+        try
+        {
+            _ = MorkReader.Parse(ms);
+        }
+        catch (Exception ex) when (IsGraceful(ex)) { /* graceful: malformed/hostile Mork -> skip */ }
+    }
+
+    public static void RunMbox(ReadOnlySpan<byte> data)
+    {
+        // MboxParser.Parse is path-based, so spill the input to a scratch file per iteration.
+        string path = Path.Combine(Path.GetTempPath(), $"m2p-fuzz-{Guid.NewGuid():N}.mbox");
+        try
+        {
+            // The temp-file WRITE is inside the try on purpose: an IOException from a full/locked
+            // temp dir is whitelisted, not a "crash". Draining the enumerable is what actually runs
+            // the parse; per-message FormatException/IOException are already turned into
+            // ParseResult.Failed inside the parser, so a well-behaved parser never throws here.
+            File.WriteAllBytes(path, data.ToArray());
+            _ = new MboxParser().Parse(path).ToList();
+        }
+        catch (Exception ex) when (IsGraceful(ex)) { /* graceful */ }
+        finally
+        {
+            try { File.Delete(path); } catch { /* best-effort cleanup */ }
+        }
+    }
+}

--- a/tools/Mail2Pst.Fuzz/Mail2Pst.Fuzz.csproj
+++ b/tools/Mail2Pst.Fuzz/Mail2Pst.Fuzz.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>mail2pst-fuzz</AssemblyName>
+    <IsPackable>false</IsPackable>
+    <!-- Deliberately NOT added to Mail2Pst.sln: dev-only fuzz tool, kept out of CI. -->
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="SharpFuzz" Version="2.3.0" />   <!-- current as of 2026-06; verify latest at restore -->
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Mail2Pst.Core/Mail2Pst.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/Mail2Pst.Fuzz/Program.cs
+++ b/tools/Mail2Pst.Fuzz/Program.cs
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Fuzz;
+using SharpFuzz;
+
+// Modes:
+//   mork | mbox                 -> libFuzzer-driven fuzzing (requires the instrumented assembly)
+//   mork-replay <dir> | mbox-replay <dir>
+//                               -> deterministic replay of every file in <dir> through the target,
+//                                  no libFuzzer. Exit 0 iff no unexpected exception escaped.
+//
+// NOTE: RunMork/RunMbox take ReadOnlySpan<byte> (a ref struct), so they CANNOT be stored in an
+// Action<ReadOnlySpan<byte>>. Dispatch directly instead. For libFuzzer mode, pass the method group
+// straight to Fuzzer.LibFuzzer.Run (SharpFuzz's own delegate type accepts a ReadOnlySpan<byte>).
+if (args.Length == 0)
+{
+    Console.Error.WriteLine("usage: mail2pst-fuzz <mork|mbox|mork-replay <dir>|mbox-replay <dir>>");
+    return 2;
+}
+
+// A byte[] argument binds implicitly to the ReadOnlySpan<byte> parameter, so replay can dispatch here.
+static void RunTarget(string mode, byte[] bytes)
+{
+    if (mode.StartsWith("mork", StringComparison.Ordinal))
+        FuzzTargets.RunMork(bytes);
+    else if (mode.StartsWith("mbox", StringComparison.Ordinal))
+        FuzzTargets.RunMbox(bytes);
+    else
+        throw new ArgumentException($"unknown mode '{mode}'");
+}
+
+if (args[0].EndsWith("-replay", StringComparison.Ordinal))
+{
+    if (args.Length < 2) { Console.Error.WriteLine("replay needs a corpus directory"); return 2; }
+    int n = 0, unexpected = 0;
+    // Sort for deterministic output across OSes/filesystems.
+    foreach (string file in Directory.EnumerateFiles(args[1]).OrderBy(p => p, StringComparer.Ordinal))
+    {
+        n++;
+        try { RunTarget(args[0], File.ReadAllBytes(file)); }
+        catch (Exception ex)
+        {
+            unexpected++;
+            Console.Error.WriteLine($"UNEXPECTED {ex.GetType().Name} on {Path.GetFileName(file)}: {ex.Message}");
+        }
+    }
+    Console.WriteLine($"{n} inputs, {unexpected} unexpected exceptions");
+    return unexpected == 0 ? 0 : 1;
+}
+
+// libFuzzer mode: pass the method group directly (verify the exact delegate signature against the
+// installed SharpFuzz version when compiling — current docs use Fuzzer.LibFuzzer.Run).
+switch (args[0])
+{
+    case "mork": Fuzzer.LibFuzzer.Run(FuzzTargets.RunMork); return 0;
+    case "mbox": Fuzzer.LibFuzzer.Run(FuzzTargets.RunMbox); return 0;
+    default:
+        Console.Error.WriteLine($"unknown mode '{args[0]}'");
+        return 2;
+}

--- a/tools/Mail2Pst.Fuzz/Program.cs
+++ b/tools/Mail2Pst.Fuzz/Program.cs
@@ -36,6 +36,11 @@ static void RunTarget(string mode, byte[] bytes)
 if (args[0].EndsWith("-replay", StringComparison.Ordinal))
 {
     if (args.Length < 2) { Console.Error.WriteLine("replay needs a corpus directory"); return 2; }
+    if (!Directory.Exists(args[1]))
+    {
+        Console.Error.WriteLine($"corpus directory not found: '{args[1]}'");
+        return 2;
+    }
     int n = 0, unexpected = 0;
     // Sort for deterministic output across OSes/filesystems.
     foreach (string file in Directory.EnumerateFiles(args[1]).OrderBy(p => p, StringComparer.Ordinal))
@@ -47,6 +52,13 @@ if (args[0].EndsWith("-replay", StringComparison.Ordinal))
             unexpected++;
             Console.Error.WriteLine($"UNEXPECTED {ex.GetType().Name} on {Path.GetFileName(file)}: {ex.Message}");
         }
+    }
+    if (n == 0)
+    {
+        // An empty corpus directory almost always means a mistyped path — fail loudly rather
+        // than reporting a clean-looking "0 inputs, 0 unexpected exceptions".
+        Console.Error.WriteLine($"no input files in corpus directory: '{args[1]}'");
+        return 2;
     }
     Console.WriteLine($"{n} inputs, {unexpected} unexpected exceptions");
     return unexpected == 0 ? 0 : 1;

--- a/tools/Mail2Pst.Fuzz/README.md
+++ b/tools/Mail2Pst.Fuzz/README.md
@@ -1,0 +1,56 @@
+<!-- SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail) -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+# mail2pst-fuzz — parser fuzzing (dev/test tool, NOT shipped)
+
+Coverage-guided fuzzing of the two byte-facing parsers (`MboxParser`, `MorkReader`) via
+[SharpFuzz](https://github.com/Metalnem/sharpfuzz) + libFuzzer. Not in `Mail2Pst.sln`, never
+linked into the product, never shipped. Same "independent dev tool" status as `tools/pst-validate`.
+
+## What counts as a crash
+
+Each target runs the parser and swallows only the **whitelisted graceful exceptions**
+(`MorkFormatException`, `FormatException`, `IOException` — the documented "degrade to a skip"
+path). Any other escaping exception, a hang (libFuzzer `-timeout`), or an OOM (libFuzzer
+`-rss_limit_mb`) is recorded as a crashing input.
+
+## One-time setup
+
+```bash
+dotnet tool install --global SharpFuzz.CommandLine   # provides the `sharpfuzz` instrumenter
+dotnet build tools/Mail2Pst.Fuzz/Mail2Pst.Fuzz.csproj -c Release
+# Instrument the assembly under test (in place), pointing at the build output:
+sharpfuzz tools/Mail2Pst.Fuzz/bin/Release/net8.0/Mail2Pst.Core.dll
+```
+
+You also need the `libfuzzer-dotnet` driver for your OS. Follow the current SharpFuzz README
+(<https://github.com/Metalnem/sharpfuzz#how-to-use>) to obtain/build it — on Linux it is built
+once with clang; on Windows use the project's `libfuzzer-dotnet-windows` driver. (Pinning a binary
+URL here would rot; the SharpFuzz README is the source of truth for the driver.)
+
+## Run
+
+```bash
+# seed corpus lives OUTSIDE the repo (may contain real-mail fragments) — see PII policy below
+libfuzzer-dotnet --target_path=tools/Mail2Pst.Fuzz/bin/Release/net8.0/mail2pst-fuzz \
+                 --target_arg=mork  testdata/fuzz/mork-corpus
+```
+
+Swap `mork` → `mbox` and the corpus dir to fuzz the mbox splitter.
+
+## Deterministic replay (no libFuzzer — CI-independent smoke)
+
+```bash
+dotnet run --project tools/Mail2Pst.Fuzz -- mork-replay testdata/fuzz/mork-corpus
+dotnet run --project tools/Mail2Pst.Fuzz -- mbox-replay fixtures
+```
+Exit 0 iff no input produced an un-whitelisted exception. Use this to sanity-check the harness and
+to re-run a saved corpus without the libFuzzer toolchain.
+
+## Seed corpus & PII policy (READ THIS)
+
+- Seeds and raw crash artifacts live under gitignored `testdata/fuzz/` — **never committed**
+  (real `.mbox`/`.mab`/`.msf` fragments are PII). Seed the mbox corpus from `fixtures/*.mbox`
+  plus any local real files; seed the mork corpus from local `.msf`/`.mab` files.
+- When a crash is found: minimize it, then **hand-author a synthetic, PII-free repro** (or verify
+  the minimized bytes contain no real mail) and add it as an xUnit regression under
+  `tests/Mail2Pst.Core.Tests/Fuzzing/`. Real bytes never enter the public repo; never `git add -f`.

--- a/tools/Mail2Pst.Fuzz/README.md
+++ b/tools/Mail2Pst.Fuzz/README.md
@@ -31,11 +31,13 @@ URL here would rot; the SharpFuzz README is the source of truth for the driver.)
 
 ```bash
 # seed corpus lives OUTSIDE the repo (may contain real-mail fragments) — see PII policy below
+# fuzz the Mork reader:
 libfuzzer-dotnet --target_path=tools/Mail2Pst.Fuzz/bin/Release/net8.0/mail2pst-fuzz \
                  --target_arg=mork  testdata/fuzz/mork-corpus
+# fuzz the mbox splitter:
+libfuzzer-dotnet --target_path=tools/Mail2Pst.Fuzz/bin/Release/net8.0/mail2pst-fuzz \
+                 --target_arg=mbox  testdata/fuzz/mbox-corpus
 ```
-
-Swap `mork` → `mbox` and the corpus dir to fuzz the mbox splitter.
 
 ## Deterministic replay (no libFuzzer — CI-independent smoke)
 


### PR DESCRIPTION
## Summary

Adds an adversarial testing layer that hunts the "one malformed input aborts the whole conversion" class of bug in the two byte-facing parsers (`MboxParser`, `MorkReader`), before it reaches users.

- **`tools/Mail2Pst.Fuzz`** — a standalone SharpFuzz coverage-guided fuzzing tool for the mbox and Mork readers, with a deterministic replay mode for a toolchain-free smoke. Dev/test-only: not in `Mail2Pst.sln`, never linked into the product, never shipped — same status as `tools/pst-validate`. Includes a README with the instrument/run recipe and the seed-corpus PII policy.
- **`tests/Mail2Pst.Core.Tests/Fuzzing/`** — the permanent, CI-gated home where fuzzer finds graduate into regression tests, seeded with two graceful-degradation locks: garbage mbox bytes enumerate to completion without an unexpected throw, and a truncated Mork stream raises only the whitelisted `MorkFormatException`.
- **`NOTICE`** — acknowledges SharpFuzz (MIT), scoped as a dev/test-only, not-shipped dependency.

No conversion logic changes; user-facing behavior is unchanged.

## Testing

- `dotnet test tests/Mail2Pst.Core.Tests` — 1298 passed, 1 skipped, 0 failed; output pristine.
- Fuzz tool builds clean and the replay smoke passes (`mbox-replay fixtures` → 9 inputs, 0 unexpected, exit 0); missing/empty corpus directories now fail with a clear message and a non-zero exit.

## Follow-ups (separate PRs)

Property-based configuration testing, `pst-validate` oracle-integrity hardening, and a generated round-trip validation harness.
