### PR TITLE
Harden the independent PST oracle and add a generative round-trip check

### DIFF
--- a/tests/Mail2Pst.Integration.Tests/GenerativeRoundTripTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/GenerativeRoundTripTests.cs
@@ -81,7 +81,7 @@ public class GenerativeRoundTripTests
 
                 var (outputs, report) = RoundTripHarness.Convert(config, outDir);
                 Assert.NotEmpty(outputs);
-                Assert.Equal(0, report.Skipped.Count); // clean profile: nothing skipped
+                Assert.Empty(report.Skipped); // clean profile: nothing skipped
 
                 // Expected (clean): known WRITTEN counts, no skips. Cross-check it agrees with BuildTruth.
                 Dictionary<string, int> expected = GenerativeTruth.BuildExpected(
@@ -94,6 +94,52 @@ public class GenerativeRoundTripTests
             }
             finally { Directory.Delete(outDir, true); }
         }, iter: 25, seed: "00001e2WUFC1", threads: 1);
+    }
+
+    // Verification lock: determine whether the PRODUCTION convert path skips a truncated final message.
+    // A truncated tail after N complete messages yields EITHER N (MimeKit parsed the fragment; no skip)
+    // OR N + a recorded skip (fragment rejected). Whichever it is, this pins it so GenerativeTruth's
+    // expected-skip count is correct. Runs without the Rust reader (asserts on the ConversionReport only).
+    [Fact]
+    [Trait("Tier", "local")]
+    public void TruncatedFinalMessage_ConvertBehavior_IsPinned()
+    {
+        using GeneratedProfile profile = new ThunderbirdProfileBuilder()
+            .WithAccount("alice@example.com", "imap.example.com")
+            .WithTruncatedFinalMessage("Inbox", fullMessageCount: 2)
+            .Build();
+
+        string outDir = Path.Combine(Path.GetTempPath(), "m2p-trunc-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outDir);
+        try
+        {
+            var config = new ConversionConfig
+            {
+                Outputs = new List<OutputGroupConfig>
+                {
+                    new()
+                    {
+                        Name = "Archive", MaxSizeMB = 50_000, FolderMapping = FolderMappingMode.Mirror,
+                        IncludeEmptyFolders = true,
+                        Sources = profile.Folders.Select(f => new SourceConfig { Type = "mbox", Path = f.FilePath }).ToList(),
+                    },
+                },
+            };
+            var (_, report) = RoundTripHarness.Convert(config, outDir);
+
+            // EMPIRICALLY PINNED (Slice 3b Task 2, 2026-07-10): 2 complete messages + 1 truncated tail
+            // were written; the PRODUCTION convert path parsed all 3 (MimeKit's entity parser accepts
+            // the truncated fragment as a malformed-but-parseable final message) — ConvertedCount == 3,
+            // Skipped.Count == 0, no skip recorded. Per-message mid-body truncation is therefore NOT a
+            // reliable convert-level skip signal; the reliable skip paths remain oversized-message
+            // (parser-level, Slice-1 coverage) and whole-source IOException. Per the Slice 3b Task 2
+            // brief's verify gate, this PARSED outcome means the adjusted-truth corruption case (Step 4)
+            // is deliberately NOT wired into the generative oracle for this shape — the generative clean
+            // round-trip (Task 1) remains the delivered oracle.
+            Assert.Equal(3, report.ConvertedCount);
+            Assert.Empty(report.Skipped);
+        }
+        finally { Directory.Delete(outDir, true); }
     }
 
     // Aggregate per-folder counts from the INDEPENDENT reader across all output parts, then assert

--- a/tests/Mail2Pst.Integration.Tests/GenerativeRoundTripTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/GenerativeRoundTripTests.cs
@@ -142,6 +142,39 @@ public class GenerativeRoundTripTests
         finally { Directory.Delete(outDir, true); }
     }
 
+    // Pure unit test of GenerativeTruth's adjusted-truth arithmetic (written - skips). No conversion or
+    // Rust reader — runs in normal CI. Covers GeneratedProfileCounts.FromAttempted + the non-empty
+    // perSourcePathSkips path, which the PARSED verify-gate outcome otherwise leaves unexercised.
+    [Fact]
+    public void GenerativeTruth_BuildExpected_SubtractsExpectedSkips()
+    {
+        // Mirror mode maps the source file to a folder named by its filename stem ("Inbox").
+        // BuildPlan does NOT read the file, so a non-existent path is fine for this pure test.
+        string src = Path.Combine(Path.GetTempPath(), "Inbox");
+        var config = new ConversionConfig
+        {
+            Outputs = new List<OutputGroupConfig>
+            {
+                new()
+                {
+                    Name = "Archive",
+                    MaxSizeMB = 50_000,
+                    FolderMapping = FolderMappingMode.Mirror,
+                    IncludeEmptyFolders = true,
+                    Sources = new List<SourceConfig> { new() { Type = "mbox", Path = src } },
+                },
+            },
+        };
+
+        var attempted = new GeneratedProfileCounts(
+            new Dictionary<string, int>(StringComparer.Ordinal) { [src] = 3 });   // 2 complete + 1 truncated tail
+        var skips = new Dictionary<string, int>(StringComparer.Ordinal) { [src] = 1 };
+
+        Dictionary<string, int> expected = GenerativeTruth.BuildExpected(config, attempted, skips);
+
+        Assert.Equal(2, expected[FolderPathKey.Join(new[] { "Inbox" })]);   // 3 - 1
+    }
+
     // Aggregate per-folder counts from the INDEPENDENT reader across all output parts, then assert
     // every expected path matches exactly and no unexpected folder appears (except known zero-count
     // store folders). Extracted here so the corruption case (Task 2) reuses the exact comparison.

--- a/tests/Mail2Pst.Integration.Tests/GenerativeRoundTripTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/GenerativeRoundTripTests.cs
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using CsCheck;
+using Mail2Pst.Core;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Mapping;
+using Mail2Pst.TestSupport;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests;
+
+[Trait("Category", "GenerativeRoundTrip")]
+public class GenerativeRoundTripTests
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(60);
+
+    // Zero-count implementation folders the from-scratch store surfaces (same as the fixed gate).
+    private static readonly HashSet<string> ZeroCountAllowlist = new(StringComparer.Ordinal)
+    {
+        FolderPathKey.Join(new[] { "Deleted Items" }),
+        FolderPathKey.Join(new[] { "Calendar" }),
+    };
+
+    // OS-creatable, PST-valid, DISTINCT folder-name pool: ASCII, a Danish PT_UNICODE name, spaces.
+    // Distinct filenames avoid on-disk collisions in the builder; mirror-mode mapping is applied
+    // identically to truth and writer, so any sanitization stays self-consistent.
+    private static readonly string[] NamePool =
+    {
+        "Inbox", "Sent", "Archive 2024", "Projects", "Færdige opgaver", "Kladder", "Rejser", "Kvitteringer",
+    };
+
+    private sealed record FolderRecipe(int NameIndex, int MessageCount);
+
+    // 1..5 folders, each with a distinct name (by index) and 0..4 messages.
+    private static readonly Gen<FolderRecipe[]> ProfileGen =
+        from indices in Gen.Shuffle(Enumerable.Range(0, NamePool.Length).ToArray())
+        from n in Gen.Int[1, 5]
+        from counts in Gen.Int[0, 4].Array[n, n]
+        select indices.Take(n).Zip(counts, (idx, c) => new FolderRecipe(idx, c)).ToArray();
+
+    [SkippableFact]
+    [Trait("Tier", "local")]
+    public void GeneratedProfiles_RoundTripCountsMatchIndependentReader()
+    {
+        Skip.If(PstValidatorRunner.ValidatorPath is null,
+            "Set MAIL2PST_PST_VALIDATOR to the built pst-validate exe.");
+        Skip.If(Environment.GetEnvironmentVariable("MAIL2PST_ENABLE_GENERATIVE_ROUNDTRIP") is not "1",
+            "Set MAIL2PST_ENABLE_GENERATIVE_ROUNDTRIP=1 to run the generative round-trip oracle (local, slow).");
+
+        ProfileGen.Sample(recipe =>
+        {
+            var builder = new ThunderbirdProfileBuilder().WithAccount("alice@example.com", "imap.example.com");
+            foreach (FolderRecipe f in recipe)
+                builder.WithFolder(NamePool[f.NameIndex], f.MessageCount);
+            using GeneratedProfile profile = builder.Build();
+
+            string outDir = Path.Combine(Path.GetTempPath(), "m2p-genrt-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(outDir);
+            try
+            {
+                var config = new ConversionConfig
+                {
+                    Outputs = new List<OutputGroupConfig>
+                    {
+                        new()
+                        {
+                            Name = "Archive",
+                            MaxSizeMB = 50_000,
+                            FolderMapping = FolderMappingMode.Mirror,
+                            IncludeEmptyFolders = true,
+                            Sources = profile.Folders
+                                .Select(f => new SourceConfig { Type = "mbox", Path = f.FilePath })
+                                .ToList(),
+                        },
+                    },
+                };
+
+                var (outputs, report) = RoundTripHarness.Convert(config, outDir);
+                Assert.NotEmpty(outputs);
+                Assert.Equal(0, report.Skipped.Count); // clean profile: nothing skipped
+
+                // Expected (clean): known WRITTEN counts, no skips. Cross-check it agrees with BuildTruth.
+                Dictionary<string, int> expected = GenerativeTruth.BuildExpected(
+                    config, GeneratedProfileCounts.FromWritten(profile), new Dictionary<string, int>());
+                Dictionary<string, int> byParse = RoundTripHarness.BuildTruth(config)
+                    .ToDictionary(kv => kv.Key, kv => kv.Value.Count, StringComparer.Ordinal);
+                Assert.Equal(byParse.OrderBy(k => k.Key), expected.OrderBy(k => k.Key)); // truth models agree
+
+                AssertIndependentCountsMatch(outputs, expected);
+            }
+            finally { Directory.Delete(outDir, true); }
+        }, iter: 25, seed: "00001e2WUFC1", threads: 1);
+    }
+
+    // Aggregate per-folder counts from the INDEPENDENT reader across all output parts, then assert
+    // every expected path matches exactly and no unexpected folder appears (except known zero-count
+    // store folders). Extracted here so the corruption case (Task 2) reuses the exact comparison.
+    private static void AssertIndependentCountsMatch(
+        IReadOnlyList<string> outputs, Dictionary<string, int> expected)
+    {
+        var actual = new Dictionary<string, long>(StringComparer.Ordinal);
+        foreach (string part in outputs)
+        {
+            ValidatorResult r = PstValidatorRunner.Run(part, Timeout);
+            Assert.True(r.Opened, $"validator could not open {Path.GetFileName(part)}: " +
+                string.Join("; ", r.Errors.Select(e => $"{e.Stage}:{e.Message}")));
+            Assert.Empty(r.Errors);
+            foreach (ValidatedFolder vf in r.Folders)
+            {
+                string key = FolderPathKey.Join(vf.Path);
+                actual[key] = actual.GetValueOrDefault(key) + vf.MessageCount;
+            }
+        }
+
+        foreach ((string key, int count) in expected)
+        {
+            Assert.True(actual.TryGetValue(key, out long got), $"expected folder '{key}' missing");
+            Assert.Equal(count, (int)got);
+        }
+        foreach ((string key, long got) in actual)
+        {
+            if (expected.ContainsKey(key)) continue;
+            if (got == 0 && ZeroCountAllowlist.Contains(key)) continue;
+            Assert.Fail($"unexpected folder '{key}' with {got} message(s)");
+        }
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/GenerativeTruth.cs
+++ b/tests/Mail2Pst.Integration.Tests/GenerativeTruth.cs
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mail2Pst.Core;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Mapping;
+using Mail2Pst.TestSupport;
+
+namespace Mail2Pst.Integration.Tests;
+
+/// <summary>
+/// Path-keyed EXPECTED message counts for a generated profile, derived from the generation truth
+/// (what the builder wrote) rather than by re-parsing. Unlike <see cref="RoundTripHarness.BuildTruth"/>
+/// (which parses each source and THROWS on a parse failure), this models an intentional skip as
+/// "written - skips", so a corruption knob whose message is expected to be dropped can still be
+/// checked. Uses <see cref="MappingEngine.BuildPlan"/> for target folder paths, so mirror-mode name
+/// sanitization / collision disambiguation match the writer exactly.
+/// </summary>
+public static class GenerativeTruth
+{
+    public static Dictionary<string, int> BuildExpected(
+        ConversionConfig config,
+        GeneratedProfileCounts truth,
+        IReadOnlyDictionary<string, int> perSourcePathSkips)
+    {
+        if (config.Outputs.Count != 1)
+            throw new InvalidOperationException($"single output group expected; got {config.Outputs.Count}.");
+
+        var expected = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        void EnsurePrefixes(IReadOnlyList<string> path)
+        {
+            for (int depth = 1; depth <= path.Count; depth++)
+            {
+                string k = FolderPathKey.Join(path.Take(depth).ToArray());
+                if (!expected.ContainsKey(k)) expected[k] = 0;
+            }
+        }
+
+        foreach (PstOutputPlan plan in MappingEngine.BuildPlan(config))
+        {
+            foreach (SourceMapping mapping in plan.SourceMappings)
+            {
+                int written = truth.CountByPath.TryGetValue(mapping.Source.Path, out int w) ? w : 0;
+                int skips = perSourcePathSkips.TryGetValue(mapping.Source.Path, out int s) ? s : 0;
+                int count = Math.Max(0, written - skips);
+
+                // Mirror the writer: >=1 msg creates the leaf (+ancestors); 0 msgs creates it only
+                // when IncludeEmptyFolders is true.
+                if (count > 0)
+                {
+                    EnsurePrefixes(mapping.TargetFolderPath);
+                    expected[FolderPathKey.Join(mapping.TargetFolderPath)] += count;
+                }
+                else if (plan.IncludeEmptyFolders)
+                {
+                    EnsurePrefixes(mapping.TargetFolderPath);
+                }
+            }
+        }
+        return expected;
+    }
+}
+
+/// <summary>Generation truth keyed by the source mbox file path.
+/// <see cref="FromAttempted"/> counts every message the builder wrote INCLUDING a truncated tail
+/// (so the adjusted-truth path subtracts the expected skip from it); <see cref="FromWritten"/> counts
+/// only the complete messages (the clean-profile case, where nothing is expected to be skipped).</summary>
+public sealed record GeneratedProfileCounts(IReadOnlyDictionary<string, int> CountByPath)
+{
+    public static GeneratedProfileCounts FromAttempted(GeneratedProfile profile) =>
+        new(profile.Folders.ToDictionary(
+            f => f.FilePath, f => f.MessageCount + f.TruncatedTailCount, StringComparer.Ordinal));
+
+    public static GeneratedProfileCounts FromWritten(GeneratedProfile profile) =>
+        new(profile.Folders.ToDictionary(
+            f => f.FilePath, f => f.MessageCount, StringComparer.Ordinal));
+}

--- a/tests/Mail2Pst.Integration.Tests/Mail2Pst.Integration.Tests.csproj
+++ b/tests/Mail2Pst.Integration.Tests/Mail2Pst.Integration.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
+    <PackageReference Include="CsCheck" Version="4.6.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/Mail2Pst.Core/Mail2Pst.Core.csproj" />

--- a/tests/Mail2Pst.TestSupport/GeneratedProfile.cs
+++ b/tests/Mail2Pst.TestSupport/GeneratedProfile.cs
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 namespace Mail2Pst.TestSupport;
 
-/// <summary>Per-folder generation truth: what was written where.</summary>
-public sealed record GeneratedFolder(string Name, string FilePath, int MessageCount);
+/// <summary>Per-folder generation truth: what was written where.
+/// TruncatedTailCount counts a deliberately-truncated trailing message (a corruption knob
+/// added by a later, stacked task); it defaults to 0 for a clean profile, so the "written"
+/// and "attempted" truth models agree when nothing is truncated.</summary>
+public sealed record GeneratedFolder(string Name, string FilePath, int MessageCount, int TruncatedTailCount = 0);
 
 /// <summary>A generated synthetic Thunderbird profile. Disposing deletes the whole
 /// temp tree (including the deep-root prefix directories above the profile dir).</summary>

--- a/tests/Mail2Pst.TestSupport/ThunderbirdProfileBuilder.cs
+++ b/tests/Mail2Pst.TestSupport/ThunderbirdProfileBuilder.cs
@@ -12,7 +12,7 @@ namespace Mail2Pst.TestSupport;
 public sealed class ThunderbirdProfileBuilder
 {
     private sealed record Account(string Email, string Hostname, string ServerType);
-    private sealed record Folder(string Name, int MessageCount);
+    private sealed record Folder(string Name, int MessageCount, bool TruncateLast = false);
 
     private readonly List<Folder> _folders = new();
     private Account? _account;
@@ -40,6 +40,16 @@ public sealed class ThunderbirdProfileBuilder
     public ThunderbirdProfileBuilder WithFolder(string name, int messageCount)
     {
         _folders.Add(new Folder(name, messageCount));
+        return this;
+    }
+
+    /// <summary>Writes <paramref name="fullMessageCount"/> complete messages then one extra final
+    /// message truncated mid-body (no trailing boundary) — a corruption knob for the round-trip
+    /// oracle's adjusted-truth path. <see cref="GeneratedFolder.MessageCount"/> only counts the
+    /// complete messages; the truncated tail is tracked separately via TruncatedTailCount.</summary>
+    public ThunderbirdProfileBuilder WithTruncatedFinalMessage(string name, int fullMessageCount)
+    {
+        _folders.Add(new Folder(name, fullMessageCount, TruncateLast: true));
         return this;
     }
 
@@ -82,8 +92,16 @@ public sealed class ThunderbirdProfileBuilder
                 sb.Append("\r\n");
                 sb.Append($"Synthetic body {messageSeq}.\r\n\r\n");
             }
+            if (folder.TruncateLast)
+            {
+                sb.Append("From sender@example.com Mon Jan 01 00:00:00 2024\r\n");
+                sb.Append($"Message-ID: <gen-{++messageSeq}@example.com>\r\n");
+                sb.Append("Subject: Truncated tail\r\n\r\n");
+                sb.Append("This body is cut off mid-stream and the file ends here with no");  // no CRLF, no boundary
+            }
             File.WriteAllText(path, sb.ToString());
-            generated.Add(new GeneratedFolder(folder.Name, path, folder.MessageCount));
+            generated.Add(new GeneratedFolder(folder.Name, path, folder.MessageCount,
+                TruncatedTailCount: folder.TruncateLast ? 1 : 0));
         }
 
         File.WriteAllText(Path.Combine(root, "prefs.js"), string.Join("\n", new[]

--- a/tools/pst-validate/README.md
+++ b/tools/pst-validate/README.md
@@ -22,3 +22,15 @@ walks the folder tree, and prints one JSON object with per-folder message counts
     pst-validate <path-to.pst>
 
 Prints one JSON object to stdout. Exit code 0 only when the file opened cleanly with no errors.
+
+## Known limitations
+
+- **Corrupt hierarchy table is read as a leaf (bounded by `outlook-pst 1.2.0`).** The crate's public
+  `Folder::hierarchy_table()` returns `Option` and collapses both "no hierarchy table" and "hierarchy
+  table present but unreadable" into `None` (its internal `read_table(..).ok()?` discards the read
+  error). There is no `Result`-returning table accessor, so this tool cannot distinguish a corrupt
+  subfolder table from a genuine leaf: in the corrupt case the subtree is silently omitted rather than
+  reported as an error. This is a dev-tool-only false-negative and does not affect validation of the
+  well-formed, from-scratch PSTs the converter writes (which this tool is used on). A real fix requires
+  an upstream crate change exposing the read error; revisit if `outlook-pst` adds a fallible table
+  accessor.

--- a/tools/pst-validate/src/main.rs
+++ b/tools/pst-validate/src/main.rs
@@ -87,7 +87,7 @@ fn open_and_report(path: &str) -> Report {
                     });
                 }
                 Ok(root_folder) => {
-                    if let Err(e) = walk_folders(&store, &root_folder, &mut Vec::new(), &mut folders) {
+                    if let Err(e) = walk_folders(&store, &root_folder, &mut Vec::new(), &mut folders, &mut errors) {
                         errors.push(ErrorEntry {
                             stage: "walk".into(),
                             message: format!("{e}"),
@@ -110,6 +110,23 @@ fn open_and_report(path: &str) -> Report {
     }
 }
 
+/// Map a folder's content-count read to `(count, optional error)`. Extracted so the fix — a
+/// `content_count()` read failure is RECORDED as an error, never silently coerced to 0 — is
+/// unit-testable without a real PST fixture. `folder_label` is the folder's full display path, so the
+/// error message locates the offending folder even when two branches share a folder name.
+fn message_count_or_error(folder_label: &str, count: io::Result<i32>) -> (u64, Option<ErrorEntry>) {
+    match count {
+        Ok(c) => (c.max(0) as u64, None),
+        Err(e) => (
+            0,
+            Some(ErrorEntry {
+                stage: "content_count".into(),
+                message: format!("{folder_label}: {e}"),
+            }),
+        ),
+    }
+}
+
 /// Recursively walk all child folders of `parent_folder`.
 /// The root/IPM subtree folder itself is NOT emitted — only its descendants.
 /// `prefix` accumulates the path segments relative to the IPM subtree root.
@@ -118,6 +135,7 @@ fn walk_folders(
     parent_folder: &Rc<dyn Folder>,
     prefix: &mut Vec<String>,
     out: &mut Vec<FolderEntry>,
+    errors: &mut Vec<ErrorEntry>,
 ) -> io::Result<()> {
     let hierarchy_table = match parent_folder.hierarchy_table() {
         None => return Ok(()), // no subfolders
@@ -131,20 +149,22 @@ fn walk_folders(
         let child_folder = store.open_folder(&entry_id)?;
 
         let name = child_folder.properties().display_name()?;
-        let count = child_folder
-            .properties()
-            .content_count()
-            .unwrap_or(0)
-            .max(0) as u64;
-
         prefix.push(name.clone());
+        let display_path = prefix.join(" / ");
+
+        let (count, count_err) =
+            message_count_or_error(&display_path, child_folder.properties().content_count());
+        if let Some(err) = count_err {
+            errors.push(err);
+        }
+
         out.push(FolderEntry {
             path: prefix.clone(),
-            display_path: prefix.join(" / "),
+            display_path,
             message_count: count,
         });
 
-        walk_folders(store, &child_folder, prefix, out)?;
+        walk_folders(store, &child_folder, prefix, out, errors)?;
         prefix.pop();
     }
 
@@ -200,6 +220,30 @@ mod tests {
             assert_eq!(v["folders"][0]["messageCount"], 1);
             assert_eq!(v["folders"][0]["displayPath"], "A");
         }
+    }
+
+    #[test]
+    fn message_count_ok_returns_count_and_no_error() {
+        let (count, err) = message_count_or_error("Inbox", Ok(5));
+        assert_eq!(count, 5);
+        assert!(err.is_none());
+    }
+
+    #[test]
+    fn message_count_negative_clamps_to_zero() {
+        let (count, err) = message_count_or_error("Inbox", Ok(-3));
+        assert_eq!(count, 0);
+        assert!(err.is_none());
+    }
+
+    #[test]
+    fn message_count_err_records_content_count_error_and_zero() {
+        let e = io::Error::new(io::ErrorKind::InvalidData, "bad content-count property");
+        let (count, err) = message_count_or_error("Archive", Err(e));
+        assert_eq!(count, 0, "a read error must not inflate the count");
+        let err = err.expect("a content_count read error must be recorded");
+        assert_eq!(err.stage, "content_count");
+        assert!(err.message.contains("Archive"), "message should locate the folder by its path label");
     }
 
 }

--- a/tools/pst-validate/src/main.rs
+++ b/tools/pst-validate/src/main.rs
@@ -138,7 +138,15 @@ fn walk_folders(
     errors: &mut Vec<ErrorEntry>,
 ) -> io::Result<()> {
     let hierarchy_table = match parent_folder.hierarchy_table() {
-        None => return Ok(()), // no subfolders
+        // Known limitation (#9, outlook-pst 1.2.0): `hierarchy_table()` returns `Option` and collapses
+        // BOTH "genuinely no hierarchy table" (a real leaf) AND "table node present but unreadable" (a
+        // CORRUPT table) into `None` — the crate's `.get_or_init(|| read_table(..).ok()?)` discards the
+        // read error, and there is no Result-returning table accessor in the public API. So a corrupt
+        // hierarchy table is indistinguishable from a leaf here and its subtree is silently omitted.
+        // This is a bounded, dev-tool-only false-negative (it never affects the well-formed from-scratch
+        // PSTs this tool validates); see README "Known limitations". A real fix needs an upstream crate
+        // change (a Result-returning table accessor).
+        None => return Ok(()),
         Some(t) => t.clone(),
     };
 


### PR DESCRIPTION
## Summary

Hardens the independent PST-validation oracle and adds a generative round-trip check. Two related pieces, bundled:

### Oracle integrity (`tools/pst-validate`, Rust, dev/test-only)
- **`content_count()` read errors are now recorded** as an `errors[]` entry (`stage:"content_count"`, labeled with the folder's full display path) instead of being coerced to `0` via `.unwrap_or(0)`. A pure `message_count_or_error` helper (unit-tested) + an `errors` sink threaded through `walk_folders`. The JSON schema is unchanged/additive (`schemaVersion` stays 1); for the converter's well-formed from-scratch PSTs the new error never fires, so the existing round-trip gate is unaffected.
- **Documented a crate-bounded limitation:** `outlook-pst 1.2.0`'s public `hierarchy_table()` collapses "no hierarchy table" and "corrupt/unreadable table" into `None` (no `Result`-returning accessor), so a corrupt subfolder table is indistinguishable from a leaf. Honestly noted in a code comment + the README "Known limitations" section rather than papered over.

### Generative round-trip oracle (`tests/Mail2Pst.Integration.Tests`, local-only)
- A CsCheck generator builds randomized synthetic Thunderbird profiles (varied folder counts, message counts, ASCII + Unicode + distinct names, empty folders); each is converted and read back with the independent `pst-validate` reader, and per-folder counts are compared to a `GenerativeTruth` model derived from the generation truth (via `MappingEngine.BuildPlan`) — catching silent drops / folder-name drift / miscounts.
- **Local-only, double-gated:** runs only when both `MAIL2PST_PST_VALIDATOR` and `MAIL2PST_ENABLE_GENERATIVE_ROUNDTRIP=1` are set, tagged `Category="GenerativeRoundTrip"` (not `IndependentValidation`), so it never runs in CI. Bounded/deterministic (`iter: 25`, `threads: 1`, pinned seed).
- A verify-gated corruption knob (`WithTruncatedFinalMessage`) with a deterministic `[Fact]` that **pins the convert behavior**: a mid-body-truncated final message is parsed, not skipped (`ConvertedCount==3, Skipped.Count==0`). A pure unit test covers the adjusted-truth `written − skips` arithmetic.

No conversion logic changes; user-facing behavior is unchanged.

## Testing

- `cd tools/pst-validate && cargo test --locked` — 5/5 pass, `cargo build --locked --release` clean.
- `dotnet test Mail2Pst.sln` — Property.Tests 8/8, Integration.Tests 113 (+18 opt-in skips, incl. the generative oracle), Core.Tests 1298 (+1); all green.
- Generative oracle verified locally with the built reader: 25 generated profiles round-trip, independent counts match truth.
