### PR TITLE
Add PST → Thunderbird mail export

### DIFF
--- a/src/Mail2Pst.Cli/ExportCommand.cs
+++ b/src/Mail2Pst.Cli/ExportCommand.cs
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#nullable enable
+using System;
+using System.IO;
+using Mail2Pst.Core.Reverse;
+
+namespace Mail2Pst.Cli;
+
+/// <summary>
+/// The reverse `export` subcommand: reads one PST and writes a Thunderbird-importable mbox tree under
+/// --output. Mirrors the forward <see cref="ConvertCommand"/> and reuses the same JSON-Lines contract
+/// (via <see cref="CliArgs.WriteJsonLine"/> → CliEventSerializer, so every event carries schemaVersion).
+/// Every event is tagged command="export" so a consumer can discriminate it from the forward stream.
+/// No config.json (one PST → one tree); no cancellation (the reverse runner has no cancellation contract).
+/// </summary>
+internal static class ExportCommand
+{
+    internal static int Run(string[] args)
+    {
+        string? input = CliArgs.Flag(args, "--input");
+        string? output = CliArgs.Flag(args, "--output");
+        bool includeEmpty = CliArgs.HasFlag(args, "--include-empty");
+
+        if (string.IsNullOrWhiteSpace(input) || string.IsNullOrWhiteSpace(output))
+        {
+            const string msg = "export requires --input <path.pst> and --output <dir>.";
+            CliArgs.WriteJsonLine(new { type = "error", command = "export", stage = "export", message = msg, fatal = true });
+            Console.Error.WriteLine(msg);
+            Console.Error.WriteLine("Usage:");
+            Console.Error.WriteLine("  continumail-convert export --input <path.pst> --output <dir> [--include-empty]");
+            return 1;
+        }
+
+        if (!File.Exists(input))
+        {
+            string msg = $"Input PST not found: {input}";
+            CliArgs.WriteJsonLine(new { type = "error", command = "export", stage = "export", message = msg, fatal = true });
+            Console.Error.WriteLine(msg);
+            return 1;
+        }
+
+        CliArgs.WriteJsonLine(new { type = "started", command = "export", input, outputDirectory = output, includeEmpty });
+
+        var runner = new PstExportRunner();
+        ExportReport report = runner.Run(
+            input, output, includeEmpty,
+            onWarning: w => CliArgs.WriteJsonLine(BuildWarningEvent(w)),
+            onProgress: p => CliArgs.WriteJsonLine(BuildProgressEvent(p)),
+            onSkipped: s => CliArgs.WriteJsonLine(BuildSkippedEvent(s)));
+
+        CliArgs.WriteJsonLine(new
+        {
+            type = "done", command = "export",
+            messagesExported = report.MessagesExported,
+            foldersWritten = report.FoldersWritten,
+            mboxFileCount = report.MboxFiles.Count,
+            skipped = report.SkippedCount,
+            warnings = report.WarningCount,
+            outputs = new[] { report.OutputRoot },
+            outputDirectory = report.OutputRoot,
+            elapsedMs = (long)report.Elapsed.TotalMilliseconds,
+        });
+        return 0;
+    }
+
+    // Event factories: one place that owns the discriminated wire shape of each streamed event, so a
+    // skip and a warning are provably disjoint and each is unit-testable without a PST.
+    internal static object BuildWarningEvent(string message) =>
+        new { type = "warning", command = "export", message };
+
+    internal static object BuildProgressEvent(ExportProgress p) =>
+        new { type = "progress", command = "export", messagesExported = p.MessagesExported, currentFolder = p.CurrentFolder };
+
+    internal static object BuildSkippedEvent(ExportSkip s) =>
+        new { type = "skipped", command = "export", folderPath = s.FolderPath, messageIndex = s.MessageIndex, reason = s.Reason };
+}

--- a/src/Mail2Pst.Cli/ExportCommand.cs
+++ b/src/Mail2Pst.Cli/ExportCommand.cs
@@ -17,6 +17,9 @@ namespace Mail2Pst.Cli;
 /// </summary>
 internal static class ExportCommand
 {
+    private const string ReportJsonSuffix = ".export-report.json";
+    private const string ReportTxtSuffix = ".export-report.txt";
+
     internal static int Run(string[] args)
     {
         string? input = CliArgs.Flag(args, "--input");
@@ -44,11 +47,56 @@ internal static class ExportCommand
         CliArgs.WriteJsonLine(new { type = "started", command = "export", input, outputDirectory = output, includeEmpty });
 
         var runner = new PstExportRunner();
-        ExportReport report = runner.Run(
-            input, output, includeEmpty,
-            onWarning: w => CliArgs.WriteJsonLine(BuildWarningEvent(w)),
-            onProgress: p => CliArgs.WriteJsonLine(BuildProgressEvent(p)),
-            onSkipped: s => CliArgs.WriteJsonLine(BuildSkippedEvent(s)));
+        ExportReport report;
+        try
+        {
+            report = runner.Run(
+                input, output, includeEmpty,
+                onWarning: w => CliArgs.WriteJsonLine(BuildWarningEvent(w)),
+                onProgress: p => CliArgs.WriteJsonLine(BuildProgressEvent(p)),
+                onSkipped: s => CliArgs.WriteJsonLine(BuildSkippedEvent(s)));
+        }
+        catch (Exception ex)
+        {
+            CliArgs.WriteJsonLine(new { type = "error", command = "export", stage = "export", message = ex.Message, fatal = true });
+            Console.Error.WriteLine($"Export failed: {ex.Message}");
+            return 1;
+        }
+
+        // The mbox tree is now PUBLISHED at report.OutputRoot. Report files go BESIDE the tree, never inside
+        // it: a PST folder can legally be named "export-report.json", and writing into the tree would clobber
+        // that mailbox. Refuse pre-existing destinations, write temps, then move each into place WITHOUT
+        // overwrite; if the second move fails, roll back the first. A report failure leaves the tree intact
+        // and never overwrites a pre-existing file.
+        string reportBase = Path.TrimEndingDirectorySeparator(report.OutputRoot);
+        string reportJsonPath = reportBase + ReportJsonSuffix;
+        string reportTxtPath = reportBase + ReportTxtSuffix;
+        string tmpJson = reportJsonPath + ".tmp-" + Guid.NewGuid().ToString("N");
+        string tmpTxt = reportTxtPath + ".tmp-" + Guid.NewGuid().ToString("N");
+        bool jsonPublished = false;
+        try
+        {
+            if (PathExists(reportJsonPath) || PathExists(reportTxtPath))
+                throw new IOException($"Export report destinations already exist beside '{report.OutputRoot}'.");
+            File.WriteAllText(tmpJson, report.ToJson());
+            File.WriteAllText(tmpTxt, report.ToSummary());
+            File.Move(tmpJson, reportJsonPath);
+            jsonPublished = true;
+            File.Move(tmpTxt, reportTxtPath);
+        }
+        catch (Exception ex)
+        {
+            TryDelete(tmpJson);
+            TryDelete(tmpTxt);
+            if (jsonPublished) TryDelete(reportJsonPath);   // roll back the first final file on a partial publish
+            CliArgs.WriteJsonLine(new
+            {
+                type = "error", command = "export", stage = "report", message = ex.Message, fatal = true,
+                outputDirectory = report.OutputRoot, outputPreserved = Directory.Exists(report.OutputRoot),
+            });
+            Console.Error.WriteLine($"Report write failed (mbox tree preserved): {ex.Message}");
+            return 1;
+        }
 
         CliArgs.WriteJsonLine(new
         {
@@ -60,6 +108,7 @@ internal static class ExportCommand
             warnings = report.WarningCount,
             outputs = new[] { report.OutputRoot },
             outputDirectory = report.OutputRoot,
+            report = reportJsonPath,
             elapsedMs = (long)report.Elapsed.TotalMilliseconds,
         });
         return 0;
@@ -75,4 +124,12 @@ internal static class ExportCommand
 
     internal static object BuildSkippedEvent(ExportSkip s) =>
         new { type = "skipped", command = "export", folderPath = s.FolderPath, messageIndex = s.MessageIndex, reason = s.Reason };
+
+    private static bool PathExists(string path) => File.Exists(path) || Directory.Exists(path);
+
+    private static void TryDelete(string path)
+    {
+        try { if (File.Exists(path)) File.Delete(path); }
+        catch { /* best-effort cleanup; the published tree is what matters */ }
+    }
 }

--- a/src/Mail2Pst.Cli/Program.cs
+++ b/src/Mail2Pst.Cli/Program.cs
@@ -22,6 +22,7 @@ if (args.Length == 0)
     Console.Error.WriteLine("Usage:");
     Console.Error.WriteLine("  continumail-convert convert  --config <config.json> --output <dir>");
     Console.Error.WriteLine("  continumail-convert convert  --profile <dir> [--config <options.json>] --output <dir>");
+    Console.Error.WriteLine("  continumail-convert export   --input <path.pst> --output <dir> [--include-empty]");
     Console.Error.WriteLine("  continumail-convert scan     --input <path> [--input <path> ...] [--input-list <file>] [--type mbox]");
     Console.Error.WriteLine("  continumail-convert discover --input <dir>");
     return 1;
@@ -30,6 +31,7 @@ if (args.Length == 0)
 return args[0] switch
 {
     "convert"            => ConvertCommand.Run(args[1..]),
+    "export"             => ExportCommand.Run(args[1..]),
     "scan"               => ScanCommand.Run(args[1..]),
     "discover"           => DiscoverCommand.Run(args[1..]),
     "version" or "--version" or "-v" => PrintVersion(),
@@ -50,6 +52,6 @@ static int PrintVersion()
 
 static int PrintUnknownCommand(string cmd)
 {
-    Console.Error.WriteLine($"Unknown command '{cmd}'. Use 'convert', 'scan', or 'discover'.");
+    Console.Error.WriteLine($"Unknown command '{cmd}'. Use 'convert', 'export', 'scan', or 'discover'.");
     return 1;
 }

--- a/src/Mail2Pst.Core/Reverse/ExportReport.cs
+++ b/src/Mail2Pst.Core/Reverse/ExportReport.cs
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+
+namespace Mail2Pst.Core.Reverse;
+
+/// <summary>One skipped message: which folder, its 0-based index in that folder (null when not applicable),
+/// and why. Mirrors the forward <c>ConversionReport.Skipped</c>'s structured skip list.</summary>
+public sealed record ExportSkip(string FolderPath, int? MessageIndex, string Reason);
+
+/// <summary>
+/// The report for a reverse (PST → Thunderbird) export. Unlike the forward <c>ConversionReport</c> (output
+/// PST files, split parts, contact/task/appointment counters), the reverse export writes a folder TREE, so
+/// this records the output root, the mbox files written, message/folder counts, structured per-message
+/// <see cref="Skipped"/> entries, and the aggregated <see cref="Warnings"/> from the reader + reconstructor +
+/// writer. Skips (a message that could not be read) are kept SEPARATE from warnings (lossy-but-recovered
+/// reconstruction decisions), mirroring the forward report's Skipped/Warnings split.
+/// </summary>
+public sealed class ExportReport
+{
+    private readonly object _lock = new();
+    private readonly List<string> _warnings = new();
+    private readonly List<ExportSkip> _skipped = new();
+
+    public ExportReport(string outputRoot) => OutputRoot = outputRoot;
+
+    public string OutputRoot { get; }
+    public int MessagesExported { get; private set; }
+    public int FoldersWritten { get; private set; }
+    public IReadOnlyList<string> MboxFiles { get; private set; } = Array.Empty<string>();
+    public TimeSpan Elapsed { get; private set; }
+
+    public IReadOnlyList<string> Warnings { get { lock (_lock) return _warnings.ToArray(); } }
+    public int WarningCount { get { lock (_lock) return _warnings.Count; } }
+    public IReadOnlyList<ExportSkip> Skipped { get { lock (_lock) return _skipped.ToArray(); } }
+    public int SkippedCount { get { lock (_lock) return _skipped.Count; } }
+
+    /// <summary>The shared warning sink the runner injects into the reader, reconstructor, and writer.</summary>
+    public void RecordWarning(string message)
+    {
+        lock (_lock) _warnings.Add(message);
+    }
+
+    /// <summary>The structured skip sink the runner injects into the reader (per-message read failure).</summary>
+    public void RecordSkipped(ExportSkip skip)
+    {
+        lock (_lock) _skipped.Add(skip);
+    }
+
+    /// <summary>Folds the writer's result and the run duration into the report. Called once by the runner.</summary>
+    internal void Complete(MboxTreeWriteResult result, TimeSpan elapsed)
+    {
+        MessagesExported = result.MessagesWritten;
+        FoldersWritten = result.FoldersWritten;
+        MboxFiles = result.MboxFiles.ToArray();   // snapshot — do not retain the writer's backing list
+        Elapsed = elapsed;
+    }
+
+    public string ToJson()
+    {
+        string[] warnings;
+        ExportSkip[] skipped;
+        lock (_lock) { warnings = _warnings.ToArray(); skipped = _skipped.ToArray(); }
+
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true,
+        };
+        return JsonSerializer.Serialize(new
+        {
+            outputRoot = OutputRoot,
+            messagesExported = MessagesExported,
+            foldersWritten = FoldersWritten,
+            elapsedMs = (long)Elapsed.TotalMilliseconds,
+            mboxFiles = MboxFiles,
+            skippedCount = skipped.Length,
+            skipped = Array.ConvertAll(skipped, s => new { folderPath = s.FolderPath, messageIndex = s.MessageIndex, reason = s.Reason }),
+            warningCount = warnings.Length,
+            warnings,
+        }, options);
+    }
+
+    public string ToSummary()
+    {
+        string[] warnings;
+        ExportSkip[] skipped;
+        lock (_lock) { warnings = _warnings.ToArray(); skipped = _skipped.ToArray(); }
+
+        var builder = new StringBuilder();
+        builder.AppendLine($"Output root: {OutputRoot}");
+        builder.AppendLine($"Messages exported: {MessagesExported}");
+        builder.AppendLine($"Folders written: {FoldersWritten}");
+        builder.AppendLine($"Mbox files: {MboxFiles.Count}");
+        builder.AppendLine($"Skipped: {skipped.Length}");
+        foreach (ExportSkip s in skipped)
+        {
+            string location = s.MessageIndex is int idx ? $"{s.FolderPath}[{idx}]" : s.FolderPath;
+            builder.AppendLine($"  SKIP {location}: {s.Reason}");
+        }
+        builder.AppendLine($"Warnings: {warnings.Length}");
+        foreach (string w in warnings)
+            builder.AppendLine($"  WARN {w}");
+        return builder.ToString();
+    }
+}

--- a/src/Mail2Pst.Core/Reverse/IMimeReconstructor.cs
+++ b/src/Mail2Pst.Core/Reverse/IMimeReconstructor.cs
@@ -6,8 +6,8 @@ using MimeKit;
 namespace Mail2Pst.Core.Reverse;
 
 /// <summary>
-/// Seam implemented by Plan 4 (<c>MimeReconstructor</c>): turns one read-back <see cref="PstMailMessage"/>
-/// into a MimeKit <see cref="MimeMessage"/> (identity/structural headers + body tree + attachments). Plan 3's
+/// Seam implemented by <c>MimeReconstructor</c>: turns one read-back <see cref="PstMailMessage"/>
+/// into a MimeKit <see cref="MimeMessage"/> (identity/structural headers + body tree + attachments). The
 /// <c>MboxTreeWriter</c> consumes this to serialize each message into the mbox tree; it does NOT reconstruct
 /// MIME itself. Implementations MUST NOT emit <c>X-Mozilla-*</c> headers — the writer owns those (it writes
 /// them as the first header lines so their position/format stay under the writer's control).

--- a/src/Mail2Pst.Core/Reverse/IMimeReconstructor.cs
+++ b/src/Mail2Pst.Core/Reverse/IMimeReconstructor.cs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using MimeKit;
+
+namespace Mail2Pst.Core.Reverse;
+
+/// <summary>
+/// Seam implemented by Plan 4 (<c>MimeReconstructor</c>): turns one read-back <see cref="PstMailMessage"/>
+/// into a MimeKit <see cref="MimeMessage"/> (identity/structural headers + body tree + attachments). Plan 3's
+/// <c>MboxTreeWriter</c> consumes this to serialize each message into the mbox tree; it does NOT reconstruct
+/// MIME itself. Implementations MUST NOT emit <c>X-Mozilla-*</c> headers — the writer owns those (it writes
+/// them as the first header lines so their position/format stay under the writer's control).
+/// </summary>
+public interface IMimeReconstructor
+{
+    MimeMessage Reconstruct(PstMailMessage message);
+}

--- a/src/Mail2Pst.Core/Reverse/MboxFolderNameSanitizer.cs
+++ b/src/Mail2Pst.Core/Reverse/MboxFolderNameSanitizer.cs
@@ -12,7 +12,7 @@ namespace Mail2Pst.Core.Reverse;
 /// leading/trailing dots+spaces, Windows reserved device names -> fallback), then additionally replaces the
 /// remaining Windows-illegal filename characters (<c>: * ? " &lt; &gt; |</c>) with '_'. A name that reduces to
 /// nothing falls back to <c>"Folder"</c>. NOTE: long-name hashing (Thunderbird's NS_MsgHashIfNecessary, which
-/// truncates+hashes names over the OS limit) is NOT implemented in v1 — see the plan self-review.
+/// truncates+hashes names over the OS limit) is NOT implemented in v1.
 /// </summary>
 public static class MboxFolderNameSanitizer
 {

--- a/src/Mail2Pst.Core/Reverse/MboxFolderNameSanitizer.cs
+++ b/src/Mail2Pst.Core/Reverse/MboxFolderNameSanitizer.cs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System.Text;
+using Mail2Pst.Core.Config;
+
+namespace Mail2Pst.Core.Reverse;
+
+/// <summary>
+/// Coerces a PST folder name into a filesystem-safe Thunderbird mbox file/dir base name. Reuses the forward
+/// <see cref="FolderNameValidator.Sanitize"/> (path separators -> space, control chars -> space, trims
+/// leading/trailing dots+spaces, Windows reserved device names -> fallback), then additionally replaces the
+/// remaining Windows-illegal filename characters (<c>: * ? " &lt; &gt; |</c>) with '_'. A name that reduces to
+/// nothing falls back to <c>"Folder"</c>. NOTE: long-name hashing (Thunderbird's NS_MsgHashIfNecessary, which
+/// truncates+hashes names over the OS limit) is NOT implemented in v1 — see the plan self-review.
+/// </summary>
+public static class MboxFolderNameSanitizer
+{
+    private const string Fallback = "Folder";
+
+    public static string ToFileName(string? folderName)
+    {
+        // Forward helper first: handles '/'\\, control chars, dots/spaces trimming, and reserved names.
+        string s = FolderNameValidator.Sanitize(folderName, Fallback);
+
+        var sb = new StringBuilder(s.Length);
+        foreach (char c in s)
+            sb.Append(IsFileNameIllegal(c) ? '_' : c);
+
+        // Replacing illegal chars cannot introduce a trailing dot/space (we insert '_'), but re-trim
+        // defensively so the result is always a legal Windows path segment.
+        string result = sb.ToString().Trim().TrimEnd('.').Trim();
+        return result.Length == 0 ? Fallback : result;
+    }
+
+    // The forward Sanitize already removes '/'\\ and control chars, but keep them here so ToFileName is
+    // correct on its own terms regardless of the upstream helper's exact rule set.
+    private static bool IsFileNameIllegal(char c) =>
+        c is ':' or '*' or '?' or '"' or '<' or '>' or '|' or '/' or '\\' || c < 0x20;
+}

--- a/src/Mail2Pst.Core/Reverse/MboxTreePlanner.cs
+++ b/src/Mail2Pst.Core/Reverse/MboxTreePlanner.cs
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Mail2Pst.Core.Reverse;
+
+/// <summary>The on-disk plan for one PST mail folder.</summary>
+/// <param name="SourcePath">Original PST folder path (identity; segments are display names).</param>
+/// <param name="MboxFilePath">Absolute path of the (extensionless) mbox file for this folder.</param>
+/// <param name="SbdDirPath">Absolute path of the <c>Name.sbd/</c> child directory, or null for a leaf.</param>
+/// <param name="IsStructuralParent">True when this folder has at least one descendant folder.</param>
+public sealed record MboxFolderPlan(
+    IReadOnlyList<string> SourcePath, string MboxFilePath, string? SbdDirPath, bool IsStructuralParent);
+
+/// <summary>Lookup over the planned folders, keyed by the folder path identity.</summary>
+public sealed class MboxTreePlan
+{
+    private readonly Dictionary<string, MboxFolderPlan> _byKey;
+
+    public IReadOnlyList<MboxFolderPlan> Folders { get; }
+
+    public MboxTreePlan(IReadOnlyList<MboxFolderPlan> folders)
+    {
+        Folders = folders;
+        _byKey = new Dictionary<string, MboxFolderPlan>(StringComparer.Ordinal);
+        foreach (MboxFolderPlan f in folders)
+            _byKey[FolderPathKey.Join(f.SourcePath)] = f;
+    }
+
+    public bool TryGet(IReadOnlyList<string> path, out MboxFolderPlan? plan)
+        => _byKey.TryGetValue(FolderPathKey.Join(path), out plan);
+}
+
+/// <summary>
+/// Turns the PST mail-folder tree (a list of folder paths) into an on-disk <see cref="MboxTreePlan"/>: the
+/// Thunderbird <c>.sbd</c> layout, with filesystem-safe name sanitization and deterministic collision
+/// suffixes. Pure: computes paths only, touches no disk. Missing intermediate folders are synthesized so a
+/// structural parent is always represented even if the reader omitted it.
+/// </summary>
+public static class MboxTreePlanner
+{
+    public static MboxTreePlan Plan(
+        IReadOnlyList<IReadOnlyList<string>> folders, string outputRoot, Action<string>? onWarning = null)
+    {
+        // 0. Expand to every ancestor prefix (distinct, shallow-first / first-seen order). Guarantees an
+        //    ancestor is always present and a structural parent is always materialized.
+        List<IReadOnlyList<string>> allPaths = ExpandWithAncestors(folders);
+
+        // 1. Structural-parent set: P is structural iff some other path has P as a strict prefix.
+        var structural = new HashSet<string>(StringComparer.Ordinal);
+        foreach (IReadOnlyList<string> p in allPaths)
+            foreach (IReadOnlyList<string> q in allPaths)
+                if (q.Count > p.Count && IsPrefix(p, q)) { structural.Add(FolderPathKey.Join(p)); break; }
+
+        // 2. Choose the on-disk segment name per folder, top-down, with per-parent collision suffixing.
+        //    Sibling names collide case-insensitively (Windows FS). A structural parent occupies BOTH its
+        //    file name and its "<name>.sbd" directory, so reserve both to avoid a file/dir clash.
+        var chosen = new Dictionary<string, string>(StringComparer.Ordinal);
+        var usedPerParent = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        foreach (IReadOnlyList<string> p in allPaths.OrderBy(x => x.Count))   // stable within a depth
+        {
+            string parentKey = FolderPathKey.Join(p.Take(p.Count - 1).ToArray());
+            if (!usedPerParent.TryGetValue(parentKey, out HashSet<string>? used))
+                usedPerParent[parentKey] = used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            string baseName = MboxFolderNameSanitizer.ToFileName(p[^1]);
+            bool isStructural = structural.Contains(FolderPathKey.Join(p));
+
+            string candidate = baseName;
+            int n = 2;
+            while (used.Contains(candidate) || (isStructural && used.Contains(candidate + ".sbd")))
+                candidate = $"{baseName} ({n++})";
+
+            if (!string.Equals(candidate, baseName, StringComparison.Ordinal))
+                onWarning?.Invoke(
+                    $"folder name '{FolderPathDisplay.Join(p)}' collides on disk; using '{candidate}'.");
+
+            used.Add(candidate);
+            if (isStructural) used.Add(candidate + ".sbd");
+            chosen[FolderPathKey.Join(p)] = candidate;
+        }
+
+        // 3. Build absolute paths from the chosen ancestor names.
+        var result = new List<MboxFolderPlan>(allPaths.Count);
+        foreach (IReadOnlyList<string> p in allPaths)
+        {
+            string dir = outputRoot;
+            for (int i = 0; i < p.Count - 1; i++)
+                dir = Path.Combine(dir, chosen[FolderPathKey.Join(p.Take(i + 1).ToArray())] + ".sbd");
+            string leaf = chosen[FolderPathKey.Join(p)];
+            string mbox = Path.Combine(dir, leaf);
+            bool isStructural = structural.Contains(FolderPathKey.Join(p));
+            string? sbd = isStructural ? Path.Combine(dir, leaf + ".sbd") : null;
+            result.Add(new MboxFolderPlan(p, mbox, sbd, isStructural));
+        }
+        return new MboxTreePlan(result);
+    }
+
+    /// <summary>Best-effort mbox path for a folder path (sanitized <c>.sbd</c> layout, NO collision
+    /// suffixing). The writer uses this only for a message whose folder was not declared in the plan.</summary>
+    public static string ResolveMboxPath(IReadOnlyList<string> path, string outputRoot)
+    {
+        string dir = outputRoot;
+        for (int i = 0; i < path.Count - 1; i++)
+            dir = Path.Combine(dir, MboxFolderNameSanitizer.ToFileName(path[i]) + ".sbd");
+        return Path.Combine(dir, MboxFolderNameSanitizer.ToFileName(path[^1]));
+    }
+
+    private static List<IReadOnlyList<string>> ExpandWithAncestors(IReadOnlyList<IReadOnlyList<string>> folders)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var ordered = new List<IReadOnlyList<string>>();
+        foreach (IReadOnlyList<string> p in folders)
+            for (int d = 1; d <= p.Count; d++)
+            {
+                string[] prefix = p.Take(d).ToArray();
+                if (seen.Add(FolderPathKey.Join(prefix)))
+                    ordered.Add(prefix);
+            }
+        return ordered;
+    }
+
+    private static bool IsPrefix(IReadOnlyList<string> p, IReadOnlyList<string> q)
+    {
+        for (int i = 0; i < p.Count; i++)
+            if (!string.Equals(p[i], q[i], StringComparison.Ordinal)) return false;
+        return true;
+    }
+}

--- a/src/Mail2Pst.Core/Reverse/MboxTreeWriter.cs
+++ b/src/Mail2Pst.Core/Reverse/MboxTreeWriter.cs
@@ -18,7 +18,7 @@ public sealed record MboxTreeWriteResult(
 /// Writes a Thunderbird mail-folder tree to disk: a <c>.sbd</c>-nested mbox layout where each streamed
 /// message becomes an mboxrd-escaped mbox entry carrying its <c>X-Mozilla-Status</c> / <c>-Status2</c> /
 /// <c>-Keys</c> headers. Structure comes from a <see cref="MboxTreePlanner"/> plan; MIME body reconstruction
-/// comes from the injected <see cref="IMimeReconstructor"/> (Plan 4). The writer owns the envelope
+/// comes from the injected <see cref="IMimeReconstructor"/>. The writer owns the envelope
 /// (<c>From </c> separator) and the three <c>X-Mozilla-*</c> header lines, which it writes as the FIRST
 /// header lines of every entry so their position and formatting stay under its control.
 /// </summary>
@@ -30,7 +30,7 @@ public sealed class MboxTreeWriter
     // keywords in place. X_MOZILLA_KEYWORDS_BLANK_LEN = 80 in mozilla/releases-comm-central:
     // mailnews/base/src/nsMsgLocalFolderHdrs.h; the compactor right-pads the VALUE with spaces up to this
     // minimum. We reproduce the reserve so TB's in-place keyword edits behave. Applies ONLY to X-Mozilla-Keys
-    // (Status/Status2 are already fixed-width via Plan 2's x4 / "00000000").
+    // (Status/Status2 are already fixed-width via the x4 hex format / "00000000").
     private const int XMozillaKeywordsBlankLen = 80;
 
     private readonly IMimeReconstructor _reconstructor;
@@ -43,7 +43,7 @@ public sealed class MboxTreeWriter
         _formatOptions.NewLineFormat = NewLineFormat.Dos;   // CRLF, matching the raw parts + forward fixtures
     }
 
-    /// <param name="items">Lazy stream of read-back messages (Plan 1). Reconstruction/serialization happens
+    /// <param name="items">Lazy stream of read-back messages. Reconstruction/serialization happens
     /// one item at a time, so attachment OpenRead closures are invoked while the item is current.</param>
     /// <param name="folders">Every mail folder path in the PST (the structure authority — includes empty
     /// folders so <paramref name="includeEmpty"/> and structural parents can be honored).</param>

--- a/src/Mail2Pst.Core/Reverse/MboxTreeWriter.cs
+++ b/src/Mail2Pst.Core/Reverse/MboxTreeWriter.cs
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using MimeKit;
+
+namespace Mail2Pst.Core.Reverse;
+
+/// <summary>Result of writing the mbox tree: the mbox files created, folder count, and message count.</summary>
+public sealed record MboxTreeWriteResult(
+    IReadOnlyList<string> MboxFiles, int FoldersWritten, int MessagesWritten);
+
+/// <summary>
+/// Writes a Thunderbird mail-folder tree to disk: a <c>.sbd</c>-nested mbox layout where each streamed
+/// message becomes an mboxrd-escaped mbox entry carrying its <c>X-Mozilla-Status</c> / <c>-Status2</c> /
+/// <c>-Keys</c> headers. Structure comes from a <see cref="MboxTreePlanner"/> plan; MIME body reconstruction
+/// comes from the injected <see cref="IMimeReconstructor"/> (Plan 4). The writer owns the envelope
+/// (<c>From </c> separator) and the three <c>X-Mozilla-*</c> header lines, which it writes as the FIRST
+/// header lines of every entry so their position and formatting stay under its control.
+/// </summary>
+public sealed class MboxTreeWriter
+{
+    private static readonly byte[] FromMarker = Encoding.ASCII.GetBytes("From ");
+
+    // Thunderbird reserves fixed-width blank space after "X-Mozilla-Keys: " so it can rewrite a message's
+    // keywords in place. X_MOZILLA_KEYWORDS_BLANK_LEN = 80 in mozilla/releases-comm-central:
+    // mailnews/base/src/nsMsgLocalFolderHdrs.h; the compactor right-pads the VALUE with spaces up to this
+    // minimum. We reproduce the reserve so TB's in-place keyword edits behave. Applies ONLY to X-Mozilla-Keys
+    // (Status/Status2 are already fixed-width via Plan 2's x4 / "00000000").
+    private const int XMozillaKeywordsBlankLen = 80;
+
+    private readonly IMimeReconstructor _reconstructor;
+    private readonly FormatOptions _formatOptions;
+
+    public MboxTreeWriter(IMimeReconstructor reconstructor)
+    {
+        _reconstructor = reconstructor ?? throw new ArgumentNullException(nameof(reconstructor));
+        _formatOptions = FormatOptions.Default.Clone();
+        _formatOptions.NewLineFormat = NewLineFormat.Dos;   // CRLF, matching the raw parts + forward fixtures
+    }
+
+    /// <param name="items">Lazy stream of read-back messages (Plan 1). Reconstruction/serialization happens
+    /// one item at a time, so attachment OpenRead closures are invoked while the item is current.</param>
+    /// <param name="folders">Every mail folder path in the PST (the structure authority — includes empty
+    /// folders so <paramref name="includeEmpty"/> and structural parents can be honored).</param>
+    /// <param name="includeEmpty">When true, empty LEAF folders are emitted as empty mbox files; structural
+    /// parents are ALWAYS emitted regardless.</param>
+    public MboxTreeWriteResult Write(
+        IEnumerable<PstMailItem> items,
+        IReadOnlyList<IReadOnlyList<string>> folders,
+        string outputRoot,
+        bool includeEmpty,
+        Action<string>? onWarning = null)
+    {
+        Directory.CreateDirectory(outputRoot);
+        MboxTreePlan plan = MboxTreePlanner.Plan(folders, outputRoot, onWarning);
+
+        var created = new List<string>();
+        var createdSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // Scaffolding: structural parents ALWAYS (empty mbox + .sbd dir); empty leaves per includeEmpty.
+        foreach (MboxFolderPlan fp in plan.Folders)
+        {
+            if (fp.IsStructuralParent)
+            {
+                Directory.CreateDirectory(fp.SbdDirPath!);
+                EnsureMbox(fp.MboxFilePath, created, createdSet);
+            }
+            else if (includeEmpty)
+            {
+                EnsureMbox(fp.MboxFilePath, created, createdSet);
+            }
+        }
+
+        int messages = 0;
+        foreach (PstMailItem item in items)
+        {
+            string mboxPath;
+            if (plan.TryGet(item.FolderPath, out MboxFolderPlan? fp) && fp is not null)
+            {
+                mboxPath = fp.MboxFilePath;
+            }
+            else
+            {
+                // Defensive: an item whose folder was not declared in `folders`. Best-effort path (no
+                // collision suffixing) so a message is never dropped; a correct orchestrator declares
+                // every folder, so this branch is not expected in practice.
+                onWarning?.Invoke(
+                    $"message in undeclared folder '{FolderPathDisplay.Join(item.FolderPath)}'; creating it best-effort.");
+                mboxPath = MboxTreePlanner.ResolveMboxPath(item.FolderPath, outputRoot);
+            }
+
+            EnsureMbox(mboxPath, created, createdSet);
+            AppendMessage(mboxPath, item.Message);
+            messages++;
+        }
+
+        return new MboxTreeWriteResult(created, created.Count, messages);
+    }
+
+    private static void EnsureMbox(string path, List<string> created, HashSet<string> createdSet)
+    {
+        if (!createdSet.Add(path)) return;
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        if (!File.Exists(path))
+            using (File.Create(path)) { }
+        created.Add(path);
+    }
+
+    private void AppendMessage(string mboxPath, PstMailMessage message)
+    {
+        MimeMessage mime = _reconstructor.Reconstruct(message);
+        MozillaStatusHeaders h = MozillaStatusMapper.Map(message);
+
+        using var fs = new FileStream(mboxPath, FileMode.Append, FileAccess.Write, FileShare.None);
+
+        // Envelope separator (postmark-shaped) then the three writer-owned X-Mozilla-* header lines, written
+        // RAW (not via MimeKit's header collection, which trims/folds trailing whitespace and would destroy
+        // the X-Mozilla-Keys reserve). Status/Status2 are already fixed-width; the Keys VALUE is right-padded
+        // with spaces to a minimum of XMozillaKeywordsBlankLen so Thunderbird can rewrite keywords in place.
+        WriteAscii(fs, "From - " + Asctime(message.Date) + "\r\n");
+        WriteAscii(fs, "X-Mozilla-Status: " + h.Status + "\r\n");
+        WriteAscii(fs, "X-Mozilla-Status2: " + h.Status2 + "\r\n");
+        WriteAscii(fs, "X-Mozilla-Keys: " + h.Keys.PadRight(XMozillaKeywordsBlankLen) + "\r\n");
+
+        // Serialize the reconstructed message (its own headers + body), then mboxrd-escape every line.
+        using var ms = new MemoryStream();
+        mime.WriteTo(_formatOptions, ms);
+        EscapeFromLines(new ReadOnlySpan<byte>(ms.GetBuffer(), 0, (int)ms.Length), fs);
+
+        WriteAscii(fs, "\r\n");   // blank-line separator before the next From_ boundary
+    }
+
+    private static string Asctime(DateTimeOffset? date)
+        => (date?.UtcDateTime ?? DateTime.UnixEpoch)
+            .ToString("ddd MMM dd HH:mm:ss yyyy", CultureInfo.InvariantCulture);
+
+    private static void WriteAscii(Stream fs, string s)
+    {
+        byte[] b = Encoding.ASCII.GetBytes(s);
+        fs.Write(b, 0, b.Length);
+    }
+
+    // mboxrd escaping: any serialized line matching ^>*From  gets ONE extra leading '>'. Exact inverse of
+    // MboxParser.WriteUnescapedFromLine (which strips one '>' from ^>+From  on read).
+    private static void EscapeFromLines(ReadOnlySpan<byte> data, Stream fs)
+    {
+        int i = 0;
+        while (i < data.Length)
+        {
+            int nl = data.Slice(i).IndexOf((byte)'\n');
+            int len = nl == -1 ? data.Length - i : nl + 1;
+            ReadOnlySpan<byte> line = data.Slice(i, len);
+
+            int gt = 0;
+            while (gt < line.Length && line[gt] == (byte)'>') gt++;
+            if (StartsWithMarkerAt(line, gt, FromMarker))
+                fs.WriteByte((byte)'>');
+            fs.Write(line);
+
+            i += len;
+        }
+    }
+
+    private static bool StartsWithMarkerAt(ReadOnlySpan<byte> line, int index, ReadOnlySpan<byte> marker)
+    {
+        if (line.Length - index < marker.Length) return false;
+        for (int i = 0; i < marker.Length; i++)
+            if (line[index + i] != marker[i]) return false;
+        return true;
+    }
+}

--- a/src/Mail2Pst.Core/Reverse/MboxTreeWriter.cs
+++ b/src/Mail2Pst.Core/Reverse/MboxTreeWriter.cs
@@ -113,7 +113,7 @@ public sealed class MboxTreeWriter
 
     private void AppendMessage(string mboxPath, PstMailMessage message)
     {
-        MimeMessage mime = _reconstructor.Reconstruct(message);
+        using MimeMessage mime = _reconstructor.Reconstruct(message);
         MozillaStatusHeaders h = MozillaStatusMapper.Map(message);
 
         using var fs = new FileStream(mboxPath, FileMode.Append, FileAccess.Write, FileShare.None);

--- a/src/Mail2Pst.Core/Reverse/MboxTreeWriter.cs
+++ b/src/Mail2Pst.Core/Reverse/MboxTreeWriter.cs
@@ -49,12 +49,16 @@ public sealed class MboxTreeWriter
     /// folders so <paramref name="includeEmpty"/> and structural parents can be honored).</param>
     /// <param name="includeEmpty">When true, empty LEAF folders are emitted as empty mbox files; structural
     /// parents are ALWAYS emitted regardless.</param>
+    /// <param name="onMessageWritten">Optional callback invoked AFTER each message is successfully appended,
+    /// with the item and the running written-count. Lets the export runner emit progress that reflects only
+    /// messages actually on disk (a message that throws during reconstruction/serialization never ticks).</param>
     public MboxTreeWriteResult Write(
         IEnumerable<PstMailItem> items,
         IReadOnlyList<IReadOnlyList<string>> folders,
         string outputRoot,
         bool includeEmpty,
-        Action<string>? onWarning = null)
+        Action<string>? onWarning = null,
+        Action<PstMailItem, int>? onMessageWritten = null)
     {
         Directory.CreateDirectory(outputRoot);
         MboxTreePlan plan = MboxTreePlanner.Plan(folders, outputRoot, onWarning);
@@ -95,8 +99,9 @@ public sealed class MboxTreeWriter
             }
 
             EnsureMbox(mboxPath, created, createdSet);
-            AppendMessage(mboxPath, item.Message);
+            AppendMessage(mboxPath, item.Message);   // throws (fatal) on reconstruct/serialize/write failure
             messages++;
+            onMessageWritten?.Invoke(item, messages);   // fires only AFTER a successful append
         }
 
         return new MboxTreeWriteResult(created, created.Count, messages);

--- a/src/Mail2Pst.Core/Reverse/MimeReconstructor.cs
+++ b/src/Mail2Pst.Core/Reverse/MimeReconstructor.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #nullable enable
 using System;
+using System.Text;
 using MimeKit;
 
 namespace Mail2Pst.Core.Reverse;
@@ -18,6 +19,14 @@ namespace Mail2Pst.Core.Reverse;
 public sealed class MimeReconstructor : IMimeReconstructor
 {
     private readonly Action<string>? _onWarning;
+
+    static MimeReconstructor()
+    {
+        // Legacy Windows code pages (1250–1258, etc.) are not in .NET's built-in encoding provider. Register
+        // the CodePages provider so Encoding.GetEncoding(1252) etc. resolve during a reverse export. Idempotent
+        // — registering the same provider twice is harmless (the forward .msf reader may also have registered it).
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+    }
 
     public MimeReconstructor(Action<string>? onWarning = null) => _onWarning = onWarning;
 
@@ -68,16 +77,65 @@ public sealed class MimeReconstructor : IMimeReconstructor
             }
     }
 
-    // Body/attachment tree. Task 1 handles plain-only + the empty fallback; Tasks 2–3 add HTML/alternative
-    // and attachments.
+    // Regenerate the body tree from discrete props. Both bodies -> multipart/alternative (least-rich first,
+    // per RFC 2046); one body -> that part; neither -> an empty text/plain so subject/headers still round-trip.
     private MimeEntity BuildBody(PstMailMessage m)
     {
-        if (m.PlainBody is not null)
-            return new TextPart("plain") { Text = m.PlainBody };
+        TextPart? plain = m.PlainBody is not null ? new TextPart("plain") { Text = m.PlainBody } : null;
 
-        // No body at all: minimal empty text/plain so subject/headers still round-trip.
+        // A present-but-empty HtmlBody (zero-length byte[]) is a PRESENT html body (the forward writer wrote an
+        // empty PidTagHtml), so treat `not null` as present — only a null HtmlBody is absent.
+        TextPart? html = null;
+        if (m.HtmlBody is not null)
+            html = new TextPart("html") { Text = DecodeHtml(m.HtmlBody, m.InternetCodepage) };
+
+        if (plain is not null && html is not null)
+        {
+            var alt = new MultipartAlternative();
+            alt.Add(plain);   // least-rich first
+            alt.Add(html);
+            return alt;
+        }
+        if (html is not null) return html;
+        if (plain is not null) return plain;
+
         return new TextPart("plain") { Text = string.Empty };
     }
+
+    private string DecodeHtml(byte[] bytes, int? codepage)
+    {
+        // ResolveEncoding returns a STRICT encoder (DecoderFallback.ExceptionFallback), so genuinely invalid
+        // bytes throw DecoderFallbackException here instead of silently becoming U+FFFD — that is what makes the
+        // fallback-and-warn path live rather than dead code. On failure, decode tolerantly as UTF-8.
+        Encoding enc = ResolveEncoding(codepage);
+        try { return enc.GetString(bytes); }
+        catch (DecoderFallbackException)
+        {
+            _onWarning?.Invoke($"failed to decode HTML body with code page {codepage}; falling back to UTF-8.");
+            return TolerantUtf8.GetString(bytes);
+        }
+    }
+
+    // InternetCodepage informs the decode charset. null/65001 -> STRICT UTF-8 fast path (the forward writer's
+    // HTML encoding). Anything else is resolved via Encoding.GetEncoding with STRICT encoder/decoder fallbacks —
+    // including legacy Windows code pages (1250–1258, etc.), which work because the static ctor registered the
+    // CodePages provider. An unknown/unsupported code page (GetEncoding throws) falls back to strict UTF-8 with a
+    // warning; invalid bytes under the chosen page are handled by DecodeHtml's DecoderFallbackException catch.
+    private Encoding ResolveEncoding(int? codepage)
+    {
+        if (codepage is null or 65001) return StrictUtf8;
+        try { return Encoding.GetEncoding(codepage.Value, EncoderFallback.ExceptionFallback, DecoderFallback.ExceptionFallback); }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException)   // unknown/unsupported code page
+        {
+            _onWarning?.Invoke($"unknown/unsupported InternetCodepage {codepage}; decoding HTML body as UTF-8.");
+            return StrictUtf8;
+        }
+    }
+
+    // STRICT: throwOnInvalidBytes=true so invalid input surfaces as DecoderFallbackException (see DecodeHtml).
+    private static readonly Encoding StrictUtf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+    // TOLERANT: the post-failure fallback — invalid bytes become U+FFFD ('�') rather than throwing again.
+    private static readonly Encoding TolerantUtf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
 
     // Transport-header carry. Stub in Task 1; implemented in Task 4.
     private void ApplyTransportHeaders(MimeMessage mime, PstMailMessage m)

--- a/src/Mail2Pst.Core/Reverse/MimeReconstructor.cs
+++ b/src/Mail2Pst.Core/Reverse/MimeReconstructor.cs
@@ -212,10 +212,59 @@ public sealed class MimeReconstructor : IMimeReconstructor
         catch { content.Dispose(); throw; }
     }
 
-    // Transport-header carry. Stub in Task 1; implemented in Task 4.
+    // Carry identity/thread/trace headers from PidTagTransportMessageHeaders — but ONLY those that a discrete
+    // prop left unset (conflict rule: discrete props win). Received has no discrete equivalent, so it is always
+    // carried. Structural headers (Content-Type, CTE, boundary, MIME-Version, Content-Disposition) and
+    // X-Mozilla-* are NEVER carried: structure is regenerated from the body tree, and the mbox writer owns the
+    // X-Mozilla-* lines. Values are added RAW (not re-parsed) so an arbitrary Outlook value is preserved verbatim.
     private void ApplyTransportHeaders(MimeMessage mime, PstMailMessage m)
     {
-        // no-op until Task 4
+        if (string.IsNullOrEmpty(m.TransportHeaders)) return;
+        HeaderList? headers = TryParseHeaders(m.TransportHeaders!);
+        if (headers is null)
+        {
+            _onWarning?.Invoke("could not parse PidTagTransportMessageHeaders; skipping transport-header carry.");
+            return;
+        }
+
+        // Note: MimeMessage's default constructor auto-generates its OWN Message-Id header (MimeUtils
+        // GenerateMessageId) even when the discrete prop is absent, so mime.Headers.Contains(HeaderId.MessageId)
+        // is always true — the conflict check for Message-Id must test the discrete PROP (m.MessageId), not the
+        // header's presence. In-Reply-To/References are never auto-populated, so header presence is the right
+        // test for those.
+        if (string.IsNullOrWhiteSpace(m.MessageId) && headers[HeaderId.MessageId] is { } mid)
+        {
+            mime.Headers.Remove(HeaderId.MessageId);   // drop the auto-generated id before carrying the transport one
+            mime.Headers.Add(HeaderId.MessageId, mid);
+        }
+        if (!mime.Headers.Contains(HeaderId.InReplyTo) && headers[HeaderId.InReplyTo] is { } irt)
+            mime.Headers.Add(HeaderId.InReplyTo, irt);
+        if (!mime.Headers.Contains(HeaderId.References) && headers[HeaderId.References] is { } refs)
+            mime.Headers.Add(HeaderId.References, refs);
+
+        // Received: no discrete equivalent — carry every occurrence, preserving order.
+        foreach (Header h in headers)
+            if (h.Id == HeaderId.Received)
+                mime.Headers.Add(HeaderId.Received, h.Value);
+    }
+
+    // Parse a raw RFC 822 header block into a HeaderList. Returns null on an expected parse failure (caller warns).
+    private static HeaderList? TryParseHeaders(string block)
+    {
+        try
+        {
+            // UTF-8, not ASCII: the block is an already-decoded .NET string, so ASCII would replace any
+            // non-ASCII header text (e.g. an internationalized display name) with '?'. TrimEnd('\r','\n') only —
+            // a bare TrimEnd() would also strip trailing spaces/tabs and could corrupt the last header's folding
+            // whitespace.
+            byte[] bytes = Encoding.UTF8.GetBytes(block.TrimEnd('\r', '\n') + "\r\n\r\n");
+            using var ms = new MemoryStream(bytes);
+            return HeaderList.Load(ms);
+        }
+        catch (Exception ex) when (ex is FormatException or IOException)   // malformed block -> null; real bugs surface
+        {
+            return null;
+        }
     }
 
     // Narrow catch: MimeKit's Message-Id/In-Reply-To/References setters reject a malformed value with

--- a/src/Mail2Pst.Core/Reverse/MimeReconstructor.cs
+++ b/src/Mail2Pst.Core/Reverse/MimeReconstructor.cs
@@ -14,7 +14,7 @@ namespace Mail2Pst.Core.Reverse;
 /// inverse of the forward <c>PstWriter</c>/<c>AttachmentWriter</c>. Discrete MAPI props win for structure and
 /// display fields; MIME-structural headers are regenerated from the built body tree; identity/thread/trace
 /// headers may be filled from <see cref="PstMailMessage.TransportHeaders"/> only where a discrete prop left
-/// them unset. NEVER emits <c>X-Mozilla-*</c> headers — Plan 3's <c>MboxTreeWriter</c> owns those. Lossy points
+/// them unset. NEVER emits <c>X-Mozilla-*</c> headers — the <c>MboxTreeWriter</c> owns those. Lossy points
 /// are reported through the constructor-injected <paramref name="onWarning"/> sink (the <see cref="Reconstruct"/>
 /// seam has no warning parameter).
 /// </summary>
@@ -37,12 +37,12 @@ public sealed class MimeReconstructor : IMimeReconstructor
         var mime = new MimeMessage();
         ApplyIdentityHeaders(mime, message);   // discrete props WIN
         mime.Body = WrapWithAttachments(BuildBody(message), message);   // regenerated MIME-structural tree
-        ApplyTransportHeaders(mime, message);  // trace/thread from transport, non-contradicting only (Task 4)
+        ApplyTransportHeaders(mime, message);  // trace/thread from transport, non-contradicting only
         return mime;
     }
 
     // Identity/display headers from discrete props. These are the authoritative values; the transport-header
-    // pass (Task 4) only fills what these leave unset.
+    // pass only fills what these leave unset.
     private void ApplyIdentityHeaders(MimeMessage mime, PstMailMessage m)
     {
         mime.Subject = m.Subject ?? string.Empty;

--- a/src/Mail2Pst.Core/Reverse/MimeReconstructor.cs
+++ b/src/Mail2Pst.Core/Reverse/MimeReconstructor.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #nullable enable
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using MimeKit;
 
@@ -34,7 +36,7 @@ public sealed class MimeReconstructor : IMimeReconstructor
     {
         var mime = new MimeMessage();
         ApplyIdentityHeaders(mime, message);   // discrete props WIN
-        mime.Body = BuildBody(message);        // regenerated MIME-structural tree (Tasks 2–3 extend this)
+        mime.Body = WrapWithAttachments(BuildBody(message), message);   // regenerated MIME-structural tree
         ApplyTransportHeaders(mime, message);  // trace/thread from transport, non-contradicting only (Task 4)
         return mime;
     }
@@ -136,6 +138,79 @@ public sealed class MimeReconstructor : IMimeReconstructor
     private static readonly Encoding StrictUtf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
     // TOLERANT: the post-failure fallback — invalid bytes become U+FFFD ('�') rather than throwing again.
     private static readonly Encoding TolerantUtf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
+
+    // Inline (CID) parts -> multipart/related around the body (inverting the forward inline-CID handling);
+    // non-inline parts -> multipart/mixed around whatever the body/related is. Attachment bytes are read
+    // SYNCHRONOUSLY here (the PstAttachment.OpenRead closure is valid only during this message's enumeration).
+    private MimeEntity WrapWithAttachments(MimeEntity body, PstMailMessage m)
+    {
+        var inline = new List<PstAttachment>();
+        var regular = new List<PstAttachment>();
+        foreach (PstAttachment a in m.Attachments)
+            (a.IsInline ? inline : regular).Add(a);
+
+        MimeEntity bodyOrRelated = body;
+        if (inline.Count > 0)
+        {
+            // Set Root in the initializer on an EMPTY collection: in MimeKit 4.17.0 the Root setter Insert(0,·)s
+            // when it can't resolve an existing root, so `related.Add(body); related.Root = body;` would insert
+            // the body TWICE. Assigning Root first (empty collection) adds it once as the root document; the
+            // inline parts are appended after.
+            var related = new MultipartRelated { Root = body };
+            foreach (PstAttachment a in inline)
+                related.Add(BuildPart(a, inlinePart: true));
+            bodyOrRelated = related;
+        }
+
+        if (regular.Count == 0) return bodyOrRelated;
+
+        var mixed = new Multipart("mixed");
+        mixed.Add(bodyOrRelated);
+        foreach (PstAttachment a in regular)
+            mixed.Add(BuildPart(a, inlinePart: false));
+        return mixed;
+    }
+
+    // Instance (not static) so it can warn on invalid attachment metadata. One detached MemoryStream that
+    // MimeContent takes ownership of — NO extra byte[]/MemoryStream copy. On any failure before the part owns
+    // the stream, dispose it so it can't leak.
+    private MimePart BuildPart(PstAttachment a, bool inlinePart)
+    {
+        MemoryStream content = a.Length is > 0 and <= int.MaxValue ? new MemoryStream((int)a.Length) : new MemoryStream();
+        try
+        {
+            using (Stream src = a.OpenRead()) src.CopyTo(content);   // read synchronously; never capture the closure
+            content.Position = 0;
+
+            ContentType ct;
+            if (ContentType.TryParse(a.ContentType, out ContentType? parsed) && parsed is not null)
+                ct = parsed;
+            else
+            {
+                ct = new ContentType("application", "octet-stream");
+                _onWarning?.Invoke($"attachment '{a.FileName}' has an invalid MIME type '{a.ContentType}'; using application/octet-stream.");
+            }
+
+            var part = new MimePart(ct)
+            {
+                Content = new MimeContent(content),
+                ContentTransferEncoding = ContentEncoding.Base64,
+                ContentDisposition = new ContentDisposition(inlinePart ? ContentDisposition.Inline : ContentDisposition.Attachment) { FileName = a.FileName },
+            };
+            part.ContentType.Name = a.FileName;
+            if (inlinePart && !string.IsNullOrWhiteSpace(a.ContentId))
+                part.ContentId = StripAngle(a.ContentId);
+            if (!string.IsNullOrWhiteSpace(a.ContentLocation))
+            {
+                if (Uri.TryCreate(a.ContentLocation, UriKind.RelativeOrAbsolute, out Uri? location))
+                    part.ContentLocation = location;
+                else
+                    _onWarning?.Invoke($"attachment '{a.FileName}' has an invalid Content-Location '{a.ContentLocation}'; omitting it.");
+            }
+            return part;
+        }
+        catch { content.Dispose(); throw; }
+    }
 
     // Transport-header carry. Stub in Task 1; implemented in Task 4.
     private void ApplyTransportHeaders(MimeMessage mime, PstMailMessage m)

--- a/src/Mail2Pst.Core/Reverse/MimeReconstructor.cs
+++ b/src/Mail2Pst.Core/Reverse/MimeReconstructor.cs
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using MimeKit;
+
+namespace Mail2Pst.Core.Reverse;
+
+/// <summary>
+/// Reconstructs a MimeKit <see cref="MimeMessage"/> from one read-back <see cref="PstMailMessage"/> — the
+/// inverse of the forward <c>PstWriter</c>/<c>AttachmentWriter</c>. Discrete MAPI props win for structure and
+/// display fields; MIME-structural headers are regenerated from the built body tree; identity/thread/trace
+/// headers may be filled from <see cref="PstMailMessage.TransportHeaders"/> only where a discrete prop left
+/// them unset. NEVER emits <c>X-Mozilla-*</c> headers — Plan 3's <c>MboxTreeWriter</c> owns those. Lossy points
+/// are reported through the constructor-injected <paramref name="onWarning"/> sink (the <see cref="Reconstruct"/>
+/// seam has no warning parameter).
+/// </summary>
+public sealed class MimeReconstructor : IMimeReconstructor
+{
+    private readonly Action<string>? _onWarning;
+
+    public MimeReconstructor(Action<string>? onWarning = null) => _onWarning = onWarning;
+
+    public MimeMessage Reconstruct(PstMailMessage message)
+    {
+        var mime = new MimeMessage();
+        ApplyIdentityHeaders(mime, message);   // discrete props WIN
+        mime.Body = BuildBody(message);        // regenerated MIME-structural tree (Tasks 2–3 extend this)
+        ApplyTransportHeaders(mime, message);  // trace/thread from transport, non-contradicting only (Task 4)
+        return mime;
+    }
+
+    // Identity/display headers from discrete props. These are the authoritative values; the transport-header
+    // pass (Task 4) only fills what these leave unset.
+    private void ApplyIdentityHeaders(MimeMessage mime, PstMailMessage m)
+    {
+        mime.Subject = m.Subject ?? string.Empty;
+
+        // Sender display name (FromName) + address -> "John Doe <john@example.com>", or the bare address when
+        // FromName is null. Routed through TryAddMailbox so one malformed address can't abort the whole message.
+        if (!string.IsNullOrWhiteSpace(m.FromAddress))
+            TryAddMailbox(mime.From, m.FromName, m.FromAddress, "from");
+
+        foreach (PstRecipient r in m.Recipients)
+        {
+            if (string.IsNullOrWhiteSpace(r.Address)) continue;   // no usable address -> skipped
+            switch (r.Kind)
+            {
+                case PstRecipientKind.To: TryAddMailbox(mime.To, r.DisplayName, r.Address, "to"); break;
+                case PstRecipientKind.Cc: TryAddMailbox(mime.Cc, r.DisplayName, r.Address, "cc"); break;
+                case PstRecipientKind.Bcc: TryAddMailbox(mime.Bcc, r.DisplayName, r.Address, "bcc"); break;
+            }
+        }
+
+        // A message with no date genuinely has none; MimeKit forces a Date header, so pin a deterministic
+        // epoch fallback rather than leaking DateTime.Now into the output.
+        mime.Date = m.Date ?? DateTimeOffset.UnixEpoch;
+
+        if (!string.IsNullOrWhiteSpace(m.MessageId))
+            TrySetHeader(() => mime.MessageId = StripAngle(m.MessageId!), "Message-Id");
+        if (!string.IsNullOrWhiteSpace(m.InReplyTo))
+            TrySetHeader(() => mime.InReplyTo = StripAngle(m.InReplyTo!), "In-Reply-To");
+        if (!string.IsNullOrWhiteSpace(m.References))
+            foreach (string id in m.References!.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
+            {
+                string cleaned = StripAngle(id);
+                TrySetHeader(() => mime.References.Add(cleaned), "References");
+            }
+    }
+
+    // Body/attachment tree. Task 1 handles plain-only + the empty fallback; Tasks 2–3 add HTML/alternative
+    // and attachments.
+    private MimeEntity BuildBody(PstMailMessage m)
+    {
+        if (m.PlainBody is not null)
+            return new TextPart("plain") { Text = m.PlainBody };
+
+        // No body at all: minimal empty text/plain so subject/headers still round-trip.
+        return new TextPart("plain") { Text = string.Empty };
+    }
+
+    // Transport-header carry. Stub in Task 1; implemented in Task 4.
+    private void ApplyTransportHeaders(MimeMessage mime, PstMailMessage m)
+    {
+        // no-op until Task 4
+    }
+
+    // Narrow catch: MimeKit's Message-Id/In-Reply-To/References setters reject a malformed value with
+    // ArgumentException/FormatException — those are recoverable (warn + skip that one header). Anything else is a
+    // real bug and must surface (repo fail-loud policy).
+    private void TrySetHeader(Action set, string what)
+    {
+        try { set(); }
+        catch (Exception ex) when (ex is ArgumentException or FormatException)
+        {
+            _onWarning?.Invoke($"could not set {what} header: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    // A malformed/legacy non-SMTP Outlook address makes new MailboxAddress throw ArgumentException; one bad
+    // address must not abort the whole message, so warn + skip it (valid addresses still land).
+    private void TryAddMailbox(InternetAddressList target, string? displayName, string address, string role)
+    {
+        // VERIFIED (MimeKit 4.17.0 MailboxAddress.cs): the ctor sets the Address property, whose setter runs
+        // TryParseAddrspec and throws MimeKit.ParseException (NOT ArgumentException) on a malformed addr-spec
+        // (e.g. "not an address"); it throws ArgumentNullException only for a null address. Catch both so one
+        // malformed Outlook address (non-SMTP/X.500/garbage) warns + skips instead of aborting the message.
+        try { target.Add(new MailboxAddress(displayName ?? string.Empty, address)); }
+        catch (Exception ex) when (ex is ParseException or ArgumentException)
+        {
+            _onWarning?.Invoke($"could not reconstruct {role} address '{address}': {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    // IDs may arrive bracketed (ContinuMail-written; NormalizeForJoin adds <>) or unbracketed (arbitrary source
+    // PSTs) — strip any surrounding <> so MimeKit (which adds its own) never double-wraps.
+    private static string StripAngle(string id)
+    {
+        id = id.Trim();
+        if (id.Length >= 2 && id.StartsWith("<", StringComparison.Ordinal) && id.EndsWith(">", StringComparison.Ordinal))
+            id = id.Substring(1, id.Length - 2);
+        return id;
+    }
+}

--- a/src/Mail2Pst.Core/Reverse/MozillaKeywordSanitizer.cs
+++ b/src/Mail2Pst.Core/Reverse/MozillaKeywordSanitizer.cs
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System.Text;
+
+namespace Mail2Pst.Core.Reverse;
+
+/// <summary>
+/// Sanitizes a PST category into a Thunderbird <c>X-Mozilla-Keys</c> keyword token. A category that is
+/// already a safe, token-like key (ASCII letters/digits/underscore) is preserved verbatim; otherwise it
+/// is lowercased and any run of unsupported characters (whitespace, punctuation, non-ASCII) collapses to
+/// a single underscore, with leading/trailing separators trimmed. A category that yields nothing usable
+/// returns <c>null</c>.
+/// </summary>
+public static class MozillaKeywordSanitizer
+{
+    /// <summary>True when <paramref name="key"/> is a non-empty run of ASCII letters, digits, or '_'.</summary>
+    public static bool IsSafeKey(string key)
+    {
+        if (string.IsNullOrEmpty(key)) return false;
+        foreach (char c in key)
+            if (!IsSafeChar(c)) return false;
+        return true;
+    }
+
+    /// <summary>
+    /// Returns the sanitized keyword for <paramref name="category"/>, or <c>null</c> when nothing usable
+    /// remains. A safe key is returned unchanged (original case preserved).
+    /// </summary>
+    public static string? Sanitize(string category)
+    {
+        if (string.IsNullOrEmpty(category)) return null;
+        if (IsSafeKey(category)) return category;
+
+        var sb = new StringBuilder(category.Length);
+        foreach (char c in category)
+        {
+            char lower = char.ToLowerInvariant(c);
+            if (IsAlphaNum(lower))
+                sb.Append(lower);                                              // keep ASCII letters/digits
+            else if (sb.Length > 0 && sb[sb.Length - 1] != '_')
+                sb.Append('_');                                                // any run of separators -> single '_'
+        }
+        // Leading separators never append (guard above); trim any trailing separator.
+        while (sb.Length > 0 && sb[sb.Length - 1] == '_') sb.Length--;
+        return sb.Length == 0 ? null : sb.ToString();
+    }
+
+    private static bool IsSafeChar(char c) =>
+        (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_';
+
+    // Sanitize keeps ASCII letters/digits and treats everything else — including underscores in an
+    // otherwise-unsafe category — as separators. Already-safe keys return before this path (preserved
+    // verbatim), so multi-word categories still keep their word boundaries.
+    private static bool IsAlphaNum(char c) =>
+        (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9');
+}

--- a/src/Mail2Pst.Core/Reverse/MozillaStatusMapper.cs
+++ b/src/Mail2Pst.Core/Reverse/MozillaStatusMapper.cs
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Mail2Pst.Core.Msf;
+using Mail2Pst.Core.OutlookCategories;
+
+namespace Mail2Pst.Core.Reverse;
+
+/// <summary>The three Thunderbird header values derived from a message's flags and categories.</summary>
+/// <param name="Status">4-digit lowercase hex for <c>X-Mozilla-Status</c> (low-word flags).</param>
+/// <param name="Status2">8-digit lowercase hex for <c>X-Mozilla-Status2</c> (reserved; "00000000" in v1).</param>
+/// <param name="Keys">Space-joined <c>X-Mozilla-Keys</c> keywords; empty string when none.</param>
+public sealed record MozillaStatusHeaders(string Status, string Status2, string Keys);
+
+/// <summary>
+/// Pure mapper: a message's read/replied/forwarded flags and categories → the Thunderbird
+/// <c>X-Mozilla-Status</c> / <c>X-Mozilla-Status2</c> / <c>X-Mozilla-Keys</c> header values that seed
+/// Thunderbird's regenerated <c>.msf</c>. The synthetic "Star" category (the forward direction's stand-in
+/// for Thunderbird "Marked") sets the Status Marked bit and is NOT re-emitted as a keyword. This is the
+/// inverse of the forward <c>MimeMessageMapper</c> <c>X-Mozilla-Status</c> parse; bit values come from
+/// <see cref="MsfMessageFlags"/> so both directions share one source of truth. (Keyword emission is the
+/// reverse-export side only; the forward parser does not re-read <c>X-Mozilla-Keys</c> into categories.)
+/// </summary>
+public static class MozillaStatusMapper
+{
+    private const string EmptyStatus2 = "00000000"; // reserved for extended flags; kept minimal in v1
+
+    /// <summary>Maps the already-decoded flags/categories of one message to its X-Mozilla-* headers.</summary>
+    public static MozillaStatusHeaders Map(
+        bool isRead, bool isReplied, bool isForwarded, IReadOnlyList<string> categories)
+    {
+        categories ??= Array.Empty<string>();
+
+        bool marked = false;
+        var keys = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (string category in categories)
+        {
+            if (string.Equals(category, StarCategory.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                marked = true;                               // "Star" -> Marked bit, consumed (not a keyword)
+                continue;
+            }
+            string? key = MozillaKeywordSanitizer.Sanitize(category);
+            if (key is not null && seen.Add(key)) keys.Add(key);
+        }
+
+        uint status = 0;
+        if (isRead)      status |= (uint)MsfMessageFlags.Read;      // 0x0001
+        if (isReplied)   status |= (uint)MsfMessageFlags.Replied;   // 0x0002
+        if (marked)      status |= (uint)MsfMessageFlags.Marked;    // 0x0004
+        if (isForwarded) status |= (uint)MsfMessageFlags.Forwarded; // 0x1000
+
+        return new MozillaStatusHeaders(
+            status.ToString("x4", CultureInfo.InvariantCulture),
+            EmptyStatus2,
+            string.Join(" ", keys));
+    }
+
+    /// <summary>Convenience overload for a read-back <see cref="PstMailMessage"/>.</summary>
+    public static MozillaStatusHeaders Map(PstMailMessage message)
+        => Map(message.IsRead, message.IsReplied, message.IsForwarded, message.Categories);
+}

--- a/src/Mail2Pst.Core/Reverse/PstExportRunner.cs
+++ b/src/Mail2Pst.Core/Reverse/PstExportRunner.cs
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace Mail2Pst.Core.Reverse;
+
+/// <summary>A progress tick, emitted AFTER a message is successfully written to the mbox tree.</summary>
+public sealed record ExportProgress(int MessagesExported, string CurrentFolder);
+
+/// <summary>
+/// Orchestrates the reverse (PST → Thunderbird) mail export — the mirror image of the forward
+/// <c>ConversionRunner</c>. Two passes over the source PST, NEITHER of which modifies it: pass 1
+/// (<see cref="PstMailReader.EnumerateFolders"/>) defines the full folder structure; pass 2
+/// (<see cref="PstMailReader.EnumerateMessages"/>) streams messages one at a time THROUGH the
+/// <see cref="MboxTreeWriter"/> (never materialized), reconstructing each to MIME via the injected
+/// <see cref="IMimeReconstructor"/>. A single warning collector is injected into the reader, reconstructor,
+/// and writer; a structured skip sink into the reader — so every lossy/skip point lands in the returned
+/// <see cref="ExportReport"/>. Progress ticks fire only AFTER a message is on disk.
+///
+/// Because <see cref="MboxTreeWriter"/> APPENDS, output is written to a sibling STAGING directory and
+/// published to <paramref name="outputRoot"/> only on success, with the atomic directory move as the FINAL
+/// throwable operation; a mid-export failure removes the staging dir and leaves <paramref name="outputRoot"/>
+/// untouched. A non-empty existing destination (or an existing file at that path) is rejected up front.
+///
+/// Failure policy: PST message-read failures AND corrupt PST subtrees are reported+skipped inside
+/// <see cref="PstMailReader"/>; lossy-but-recovered reconstruction decisions are warnings. UNEXPECTED
+/// reconstruction / attachment-read / MIME-serialization / filesystem-write failures are FATAL and propagate
+/// (the writer does not catch them) — the CLI (Plan 6) turns a propagated failure into a fatal error event.
+/// A fatal PST-open / root-walk failure likewise propagates.
+/// </summary>
+public sealed class PstExportRunner
+{
+    private readonly Func<Action<string>?, IMimeReconstructor> _reconstructorFactory;
+
+    public PstExportRunner(Func<Action<string>?, IMimeReconstructor>? reconstructorFactory = null)
+        => _reconstructorFactory = reconstructorFactory ?? (onWarning => new MimeReconstructor(onWarning));
+
+    /// <param name="onWarning">Optional live sink (Plan 6's warning-event stream). Invoked IN ADDITION to
+    /// recording into the report. Structured skips are also forwarded here as text for the live stream.</param>
+    /// <param name="onProgress">Optional live progress sink, one tick per successfully written message.</param>
+    public ExportReport Run(
+        string pstPath, string outputRoot, bool includeEmpty,
+        Action<string>? onWarning = null, Action<ExportProgress>? onProgress = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pstPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputRoot);
+
+        // Normalize FIRST: a trailing separator makes Path.GetFileName empty -> staging would land INSIDE dest.
+        string fullOutput = Path.TrimEndingDirectorySeparator(Path.GetFullPath(outputRoot));
+
+        // Reject an existing FILE, and a non-empty existing DIR, before doing any work (MboxTreeWriter APPENDS).
+        if (File.Exists(fullOutput))
+            throw new IOException($"Output path '{fullOutput}' is an existing file.");
+        if (Directory.Exists(fullOutput) && Directory.EnumerateFileSystemEntries(fullOutput).Any())
+            throw new IOException(
+                $"Output directory '{fullOutput}' already exists and is not empty; refusing to export into it.");
+
+        var report = new ExportReport(fullOutput);
+
+        // Two DISTINCT sinks: Collect writes report.Warnings (+ live). CollectSkip writes report.Skipped ONLY
+        // (never report.Warnings — no double count), plus a formatted line to the LIVE sink for the CLI stream.
+        void Collect(string message) { report.RecordWarning(message); onWarning?.Invoke(message); }
+        void CollectSkip(ExportSkip skip)
+        {
+            report.RecordSkipped(skip);
+            onWarning?.Invoke($"skipped message {skip.MessageIndex} in '{skip.FolderPath}': {skip.Reason}");
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+
+        // Pass 1 (structure authority) also performs the fatal PST-open — a bad/missing/corrupt store throws
+        // here and propagates out of Run (before any staging dir is created).
+        IReadOnlyList<IReadOnlyList<string>> folders = PstMailReader.EnumerateFolders(pstPath, Collect);
+
+        string parent = Path.GetDirectoryName(fullOutput) ?? fullOutput;
+        string staging = Path.Combine(parent, Path.GetFileName(fullOutput) + ".partial-" + Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            IMimeReconstructor reconstructor = _reconstructorFactory(Collect)
+                ?? throw new InvalidOperationException("Reconstructor factory returned null.");
+            var writer = new MboxTreeWriter(reconstructor);
+
+            // Progress fires from the writer AFTER a successful append, so a message that throws never ticks.
+            Action<PstMailItem, int>? written = onProgress is null
+                ? null
+                : (item, count) => onProgress(new ExportProgress(count, FolderPathDisplay.Join(item.FolderPath)));
+
+            // Pass 2: lazy stream straight into the writer (attachment OpenRead fires while the item is current;
+            // no .ToList()). Skips flow to CollectSkip, warnings to Collect.
+            MboxTreeWriteResult staged = writer.Write(
+                PstMailReader.EnumerateMessages(pstPath, Collect, CollectSkip),
+                folders, staging, includeEmpty, Collect, written);
+
+            // Build the published result BEFORE the move, so the move is the final throwable op.
+            string[] publishedFiles = staged.MboxFiles
+                .Select(f => Path.Combine(fullOutput, Path.GetRelativePath(staging, f)))
+                .ToArray();
+            MboxTreeWriteResult published = staged with { MboxFiles = publishedFiles };
+            stopwatch.Stop();
+            report.Complete(published, stopwatch.Elapsed);
+
+            // Re-check the destination immediately before publishing (TOCTOU): only remove an ALLOWED empty dir.
+            if (Directory.Exists(fullOutput))
+            {
+                if (Directory.EnumerateFileSystemEntries(fullOutput).Any())
+                    throw new IOException($"Output directory '{fullOutput}' became non-empty during export.");
+                Directory.Delete(fullOutput, recursive: false);
+            }
+            Directory.Move(staging, fullOutput);   // FINAL throwable op
+            return report;
+        }
+        catch
+        {
+            try { if (Directory.Exists(staging)) Directory.Delete(staging, recursive: true); }
+            catch { /* best-effort staging cleanup; surface the original failure */ }
+            throw;
+        }
+    }
+}

--- a/src/Mail2Pst.Core/Reverse/PstExportRunner.cs
+++ b/src/Mail2Pst.Core/Reverse/PstExportRunner.cs
@@ -41,11 +41,14 @@ public sealed class PstExportRunner
         => _reconstructorFactory = reconstructorFactory ?? (onWarning => new MimeReconstructor(onWarning));
 
     /// <param name="onWarning">Optional live sink (Plan 6's warning-event stream). Invoked IN ADDITION to
-    /// recording into the report. Structured skips are also forwarded here as text for the live stream.</param>
+    /// recording into the report. Skips are NOT forwarded here — see <paramref name="onSkipped"/>.</param>
     /// <param name="onProgress">Optional live progress sink, one tick per successfully written message.</param>
+    /// <param name="onSkipped">Optional live sink for structured per-message skips (Plan 6's skip-event
+    /// stream). Invoked IN ADDITION to recording into the report; disjoint from <paramref name="onWarning"/>.</param>
     public ExportReport Run(
         string pstPath, string outputRoot, bool includeEmpty,
-        Action<string>? onWarning = null, Action<ExportProgress>? onProgress = null)
+        Action<string>? onWarning = null, Action<ExportProgress>? onProgress = null,
+        Action<ExportSkip>? onSkipped = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(pstPath);
         ArgumentException.ThrowIfNullOrWhiteSpace(outputRoot);
@@ -62,13 +65,14 @@ public sealed class PstExportRunner
 
         var report = new ExportReport(fullOutput);
 
-        // Two DISTINCT sinks: Collect writes report.Warnings (+ live). CollectSkip writes report.Skipped ONLY
-        // (never report.Warnings — no double count), plus a formatted line to the LIVE sink for the CLI stream.
+        // Two DISTINCT sinks: Collect writes report.Warnings (+ live warning stream). CollectSkip writes
+        // report.Skipped ONLY (never report.Warnings — no double count) and forwards the STRUCTURED skip to
+        // the live skip sink, so a consumer's warning and skip counts stay disjoint and match the report.
         void Collect(string message) { report.RecordWarning(message); onWarning?.Invoke(message); }
         void CollectSkip(ExportSkip skip)
         {
             report.RecordSkipped(skip);
-            onWarning?.Invoke($"skipped message {skip.MessageIndex} in '{skip.FolderPath}': {skip.Reason}");
+            onSkipped?.Invoke(skip);
         }
 
         var stopwatch = Stopwatch.StartNew();

--- a/src/Mail2Pst.Core/Reverse/PstExportRunner.cs
+++ b/src/Mail2Pst.Core/Reverse/PstExportRunner.cs
@@ -30,7 +30,7 @@ public sealed record ExportProgress(int MessagesExported, string CurrentFolder);
 /// Failure policy: PST message-read failures AND corrupt PST subtrees are reported+skipped inside
 /// <see cref="PstMailReader"/>; lossy-but-recovered reconstruction decisions are warnings. UNEXPECTED
 /// reconstruction / attachment-read / MIME-serialization / filesystem-write failures are FATAL and propagate
-/// (the writer does not catch them) — the CLI (Plan 6) turns a propagated failure into a fatal error event.
+/// (the writer does not catch them) — the CLI turns a propagated failure into a fatal error event.
 /// A fatal PST-open / root-walk failure likewise propagates.
 /// </summary>
 public sealed class PstExportRunner
@@ -40,10 +40,10 @@ public sealed class PstExportRunner
     public PstExportRunner(Func<Action<string>?, IMimeReconstructor>? reconstructorFactory = null)
         => _reconstructorFactory = reconstructorFactory ?? (onWarning => new MimeReconstructor(onWarning));
 
-    /// <param name="onWarning">Optional live sink (Plan 6's warning-event stream). Invoked IN ADDITION to
+    /// <param name="onWarning">Optional live sink (the CLI's warning-event stream). Invoked IN ADDITION to
     /// recording into the report. Skips are NOT forwarded here — see <paramref name="onSkipped"/>.</param>
     /// <param name="onProgress">Optional live progress sink, one tick per successfully written message.</param>
-    /// <param name="onSkipped">Optional live sink for structured per-message skips (Plan 6's skip-event
+    /// <param name="onSkipped">Optional live sink for structured per-message skips (the CLI's skip-event
     /// stream). Invoked IN ADDITION to recording into the report; disjoint from <paramref name="onWarning"/>.</param>
     public ExportReport Run(
         string pstPath, string outputRoot, bool includeEmpty,

--- a/src/Mail2Pst.Core/Reverse/PstMailReader.cs
+++ b/src/Mail2Pst.Core/Reverse/PstMailReader.cs
@@ -114,7 +114,10 @@ public static class PstMailReader
                 name, mime, contentId,
                 IsInline: hidden || !string.IsNullOrEmpty(contentId),
                 OpenRead: () => new MemoryStream(att.PC.GetBytesProperty(PropertyID.PidTagAttachData) ?? Array.Empty<byte>()),
-                Length: null));
+                Length: null)
+            {
+                ContentLocation = att.PC.GetStringProperty(PropertyID.PidTagAttachContentLocation),
+            });
         }
 
         byte[]? html = note.PC.GetBytesProperty(PropertyID.PidTagHtml);

--- a/src/Mail2Pst.Core/Reverse/PstMailReader.cs
+++ b/src/Mail2Pst.Core/Reverse/PstMailReader.cs
@@ -30,6 +30,46 @@ public static class PstMailReader
         finally { pst.CloseFile(); }
     }
 
+    /// <summary>
+    /// The STRUCTURE AUTHORITY for the reverse export: walks the whole tree from TopOfPersonalFolders and
+    /// returns every mail folder's path INCLUDING empty ones (which <see cref="EnumerateMessages"/> never
+    /// yields). Recurses THROUGH non-mail containers so their mail descendants are returned with their full
+    /// path (the container itself is not a mail folder and is not returned; MboxTreePlanner synthesizes it as
+    /// a structural parent). Reads no messages and does NOT modify the store. A fatal open/root-walk failure
+    /// propagates; a corrupt child-walk is reported via <paramref name="onWarning"/> and that subtree stops.
+    /// </summary>
+    public static IReadOnlyList<IReadOnlyList<string>> EnumerateFolders(string pstPath, Action<string>? onWarning = null)
+    {
+        var pst = new PSTFile(pstPath, FileAccess.Read);          // fatal on failure -> propagate
+        try
+        {
+            var result = new List<IReadOnlyList<string>>();
+            foreach (PSTFolder child in pst.TopOfPersonalFolders.GetChildFolders())
+                CollectFolders(child, new List<string>(), result, onWarning);
+            return result;
+        }
+        finally { pst.CloseFile(); }
+    }
+
+    private static void CollectFolders(
+        PSTFolder folder, List<string> parentPath, List<IReadOnlyList<string>> acc, Action<string>? onWarning)
+    {
+        var path = new List<string>(parentPath) { folder.DisplayName };
+        if (folder is MailFolder)
+            acc.Add(path);                                        // mail folder (possibly empty) -> structure
+
+        List<PSTFolder> children;
+        try { children = folder.GetChildFolders(); }
+        catch (Exception ex) when (ex is not OutOfMemoryException) // corrupt subtree: warn + stop this branch
+        {
+            onWarning?.Invoke(
+                $"could not read subfolders of '{FolderPathDisplay.Join(path)}': {ex.GetType().Name}: {ex.Message}");
+            return;
+        }
+        foreach (PSTFolder c in children)
+            CollectFolders(c, path, acc, onWarning);
+    }
+
     private static IEnumerable<PstMailItem> EnumerateFolder(
         PSTFolder folder, List<string> parentPath, ushort? keywordsId, Action<string>? onWarning)
     {

--- a/src/Mail2Pst.Core/Reverse/PstMailReader.cs
+++ b/src/Mail2Pst.Core/Reverse/PstMailReader.cs
@@ -121,6 +121,8 @@ public static class PstMailReader
             Recipients: recipients,
             Date: date,
             MessageId: note.PC.GetStringProperty(PropertyID.PidTagInternetMessageId),
+            InReplyTo: note.PC.GetStringProperty(PropertyID.PidTagInReplyToId),
+            References: note.PC.GetStringProperty(PropertyID.PidTagInternetReferences),
             PlainBody: note.Body,
             HtmlBody: html is { Length: > 0 } ? html : null,
             InternetCodepage: note.PC.GetInt32Property(PropertyID.PidTagInternetCodepage),

--- a/src/Mail2Pst.Core/Reverse/PstMailReader.cs
+++ b/src/Mail2Pst.Core/Reverse/PstMailReader.cs
@@ -37,7 +37,15 @@ public static class PstMailReader
 
         if (folder is MailFolder mf)
         {
-            for (int i = 0; i < mf.MessageCount; i++)
+            int count = 0;
+            try { count = mf.MessageCount; }
+            catch (Exception ex) when (ex is not OutOfMemoryException)       // corrupt contents table: warn + skip
+            {
+                onWarning?.Invoke(
+                    $"could not read message count of '{string.Join(" / ", path)}': {ex.GetType().Name}: {ex.Message}");
+                count = 0;
+            }
+            for (int i = 0; i < count; i++)
             {
                 PstMailMessage? msg = null;
                 try { msg = ReadNote(mf.GetNote(i), keywordsId, onWarning); }
@@ -50,11 +58,22 @@ public static class PstMailReader
                     yield return new PstMailItem(path, msg);                  // yield OUTSIDE the try/catch
             }
         }
-        else if (folder.MessageCount > 0)                                    // non-mail with messages: warn + skip
+        else
         {
-            onWarning?.Invoke(
-                $"folder '{string.Join(" / ", path)}' has {folder.MessageCount} message(s) but is not a mail " +
-                "folder (container class differs); skipping its messages.");
+            int nonMailCount = 0;
+            try { nonMailCount = folder.MessageCount; }
+            catch (Exception ex) when (ex is not OutOfMemoryException)       // corrupt contents table: warn + skip
+            {
+                onWarning?.Invoke(
+                    $"could not read message count of '{string.Join(" / ", path)}': {ex.GetType().Name}: {ex.Message}");
+                nonMailCount = 0;
+            }
+            if (nonMailCount > 0)                                            // non-mail with messages: warn + skip
+            {
+                onWarning?.Invoke(
+                    $"folder '{string.Join(" / ", path)}' has {nonMailCount} message(s) but is not a mail " +
+                    "folder (container class differs); skipping its messages.");
+            }
         }
 
         // NOTE: C# iterators forbid `yield` inside a catch clause, so this must NOT `yield break` in the
@@ -142,12 +161,12 @@ public static class PstMailReader
             RecipientType.To => PstRecipientKind.To,
             RecipientType.Cc => PstRecipientKind.Cc,
             RecipientType.Bcc => PstRecipientKind.Bcc,
-            var other => Warn(other, onWarning),
+            var other => Warn(other, raw.Value, onWarning),
         };
 
-        PstRecipientKind Warn(RecipientType other, Action<string>? onWarning)
+        static PstRecipientKind Warn(RecipientType other, int rawValue, Action<string>? onWarning)
         {
-            onWarning?.Invoke($"unexpected recipient type raw={raw} enum='{other}' -> treated as To");
+            onWarning?.Invoke($"unexpected recipient type raw={rawValue} enum='{other}' -> treated as To");
             return PstRecipientKind.To;
         }
     }

--- a/src/Mail2Pst.Core/Reverse/PstMailReader.cs
+++ b/src/Mail2Pst.Core/Reverse/PstMailReader.cs
@@ -150,7 +150,10 @@ public static class PstMailReader
             IsReplied: lastVerb is 102 or 103,
             IsForwarded: lastVerb is 104,
             Categories: categories,
-            Attachments: attachments);
+            Attachments: attachments)
+        {
+            FromName = note.PC.GetStringProperty(PropertyID.PidTagSentRepresentingName),
+        };
     }
 
     private static PstRecipientKind MapKind(int? raw, Action<string>? onWarning)

--- a/src/Mail2Pst.Core/Reverse/PstMailReader.cs
+++ b/src/Mail2Pst.Core/Reverse/PstMailReader.cs
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using PSTFileFormat;
+
+namespace Mail2Pst.Core.Reverse;
+
+/// <summary>
+/// Streams mail messages from a PST for the reverse (PST→Thunderbird) export — one message alive at a
+/// time, so a large PST is never fully materialized. Productionized from the Integration.Tests PstReader
+/// spike. Failure policy: a non-mail folder with messages, or a per-message read failure, is reported via
+/// onWarning and skipped; OutOfMemory/process failures and a fatal open/root-walk failure propagate.
+/// </summary>
+public static class PstMailReader
+{
+    /// <summary>Lazy: the PST stays open while iterating. Attachment OpenRead must be called during iteration.</summary>
+    public static IEnumerable<PstMailItem> EnumerateMessages(string pstPath, Action<string>? onWarning = null)
+    {
+        var pst = new PSTFile(pstPath, FileAccess.Read);            // fatal on failure -> propagate
+        try
+        {
+            ushort? keywordsId = PropertyNameToIDMap.ResolveStringNamedProperty(pst, 2, "Keywords");
+            foreach (PSTFolder child in pst.TopOfPersonalFolders.GetChildFolders())
+                foreach (PstMailItem item in EnumerateFolder(child, new List<string>(), keywordsId, onWarning))
+                    yield return item;
+        }
+        finally { pst.CloseFile(); }
+    }
+
+    private static IEnumerable<PstMailItem> EnumerateFolder(
+        PSTFolder folder, List<string> parentPath, ushort? keywordsId, Action<string>? onWarning)
+    {
+        var path = new List<string>(parentPath) { folder.DisplayName };
+
+        if (folder is MailFolder mf)
+        {
+            for (int i = 0; i < mf.MessageCount; i++)
+            {
+                PstMailMessage? msg = null;
+                try { msg = ReadNote(mf.GetNote(i), keywordsId, onWarning); }
+                catch (Exception ex) when (ex is not OutOfMemoryException)   // bad message: skip + warn
+                {
+                    onWarning?.Invoke(
+                        $"skipped message {i} in '{string.Join(" / ", path)}': {ex.GetType().Name}: {ex.Message}");
+                }
+                if (msg is not null)
+                    yield return new PstMailItem(path, msg);                  // yield OUTSIDE the try/catch
+            }
+        }
+        else if (folder.MessageCount > 0)                                    // non-mail with messages: warn + skip
+        {
+            onWarning?.Invoke(
+                $"folder '{string.Join(" / ", path)}' has {folder.MessageCount} message(s) but is not a mail " +
+                "folder (container class differs); skipping its messages.");
+        }
+
+        // NOTE: C# iterators forbid `yield` inside a catch clause, so this must NOT `yield break` in the
+        // catch. On a corrupt child-walk we warn and fall through with an empty child list (skips subtree).
+        List<PSTFolder> children;
+        try { children = folder.GetChildFolders(); }
+        catch (Exception ex) when (ex is not OutOfMemoryException)           // corrupt subtree: warn + skip
+        {
+            onWarning?.Invoke(
+                $"could not read subfolders of '{string.Join(" / ", path)}': {ex.GetType().Name}: {ex.Message}");
+            children = new List<PSTFolder>();
+        }
+        foreach (PSTFolder c in children)
+            foreach (PstMailItem item in EnumerateFolder(c, path, keywordsId, onWarning))
+                yield return item;
+    }
+
+    private static PstMailMessage ReadNote(Note note, ushort? keywordsId, Action<string>? onWarning)
+    {
+        var recipients = new List<PstRecipient>();
+        for (int i = 0; i < note.RecipientCount; i++)
+        {
+            MessageRecipient r = note.GetRecipient(i);
+            int? typeRaw = note.RecipientsTable!.GetInt32Property(i, PropertyID.PidTagRecipientType);
+            recipients.Add(new PstRecipient(r.EmailAddress ?? string.Empty, r.DisplayName, MapKind(typeRaw, onWarning)));
+        }
+
+        var attachments = new List<PstAttachment>();
+        for (int i = 0; i < note.AttachmentCount; i++)
+        {
+            AttachmentObject att = note.GetAttachmentObject(i);
+            string? contentId = att.PC.GetStringProperty(PropertyID.PidTagAttachContentId);
+            bool hidden = att.PC.GetBooleanProperty(PropertyID.PidTagAttachmentHidden) ?? false;
+            string name = att.PC.GetStringProperty(PropertyID.PidTagAttachLongFilename)
+                          ?? att.PC.GetStringProperty(PropertyID.PidTagDisplayName) ?? string.Empty;
+            string? mime = att.PC.GetStringProperty(PropertyID.PidTagAttachMimeTag);
+            attachments.Add(new PstAttachment(
+                name, mime, contentId,
+                IsInline: hidden || !string.IsNullOrEmpty(contentId),
+                OpenRead: () => new MemoryStream(att.PC.GetBytesProperty(PropertyID.PidTagAttachData) ?? Array.Empty<byte>()),
+                Length: null));
+        }
+
+        byte[]? html = note.PC.GetBytesProperty(PropertyID.PidTagHtml);
+        DateTimeOffset? date = null;
+        DateTime? submit = note.PC.GetDateTimeProperty(PropertyID.PidTagClientSubmitTime);
+        if (submit.HasValue)
+            date = new DateTimeOffset(DateTime.SpecifyKind(submit.Value, DateTimeKind.Utc));
+
+        int msgFlags = note.PC.GetInt32Property(PropertyID.PidTagMessageFlags) ?? 0;
+        int? lastVerb = note.PC.GetInt32Property(PropertyID.PidTagLastVerbExecuted);
+
+        IReadOnlyList<string> categories = Array.Empty<string>();
+        if (keywordsId is ushort kid)
+        {
+            var rec = note.PC.GetRecordByPropertyID((PropertyID)kid);
+            if (rec != null)
+                categories = PropertyContext.DeserializeMultiString(note.PC.GetExternalRecordData(rec));
+        }
+
+        return new PstMailMessage(
+            Subject: note.Subject,
+            FromAddress: note.PC.GetStringProperty(PropertyID.PidTagSentRepresentingEmailAddress),
+            Recipients: recipients,
+            Date: date,
+            MessageId: note.PC.GetStringProperty(PropertyID.PidTagInternetMessageId),
+            PlainBody: note.Body,
+            HtmlBody: html is { Length: > 0 } ? html : null,
+            InternetCodepage: note.PC.GetInt32Property(PropertyID.PidTagInternetCodepage),
+            TransportHeaders: note.PC.GetStringProperty(PropertyID.PidTagTransportMessageHeaders),
+            IsRead: (msgFlags & 0x0001) != 0,
+            IsReplied: lastVerb is 102 or 103,
+            IsForwarded: lastVerb is 104,
+            Categories: categories,
+            Attachments: attachments);
+    }
+
+    private static PstRecipientKind MapKind(int? raw, Action<string>? onWarning)
+    {
+        if (!raw.HasValue) return PstRecipientKind.To;
+        return (RecipientType)(uint)raw.Value switch
+        {
+            RecipientType.To => PstRecipientKind.To,
+            RecipientType.Cc => PstRecipientKind.Cc,
+            RecipientType.Bcc => PstRecipientKind.Bcc,
+            var other => Warn(other, onWarning),
+        };
+
+        PstRecipientKind Warn(RecipientType other, Action<string>? onWarning)
+        {
+            onWarning?.Invoke($"unexpected recipient type raw={raw} enum='{other}' -> treated as To");
+            return PstRecipientKind.To;
+        }
+    }
+
+    /// <summary>TEST ONLY. Materializes all folders/messages (attachment bytes still lazy via OpenRead,
+    /// which must be read during the underlying enumeration — so tests that assert attachment payload
+    /// should use EnumerateMessages directly, not this helper).</summary>
+    public static IReadOnlyList<PstMailFolder> ReadAllForTests(string pstPath, Action<string>? onWarning = null)
+    {
+        var byKey = new Dictionary<string, (List<string> Path, List<PstMailMessage> Msgs)>(StringComparer.Ordinal);
+        var order = new List<string>();
+        foreach (PstMailItem item in EnumerateMessages(pstPath, onWarning))
+        {
+            string key = FolderPathKey.Join(item.FolderPath);
+            if (!byKey.TryGetValue(key, out var entry))
+            {
+                entry = (new List<string>(item.FolderPath), new List<PstMailMessage>());
+                byKey[key] = entry; order.Add(key);
+            }
+            entry.Msgs.Add(item.Message);
+        }
+        var result = new List<PstMailFolder>();
+        foreach (string k in order) result.Add(new PstMailFolder(byKey[k].Path, byKey[k].Msgs));
+        return result;
+    }
+}

--- a/src/Mail2Pst.Core/Reverse/PstMailReader.cs
+++ b/src/Mail2Pst.Core/Reverse/PstMailReader.cs
@@ -17,14 +17,15 @@ namespace Mail2Pst.Core.Reverse;
 public static class PstMailReader
 {
     /// <summary>Lazy: the PST stays open while iterating. Attachment OpenRead must be called during iteration.</summary>
-    public static IEnumerable<PstMailItem> EnumerateMessages(string pstPath, Action<string>? onWarning = null)
+    public static IEnumerable<PstMailItem> EnumerateMessages(
+        string pstPath, Action<string>? onWarning = null, Action<ExportSkip>? onSkipped = null)
     {
         var pst = new PSTFile(pstPath, FileAccess.Read);            // fatal on failure -> propagate
         try
         {
             ushort? keywordsId = PropertyNameToIDMap.ResolveStringNamedProperty(pst, 2, "Keywords");
             foreach (PSTFolder child in pst.TopOfPersonalFolders.GetChildFolders())
-                foreach (PstMailItem item in EnumerateFolder(child, new List<string>(), keywordsId, onWarning))
+                foreach (PstMailItem item in EnumerateFolder(child, new List<string>(), keywordsId, onWarning, onSkipped))
                     yield return item;
         }
         finally { pst.CloseFile(); }
@@ -70,8 +71,26 @@ public static class PstMailReader
             CollectFolders(c, path, acc, onWarning);
     }
 
+    /// <summary>
+    /// Reports a per-message read failure. When <paramref name="onSkipped"/> is supplied (the export runner),
+    /// records a STRUCTURED skip ONLY — it is NOT also emitted as a warning, so a skip is not double-counted.
+    /// When <paramref name="onSkipped"/> is null (legacy 2-arg callers such as ReadAllForTests), the
+    /// human-readable warning is emitted instead. Reason carries the exception type name + message.
+    /// </summary>
+    internal static void ReportMessageReadFailure(
+        IReadOnlyList<string> path, int index, Exception ex, Action<string>? onWarning, Action<ExportSkip>? onSkipped)
+    {
+        string display = string.Join(" / ", path);
+        string reason = $"{ex.GetType().Name}: {ex.Message}";
+        if (onSkipped is not null)
+            onSkipped(new ExportSkip(display, index, reason));
+        else
+            onWarning?.Invoke($"skipped message {index} in '{display}': {reason}");
+    }
+
     private static IEnumerable<PstMailItem> EnumerateFolder(
-        PSTFolder folder, List<string> parentPath, ushort? keywordsId, Action<string>? onWarning)
+        PSTFolder folder, List<string> parentPath, ushort? keywordsId, Action<string>? onWarning,
+        Action<ExportSkip>? onSkipped)
     {
         var path = new List<string>(parentPath) { folder.DisplayName };
 
@@ -89,10 +108,9 @@ public static class PstMailReader
             {
                 PstMailMessage? msg = null;
                 try { msg = ReadNote(mf.GetNote(i), keywordsId, onWarning); }
-                catch (Exception ex) when (ex is not OutOfMemoryException)   // bad message: skip + warn
+                catch (Exception ex) when (ex is not OutOfMemoryException)   // bad message: structured skip or legacy warn
                 {
-                    onWarning?.Invoke(
-                        $"skipped message {i} in '{string.Join(" / ", path)}': {ex.GetType().Name}: {ex.Message}");
+                    ReportMessageReadFailure(path, i, ex, onWarning, onSkipped);
                 }
                 if (msg is not null)
                     yield return new PstMailItem(path, msg);                  // yield OUTSIDE the try/catch
@@ -127,7 +145,7 @@ public static class PstMailReader
             children = new List<PSTFolder>();
         }
         foreach (PSTFolder c in children)
-            foreach (PstMailItem item in EnumerateFolder(c, path, keywordsId, onWarning))
+            foreach (PstMailItem item in EnumerateFolder(c, path, keywordsId, onWarning, onSkipped))
                 yield return item;
     }
 

--- a/src/Mail2Pst.Core/Reverse/PstMailReader.cs
+++ b/src/Mail2Pst.Core/Reverse/PstMailReader.cs
@@ -10,8 +10,8 @@ namespace Mail2Pst.Core.Reverse;
 
 /// <summary>
 /// Streams mail messages from a PST for the reverse (PST→Thunderbird) export — one message alive at a
-/// time, so a large PST is never fully materialized. Productionized from the Integration.Tests PstReader
-/// spike. Failure policy: a non-mail folder with messages, or a per-message read failure, is reported via
+/// time, so a large PST is never fully materialized. Based on the Integration.Tests PstReader.
+/// Failure policy: a non-mail folder with messages, or a per-message read failure, is reported via
 /// onWarning and skipped; OutOfMemory/process failures and a fatal open/root-walk failure propagate.
 /// </summary>
 public static class PstMailReader

--- a/src/Mail2Pst.Core/Reverse/PstMailRecords.cs
+++ b/src/Mail2Pst.Core/Reverse/PstMailRecords.cs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Mail2Pst.Core.Reverse;
+
+public enum PstRecipientKind { To, Cc, Bcc }
+
+/// <summary>One resolved recipient: address (+ optional display name) and To/Cc/Bcc kind.</summary>
+public sealed record PstRecipient(string Address, string? DisplayName, PstRecipientKind Kind);
+
+/// <summary>
+/// One attachment. <see cref="OpenRead"/> is deferred and materializes the payload on demand — it MUST
+/// be invoked while the source PST is still open (i.e. during enumeration of the owning message).
+/// <see cref="Length"/> is null when unknown without reading (the current vendored reader).
+/// </summary>
+public sealed record PstAttachment(
+    string FileName, string? ContentType, string? ContentId, bool IsInline,
+    Func<Stream> OpenRead, long? Length);
+
+/// <summary>Full payload of one mail message (all fields materialized except attachment bytes).</summary>
+public sealed record PstMailMessage(
+    string? Subject,
+    string? FromAddress,
+    IReadOnlyList<PstRecipient> Recipients,
+    DateTimeOffset? Date,
+    string? MessageId,
+    string? PlainBody,
+    byte[]? HtmlBody,
+    int? InternetCodepage,
+    string? TransportHeaders,
+    bool IsRead,
+    bool IsReplied,
+    bool IsForwarded,
+    IReadOnlyList<string> Categories,
+    IReadOnlyList<PstAttachment> Attachments);
+
+/// <summary>One streamed item: which folder it came from, and the message.</summary>
+public sealed record PstMailItem(IReadOnlyList<string> FolderPath, PstMailMessage Message);
+
+/// <summary>A mail folder grouping (test-only convenience; the production path streams items).</summary>
+public sealed record PstMailFolder(IReadOnlyList<string> Path, IReadOnlyList<PstMailMessage> Messages)
+{
+    public string DisplayPath => string.Join(" / ", Path);
+}

--- a/src/Mail2Pst.Core/Reverse/PstMailRecords.cs
+++ b/src/Mail2Pst.Core/Reverse/PstMailRecords.cs
@@ -38,7 +38,11 @@ public sealed record PstMailMessage(
     bool IsReplied,
     bool IsForwarded,
     IReadOnlyList<string> Categories,
-    IReadOnlyList<PstAttachment> Attachments);
+    IReadOnlyList<PstAttachment> Attachments)
+{
+    /// <summary>Sender display name (PidTagSentRepresentingName); null when absent. Paired with FromAddress.</summary>
+    public string? FromName { get; init; }
+}
 
 /// <summary>One streamed item: which folder it came from, and the message.</summary>
 public sealed record PstMailItem(IReadOnlyList<string> FolderPath, PstMailMessage Message);

--- a/src/Mail2Pst.Core/Reverse/PstMailRecords.cs
+++ b/src/Mail2Pst.Core/Reverse/PstMailRecords.cs
@@ -19,7 +19,11 @@ public sealed record PstRecipient(string Address, string? DisplayName, PstRecipi
 /// </summary>
 public sealed record PstAttachment(
     string FileName, string? ContentType, string? ContentId, bool IsInline,
-    Func<Stream> OpenRead, long? Length);
+    Func<Stream> OpenRead, long? Length)
+{
+    /// <summary>Content-Location (PidTagAttachContentLocation); null when absent.</summary>
+    public string? ContentLocation { get; init; }
+}
 
 /// <summary>Full payload of one mail message (all fields materialized except attachment bytes).</summary>
 public sealed record PstMailMessage(

--- a/src/Mail2Pst.Core/Reverse/PstMailRecords.cs
+++ b/src/Mail2Pst.Core/Reverse/PstMailRecords.cs
@@ -28,6 +28,8 @@ public sealed record PstMailMessage(
     IReadOnlyList<PstRecipient> Recipients,
     DateTimeOffset? Date,
     string? MessageId,
+    string? InReplyTo,
+    string? References,
     string? PlainBody,
     byte[]? HtmlBody,
     int? InternetCodepage,

--- a/tests/Mail2Pst.Core.Tests/Cli/ExportCommandE2ETests.cs
+++ b/tests/Mail2Pst.Core.Tests/Cli/ExportCommandE2ETests.cs
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Cli;
+
+// End-to-end guard for the reverse `export` subcommand: spawns the real built CLI so dispatch,
+// stdout encoding, arg validation, PstExportRunner wiring, and the JSON-Lines stream are exercised
+// together. The happy path first runs `convert` to produce a PST (no committed PST fixture needed),
+// then runs `export` against it — the vendored PST read happens inside the spawned CLI process.
+public class ExportCommandE2ETests
+{
+    // Concurrent async reads + an enforced timeout: reading one stream to end while the child fills
+    // the other can deadlock, and Process.WaitForExit(ms) does NOT bound ReadToEnd(). Start both reads
+    // first, await exit under a CancellationTokenSource, kill the tree AND drain the exit on timeout.
+    private static async Task<(int exit, string stdout, string stderr)> RunCliAsync(params string[] cliArgs)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = CliE2EProcess.RepoRoot(),
+        };
+        psi.ArgumentList.Add(CliE2EProcess.CliDllPath());
+        foreach (string a in cliArgs) psi.ArgumentList.Add(a);
+
+        using Process proc = Process.Start(psi)!;
+        Task<string> outTask = proc.StandardOutput.ReadToEndAsync();
+        Task<string> errTask = proc.StandardError.ReadToEndAsync();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        try
+        {
+            await proc.WaitForExitAsync(cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { /* already gone */ }
+            try { await proc.WaitForExitAsync(); } catch { /* best-effort drain so the read tasks detach */ }
+            throw new TimeoutException("CLI process did not exit within 2 minutes.");
+        }
+
+        string stdout = await outTask;
+        string stderr = await errTask;
+        return (proc.ExitCode, stdout, stderr);
+    }
+
+    // Parse each JSON line ONCE, clone the root, dispose the doc — so the returned elements outlive
+    // their JsonDocument and there is no repeated deferred-LINQ reparse.
+    private static JsonElement ParseObject(string line)
+    {
+        using JsonDocument doc = JsonDocument.Parse(line);
+        return doc.RootElement.Clone();
+    }
+
+    private static JsonElement[] Events(string stdout) =>
+        stdout.Split('\n').Select(l => l.Trim()).Where(l => l.Length > 0).Select(ParseObject).ToArray();
+
+    private static string Type(JsonElement e) => e.GetProperty("type").GetString()!;
+
+    // Run `convert` on the committed sample fixture; return the first output PST path.
+    private static async Task<string> ConvertSampleToPstAsync(string outDir)
+    {
+        (int exit, string stdout, _) = await RunCliAsync(
+            "convert", "--config", "fixtures/sample-config.json", "--output", outDir);
+        Assert.Equal(0, exit);
+        JsonElement done = Events(stdout).Single(e => Type(e) == "done");
+        string pst = done.GetProperty("outputs")[0].GetString()!;
+        Assert.True(File.Exists(pst), $"expected a produced PST at {pst}");
+        return pst;
+    }
+
+    [Fact]
+    public async Task Export_NoArgs_EmitsOnlyValidationError_NoStarted_ExitOne()
+    {
+        (int exit, string stdout, _) = await RunCliAsync("export");
+
+        Assert.Equal(1, exit);
+        JsonElement[] events = Events(stdout);
+        JsonElement err = Assert.Single(events);                 // the error is the ONLY stdout event
+        Assert.Equal("error", Type(err));
+        Assert.Equal("export", err.GetProperty("command").GetString());
+        Assert.Equal("export", err.GetProperty("stage").GetString());
+        Assert.True(err.GetProperty("fatal").GetBoolean());
+        Assert.Equal(1, err.GetProperty("schemaVersion").GetInt32());
+        Assert.DoesNotContain(events, e => Type(e) == "started");
+    }
+
+    [Fact]
+    public async Task Export_MissingInputFile_EmitsOnlyValidationError_NoStarted_ExitOne()
+    {
+        string missing = Path.Combine(Path.GetTempPath(), "m2p-nope-" + Guid.NewGuid() + ".pst");
+        string outDir = Path.Combine(Path.GetTempPath(), "m2p-export-tree-" + Guid.NewGuid());
+
+        (int exit, string stdout, _) = await RunCliAsync("export", "--input", missing, "--output", outDir);
+
+        Assert.Equal(1, exit);
+        JsonElement[] events = Events(stdout);
+        JsonElement err = Assert.Single(events);
+        Assert.Equal("error", Type(err));
+        Assert.Equal("export", err.GetProperty("command").GetString());
+        Assert.DoesNotContain(events, e => Type(e) == "started");
+        Assert.False(Directory.Exists(outDir));                  // no tree, no sibling report created
+        Assert.False(File.Exists(outDir + ".export-report.json"));
+    }
+
+    [Fact]
+    public async Task Export_ForwardWrittenPst_StreamsStartedProgressDone()
+    {
+        string pstDir = Path.Combine(Path.GetTempPath(), "m2p-export-pst-" + Guid.NewGuid());
+        string mboxDir = Path.Combine(Path.GetTempPath(), "m2p-export-tree-" + Guid.NewGuid());
+        try
+        {
+            string pst = await ConvertSampleToPstAsync(pstDir);
+
+            (int exit, string stdout, _) = await RunCliAsync("export", "--input", pst, "--output", mboxDir);
+
+            Assert.Equal(0, exit);
+            JsonElement[] events = Events(stdout);
+
+            // Contract invariants: schemaVersion + command discriminator on EVERY export event.
+            foreach (JsonElement e in events)
+            {
+                Assert.Equal(1, e.GetProperty("schemaVersion").GetInt32());
+                Assert.Equal("export", e.GetProperty("command").GetString());
+            }
+
+            string[] types = events.Select(Type).ToArray();
+            Assert.Equal("started", types[0]);
+            Assert.False(events[0].GetProperty("includeEmpty").GetBoolean());  // flag defaults off
+
+            Assert.Contains("progress", types);                               // sample has ≥1 message
+            string[] terminals = types.Where(t => t is "done" or "error" or "cancelled").ToArray();
+            Assert.Single(terminals);
+            Assert.Equal("done", types[^1]);                                  // terminal is the LAST event
+
+            JsonElement done = events.Single(e => Type(e) == "done");
+            Assert.True(done.GetProperty("messagesExported").GetInt32() >= 1);
+            Assert.True(done.GetProperty("foldersWritten").GetInt32() >= 1);
+            Assert.True(done.GetProperty("mboxFileCount").GetInt32() >= 1);
+            Assert.Equal(1, done.GetProperty("outputs").GetArrayLength());     // bounded: root only
+
+            // Live event counts match the terminal report counts — locks the disjoint warning/skip semantics.
+            Assert.Equal(events.Count(e => Type(e) == "warning"), done.GetProperty("warnings").GetInt32());
+            Assert.Equal(events.Count(e => Type(e) == "skipped"), done.GetProperty("skipped").GetInt32());
+        }
+        finally
+        {
+            if (Directory.Exists(pstDir)) Directory.Delete(pstDir, true);
+            if (Directory.Exists(mboxDir)) Directory.Delete(mboxDir, true);
+        }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Cli/ExportCommandE2ETests.cs
+++ b/tests/Mail2Pst.Core.Tests/Cli/ExportCommandE2ETests.cs
@@ -160,4 +160,132 @@ public class ExportCommandE2ETests
             if (Directory.Exists(mboxDir)) Directory.Delete(mboxDir, true);
         }
     }
+
+    [Fact]
+    public async Task Export_WritesReportFiles_AsSiblings_WithMatchingElapsed()
+    {
+        string pstDir = Path.Combine(Path.GetTempPath(), "m2p-export-pst-" + Guid.NewGuid());
+        string mboxDir = Path.Combine(Path.GetTempPath(), "m2p-export-tree-" + Guid.NewGuid());
+        try
+        {
+            string pst = await ConvertSampleToPstAsync(pstDir);
+            (int exit, string stdout, _) = await RunCliAsync("export", "--input", pst, "--output", mboxDir);
+            Assert.Equal(0, exit);
+
+            string reportJson = mboxDir + ".export-report.json";     // SIBLING, not inside the tree
+            string reportTxt = mboxDir + ".export-report.txt";
+            Assert.True(File.Exists(reportJson), $"expected sibling {reportJson}");
+            Assert.True(File.Exists(reportTxt), $"expected sibling {reportTxt}");
+            Assert.False(File.Exists(Path.Combine(mboxDir, "export-report.json")), "report must NOT be inside the tree");
+
+            JsonElement done = Events(stdout).Single(e => Type(e) == "done");
+            Assert.Equal(reportJson, done.GetProperty("report").GetString());
+
+            using JsonDocument reportDoc = JsonDocument.Parse(File.ReadAllText(reportJson));
+            Assert.Equal(done.GetProperty("messagesExported").GetInt32(),
+                         reportDoc.RootElement.GetProperty("messagesExported").GetInt32());
+            Assert.Equal(done.GetProperty("elapsedMs").GetInt64(),
+                         reportDoc.RootElement.GetProperty("elapsedMs").GetInt64());
+        }
+        finally
+        {
+            if (Directory.Exists(pstDir)) Directory.Delete(pstDir, true);
+            if (Directory.Exists(mboxDir)) Directory.Delete(mboxDir, true);
+            foreach (string s in new[] { mboxDir + ".export-report.json", mboxDir + ".export-report.txt" })
+                if (File.Exists(s)) File.Delete(s);
+        }
+    }
+
+    [Fact]
+    public async Task Export_ReportWriteFails_PreservesPublishedTree_EmitsReportStageError()
+    {
+        string pstDir = Path.Combine(Path.GetTempPath(), "m2p-export-pst-" + Guid.NewGuid());
+        string mboxDir = Path.Combine(Path.GetTempPath(), "m2p-export-tree-" + Guid.NewGuid());
+        string blockingDir = mboxDir + ".export-report.json";        // a DIRECTORY where the report file must go
+        try
+        {
+            string pst = await ConvertSampleToPstAsync(pstDir);
+            Directory.CreateDirectory(blockingDir);                  // report publish is refused up front
+
+            (int exit, string stdout, _) = await RunCliAsync("export", "--input", pst, "--output", mboxDir);
+
+            Assert.NotEqual(0, exit);
+            JsonElement[] events = Events(stdout);
+            Assert.DoesNotContain(events, e => Type(e) == "done");   // never claims success
+            Assert.Equal("error", events.Select(Type).Last());       // terminal is the error
+            JsonElement err = Assert.Single(events.Where(e => Type(e) == "error"));
+            Assert.Equal("export", err.GetProperty("command").GetString());
+            Assert.Equal("report", err.GetProperty("stage").GetString());
+            Assert.True(err.GetProperty("fatal").GetBoolean());
+            Assert.True(err.GetProperty("outputPreserved").GetBoolean());
+            Assert.True(Directory.Exists(mboxDir), "the published mbox tree must survive a report failure");
+            Assert.NotEmpty(Directory.GetFileSystemEntries(mboxDir));
+        }
+        finally
+        {
+            if (Directory.Exists(pstDir)) Directory.Delete(pstDir, true);
+            if (Directory.Exists(mboxDir)) Directory.Delete(mboxDir, true);
+            if (Directory.Exists(blockingDir)) Directory.Delete(blockingDir, true);
+            if (File.Exists(mboxDir + ".export-report.txt")) File.Delete(mboxDir + ".export-report.txt");
+        }
+    }
+
+    [Fact]
+    public async Task Export_SecondReportPublishFails_RollsBackFirstReport()
+    {
+        string pstDir = Path.Combine(Path.GetTempPath(), "m2p-export-pst-" + Guid.NewGuid());
+        string mboxDir = Path.Combine(Path.GetTempPath(), "m2p-export-tree-" + Guid.NewGuid());
+        string blockingTxtDir = mboxDir + ".export-report.txt";      // .txt destination is occupied
+        try
+        {
+            string pst = await ConvertSampleToPstAsync(pstDir);
+            Directory.CreateDirectory(blockingTxtDir);
+
+            (int exit, string stdout, _) = await RunCliAsync("export", "--input", pst, "--output", mboxDir);
+
+            Assert.NotEqual(0, exit);
+            JsonElement err = Assert.Single(Events(stdout).Where(e => Type(e) == "error"));
+            Assert.Equal("report", err.GetProperty("stage").GetString());
+            // The JSON report must NOT be left published, and no temp files may remain (roll back / never publish).
+            Assert.False(File.Exists(mboxDir + ".export-report.json"), "the first report file must not be left behind");
+            string parent = Path.GetDirectoryName(mboxDir)!;
+            Assert.Empty(Directory.GetFiles(parent, Path.GetFileName(mboxDir) + "*.tmp-*"));
+            Assert.True(Directory.Exists(mboxDir), "the published mbox tree must survive");
+        }
+        finally
+        {
+            if (Directory.Exists(pstDir)) Directory.Delete(pstDir, true);
+            if (Directory.Exists(mboxDir)) Directory.Delete(mboxDir, true);
+            if (Directory.Exists(blockingTxtDir)) Directory.Delete(blockingTxtDir, true);
+            if (File.Exists(mboxDir + ".export-report.json")) File.Delete(mboxDir + ".export-report.json");
+        }
+    }
+
+    [Fact]
+    public async Task Export_PreExistingReportFile_IsRejectedWithoutOverwritingIt()
+    {
+        string pstDir = Path.Combine(Path.GetTempPath(), "m2p-export-pst-" + Guid.NewGuid());
+        string mboxDir = Path.Combine(Path.GetTempPath(), "m2p-export-tree-" + Guid.NewGuid());
+        string existingReport = mboxDir + ".export-report.json";
+        try
+        {
+            string pst = await ConvertSampleToPstAsync(pstDir);
+            File.WriteAllText(existingReport, "ORIGINAL");           // a pre-existing sibling the user owns
+
+            (int exit, string stdout, _) = await RunCliAsync("export", "--input", pst, "--output", mboxDir);
+
+            Assert.NotEqual(0, exit);
+            JsonElement err = Assert.Single(Events(stdout).Where(e => Type(e) == "error"));
+            Assert.Equal("report", err.GetProperty("stage").GetString());
+            Assert.Equal("ORIGINAL", File.ReadAllText(existingReport)); // NOT overwritten
+            Assert.True(Directory.Exists(mboxDir), "the published mbox tree must survive");
+        }
+        finally
+        {
+            if (Directory.Exists(pstDir)) Directory.Delete(pstDir, true);
+            if (Directory.Exists(mboxDir)) Directory.Delete(mboxDir, true);
+            if (File.Exists(existingReport)) File.Delete(existingReport);
+            if (File.Exists(mboxDir + ".export-report.txt")) File.Delete(mboxDir + ".export-report.txt");
+        }
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Cli/ExportCommandE2ETests.cs
+++ b/tests/Mail2Pst.Core.Tests/Cli/ExportCommandE2ETests.cs
@@ -262,6 +262,41 @@ public class ExportCommandE2ETests
     }
 
     [Fact]
+    public async Task Export_UnreadablePst_EmitsStartedThenSingleFatalError_ExitOne_NoReport()
+    {
+        // A file that EXISTS (passes the File.Exists guard) but is not a valid PST — the runner opens it
+        // during pass 1 and throws; the CLI must turn that into ONE fatal error after `started`, exit 1.
+        string junkPst = Path.Combine(Path.GetTempPath(), "m2p-export-junk-" + Guid.NewGuid() + ".pst");
+        string mboxDir = Path.Combine(Path.GetTempPath(), "m2p-export-tree-" + Guid.NewGuid());
+        File.WriteAllText(junkPst, "this is not a pst file");
+        try
+        {
+            (int exit, string stdout, _) = await RunCliAsync("export", "--input", junkPst, "--output", mboxDir);
+
+            Assert.Equal(1, exit);
+            string[] types = Events(stdout).Select(Type).ToArray();
+            Assert.Equal("started", types[0]);                       // started ALWAYS precedes the open
+            Assert.Equal("error", types[^1]);                        // terminal error is the LAST event
+            Assert.Equal(1, types.Count(t => t == "error"));
+            Assert.DoesNotContain("done", types);
+
+            JsonElement err = Events(stdout).Single(e => Type(e) == "error");
+            Assert.Equal("export", err.GetProperty("command").GetString());
+            Assert.Equal("export", err.GetProperty("stage").GetString());
+            Assert.True(err.GetProperty("fatal").GetBoolean());
+
+            // A pre-publication failure leaves no tree and no sibling report.
+            Assert.False(Directory.Exists(mboxDir));
+            Assert.False(File.Exists(mboxDir + ".export-report.json"));
+        }
+        finally
+        {
+            if (File.Exists(junkPst)) File.Delete(junkPst);
+            if (Directory.Exists(mboxDir)) Directory.Delete(mboxDir, true);
+        }
+    }
+
+    [Fact]
     public async Task Export_PreExistingReportFile_IsRejectedWithoutOverwritingIt()
     {
         string pstDir = Path.Combine(Path.GetTempPath(), "m2p-export-pst-" + Guid.NewGuid());

--- a/tests/Mail2Pst.Core.Tests/Reverse/ExportReportTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Reverse/ExportReportTests.cs
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Text.Json;
+using Mail2Pst.Core.Reverse;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Reverse;
+
+public class ExportReportTests
+{
+    [Fact]
+    public void Complete_Warnings_And_Skips_PopulateReport()
+    {
+        var report = new ExportReport(@"C:\out");
+        report.RecordWarning("lossy prop dropped");
+        report.RecordSkipped(new ExportSkip("Inbox", 3, "System.IO.InvalidDataException: bad node"));
+        report.Complete(
+            new MboxTreeWriteResult(new[] { @"C:\out\Inbox", @"C:\out\Sent" }, FoldersWritten: 2, MessagesWritten: 5),
+            TimeSpan.FromMilliseconds(1234));
+
+        Assert.Equal(@"C:\out", report.OutputRoot);
+        Assert.Equal(5, report.MessagesExported);
+        Assert.Equal(2, report.FoldersWritten);
+        Assert.Equal(2, report.MboxFiles.Count);
+        Assert.Equal(1, report.WarningCount);
+        Assert.Contains("lossy prop dropped", report.Warnings);
+        Assert.Equal(1, report.SkippedCount);
+        Assert.Equal("Inbox", report.Skipped[0].FolderPath);
+        Assert.Equal(3, report.Skipped[0].MessageIndex);
+        Assert.Equal(TimeSpan.FromMilliseconds(1234), report.Elapsed);
+    }
+
+    [Fact]
+    public void ToJson_EmitsCamelCaseShape_WithSkippedAndCounts()
+    {
+        var report = new ExportReport(@"C:\out");
+        report.RecordWarning("w1");
+        report.RecordSkipped(new ExportSkip("Sent", null, "unreadable"));
+        report.Complete(new MboxTreeWriteResult(new[] { @"C:\out\Inbox" }, 1, 3), TimeSpan.FromMilliseconds(50));
+
+        using JsonDocument doc = JsonDocument.Parse(report.ToJson());
+        JsonElement root = doc.RootElement;
+        Assert.Equal(3, root.GetProperty("messagesExported").GetInt32());
+        Assert.Equal(1, root.GetProperty("foldersWritten").GetInt32());
+        Assert.Equal(50, root.GetProperty("elapsedMs").GetInt64());
+        Assert.Equal(1, root.GetProperty("skippedCount").GetInt32());
+        Assert.Equal(1, root.GetProperty("warningCount").GetInt32());
+        Assert.Equal("Sent", root.GetProperty("skipped")[0].GetProperty("folderPath").GetString());
+        Assert.Equal("w1", root.GetProperty("warnings")[0].GetString());
+        Assert.Equal(@"C:\out\Inbox", root.GetProperty("mboxFiles")[0].GetString());
+    }
+
+    [Fact]
+    public void ToSummary_ListsCountsWarningsAndSkips_NullIndexHasNoEmptyBrackets()
+    {
+        var report = new ExportReport(@"C:\out");
+        report.RecordWarning("dropped X");
+        report.RecordSkipped(new ExportSkip("Inbox", 7, "boom"));
+        report.RecordSkipped(new ExportSkip("Sent", null, "folder-level"));
+        report.Complete(new MboxTreeWriteResult(Array.Empty<string>(), 0, 0), TimeSpan.Zero);
+
+        string s = report.ToSummary();
+        Assert.Contains("Messages exported: 0", s);
+        Assert.Contains("Skipped: 2", s);
+        Assert.Contains("Inbox[7]", s);
+        Assert.Contains("SKIP Sent: folder-level", s);   // null index -> no "[]"
+        Assert.DoesNotContain("Sent[]", s);
+        Assert.Contains("Warnings: 1", s);
+        Assert.Contains("dropped X", s);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Reverse/FakeMimeReconstructor.cs
+++ b/tests/Mail2Pst.Core.Tests/Reverse/FakeMimeReconstructor.cs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using Mail2Pst.Core.Reverse;
+using MimeKit;
+
+namespace Mail2Pst.Core.Tests.Reverse;
+
+/// <summary>Stand-in for Plan 4's MimeReconstructor: builds a minimal, deterministic text/plain message
+/// from a <see cref="PstMailMessage"/>. Deliberately does NOT emit X-Mozilla-* headers (the writer owns
+/// those). Content-transfer-encoding is pinned to 7bit so serialization of ASCII bodies is byte-stable
+/// (no quoted-printable surprises when asserting on mboxrd 'From ' escaping).</summary>
+internal sealed class FakeMimeReconstructor : IMimeReconstructor
+{
+    public MimeMessage Reconstruct(PstMailMessage message)
+    {
+        var m = new MimeMessage();
+        m.From.Add(new MailboxAddress(string.Empty, message.FromAddress ?? "sender@example.com"));
+        m.To.Add(new MailboxAddress(string.Empty, "recipient@example.com"));
+        m.Subject = message.Subject ?? string.Empty;
+        m.Date = message.Date ?? DateTimeOffset.UnixEpoch;
+        if (!string.IsNullOrEmpty(message.MessageId))
+            m.MessageId = message.MessageId!.Trim().TrimStart('<').TrimEnd('>');
+        m.Body = new TextPart("plain")
+        {
+            Text = message.PlainBody ?? string.Empty,
+            ContentTransferEncoding = ContentEncoding.SevenBit,
+        };
+        return m;
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Reverse/FakeMimeReconstructor.cs
+++ b/tests/Mail2Pst.Core.Tests/Reverse/FakeMimeReconstructor.cs
@@ -7,7 +7,7 @@ using MimeKit;
 
 namespace Mail2Pst.Core.Tests.Reverse;
 
-/// <summary>Stand-in for Plan 4's MimeReconstructor: builds a minimal, deterministic text/plain message
+/// <summary>Stand-in for the MimeReconstructor: builds a minimal, deterministic text/plain message
 /// from a <see cref="PstMailMessage"/>. Deliberately does NOT emit X-Mozilla-* headers (the writer owns
 /// those). Content-transfer-encoding is pinned to 7bit so serialization of ASCII bodies is byte-stable
 /// (no quoted-printable surprises when asserting on mboxrd 'From ' escaping).</summary>

--- a/tests/Mail2Pst.Core.Tests/Reverse/MboxFolderNameSanitizerTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Reverse/MboxFolderNameSanitizerTests.cs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using Mail2Pst.Core.Reverse;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Reverse;
+
+public class MboxFolderNameSanitizerTests
+{
+    [Theory]
+    [InlineData("Inbox", "Inbox")]                 // already safe, preserved
+    [InlineData("Team/Alpha", "Team Alpha")]       // forward Sanitize maps '/' -> space
+    [InlineData("In:box*?", "In_box__")]           // Windows-illegal filename chars -> '_'
+    [InlineData("a\"b<c>d|e", "a_b_c_d_e")]         // more illegal chars -> '_'
+    [InlineData("  spaced  ", "spaced")]           // leading/trailing whitespace trimmed
+    [InlineData("dotted.", "dotted")]              // trailing dot trimmed (Windows)
+    [InlineData("CON", "Folder")]                  // reserved device name -> fallback
+    [InlineData("", "Folder")]                     // empty -> fallback
+    [InlineData("   ", "Folder")]                  // whitespace-only -> fallback
+    public void ToFileName_Cases(string input, string expected)
+        => Assert.Equal(expected, MboxFolderNameSanitizer.ToFileName(input));
+
+    [Fact]
+    public void ToFileName_Null_ReturnsFallback()
+        => Assert.Equal("Folder", MboxFolderNameSanitizer.ToFileName(null));
+}

--- a/tests/Mail2Pst.Core.Tests/Reverse/MboxTreePlannerTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Reverse/MboxTreePlannerTests.cs
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System.Collections.Generic;
+using System.IO;
+using Mail2Pst.Core.Reverse;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Reverse;
+
+public class MboxTreePlannerTests
+{
+    private static IReadOnlyList<string> P(params string[] segments) => segments;
+
+    [Fact]
+    public void Plan_NestedTree_BuildsSbdLayout()
+    {
+        string root = Path.Combine("out", "root");
+        var plan = MboxTreePlanner.Plan(new[] { P("A"), P("A", "B"), P("A", "B", "C") }, root);
+
+        Assert.True(plan.TryGet(P("A"), out var a));
+        Assert.Equal(Path.Combine(root, "A"), a!.MboxFilePath);
+        Assert.Equal(Path.Combine(root, "A.sbd"), a.SbdDirPath);
+        Assert.True(a.IsStructuralParent);
+
+        Assert.True(plan.TryGet(P("A", "B"), out var b));
+        Assert.Equal(Path.Combine(root, "A.sbd", "B"), b!.MboxFilePath);
+        Assert.Equal(Path.Combine(root, "A.sbd", "B.sbd"), b.SbdDirPath);
+        Assert.True(b.IsStructuralParent);
+
+        Assert.True(plan.TryGet(P("A", "B", "C"), out var c));
+        Assert.Equal(Path.Combine(root, "A.sbd", "B.sbd", "C"), c!.MboxFilePath);
+        Assert.Null(c.SbdDirPath);                 // leaf: no .sbd
+        Assert.False(c.IsStructuralParent);
+    }
+
+    [Fact]
+    public void Plan_SynthesizesMissingAncestor()
+    {
+        // Only the child is listed; the planner must still materialize "A" as a structural parent.
+        string root = "r";
+        var plan = MboxTreePlanner.Plan(new[] { P("A", "B") }, root);
+        Assert.True(plan.TryGet(P("A"), out var a));
+        Assert.True(a!.IsStructuralParent);
+        Assert.Equal(Path.Combine(root, "A.sbd"), a.SbdDirPath);
+    }
+
+    [Fact]
+    public void Plan_CollidingSanitizedNames_GetDeterministicSuffix_AndWarn()
+    {
+        // "Team/Alpha" and "Team Alpha" both sanitize to "Team Alpha".
+        var warnings = new List<string>();
+        var plan = MboxTreePlanner.Plan(new[] { P("Team/Alpha"), P("Team Alpha") }, "r", warnings.Add);
+
+        Assert.True(plan.TryGet(P("Team/Alpha"), out var first));
+        Assert.True(plan.TryGet(P("Team Alpha"), out var second));
+        Assert.Equal(Path.Combine("r", "Team Alpha"), first!.MboxFilePath);        // first wins
+        Assert.Equal(Path.Combine("r", "Team Alpha (2)"), second!.MboxFilePath);   // second suffixed
+        Assert.Contains(warnings, w => w.Contains("collides"));
+    }
+
+    [Fact]
+    public void Plan_StructuralParentSbdVsLiteralSbdLeaf_DoNotClash()
+    {
+        // "X" is a structural parent -> file "X" + dir "X.sbd". A sibling leaf literally named "X.sbd"
+        // would sanitize to "X.sbd" and clash with that directory; the planner must avoid it + warn.
+        var warnings = new List<string>();
+        var plan = MboxTreePlanner.Plan(new[] { P("X", "Child"), P("X.sbd") }, "r", warnings.Add);
+
+        Assert.True(plan.TryGet(P("X"), out var x));
+        Assert.True(plan.TryGet(P("X.sbd"), out var leaf));
+        Assert.True(x!.IsStructuralParent);
+        Assert.NotEqual(x.SbdDirPath, leaf!.MboxFilePath);   // the .sbd dir and the leaf file must differ
+        Assert.Contains(warnings, w => w.Contains("collides"));
+    }
+
+    [Fact]
+    public void ResolveMboxPath_BuildsSbdPath_NoCollisionTracking()
+        => Assert.Equal(
+            Path.Combine("r", "A.sbd", "B"),
+            MboxTreePlanner.ResolveMboxPath(P("A", "B"), "r"));
+}

--- a/tests/Mail2Pst.Core.Tests/Reverse/MboxTreeRoundTripTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Reverse/MboxTreeRoundTripTests.cs
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Parsing;
+using Mail2Pst.Core.Reverse;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Reverse;
+
+public class MboxTreeRoundTripTests
+{
+    private static IReadOnlyList<string> P(params string[] segments) => segments;
+
+    private static PstMailMessage Msg(
+        string subject, string body, bool read, string[]? categories = null)
+        => new PstMailMessage(
+            Subject: subject, FromAddress: "sender@example.com",
+            Recipients: Array.Empty<PstRecipient>(), Date: DateTimeOffset.UnixEpoch, MessageId: null,
+            InReplyTo: null, References: null,
+            PlainBody: body, HtmlBody: null, InternetCodepage: null, TransportHeaders: null,
+            IsRead: read, IsReplied: false, IsForwarded: false,
+            Categories: categories ?? Array.Empty<string>(), Attachments: Array.Empty<PstAttachment>());
+
+    [Fact]
+    public void ExportedMbox_CarriesMozillaHeaders_AndReparsesWithMboxParser()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "m2p-rt-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var items = new[]
+            {
+                new PstMailItem(P("Inbox"), Msg("Read and starred", "first body",  read: true,
+                                                categories: new[] { "Star", "Work" })),
+                new PstMailItem(P("Inbox"), Msg("Unread plain",     "second body", read: false)),
+            };
+            var writer = new MboxTreeWriter(new FakeMimeReconstructor());
+            MboxTreeWriteResult result = writer.Write(items, new[] { P("Inbox") }, root, includeEmpty: false);
+
+            Assert.Equal(2, result.MessagesWritten);
+            string mbox = Path.Combine(root, "Inbox");
+
+            // Raw-scan: both messages carry all three headers; the starred/read one is Read|Marked = 0x0005.
+            string[] lines = File.ReadAllLines(mbox);
+            Assert.Equal(2, lines.Count(l => l.StartsWith("X-Mozilla-Status:", StringComparison.Ordinal)));
+            Assert.Equal(2, lines.Count(l => l.StartsWith("X-Mozilla-Status2:", StringComparison.Ordinal)));
+            Assert.Equal(2, lines.Count(l => l.StartsWith("X-Mozilla-Keys:", StringComparison.Ordinal)));
+            Assert.Contains("X-Mozilla-Status: 0005", lines);                       // Read | Marked
+            Assert.Contains("X-Mozilla-Status: 0000", lines);                       // unread, no flags
+            Assert.Contains(lines, l => l.StartsWith("X-Mozilla-Keys: Work", StringComparison.Ordinal));
+
+            // Self-consistency: our own forward parser re-reads the exported mbox as two messages.
+            var reparsed = new MboxParser().Parse(mbox).ToList();
+            Assert.Equal(2, reparsed.Count);
+            Assert.All(reparsed, r => Assert.True(r.Success, r.Error));
+            Assert.Equal("Read and starred", reparsed[0].Message!.Subject);
+            Assert.Equal("Unread plain",     reparsed[1].Message!.Subject);
+
+            // Flag state survives the round trip: MimeMessageMapper parses X-Mozilla-Status back into
+            // IsRead (0x0001) and IsFlagged (Marked 0x0004, from our consumed "Star" category).
+            Assert.True(reparsed[0].Message!.IsRead);
+            Assert.True(reparsed[0].Message!.IsFlagged);
+            Assert.False(reparsed[1].Message!.IsRead);
+            Assert.False(reparsed[1].Message!.IsFlagged);
+        }
+        finally { Directory.Delete(root, true); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Reverse/MboxTreeWriterTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Reverse/MboxTreeWriterTests.cs
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Reverse;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Reverse;
+
+public class MboxTreeWriterTests
+{
+    private static IReadOnlyList<string> P(params string[] segments) => segments;
+
+    private static PstMailMessage Msg(
+        string subject, string body, bool read = false, string? messageId = null,
+        string[]? categories = null)
+        => new PstMailMessage(
+            Subject: subject, FromAddress: "sender@example.com",
+            Recipients: Array.Empty<PstRecipient>(), Date: DateTimeOffset.UnixEpoch, MessageId: messageId,
+            InReplyTo: null, References: null,
+            PlainBody: body, HtmlBody: null, InternetCodepage: null, TransportHeaders: null,
+            IsRead: read, IsReplied: false, IsForwarded: false,
+            Categories: categories ?? Array.Empty<string>(), Attachments: Array.Empty<PstAttachment>());
+
+    private static string NewTempDir()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "m2p-mboxtree-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static MboxTreeWriter NewWriter() => new(new FakeMimeReconstructor());
+
+    [Fact]
+    public void Write_SingleMessage_WritesEnvelopeAndMozillaHeaders()
+    {
+        string root = NewTempDir();
+        try
+        {
+            var items = new[] { new PstMailItem(P("Inbox"), Msg("Hi", "Body text", read: true)) };
+            MboxTreeWriteResult r = NewWriter().Write(items, new[] { P("Inbox") }, root, includeEmpty: false);
+
+            string mbox = Path.Combine(root, "Inbox");
+            Assert.Equal(1, r.MessagesWritten);
+            Assert.Contains(mbox, r.MboxFiles);
+
+            string text = File.ReadAllText(mbox);
+            Assert.StartsWith("From - ", text);                       // postmark-shaped separator
+            Assert.Contains("X-Mozilla-Status: 0001", text);          // Read bit
+            Assert.Contains("X-Mozilla-Status2: 00000000", text);
+            Assert.Contains("X-Mozilla-Keys:", text);
+            Assert.Contains("Subject: Hi", text);
+            Assert.Contains("Body text", text);
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public void Write_StructuralParentWithZeroMessages_EmitsEmptyMbox_AndSbdDir()
+    {
+        string root = NewTempDir();
+        try
+        {
+            // Only the child carries a message; the parent has zero messages but must still be emitted.
+            var items = new[] { new PstMailItem(P("Parent", "Child"), Msg("c", "child body")) };
+            NewWriter().Write(items, new[] { P("Parent"), P("Parent", "Child") }, root, includeEmpty: false);
+
+            string parentMbox = Path.Combine(root, "Parent");
+            Assert.True(File.Exists(parentMbox));                     // structural parent emitted...
+            Assert.Equal(0, new FileInfo(parentMbox).Length);         // ...as a zero-length mbox
+            Assert.True(Directory.Exists(Path.Combine(root, "Parent.sbd")));
+            Assert.True(File.Exists(Path.Combine(root, "Parent.sbd", "Child")));
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public void Write_BodyLines_AreMboxrdEscaped_LineByLine()
+    {
+        string root = NewTempDir();
+        try
+        {
+            // Three pinned mboxrd cases in one body:
+            //   "From here to there"        -> ">From here to there"   (^From  gets one '>')
+            //   ">From already escaped"     -> ">>From already escaped" (^>From  gets one more '>')
+            //   "From: header-like but body"-> unchanged                (colon, not space -> not a boundary)
+            string body = "From here to there\r\n>From already escaped\r\nFrom: header-like but body";
+            var items = new[] { new PstMailItem(P("Inbox"), Msg("s", body)) };
+            NewWriter().Write(items, new[] { P("Inbox") }, root, includeEmpty: false);
+
+            string[] lines = File.ReadAllLines(Path.Combine(root, "Inbox"));
+            Assert.Contains(">From here to there", lines);
+            Assert.DoesNotContain("From here to there", lines);       // the un-escaped form must NOT appear
+            Assert.Contains(">>From already escaped", lines);
+            Assert.Contains("From: header-like but body", lines);     // header-like body line left as-is
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public void Write_XMozillaKeys_IsRightPaddedToBlankReserve()
+    {
+        string root = NewTempDir();
+        try
+        {
+            // With keys "Work": value is "Work" + spaces up to 80 chars. With no keys: value is 80 spaces.
+            var items = new[]
+            {
+                new PstMailItem(P("Inbox"), Msg("tagged", "b", categories: new[] { "Work" })),
+                new PstMailItem(P("Inbox"), Msg("plain",  "b")),
+            };
+            NewWriter().Write(items, new[] { P("Inbox") }, root, includeEmpty: false);
+
+            string[] lines = File.ReadAllLines(Path.Combine(root, "Inbox"));
+            const string prefix = "X-Mozilla-Keys: ";
+            var keyLines = lines.Where(l => l.StartsWith(prefix, StringComparison.Ordinal)).ToList();
+            Assert.Equal(2, keyLines.Count);
+
+            string tagged = keyLines[0].Substring(prefix.Length);
+            Assert.True(tagged.Length >= 80, $"expected padded value >= 80, got {tagged.Length}");
+            Assert.Equal("Work" + new string(' ', 80 - "Work".Length), tagged);
+
+            string plain = keyLines[1].Substring(prefix.Length);
+            Assert.Equal(new string(' ', 80), plain);                 // blank reserve = 80 spaces
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public void Write_EmptyLeaf_ObeysIncludeEmpty()
+    {
+        // "Archive" is an empty leaf (no messages); "Inbox" carries one.
+        var items = new[] { new PstMailItem(P("Inbox"), Msg("s", "b")) };
+        var folders = new[] { P("Inbox"), P("Archive") };
+
+        string off = NewTempDir();
+        try
+        {
+            NewWriter().Write(items, folders, off, includeEmpty: false);
+            Assert.True(File.Exists(Path.Combine(off, "Inbox")));
+            Assert.False(File.Exists(Path.Combine(off, "Archive")));  // empty leaf skipped
+        }
+        finally { Directory.Delete(off, true); }
+
+        string on = NewTempDir();
+        try
+        {
+            NewWriter().Write(items, folders, on, includeEmpty: true);
+            Assert.True(File.Exists(Path.Combine(on, "Inbox")));
+            Assert.True(File.Exists(Path.Combine(on, "Archive")));    // empty leaf emitted
+            Assert.Equal(0, new FileInfo(Path.Combine(on, "Archive")).Length);
+        }
+        finally { Directory.Delete(on, true); }
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Reverse/MimeReconstructorTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Reverse/MimeReconstructorTests.cs
@@ -170,4 +170,94 @@ public class MimeReconstructorTests
         Assert.Equal(string.Empty, body.Text);
         Assert.Equal(string.Empty, m.Subject);
     }
+
+    // ---- Task 2 tests ----------------------------------------------------------------------------
+
+    private static byte[] Utf8(string s) => System.Text.Encoding.UTF8.GetBytes(s);
+
+    [Fact]
+    public void Reconstruct_BothBodies_ProducesMultipartAlternative_PlainThenHtml()
+    {
+        var msg = Msg(plainBody: "plain version", htmlBody: Utf8("<p>html version</p>"), codepage: 65001);
+        MimeMessage m = new MimeReconstructor().Reconstruct(msg);
+
+        MultipartAlternative alt = Assert.IsType<MultipartAlternative>(m.Body);
+        Assert.Equal(2, alt.Count);
+        Assert.True(((TextPart)alt[0]).ContentType.IsMimeType("text", "plain"));   // least-rich first
+        Assert.True(((TextPart)alt[1]).ContentType.IsMimeType("text", "html"));
+        Assert.Equal("plain version", ((TextPart)alt[0]).Text);
+        Assert.Contains("html version", ((TextPart)alt[1]).Text);
+    }
+
+    [Fact]
+    public void Reconstruct_HtmlOnly_ProducesTextHtml()
+    {
+        MimeMessage m = new MimeReconstructor().Reconstruct(
+            Msg(plainBody: null, htmlBody: Utf8("<p>only html</p>"), codepage: 65001));
+
+        TextPart body = Assert.IsType<TextPart>(m.Body);
+        Assert.True(body.ContentType.IsMimeType("text", "html"));
+        Assert.Contains("only html", body.Text);
+    }
+
+    [Fact]
+    public void Reconstruct_EmptyHtmlProperty_ProducesEmptyTextHtml()
+    {
+        // A present-but-empty PidTagHtml is a PRESENT html body, not an absent one -> empty text/html, not a
+        // text/plain fallback.
+        MimeMessage m = new MimeReconstructor().Reconstruct(
+            Msg(plainBody: null, htmlBody: Array.Empty<byte>(), codepage: 65001));
+
+        TextPart body = Assert.IsType<TextPart>(m.Body);
+        Assert.True(body.IsHtml);
+        Assert.Equal(string.Empty, body.Text);
+    }
+
+    [Fact]
+    public void Reconstruct_HtmlBytes_DecodedAsUtf8_ByDefault()
+    {
+        // Non-ASCII content proves the bytes are decoded (not mangled). Forward writer always writes UTF-8.
+        MimeMessage m = new MimeReconstructor().Reconstruct(
+            Msg(plainBody: null, htmlBody: Utf8("<p>café — naïve</p>"), codepage: 65001));
+        Assert.Contains("café — naïve", ((TextPart)m.Body).Text);
+    }
+
+    [Fact]
+    public void Reconstruct_LegacyCodepage1252_DecodesToCorrectUnicode()
+    {
+        // Windows-1252 byte 0xE9 = 'é' and 0x93/0x94 = curly double quotes. In UTF-8 these are invalid/mangled,
+        // so a correct result proves the 1252 provider decode ran (not a UTF-8 fallback). Requires the
+        // CodePages provider the static ctor registers.
+        byte[] cp1252 = { 0x93, (byte)'c', (byte)'a', (byte)'f', 0xE9, 0x94 };   // "café" in curly quotes
+        MimeMessage m = new MimeReconstructor().Reconstruct(
+            Msg(plainBody: null, htmlBody: cp1252, codepage: 1252));
+
+        string text = ((TextPart)m.Body).Text;
+        Assert.Contains("café", text);            // 0xE9 -> é
+        Assert.Contains("“", text);          // 0x93 -> left double quotation mark
+        Assert.Contains("”", text);          // 0x94 -> right double quotation mark
+    }
+
+    [Fact]
+    public void Reconstruct_InvalidUtf8Bytes_FallBackTolerantly_AndWarn()
+    {
+        MimeReconstructor rec = NewReconstructor(out List<string> warnings);
+        // {0xC3,0x28} is an invalid UTF-8 sequence. Under the STRICT UTF-8 decoder it throws
+        // DecoderFallbackException; DecodeHtml then decodes tolerantly (invalid -> U+FFFD '�') and warns.
+        MimeMessage m = rec.Reconstruct(Msg(plainBody: null, htmlBody: new byte[] { 0xC3, 0x28 }, codepage: 65001));
+
+        Assert.Contains("�", ((TextPart)m.Body).Text);     // '�' replacement char
+        Assert.Contains(warnings, w => w.Contains("failed to decode HTML body"));
+    }
+
+    [Fact]
+    public void Reconstruct_UnknownCodepage_FallsBackToUtf8_AndWarns()
+    {
+        MimeReconstructor rec = NewReconstructor(out List<string> warnings);
+        // 999999 is not a real code page -> Encoding.GetEncoding throws -> UTF-8 fallback + warning.
+        MimeMessage m = rec.Reconstruct(Msg(plainBody: null, htmlBody: Utf8("<p>hi</p>"), codepage: 999999));
+
+        Assert.Contains("hi", ((TextPart)m.Body).Text);
+        Assert.Contains(warnings, w => w.Contains("999999") && w.Contains("UTF-8", StringComparison.OrdinalIgnoreCase));
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Reverse/MimeReconstructorTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Reverse/MimeReconstructorTests.cs
@@ -260,4 +260,112 @@ public class MimeReconstructorTests
         Assert.Contains("hi", ((TextPart)m.Body).Text);
         Assert.Contains(warnings, w => w.Contains("999999") && w.Contains("UTF-8", StringComparison.OrdinalIgnoreCase));
     }
+
+    // ---- Task 3 tests ----------------------------------------------------------------------------
+
+    // In-memory attachment; `read` flips true when the closure is invoked, proving synchronous reads.
+    private static PstAttachment Att(
+        string fileName, string? contentType, string? contentId, bool inline, byte[] bytes,
+        Action? onOpen = null, string? contentLocation = null)
+        => new PstAttachment(
+            fileName, contentType, contentId, inline,
+            OpenRead: () => { onOpen?.Invoke(); return new MemoryStream(bytes, writable: false); },
+            Length: bytes.Length)
+        { ContentLocation = contentLocation };   // Plan-1 addendum: init-only PidTagAttachContentLocation
+
+    [Fact]
+    public void Reconstruct_NonInlineAttachment_ProducesMultipartMixed_WithExactBytes()
+    {
+        byte[] payload = { 1, 2, 3, 4, 5, 42, 200, 255 };
+        var msg = Msg(
+            plainBody: "see attachment",
+            attachments: new[] { Att("data.bin", "application/octet-stream", null, inline: false, payload) });
+
+        MimeMessage m = new MimeReconstructor().Reconstruct(msg);
+
+        Multipart mixed = Assert.IsType<Multipart>(m.Body);
+        Assert.True(mixed.ContentType.IsMimeType("multipart", "mixed"));
+        Assert.True(mixed[0].ContentType.IsMimeType("text", "plain"));           // body first
+        MimePart att = Assert.IsType<MimePart>(mixed[1]);
+        Assert.Equal("data.bin", att.FileName);
+        Assert.Equal(ContentDisposition.Attachment, att.ContentDisposition!.Disposition);
+
+        using var got = new MemoryStream();
+        att.Content.DecodeTo(got);
+        Assert.Equal(payload, got.ToArray());
+    }
+
+    [Fact]
+    public void Reconstruct_InlineCidAttachment_ProducesMultipartRelated_WithContentId()
+    {
+        byte[] png = { 0x89, 0x50, 0x4E, 0x47 };
+        var msg = Msg(
+            plainBody: null, htmlBody: Utf8("<img src=\"cid:img1@example\">"), codepage: 65001,
+            attachments: new[] { Att("logo.png", "image/png", "img1@example", inline: true, png) });
+
+        MimeMessage m = new MimeReconstructor().Reconstruct(msg);
+
+        MultipartRelated related = Assert.IsType<MultipartRelated>(m.Body);
+        Assert.Equal(2, related.Count);                                          // root + one inline, no duplicate
+        Assert.Same(related[0], related.Root);                                   // body is the root, added once
+        Assert.True(related.Root.ContentType.IsMimeType("text", "html"));        // root document is the html
+        MimePart inline = related.OfType<MimePart>().Single(p => p.ContentId is not null);
+        Assert.Equal("img1@example", inline.ContentId);                          // matches the cid: reference
+        Assert.Equal(ContentDisposition.Inline, inline.ContentDisposition!.Disposition);
+    }
+
+    [Fact]
+    public void Reconstruct_AttachmentContentLocation_IsRestored()
+    {
+        var msg = Msg(
+            plainBody: null, htmlBody: Utf8("<img src=\"img/logo.png\">"), codepage: 65001,
+            attachments: new[]
+            {
+                Att("logo.png", "image/png", "img1@example", inline: true, new byte[] { 1 },
+                    contentLocation: "img/logo.png"),
+            });
+
+        MimeMessage m = new MimeReconstructor().Reconstruct(msg);
+
+        MultipartRelated related = Assert.IsType<MultipartRelated>(m.Body);
+        Assert.Equal(2, related.Count);                                          // root + one inline, no duplicate
+        Assert.Same(related[0], related.Root);
+        MimePart inline = related.OfType<MimePart>().Single(p => p.ContentId is not null);
+        Assert.NotNull(inline.ContentLocation);
+        Assert.Equal("img/logo.png", inline.ContentLocation!.ToString());
+    }
+
+    [Fact]
+    public void Reconstruct_ReadsAttachmentBytesSynchronously_DuringReconstruct()
+    {
+        bool read = false;
+        var msg = Msg(attachments: new[]
+        {
+            Att("f.bin", "application/octet-stream", null, inline: false, new byte[] { 9 }, onOpen: () => read = true),
+        });
+
+        new MimeReconstructor().Reconstruct(msg);
+        Assert.True(read, "attachment OpenRead must be invoked synchronously during Reconstruct");
+    }
+
+    [Fact]
+    public void Reconstruct_InlineAndRegular_NestsRelatedInsideMixed()
+    {
+        var msg = Msg(
+            plainBody: "body", htmlBody: Utf8("<img src=\"cid:c@x\">"), codepage: 65001,
+            attachments: new[]
+            {
+                Att("logo.png", "image/png", "c@x", inline: true, new byte[] { 1 }),
+                Att("report.pdf", "application/pdf", null, inline: false, new byte[] { 2 }),
+            });
+
+        MimeMessage m = new MimeReconstructor().Reconstruct(msg);
+
+        Multipart mixed = Assert.IsType<Multipart>(m.Body);
+        Assert.True(mixed.ContentType.IsMimeType("multipart", "mixed"));
+        MultipartRelated related = Assert.IsType<MultipartRelated>(mixed[0]);     // related nested inside mixed
+        Assert.Equal(2, related.Count);                                          // root + one inline, no duplicate
+        Assert.Equal("report.pdf", Assert.IsType<MimePart>(mixed[1]).FileName);
+        AssertNoMozillaHeaders(m);
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Reverse/MimeReconstructorTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Reverse/MimeReconstructorTests.cs
@@ -368,4 +368,77 @@ public class MimeReconstructorTests
         Assert.Equal("report.pdf", Assert.IsType<MimePart>(mixed[1]).FileName);
         AssertNoMozillaHeaders(m);
     }
+
+    // ---- Task 4 tests ----------------------------------------------------------------------------
+
+    private const string TransportBlock =
+        "Message-ID: <transport-id@example.com>\r\n" +
+        "In-Reply-To: <transport-parent@example.com>\r\n" +
+        "References: <transport-root@example.com>\r\n" +
+        "Received: from mx1.example.com by mx2.example.com; Tue, 01 Jun 2021 12:00:00 +0000\r\n" +
+        "X-Mozilla-Status: 1234\r\n" +                       // must NOT be carried (writer owns it)
+        "Content-Type: text/plain; boundary=\"STALE-BOGUS-BOUNDARY\"\r\n" +   // must NOT be copied
+        "Content-Transfer-Encoding: x-bogus\r\n" +           // structural: must NOT be copied
+        "Content-Disposition: attachment; filename=\"stale.txt\"\r\n" +       // structural: must NOT be copied
+        "MIME-Version: 9.9\r\n";                             // must be regenerated, not copied
+
+    [Fact]
+    public void Reconstruct_TransportHeaders_RegeneratesStructuralHeaders_NotCopied()
+    {
+        // Both bodies force a multipart/alternative; NONE of the stale structural headers may appear — they are
+        // regenerated from the real body/attachment tree, never copied from the transport block.
+        var msg = Msg(
+            messageId: null, plainBody: "p", htmlBody: Utf8("<p>h</p>"), codepage: 65001,
+            transportHeaders: TransportBlock);
+
+        MimeMessage m = new MimeReconstructor().Reconstruct(msg);
+        string wire = Serialize(m);
+
+        Assert.IsType<MultipartAlternative>(m.Body);
+        Assert.DoesNotContain("STALE-BOGUS-BOUNDARY", wire);          // stale boundary dropped
+        Assert.DoesNotContain("x-bogus", wire);                      // stale CTE dropped
+        Assert.DoesNotContain("stale.txt", wire);                    // stale Content-Disposition dropped
+        Assert.Contains("multipart/alternative", wire);              // fresh structural Content-Type
+        Assert.Contains("MIME-Version: 1.0", wire);                  // regenerated, not the bogus 9.9
+        Assert.DoesNotContain("MIME-Version: 9.9", wire);
+    }
+
+    [Fact]
+    public void Reconstruct_TransportHeaders_CarryTraceAndThread_WhenDiscreteAbsent()
+    {
+        // No discrete Message-ID/In-Reply-To/References -> filled from the transport block; Received carried.
+        var msg = Msg(messageId: null, inReplyTo: null, references: null, transportHeaders: TransportBlock);
+
+        MimeMessage m = new MimeReconstructor().Reconstruct(msg);
+
+        Assert.Equal("transport-id@example.com", m.MessageId);
+        Assert.Equal("transport-parent@example.com", m.InReplyTo);
+        Assert.Contains("transport-root@example.com", m.References);
+        Assert.Contains(m.Headers, h => h.Id == HeaderId.Received);
+        AssertNoMozillaHeaders(m);                                    // X-Mozilla-Status NOT carried
+    }
+
+    [Fact]
+    public void Reconstruct_DiscreteProps_WinOverTransportHeaders()
+    {
+        // Discrete Message-ID is present -> the transport Message-ID must be ignored (conflict rule).
+        var msg = Msg(messageId: "discrete-id@example.com", transportHeaders: TransportBlock);
+
+        MimeMessage m = new MimeReconstructor().Reconstruct(msg);
+
+        Assert.Equal("discrete-id@example.com", m.MessageId);
+        Assert.Single(m.Headers, h => h.Id == HeaderId.MessageId);    // no duplicate Message-ID
+    }
+
+    [Fact]
+    public void Reconstruct_TransportReceivedHeader_RoundTripsUnchanged()
+    {
+        const string received = "from mx1.example.com by mx2.example.com; Tue, 01 Jun 2021 12:00:00 +0000";
+        var msg = Msg(transportHeaders: "Received: " + received + "\r\n");
+
+        MimeMessage m = new MimeReconstructor().Reconstruct(msg);
+
+        Header carried = Assert.Single(m.Headers, h => h.Id == HeaderId.Received);
+        Assert.Equal(received, carried.Value);                       // Received value survives verbatim
+    }
 }

--- a/tests/Mail2Pst.Core.Tests/Reverse/MimeReconstructorTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Reverse/MimeReconstructorTests.cs
@@ -39,7 +39,7 @@ public class MimeReconstructorTests
             IsRead: false, IsReplied: false, IsForwarded: false,
             Categories: categories ?? Array.Empty<string>(),
             Attachments: attachments ?? Array.Empty<PstAttachment>())
-        { FromName = fromName };   // Plan-1 addendum: init-only sender display name
+        { FromName = fromName };   // init-only sender display name
 
     private static PstRecipient Rcpt(string address, PstRecipientKind kind, string? display = null)
         => new PstRecipient(address, display, kind);
@@ -66,7 +66,7 @@ public class MimeReconstructorTests
                 $"reconstructor must not emit '{h.Field}' (the mbox writer owns X-Mozilla-* headers)");
     }
 
-    // ---- Task 1 tests ----------------------------------------------------------------------------
+    // ---- identity/header tests ---------------------------------------------------------------------
 
     [Fact]
     public void Reconstruct_DiscreteProps_SetsIdentityAndDisplayHeaders()
@@ -171,7 +171,7 @@ public class MimeReconstructorTests
         Assert.Equal(string.Empty, m.Subject);
     }
 
-    // ---- Task 2 tests ----------------------------------------------------------------------------
+    // ---- body tests ----------------------------------------------------------------------------------
 
     private static byte[] Utf8(string s) => System.Text.Encoding.UTF8.GetBytes(s);
 
@@ -261,7 +261,7 @@ public class MimeReconstructorTests
         Assert.Contains(warnings, w => w.Contains("999999") && w.Contains("UTF-8", StringComparison.OrdinalIgnoreCase));
     }
 
-    // ---- Task 3 tests ----------------------------------------------------------------------------
+    // ---- attachment tests ------------------------------------------------------------------------
 
     // In-memory attachment; `read` flips true when the closure is invoked, proving synchronous reads.
     private static PstAttachment Att(
@@ -271,7 +271,7 @@ public class MimeReconstructorTests
             fileName, contentType, contentId, inline,
             OpenRead: () => { onOpen?.Invoke(); return new MemoryStream(bytes, writable: false); },
             Length: bytes.Length)
-        { ContentLocation = contentLocation };   // Plan-1 addendum: init-only PidTagAttachContentLocation
+        { ContentLocation = contentLocation };   // init-only PidTagAttachContentLocation
 
     [Fact]
     public void Reconstruct_NonInlineAttachment_ProducesMultipartMixed_WithExactBytes()
@@ -369,7 +369,7 @@ public class MimeReconstructorTests
         AssertNoMozillaHeaders(m);
     }
 
-    // ---- Task 4 tests ----------------------------------------------------------------------------
+    // ---- transport-header tests ------------------------------------------------------------------
 
     private const string TransportBlock =
         "Message-ID: <transport-id@example.com>\r\n" +

--- a/tests/Mail2Pst.Core.Tests/Reverse/MimeReconstructorTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Reverse/MimeReconstructorTests.cs
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Reverse;
+using MimeKit;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Reverse;
+
+public class MimeReconstructorTests
+{
+    // ---- builders --------------------------------------------------------------------------------
+
+    private static PstMailMessage Msg(
+        string? subject = "Subject",
+        string? from = "sender@example.com",
+        string? fromName = null,
+        IReadOnlyList<PstRecipient>? recipients = null,
+        DateTimeOffset? date = null,
+        string? messageId = null,
+        string? inReplyTo = null,
+        string? references = null,
+        string? plainBody = "Body text",
+        byte[]? htmlBody = null,
+        int? codepage = null,
+        string? transportHeaders = null,
+        IReadOnlyList<string>? categories = null,
+        IReadOnlyList<PstAttachment>? attachments = null)
+        => new PstMailMessage(
+            Subject: subject, FromAddress: from,
+            Recipients: recipients ?? Array.Empty<PstRecipient>(),
+            Date: date, MessageId: messageId, InReplyTo: inReplyTo, References: references,
+            PlainBody: plainBody, HtmlBody: htmlBody, InternetCodepage: codepage,
+            TransportHeaders: transportHeaders,
+            IsRead: false, IsReplied: false, IsForwarded: false,
+            Categories: categories ?? Array.Empty<string>(),
+            Attachments: attachments ?? Array.Empty<PstAttachment>())
+        { FromName = fromName };   // Plan-1 addendum: init-only sender display name
+
+    private static PstRecipient Rcpt(string address, PstRecipientKind kind, string? display = null)
+        => new PstRecipient(address, display, kind);
+
+    private static MimeReconstructor NewReconstructor(out List<string> warnings)
+    {
+        warnings = new List<string>();
+        var captured = warnings;
+        return new MimeReconstructor(captured.Add);
+    }
+
+    private static string Serialize(MimeMessage m)
+    {
+        using var ms = new MemoryStream();
+        m.WriteTo(ms);
+        return System.Text.Encoding.UTF8.GetString(ms.ToArray());
+    }
+
+    private static void AssertNoMozillaHeaders(MimeMessage m)
+    {
+        foreach (Header h in m.Headers)
+            Assert.False(
+                h.Field.StartsWith("X-Mozilla", StringComparison.OrdinalIgnoreCase),
+                $"reconstructor must not emit '{h.Field}' (the mbox writer owns X-Mozilla-* headers)");
+    }
+
+    // ---- Task 1 tests ----------------------------------------------------------------------------
+
+    [Fact]
+    public void Reconstruct_DiscreteProps_SetsIdentityAndDisplayHeaders()
+    {
+        var msg = Msg(
+            subject: "Hello world",
+            from: "alice@example.com",
+            recipients: new[]
+            {
+                Rcpt("bob@example.com", PstRecipientKind.To, "Bob"),
+                Rcpt("carol@example.com", PstRecipientKind.Cc),
+                Rcpt("dave@example.com", PstRecipientKind.Bcc),
+            },
+            date: new DateTimeOffset(2021, 6, 1, 12, 0, 0, TimeSpan.Zero),
+            messageId: "id-1@example.com",           // unbracketed here; both forms covered by the Theory below
+            inReplyTo: "parent@example.com",
+            references: "root@example.com parent@example.com");
+
+        MimeMessage m = new MimeReconstructor().Reconstruct(msg);
+
+        Assert.Equal("Hello world", m.Subject);
+        Assert.Equal("alice@example.com", Assert.IsType<MailboxAddress>(m.From[0]).Address);
+        Assert.Equal("bob@example.com", Assert.IsType<MailboxAddress>(m.To[0]).Address);
+        Assert.Equal("Bob", Assert.IsType<MailboxAddress>(m.To[0]).Name);
+        Assert.Equal("carol@example.com", Assert.IsType<MailboxAddress>(m.Cc[0]).Address);
+        Assert.Equal("dave@example.com", Assert.IsType<MailboxAddress>(m.Bcc[0]).Address);
+        Assert.Equal(new DateTimeOffset(2021, 6, 1, 12, 0, 0, TimeSpan.Zero), m.Date);
+        Assert.Equal("id-1@example.com", m.MessageId);          // MimeKit stores id without <>
+        Assert.Equal("parent@example.com", m.InReplyTo);
+        Assert.Equal(new[] { "root@example.com", "parent@example.com" }, m.References.ToArray());
+        AssertNoMozillaHeaders(m);
+    }
+
+    [Theory]
+    [InlineData("id-1@example.com")]        // arbitrary source PST may surface an unbracketed id
+    [InlineData("<id-1@example.com>")]      // ContinuMail-written ids are bracketed (NormalizeForJoin adds <>)
+    public void Reconstruct_MessageId_AcceptsBracketedAndUnbracketed(string id)
+        => Assert.Equal("id-1@example.com", new MimeReconstructor().Reconstruct(Msg(messageId: id)).MessageId);
+
+    [Fact]
+    public void Reconstruct_FromName_Present_SetsDisplayNameOnFrom()
+    {
+        MimeMessage m = new MimeReconstructor().Reconstruct(
+            Msg(from: "john@example.com", fromName: "John Doe"));
+
+        MailboxAddress from = Assert.IsType<MailboxAddress>(m.From[0]);
+        Assert.Equal("John Doe", from.Name);            // display name preserved -> "John Doe <john@example.com>"
+        Assert.Equal("john@example.com", from.Address);
+    }
+
+    [Fact]
+    public void Reconstruct_FromName_Null_LeavesBareAddress()
+    {
+        MimeMessage m = new MimeReconstructor().Reconstruct(
+            Msg(from: "john@example.com", fromName: null));
+
+        MailboxAddress from = Assert.IsType<MailboxAddress>(m.From[0]);
+        Assert.Equal(string.Empty, from.Name);          // no display name -> bare address
+        Assert.Equal("john@example.com", from.Address);
+    }
+
+    [Fact]
+    public void Reconstruct_MalformedRecipientAddress_SkipsItWithWarning_KeepsValidOnes()
+    {
+        MimeReconstructor rec = NewReconstructor(out List<string> warnings);
+        var msg = Msg(recipients: new[]
+        {
+            Rcpt("not an address", PstRecipientKind.To),      // malformed -> skipped + warned
+            Rcpt("valid@example.com", PstRecipientKind.To),   // valid -> still lands
+        });
+
+        MimeMessage m = rec.Reconstruct(msg);                 // must NOT throw
+
+        Assert.Contains(m.To.Mailboxes, mb => mb.Address == "valid@example.com");
+        Assert.Contains(warnings, w => w.Contains("could not reconstruct to address"));
+    }
+
+    [Fact]
+    public void Reconstruct_PlainOnly_ProducesTextPlainBody()
+    {
+        MimeMessage m = new MimeReconstructor().Reconstruct(Msg(plainBody: "Just plain text", htmlBody: null));
+
+        TextPart body = Assert.IsType<TextPart>(m.Body);
+        Assert.True(body.ContentType.IsMimeType("text", "plain"));
+        Assert.Equal("Just plain text", body.Text);
+    }
+
+    [Fact]
+    public void Reconstruct_NeverEmitsXMozillaHeaders()
+        => AssertNoMozillaHeaders(new MimeReconstructor().Reconstruct(Msg()));
+
+    [Fact]
+    public void Reconstruct_EmptyMessage_ProducesMinimalTextPlain()
+    {
+        // No usable discrete props and no body at all: still round-trips as an empty text/plain part.
+        var msg = Msg(subject: null, from: null, plainBody: null, htmlBody: null);
+        MimeMessage m = new MimeReconstructor().Reconstruct(msg);
+
+        TextPart body = Assert.IsType<TextPart>(m.Body);
+        Assert.True(body.ContentType.IsMimeType("text", "plain"));
+        Assert.Equal(string.Empty, body.Text);
+        Assert.Equal(string.Empty, m.Subject);
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Reverse/MozillaKeywordSanitizerTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Reverse/MozillaKeywordSanitizerTests.cs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using Mail2Pst.Core.Reverse;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Reverse;
+
+public class MozillaKeywordSanitizerTests
+{
+    [Theory]
+    [InlineData("Work", true)]
+    [InlineData("work_2", true)]
+    [InlineData("_x", true)]
+    [InlineData("Follow Up", false)]   // space
+    [InlineData("a-b", false)]         // hyphen
+    [InlineData("café", false)]        // non-ASCII letter
+    [InlineData("", false)]
+    public void IsSafeKey_Cases(string key, bool expected)
+        => Assert.Equal(expected, MozillaKeywordSanitizer.IsSafeKey(key));
+
+    [Theory]
+    [InlineData("Work", "Work")]            // safe key preserved verbatim (original case kept)
+    [InlineData("work_2", "work_2")]
+    [InlineData("Follow Up", "follow_up")]  // lowercase + whitespace -> underscore
+    [InlineData("Follow  Up", "follow_up")] // whitespace run collapses to one underscore
+    [InlineData("  Padded  ", "padded")]    // leading/trailing separators trimmed
+    [InlineData("Follow-Up", "follow_up")]  // hyphen -> single underscore separator
+    [InlineData("Q1/Q2", "q1_q2")]          // slash -> separator
+    [InlineData("example.com", "example_com")] // dot -> separator
+    [InlineData("Café", "caf")]             // trailing non-ASCII -> separator, trimmed
+    [InlineData("a - b", "a_b")]            // space-hyphen-space run -> single underscore
+    [InlineData("a_b!", "a_b")]             // unsafe (has '!'): '_' + trailing '!' both collapse/trim
+    [InlineData("a__b!", "a_b")]            // run of '_' collapses to one; trailing '!' trimmed
+    public void Sanitize_ProducesKey(string input, string expected)
+        => Assert.Equal(expected, MozillaKeywordSanitizer.Sanitize(input));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("!!!")]
+    public void Sanitize_NothingUsable_ReturnsNull(string input)
+        => Assert.Null(MozillaKeywordSanitizer.Sanitize(input));
+}

--- a/tests/Mail2Pst.Core.Tests/Reverse/MozillaStatusMapperTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Reverse/MozillaStatusMapperTests.cs
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Globalization;
+using Mail2Pst.Core.Msf;
+using Mail2Pst.Core.Reverse;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Reverse;
+
+public class MozillaStatusMapperTests
+{
+    private static string[] None => Array.Empty<string>();
+
+    // The mapper single-sources its Status bits from MsfMessageFlags. Pin the four values it relies on so
+    // that an accidental change to the shared enum fails loudly here rather than silently shifting headers.
+    [Fact]
+    public void MsfMessageFlags_ExpectedThunderbirdBits_AreStable()
+    {
+        Assert.Equal(0x0001u, (uint)MsfMessageFlags.Read);
+        Assert.Equal(0x0002u, (uint)MsfMessageFlags.Replied);
+        Assert.Equal(0x0004u, (uint)MsfMessageFlags.Marked);
+        Assert.Equal(0x1000u, (uint)MsfMessageFlags.Forwarded);
+    }
+
+    [Fact]
+    public void Map_NoFlagsNoCategories_AllZero()
+    {
+        MozillaStatusHeaders h = MozillaStatusMapper.Map(false, false, false, None);
+        Assert.Equal("0000", h.Status);
+        Assert.Equal("00000000", h.Status2);
+        Assert.Equal("", h.Keys);
+    }
+
+    [Theory]
+    [InlineData(true, false, false, "0001")]   // Read
+    [InlineData(false, true, false, "0002")]   // Replied
+    [InlineData(false, false, true, "1000")]   // Forwarded
+    [InlineData(true, true, true, "1003")]     // Read | Replied | Forwarded
+    public void Map_Flags_SetStatusBits(bool read, bool replied, bool forwarded, string expected)
+        => Assert.Equal(expected, MozillaStatusMapper.Map(read, replied, forwarded, None).Status);
+
+    [Theory]
+    [InlineData("Star")]
+    [InlineData("star")]   // case-insensitive, matching the forward StarCategory match
+    public void Map_StarCategory_SetsMarkedBit_AndIsNotAKeyword(string star)
+    {
+        MozillaStatusHeaders h = MozillaStatusMapper.Map(false, false, false, new[] { star });
+        Assert.Equal("0004", h.Status);   // Marked
+        Assert.Equal("", h.Keys);         // Star consumed, not emitted as a keyword
+    }
+
+    [Fact]
+    public void Map_Categories_BecomeSanitizedKeys()
+    {
+        MozillaStatusHeaders h = MozillaStatusMapper.Map(false, false, false, new[] { "Work", "Follow Up" });
+        Assert.Equal("0000", h.Status);
+        Assert.Equal("Work follow_up", h.Keys);
+    }
+
+    [Fact]
+    public void Map_StarPlusTags_MarksAndKeepsOtherTags()
+    {
+        MozillaStatusHeaders h = MozillaStatusMapper.Map(true, false, false, new[] { "Star", "Work" });
+        Assert.Equal("0005", h.Status);   // Read | Marked
+        Assert.Equal("Work", h.Keys);
+    }
+
+    [Fact]
+    public void Map_DuplicateAndEmptyKeys_AreDeduplicatedAndDropped()
+    {
+        MozillaStatusHeaders h = MozillaStatusMapper.Map(
+            false, false, false, new[] { "Follow Up", "follow_up", "!!!", "Work" });
+        // "Follow Up" -> follow_up (added); "follow_up" -> follow_up (dup, dropped);
+        // "!!!" -> nothing usable (dropped); "Work" -> Work.
+        Assert.Equal("follow_up Work", h.Keys);
+    }
+
+    [Fact]
+    public void Map_StatusHex_RoundTripsThroughForwardHexParse()
+    {
+        // Symmetry with the forward MimeMessageMapper, which reads X-Mozilla-Status via
+        // uint.TryParse(value, HexNumber). Proves our emitted hex parses back to the same bits.
+        MozillaStatusHeaders h = MozillaStatusMapper.Map(true, false, true, None); // Read | Forwarded = 0x1001
+        Assert.True(uint.TryParse(h.Status, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint flags));
+        Assert.Equal(0x1001u, flags);
+    }
+
+    [Fact]
+    public void Map_MessageOverload_MatchesDiscreteOverload()
+    {
+        var message = new PstMailMessage(
+            Subject: "s", FromAddress: "a@b", Recipients: Array.Empty<PstRecipient>(),
+            Date: null, MessageId: null, InReplyTo: null, References: null, PlainBody: null, HtmlBody: null,
+            InternetCodepage: null, TransportHeaders: null, IsRead: true, IsReplied: false, IsForwarded: false,
+            Categories: new[] { "Star", "Work" }, Attachments: Array.Empty<PstAttachment>());
+        Assert.Equal(
+            MozillaStatusMapper.Map(true, false, false, new[] { "Star", "Work" }),
+            MozillaStatusMapper.Map(message));
+    }
+}

--- a/tests/Mail2Pst.Core.Tests/Reverse/PstMailReaderSkipTests.cs
+++ b/tests/Mail2Pst.Core.Tests/Reverse/PstMailReaderSkipTests.cs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Mail2Pst.Core.Reverse;
+using Xunit;
+
+namespace Mail2Pst.Core.Tests.Reverse;
+
+public class PstMailReaderSkipTests
+{
+    [Fact]
+    public void ReportMessageReadFailure_WithOnSkipped_RecordsStructuredSkip_NoDuplicateWarning()
+    {
+        var skips = new List<ExportSkip>();
+        var warns = new List<string>();
+        PstMailReader.ReportMessageReadFailure(
+            new[] { "Parent", "Inbox" }, 4, new InvalidDataException("bad node"), warns.Add, skips.Add);
+
+        ExportSkip s = Assert.Single(skips);
+        Assert.Empty(warns);                                   // NOT double-reported as a warning
+        Assert.Equal("Parent / Inbox", s.FolderPath);
+        Assert.Equal(4, s.MessageIndex);
+        Assert.Contains("InvalidDataException", s.Reason);     // (iii) type name + message
+        Assert.Contains("bad node", s.Reason);
+    }
+
+    [Fact]
+    public void ReportMessageReadFailure_WithoutOnSkipped_EmitsLegacyWarningOnly()
+    {
+        var warns = new List<string>();
+        PstMailReader.ReportMessageReadFailure(
+            new[] { "Inbox" }, 2, new IOException("io"), warns.Add, onSkipped: null);
+
+        string w = Assert.Single(warns);
+        Assert.Contains("skipped message 2 in 'Inbox'", w);
+        Assert.Contains("IOException", w);
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/Reverse/ExportCommandTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/Reverse/ExportCommandTests.cs
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Mail2Pst.Cli;                    // ExportCommand (internal, visible via InternalsVisibleTo)
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Parsing;           // MboxParser / ParseResult
+using Mail2Pst.TestSupport;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests.Reverse;
+
+// Console.SetOut is process-global; in-process ExportCommand tests capture it, so they must not run in
+// parallel with each other or with any other console-capturing test.
+[CollectionDefinition("Console output", DisableParallelization = true)]
+public sealed class ConsoleOutputCollection { }
+
+// In-process ExportCommand.Run tests for scenarios that need a specifically-shaped PST. Builds the PST
+// with the forward pipeline (RoundTripHarness.Convert) and captures the CLI's stdout via Console.SetOut.
+[Collection("Console output")]
+public class ExportCommandTests
+{
+    private static (int exit, JsonElement[] events) RunExport(params string[] args)
+    {
+        var sw = new StringWriter();
+        TextWriter original = Console.Out;
+        int exit;
+        Console.SetOut(sw);
+        try { exit = ExportCommand.Run(args); }
+        finally { Console.SetOut(original); }
+
+        JsonElement[] events = sw.ToString()
+            .Split('\n').Select(l => l.Trim()).Where(l => l.Length > 0)
+            .Select(l => { using JsonDocument d = JsonDocument.Parse(l); return d.RootElement.Clone(); })
+            .ToArray();
+        return (exit, events);
+    }
+
+    // Build a PST whose single mail folder is named EXACTLY `folderName` (TargetFolderPath is honored
+    // verbatim; mirror mode would strip the extension, so a raw source-file name cannot produce this).
+    private static (string pst, string convertDir) BuildPstWithTargetFolder(string folderName)
+    {
+        using GeneratedProfile profile = new ThunderbirdProfileBuilder()
+            .WithAccount("alice@example.com", "imap.example.com").WithFolder("Src", 1).Build();
+        var config = new ConversionConfig { Outputs = { new()
+        {
+            Name = "Archive", MaxSizeMB = 50_000, FolderMapping = FolderMappingMode.Mirror, IncludeEmptyFolders = true,
+            Sources = { new SourceConfig { Type = "mbox", Path = profile.Folders[0].FilePath, TargetFolderPath = new List<string> { folderName } } },
+        }}};
+        string dir = Path.Combine(Path.GetTempPath(), "m2p-exportcmd-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var (outputs, _) = RoundTripHarness.Convert(config, dir);
+        return (Assert.Single(outputs), dir);
+    }
+
+    private static (string pst, string convertDir) BuildMirrorPst(GeneratedProfile profile)
+    {
+        var config = new ConversionConfig { Outputs = { new()
+        {
+            Name = "Archive", MaxSizeMB = 50_000, FolderMapping = FolderMappingMode.Mirror, IncludeEmptyFolders = true,
+            Sources = profile.Folders.Select(f => new SourceConfig { Type = "mbox", Path = f.FilePath }).ToList(),
+        }}};
+        string dir = Path.Combine(Path.GetTempPath(), "m2p-exportcmd-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var (outputs, _) = RoundTripHarness.Convert(config, dir);
+        return (Assert.Single(outputs), dir);
+    }
+
+    private static string FreshOutDir() =>
+        Path.Combine(Path.GetTempPath(), "m2p-exportcmd-out-" + Guid.NewGuid().ToString("N"));
+
+    private static void CleanupSiblings(string outRoot)
+    {
+        foreach (string s in new[] { outRoot + ".export-report.json", outRoot + ".export-report.txt" })
+            if (File.Exists(s)) File.Delete(s);
+    }
+
+    [Theory]
+    [InlineData("export-report.json")]
+    [InlineData("export-report.txt")]
+    public void Export_FolderNamedLikeReport_DoesNotOverwriteMailbox_ReportGoesToSibling(string reservedName)
+    {
+        var (pst, convertDir) = BuildPstWithTargetFolder(reservedName);
+        string outRoot = FreshOutDir();
+        try
+        {
+            (int exit, JsonElement[] events) = RunExport("--input", pst, "--output", outRoot);
+            Assert.Equal(0, exit);
+
+            string outRootFull = Path.TrimEndingDirectorySeparator(Path.GetFullPath(outRoot));
+            string mailbox = Path.Combine(outRoot, reservedName);                 // the MAILBOX, INSIDE the tree
+            string reportJson = outRootFull + ".export-report.json";              // reports are SIBLINGS
+            string reportTxt = outRootFull + ".export-report.txt";
+
+            Assert.True(File.Exists(mailbox), "the mailbox named like a report must survive");
+            ParseResult parsed = Assert.Single(new MboxParser().Parse(mailbox));
+            Assert.True(parsed.Success);
+            Assert.NotNull(parsed.Message);                                       // its message payload is intact
+
+            Assert.True(File.Exists(reportJson), "the report must be written OUTSIDE the mbox tree");
+            Assert.True(File.Exists(reportTxt));
+            Assert.NotEqual(Path.GetFullPath(mailbox), reportJson);
+            Assert.NotEqual(Path.GetFullPath(mailbox), reportTxt);
+
+            using JsonDocument r = JsonDocument.Parse(File.ReadAllText(reportJson));
+            Assert.True(r.RootElement.GetProperty("messagesExported").GetInt32() >= 1);
+            Assert.Contains(events, e => e.GetProperty("type").GetString() == "done");
+        }
+        finally
+        {
+            Directory.Delete(convertDir, true);
+            if (Directory.Exists(outRoot)) Directory.Delete(outRoot, true);
+            CleanupSiblings(outRoot);
+        }
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/Reverse/ExportCommandTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/Reverse/ExportCommandTests.cs
@@ -80,6 +80,36 @@ public class ExportCommandTests
             if (File.Exists(s)) File.Delete(s);
     }
 
+    [Fact]
+    public void Export_IncludeEmptyFlag_ControlsWhetherEmptyLeafMboxIsEmitted()
+    {
+        using GeneratedProfile profile = new ThunderbirdProfileBuilder()
+            .WithAccount("alice@example.com", "imap.example.com")
+            .WithFolder("Inbox", 1).WithFolder("Empty", 0).Build();
+        var (pst, convertDir) = BuildMirrorPst(profile);   // IncludeEmptyFolders:true → the empty folder exists in the PST
+        string withEmpty = FreshOutDir();
+        string withoutEmpty = FreshOutDir();
+        try
+        {
+            (int e1, _) = RunExport("--input", pst, "--output", withEmpty, "--include-empty");
+            Assert.Equal(0, e1);
+            Assert.True(File.Exists(Path.Combine(withEmpty, "Empty")), "empty leaf emitted WITH --include-empty");
+
+            (int e2, _) = RunExport("--input", pst, "--output", withoutEmpty);
+            Assert.Equal(0, e2);
+            Assert.False(File.Exists(Path.Combine(withoutEmpty, "Empty")), "empty leaf skipped WITHOUT --include-empty");
+        }
+        finally
+        {
+            Directory.Delete(convertDir, true);
+            foreach (string d in new[] { withEmpty, withoutEmpty })
+            {
+                if (Directory.Exists(d)) Directory.Delete(d, true);
+                CleanupSiblings(d);
+            }
+        }
+    }
+
     [Theory]
     [InlineData("export-report.json")]
     [InlineData("export-report.txt")]

--- a/tests/Mail2Pst.Integration.Tests/Reverse/ExportEventBuilderTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/Reverse/ExportEventBuilderTests.cs
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+
+using System.Text.Json;
+using Mail2Pst.Cli;                    // ExportCommand (internal, visible via InternalsVisibleTo)
+using Mail2Pst.Core.Cli;              // CliEventSerializer
+using Mail2Pst.Core.Reverse;          // ExportSkip / ExportProgress
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests.Reverse;
+
+// Pure unit proof that the CLI builds DISCRIMINATED, disjoint skip vs warning events — the exact wire
+// shape of the `skipped` event type, which no PST-scenario test can force without a corrupt store. The
+// reader→onSkipped link is covered by PstMailReaderSkipTests; the runner clean-path by PstExportRunnerTests.
+public class ExportEventBuilderTests
+{
+    private static JsonElement Serialize(object payload)
+    {
+        using JsonDocument doc = JsonDocument.Parse(CliEventSerializer.Serialize(payload));
+        return doc.RootElement.Clone();
+    }
+
+    [Fact]
+    public void BuildSkippedEvent_IsDiscriminatedSkip_NotAWarning()
+    {
+        JsonElement e = Serialize(ExportCommand.BuildSkippedEvent(new ExportSkip("Parent / Inbox", 4, "InvalidDataException: bad node")));
+        Assert.Equal("skipped", e.GetProperty("type").GetString());
+        Assert.Equal("export", e.GetProperty("command").GetString());
+        Assert.Equal("Parent / Inbox", e.GetProperty("folderPath").GetString());
+        Assert.Equal(4, e.GetProperty("messageIndex").GetInt32());
+        Assert.Equal("InvalidDataException: bad node", e.GetProperty("reason").GetString());
+        Assert.False(e.TryGetProperty("message", out _));   // NOT a warning
+    }
+
+    [Fact]
+    public void BuildWarningEvent_IsDiscriminatedWarning_NotASkip()
+    {
+        JsonElement e = Serialize(ExportCommand.BuildWarningEvent("reconstructor warning"));
+        Assert.Equal("warning", e.GetProperty("type").GetString());
+        Assert.Equal("export", e.GetProperty("command").GetString());
+        Assert.Equal("reconstructor warning", e.GetProperty("message").GetString());
+        Assert.False(e.TryGetProperty("folderPath", out _));   // NOT a skip
+        Assert.False(e.TryGetProperty("reason", out _));
+    }
+
+    [Fact]
+    public void BuildSkippedEvent_NullMessageIndex_SerializesJsonNull()
+    {
+        JsonElement e = Serialize(ExportCommand.BuildSkippedEvent(new ExportSkip("Contacts", null, "non-mail folder")));
+        Assert.Equal(JsonValueKind.Null, e.GetProperty("messageIndex").ValueKind);
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/Reverse/ExportRoundTripTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/Reverse/ExportRoundTripTests.cs
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Mapping;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Parsing;
+using Mail2Pst.Core.Reverse;
+using Mail2Pst.TestSupport;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests.Reverse;
+
+public class ExportRoundTripTests
+{
+    // Headline gate: a NESTED profile -> forward ConversionRunner -> PST -> reverse export -> mbox tree,
+    // re-parsed with our own MboxParser. Asserts nested folder structure via RELATIVE output paths (leaf
+    // names would lose hierarchy and collide), per-folder message counts, and per-message fidelity.
+    [Fact]
+    public void ForwardThenReverse_PreservesNestedStructureCountsAndFields()
+    {
+        using GeneratedProfile profile = new ThunderbirdProfileBuilder()
+            .WithAccount("alice@example.com", "imap.example.com")
+            .WithFolder("InboxSrc", messageCount: 3)
+            .WithFolder("SentSrc", messageCount: 2)
+            .WithFolder("EmptySrc", messageCount: 0)
+            .Build();
+
+        // Map the three sources to a NESTED destination via explicit TargetFolderPath:
+        //   Parent/Inbox (3), Sent (2), Empty (0).
+        GeneratedFolder inbox = profile.Folders.First(f => f.Name == "InboxSrc");
+        GeneratedFolder sent = profile.Folders.First(f => f.Name == "SentSrc");
+        GeneratedFolder empty = profile.Folders.First(f => f.Name == "EmptySrc");
+        var config = new ConversionConfig { Outputs = { new()
+        {
+            Name = "Archive", MaxSizeMB = 50_000, FolderMapping = FolderMappingMode.Mirror, IncludeEmptyFolders = true,
+            Sources =
+            {
+                new SourceConfig { Type = "mbox", Path = inbox.FilePath, TargetFolderPath = new List<string> { "Parent", "Inbox" } },
+                new SourceConfig { Type = "mbox", Path = sent.FilePath,  TargetFolderPath = new List<string> { "Sent" } },
+                new SourceConfig { Type = "mbox", Path = empty.FilePath, TargetFolderPath = new List<string> { "Empty" } },
+            },
+        }}};
+
+        string convertDir = Path.Combine(Path.GetTempPath(), "m2p-rt-conv-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(convertDir);
+        string outRoot = Path.Combine(Path.GetTempPath(), "m2p-rt-out-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var (outputs, _) = RoundTripHarness.Convert(config, convertDir);
+            string pst = Assert.Single(outputs);
+
+            ExportReport report = new PstExportRunner().Run(pst, outRoot, includeEmpty: true);
+            Assert.Equal(5, report.MessagesExported);
+            Assert.Equal(0, report.SkippedCount);
+
+            var countByPath = new Dictionary<string, int>(StringComparer.Ordinal);
+            foreach (string mbox in report.MboxFiles)
+            {
+                int n = 0;
+                foreach (ParseResult r in new MboxParser().Parse(mbox))
+                {
+                    Assert.True(r.Success);
+                    MailMessage m = r.Message!;
+                    Assert.StartsWith("Generated message", m.Subject);
+                    Assert.Equal("sender@example.com", m.From!.Email);
+                    Assert.Contains(m.To, a => a.Email == "alice@example.com");
+                    Assert.Contains("Synthetic body", m.TextBody ?? m.HtmlBody ?? string.Empty);
+                    n++;
+                }
+                string relative = Path.GetRelativePath(outRoot, mbox).Replace(Path.DirectorySeparatorChar, '/');
+                countByPath[relative] = n;
+            }
+
+            // Nested structure via relative paths (not leaf names).
+            Assert.Equal(3, countByPath["Parent.sbd/Inbox"]);
+            Assert.Equal(2, countByPath["Sent"]);
+            Assert.Equal(0, countByPath["Parent"]);   // structural parent: empty mbox + Parent.sbd/
+            Assert.Equal(0, countByPath["Empty"]);    // empty leaf, emitted because includeEmpty=true
+
+            // No warnings expected on this clean fixture. If a benign one ever appears, document + filter it
+            // here rather than loosening the assertion.
+            Assert.Empty(report.Warnings);
+        }
+        finally
+        {
+            Directory.Delete(convertDir, true);
+            if (Directory.Exists(outRoot)) Directory.Delete(outRoot, true);
+        }
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/Reverse/OutlookPstSmokeTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/Reverse/OutlookPstSmokeTests.cs
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Linq;
+using Mail2Pst.Core.Reverse;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests.Reverse;
+
+[Trait("Category", "OutlookPstSmoke")]
+public class OutlookPstSmokeTests
+{
+    [SkippableFact]
+    public void Read_RealOutlookPst_ResolvesRootAndReconstructsMessages()
+    {
+        string? pst = Environment.GetEnvironmentVariable("MAIL2PST_OUTLOOK_PST");
+        Skip.If(string.IsNullOrEmpty(pst),
+            "Set MAIL2PST_OUTLOOK_PST to a real Outlook-authored .pst to run the reverse-reader smoke.");
+
+        var items = PstMailReader.EnumerateMessages(pst!, _ => { }).ToList();
+
+        Assert.NotEmpty(items);                                     // TopOfPersonalFolders found the tree
+        Assert.Contains(items, it =>                                // at least one message reconstructs
+            !string.IsNullOrEmpty(it.Message.Subject)
+            || !string.IsNullOrEmpty(it.Message.PlainBody)
+            || (it.Message.HtmlBody is { Length: > 0 }));
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/Reverse/PstExportRunnerTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/Reverse/PstExportRunnerTests.cs
@@ -335,6 +335,68 @@ public class PstExportRunnerTests
         }
     }
 
+    // Companion to the attachment-payload round trip: proves that read, starred, and tagged state
+    // written by the forward PST writer surfaces as the expected X-Mozilla-* headers in the exported
+    // mbox and reparses into the corresponding read/starred state.
+    [Fact]
+    public void Run_ReadFlaggedTaggedMessage_CarriesMozillaHeadersThroughFullExport()
+    {
+        var msg = new MailMessage
+        {
+            MessageId = "<flag-tag-loop@test>",
+            Subject = "Flag and tag round trip",
+            IsRead = true,
+            IsFlagged = true,                          // forward writer appends the synthetic "Star" category
+            Categories = new List<string> { "Work" },  // a real tag, distinct from Star
+        };
+
+        string convertDir = Path.Combine(Path.GetTempPath(), "m2p-rev-flag-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(convertDir);
+        string outRoot = FreshOutDir();
+        try
+        {
+            var plan = new PstOutputPlan { Name = "Flag", MaxSizeBytes = 100L * 1024 * 1024, IncludeEmptyFolders = false };
+            PlannedMessage[] planned = [ new() { Message = msg, TargetFolderPath = new[] { "Inbox" } } ];
+            string pst = Assert.Single(new PstWriter().WritePlan(plan, planned, convertDir, new ConversionReport()));
+
+            ExportReport report = new PstExportRunner().Run(pst, outRoot, includeEmpty: false);
+            Assert.Equal(1, report.MessagesExported);
+            Assert.Equal(0, report.SkippedCount);          // no degradation
+            Assert.Equal(0, report.WarningCount);
+
+            string inbox = Path.Combine(outRoot, "Inbox");
+            Assert.True(File.Exists(inbox));
+            string[] lines = File.ReadAllLines(inbox);
+
+            // EXACT status token (Read 0x0001 | Marked 0x0004 = 0005), not a substring match.
+            string status = Assert.Single(lines.Where(l => l.StartsWith("X-Mozilla-Status:", StringComparison.Ordinal)));
+            Assert.Equal("X-Mozilla-Status: 0005", status);
+            Assert.Contains("X-Mozilla-Status2: 00000000", lines);
+
+            // EXACT keyword tokens: split the Keys value on spaces. Work is emitted; Star was consumed
+            // into the Marked status bit and must NOT also appear as a keyword.
+            string keysLine = Assert.Single(lines.Where(l => l.StartsWith("X-Mozilla-Keys:", StringComparison.Ordinal)));
+            string[] keys = keysLine.Substring("X-Mozilla-Keys:".Length)
+                                    .Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            Assert.Contains("Work", keys);
+            Assert.DoesNotContain(keys, k => string.Equals(k, "Star", StringComparison.OrdinalIgnoreCase));
+
+            // The exported headers reparse back into read/starred state via the forward MboxParser.
+            // NOTE: MboxParser/MimeMessageMapper reparses only X-Mozilla-Status bits, NOT X-Mozilla-Keys
+            // into Categories — so do not assert parsed.Message.Categories here.
+            ParseResult parsed = Assert.Single(new MboxParser().Parse(inbox));
+            Assert.True(parsed.Success);
+            Assert.NotNull(parsed.Message);
+            Assert.True(parsed.Message.IsRead);
+            Assert.True(parsed.Message.IsFlagged);
+        }
+        finally
+        {
+            Directory.Delete(convertDir, true);
+            if (Directory.Exists(outRoot)) Directory.Delete(outRoot, true);
+        }
+    }
+
     [Fact]
     public void Run_AcceptsOnSkipped_CleanPstProducesNoSkipCallbacks()
     {

--- a/tests/Mail2Pst.Integration.Tests/Reverse/PstExportRunnerTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/Reverse/PstExportRunnerTests.cs
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Mapping;
+using Mail2Pst.Core.Models;
+using Mail2Pst.Core.Parsing;
+using Mail2Pst.Core.Reporting;
+using Mail2Pst.Core.Reverse;
+using Mail2Pst.Core.Writing;
+using Mail2Pst.TestSupport;
+using MimeKit;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests.Reverse;
+
+public class PstExportRunnerTests
+{
+    private static (IReadOnlyList<string> outputs, string dir) ConvertProfile(ConversionConfig config)
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "m2p-rev-run-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var (outputs, _) = RoundTripHarness.Convert(config, dir);
+        return (outputs, dir);
+    }
+
+    private static string FreshOutDir() =>
+        Path.Combine(Path.GetTempPath(), "m2p-rev-out-" + Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void Run_Success_PublishesOnlyFinalOutputRoot()
+    {
+        using GeneratedProfile profile = new ThunderbirdProfileBuilder()
+            .WithAccount("alice@example.com", "imap.example.com")
+            .WithFolder("Inbox", messageCount: 2)
+            .WithFolder("Sent", messageCount: 1)
+            .Build();
+        var config = new ConversionConfig { Outputs = { new()
+        {
+            Name = "Archive", MaxSizeMB = 50_000, FolderMapping = FolderMappingMode.Mirror, IncludeEmptyFolders = false,
+            Sources = profile.Folders.Select(f => new SourceConfig { Type = "mbox", Path = f.FilePath }).ToList(),
+        }}};
+        var (outputs, convertDir) = ConvertProfile(config);
+        string pst = Assert.Single(outputs);
+
+        string outRoot = FreshOutDir();
+        string parent = Path.GetDirectoryName(outRoot)!;
+        try
+        {
+            ExportReport report = new PstExportRunner().Run(pst, outRoot, includeEmpty: false);
+
+            Assert.Equal(3, report.MessagesExported);
+            Assert.Equal(Path.TrimEndingDirectorySeparator(Path.GetFullPath(outRoot)), report.OutputRoot);
+            Assert.Equal(0, report.SkippedCount);
+            Assert.True(Directory.Exists(outRoot));
+            Assert.True(File.Exists(Path.Combine(outRoot, "Inbox")));
+            // Report mbox paths resolve UNDER the published root (not staging, no traversal).
+            Assert.All(report.MboxFiles, f =>
+            {
+                string rel = Path.GetRelativePath(Path.GetFullPath(outRoot), Path.GetFullPath(f));
+                Assert.False(rel.StartsWith("..", StringComparison.Ordinal));
+                Assert.False(Path.IsPathRooted(rel));
+            });
+            // No staging dir survives publication.
+            Assert.Empty(Directory.GetDirectories(parent, Path.GetFileName(outRoot) + ".partial-*"));
+        }
+        finally
+        {
+            Directory.Delete(convertDir, true);
+            if (Directory.Exists(outRoot)) Directory.Delete(outRoot, true);
+        }
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/Reverse/PstExportRunnerTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/Reverse/PstExportRunnerTests.cs
@@ -50,6 +50,24 @@ public class PstExportRunnerTests
         }
     }
 
+    // Emits a known warning through its injected sink, then a minimal real reconstruction.
+    private sealed class WarningReconstructor : IMimeReconstructor
+    {
+        private readonly Action<string>? _onWarning;
+        public WarningReconstructor(Action<string>? onWarning) => _onWarning = onWarning;
+        public MimeMessage Reconstruct(PstMailMessage message)
+        {
+            _onWarning?.Invoke("reconstructor-warning");
+            var m = new MimeMessage();
+            m.From.Add(new MailboxAddress(string.Empty, message.FromAddress ?? "s@example.com"));
+            m.To.Add(new MailboxAddress(string.Empty, "r@example.com"));
+            m.Subject = message.Subject ?? string.Empty;
+            m.Date = message.Date ?? DateTimeOffset.UnixEpoch;
+            m.Body = new TextPart("plain") { Text = message.PlainBody ?? string.Empty, ContentTransferEncoding = ContentEncoding.SevenBit };
+            return m;
+        }
+    }
+
     private static ConversionConfig OneInbox(GeneratedProfile profile, int _) => new()
     {
         Outputs = { new()
@@ -200,5 +218,70 @@ public class PstExportRunnerTests
             Directory.Delete(convertDir, true);
             if (Directory.Exists(outRoot)) Directory.Delete(outRoot, true);
         }
+    }
+
+    [Fact]
+    public void Run_ReconstructorWarning_ReachesReportAndLiveSink()
+    {
+        using GeneratedProfile profile = new ThunderbirdProfileBuilder()
+            .WithAccount("alice@example.com", "imap.example.com").WithFolder("Inbox", 1).Build();
+        var (outputs, convertDir) = ConvertProfile(OneInbox(profile, 0));
+        string pst = Assert.Single(outputs);
+
+        string outRoot = FreshOutDir();
+        try
+        {
+            var live = new List<string>();
+            var runner = new PstExportRunner(onWarning => new WarningReconstructor(onWarning));
+            ExportReport report = runner.Run(pst, outRoot, includeEmpty: false, onWarning: live.Add);
+
+            Assert.Contains("reconstructor-warning", report.Warnings);   // shared collector -> report
+            Assert.Contains("reconstructor-warning", live);              // ... and the live sink
+        }
+        finally { Directory.Delete(convertDir, true); if (Directory.Exists(outRoot)) Directory.Delete(outRoot, true); }
+    }
+
+    [Fact]
+    public void Run_Progress_TicksOncePerSuccessfullyWrittenMessage()
+    {
+        using GeneratedProfile profile = new ThunderbirdProfileBuilder()
+            .WithAccount("alice@example.com", "imap.example.com").WithFolder("Inbox", 3).Build();
+        var (outputs, convertDir) = ConvertProfile(OneInbox(profile, 0));
+        string pst = Assert.Single(outputs);
+
+        string outRoot = FreshOutDir();
+        try
+        {
+            var ticks = new List<ExportProgress>();
+            ExportReport report = new PstExportRunner().Run(pst, outRoot, includeEmpty: false, onProgress: ticks.Add);
+
+            Assert.Equal(3, ticks.Count);
+            Assert.Equal(new[] { 1, 2, 3 }, ticks.Select(t => t.MessagesExported).ToArray());
+            Assert.All(ticks, t => Assert.False(string.IsNullOrEmpty(t.CurrentFolder)));
+            Assert.Equal(report.MessagesExported, ticks[^1].MessagesExported);
+        }
+        finally { Directory.Delete(convertDir, true); if (Directory.Exists(outRoot)) Directory.Delete(outRoot, true); }
+    }
+
+    [Fact]
+    public void Run_ProgressCountsOnlySuccessfullyWrittenMessages()
+    {
+        using GeneratedProfile profile = new ThunderbirdProfileBuilder()
+            .WithAccount("alice@example.com", "imap.example.com").WithFolder("Inbox", 3).Build();
+        var (outputs, convertDir) = ConvertProfile(OneInbox(profile, 0));
+        string pst = Assert.Single(outputs);
+
+        string outRoot = FreshOutDir();
+        try
+        {
+            var ticks = new List<ExportProgress>();
+            var runner = new PstExportRunner(_ => new ThrowOnNthReconstructor(throwOn: 2));   // msg 2 throws
+            Assert.Throws<InvalidOperationException>(
+                () => runner.Run(pst, outRoot, includeEmpty: false, onProgress: ticks.Add));
+
+            // Only message 1 was written before the fatal throw, so progress saw exactly one tick.
+            Assert.Equal(new[] { 1 }, ticks.Select(t => t.MessagesExported).ToArray());
+        }
+        finally { Directory.Delete(convertDir, true); if (Directory.Exists(outRoot)) Directory.Delete(outRoot, true); }
     }
 }

--- a/tests/Mail2Pst.Integration.Tests/Reverse/PstExportRunnerTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/Reverse/PstExportRunnerTests.cs
@@ -284,4 +284,54 @@ public class PstExportRunnerTests
         }
         finally { Directory.Delete(convertDir, true); if (Directory.Exists(outRoot)) Directory.Delete(outRoot, true); }
     }
+
+    // Attachment OpenRead closures are only valid while the message is current in the PST enumeration. If the
+    // runner read attachments after the PST closed (e.g. by materializing the stream first), the payload would
+    // be empty. Proving a visible attachment's bytes survive into the exported mbox proves the PST-bound
+    // lifetime is respected end-to-end (reconstruction + serialization + re-parse).
+    [Fact]
+    public void Run_PreservesAttachmentPayloadThroughFullExport()
+    {
+        byte[] payload = { 10, 20, 30, 40, 50, 60, 70, 80 };
+        var msg = new MailMessage
+        {
+            MessageId = "<attach-payload@test>",
+            Subject = "Attachment payload",
+            Attachments = new List<MailAttachment>
+            {
+                new() { FileName = "note.bin", MimeType = "application/octet-stream", Content = AttachmentContent.FromBytes(payload) },
+            },
+        };
+
+        string convertDir = Path.Combine(Path.GetTempPath(), "m2p-rev-att-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(convertDir);
+        string outRoot = FreshOutDir();
+        try
+        {
+            var plan = new PstOutputPlan { Name = "Att", MaxSizeBytes = 100L * 1024 * 1024, IncludeEmptyFolders = false };
+            PlannedMessage[] planned = [ new() { Message = msg, TargetFolderPath = new[] { "Inbox" } } ];
+            string pst = Assert.Single(new PstWriter().WritePlan(plan, planned, convertDir, new ConversionReport()));
+
+            ExportReport report = new PstExportRunner().Run(pst, outRoot, includeEmpty: false);
+            Assert.Equal(1, report.MessagesExported);
+
+            string inbox = Path.Combine(outRoot, "Inbox");
+            Assert.True(File.Exists(inbox));
+            ParseResult parsed = Assert.Single(new MboxParser().Parse(inbox));
+            Assert.True(parsed.Success);
+            MailAttachment att = Assert.Single(parsed.Message!.Attachments);
+            using (Stream content = att.Content.OpenRead())
+            using (var ms = new MemoryStream())
+            {
+                content.CopyTo(ms);
+                Assert.Equal(payload, ms.ToArray());
+            }
+            att.Content.Dispose();
+        }
+        finally
+        {
+            Directory.Delete(convertDir, true);
+            if (Directory.Exists(outRoot)) Directory.Delete(outRoot, true);
+        }
+    }
 }

--- a/tests/Mail2Pst.Integration.Tests/Reverse/PstExportRunnerTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/Reverse/PstExportRunnerTests.cs
@@ -31,6 +31,133 @@ public class PstExportRunnerTests
     private static string FreshOutDir() =>
         Path.Combine(Path.GetTempPath(), "m2p-rev-out-" + Guid.NewGuid().ToString("N"));
 
+    // A reconstructor that throws on the Nth message — forces an UNEXPECTED mid-export failure (fatal path).
+    private sealed class ThrowOnNthReconstructor : IMimeReconstructor
+    {
+        private readonly int _throwOn;
+        private int _seen;
+        public ThrowOnNthReconstructor(int throwOn) => _throwOn = throwOn;
+        public MimeMessage Reconstruct(PstMailMessage message)
+        {
+            if (++_seen == _throwOn) throw new InvalidOperationException("boom during reconstruction");
+            var m = new MimeMessage();
+            m.From.Add(new MailboxAddress(string.Empty, message.FromAddress ?? "s@example.com"));
+            m.To.Add(new MailboxAddress(string.Empty, "r@example.com"));
+            m.Subject = message.Subject ?? string.Empty;
+            m.Date = message.Date ?? DateTimeOffset.UnixEpoch;
+            m.Body = new TextPart("plain") { Text = message.PlainBody ?? string.Empty, ContentTransferEncoding = ContentEncoding.SevenBit };
+            return m;
+        }
+    }
+
+    private static ConversionConfig OneInbox(GeneratedProfile profile, int _) => new()
+    {
+        Outputs = { new()
+        {
+            Name = "Archive", MaxSizeMB = 50_000, FolderMapping = FolderMappingMode.Mirror, IncludeEmptyFolders = false,
+            Sources = profile.Folders.Select(f => new SourceConfig { Type = "mbox", Path = f.FilePath }).ToList(),
+        }}
+    };
+
+    [Fact]
+    public void Run_NonEmptyOutputRoot_IsRejectedWithoutModification()
+    {
+        using GeneratedProfile profile = new ThunderbirdProfileBuilder()
+            .WithAccount("alice@example.com", "imap.example.com").WithFolder("Inbox", 1).Build();
+        var (outputs, convertDir) = ConvertProfile(OneInbox(profile, 0));
+        string pst = Assert.Single(outputs);
+
+        string outRoot = FreshOutDir();
+        Directory.CreateDirectory(outRoot);
+        string sentinel = Path.Combine(outRoot, "existing.txt");
+        File.WriteAllText(sentinel, "keep me");
+        try
+        {
+            Assert.ThrowsAny<Exception>(() => new PstExportRunner().Run(pst, outRoot, includeEmpty: false));
+            Assert.True(File.Exists(sentinel));                           // destination untouched
+            Assert.Equal("keep me", File.ReadAllText(sentinel));
+        }
+        finally { Directory.Delete(convertDir, true); Directory.Delete(outRoot, true); }
+    }
+
+    [Fact]
+    public void Run_OutputPathIsExistingFile_FailsBeforeCreatingStaging()
+    {
+        using GeneratedProfile profile = new ThunderbirdProfileBuilder()
+            .WithAccount("alice@example.com", "imap.example.com").WithFolder("Inbox", 1).Build();
+        var (outputs, convertDir) = ConvertProfile(OneInbox(profile, 0));
+        string pst = Assert.Single(outputs);
+
+        string outFile = Path.Combine(Path.GetTempPath(), "m2p-rev-file-" + Guid.NewGuid().ToString("N"));
+        File.WriteAllText(outFile, "i am a file");
+        string parent = Path.GetDirectoryName(outFile)!;
+        try
+        {
+            Assert.Throws<IOException>(() => new PstExportRunner().Run(pst, outFile, includeEmpty: false));
+            Assert.Empty(Directory.GetDirectories(parent, Path.GetFileName(outFile) + ".partial-*"));   // no staging created
+            Assert.Equal("i am a file", File.ReadAllText(outFile));                                      // file untouched
+        }
+        finally { Directory.Delete(convertDir, true); File.Delete(outFile); }
+    }
+
+    [Fact]
+    public void Run_OutputRootWithTrailingSeparator_PublishesCorrectly()
+    {
+        using GeneratedProfile profile = new ThunderbirdProfileBuilder()
+            .WithAccount("alice@example.com", "imap.example.com").WithFolder("Inbox", 2).Build();
+        var (outputs, convertDir) = ConvertProfile(OneInbox(profile, 0));
+        string pst = Assert.Single(outputs);
+
+        string outRoot = FreshOutDir();
+        string withSep = outRoot + Path.DirectorySeparatorChar;   // trailing separator
+        try
+        {
+            ExportReport report = new PstExportRunner().Run(pst, withSep, includeEmpty: false);
+            Assert.Equal(2, report.MessagesExported);
+            Assert.Equal(outRoot, report.OutputRoot);                 // normalized (separator trimmed)
+            Assert.True(File.Exists(Path.Combine(outRoot, "Inbox")));
+            Assert.Empty(Directory.GetDirectories(outRoot, "*.partial-*"));   // staging NOT nested inside dest
+        }
+        finally { Directory.Delete(convertDir, true); if (Directory.Exists(outRoot)) Directory.Delete(outRoot, true); }
+    }
+
+    [Fact]
+    public void Run_FatalMidExport_RemovesStagingOutput()
+    {
+        using GeneratedProfile profile = new ThunderbirdProfileBuilder()
+            .WithAccount("alice@example.com", "imap.example.com").WithFolder("Inbox", 2).Build();
+        var (outputs, convertDir) = ConvertProfile(OneInbox(profile, 0));
+        string pst = Assert.Single(outputs);
+
+        string outRoot = FreshOutDir();
+        string parent = Path.GetDirectoryName(outRoot)!;
+        try
+        {
+            var runner = new PstExportRunner(_ => new ThrowOnNthReconstructor(throwOn: 2));
+            Assert.Throws<InvalidOperationException>(() => runner.Run(pst, outRoot, includeEmpty: false));
+
+            Assert.False(Directory.Exists(outRoot));                                              // never published
+            Assert.Empty(Directory.GetDirectories(parent, Path.GetFileName(outRoot) + ".partial-*")); // staging cleaned up
+        }
+        finally { Directory.Delete(convertDir, true); if (Directory.Exists(outRoot)) Directory.Delete(outRoot, true); }
+    }
+
+    [Fact]
+    public void Run_InvalidPst_PropagatesAndCreatesNoOutput()
+    {
+        string bogusPst = Path.Combine(Path.GetTempPath(), "m2p-not-a-pst-" + Guid.NewGuid().ToString("N") + ".pst");
+        File.WriteAllText(bogusPst, "this is not a PST file");
+        string outRoot = FreshOutDir();
+        string parent = Path.GetDirectoryName(outRoot)!;
+        try
+        {
+            Assert.ThrowsAny<Exception>(() => new PstExportRunner().Run(bogusPst, outRoot, includeEmpty: false));
+            Assert.False(Directory.Exists(outRoot));                                              // no output published
+            Assert.Empty(Directory.GetDirectories(parent, Path.GetFileName(outRoot) + ".partial-*")); // no staging created
+        }
+        finally { File.Delete(bogusPst); if (Directory.Exists(outRoot)) Directory.Delete(outRoot, true); }
+    }
+
     [Fact]
     public void Run_Success_PublishesOnlyFinalOutputRoot()
     {

--- a/tests/Mail2Pst.Integration.Tests/Reverse/PstExportRunnerTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/Reverse/PstExportRunnerTests.cs
@@ -334,4 +334,34 @@ public class PstExportRunnerTests
             if (Directory.Exists(outRoot)) Directory.Delete(outRoot, true);
         }
     }
+
+    [Fact]
+    public void Run_AcceptsOnSkipped_CleanPstProducesNoSkipCallbacks()
+    {
+        using GeneratedProfile profile = new ThunderbirdProfileBuilder()
+            .WithAccount("alice@example.com", "imap.example.com").WithFolder("Inbox", 2).Build();
+        var config = new ConversionConfig { Outputs = { new()
+        {
+            Name = "Archive", MaxSizeMB = 50_000, FolderMapping = FolderMappingMode.Mirror, IncludeEmptyFolders = true,
+            Sources = profile.Folders.Select(f => new SourceConfig { Type = "mbox", Path = f.FilePath }).ToList(),
+        }}};
+        var (outputs, convertDir) = ConvertProfile(config);
+        string pst = Assert.Single(outputs);
+
+        string outRoot = FreshOutDir();
+        try
+        {
+            var skips = new List<ExportSkip>();
+            var warns = new List<string>();
+            ExportReport report = new PstExportRunner().Run(
+                pst, outRoot, includeEmpty: false, onWarning: warns.Add, onSkipped: skips.Add);
+
+            Assert.Equal(2, report.MessagesExported);
+            Assert.Empty(skips);                  // no per-message read failures on a clean engine-written PST
+            Assert.Empty(warns);                  // ... and nothing leaked into the warning stream
+            Assert.Equal(0, report.SkippedCount); // the report agrees on both
+            Assert.Equal(0, report.WarningCount);
+        }
+        finally { Directory.Delete(convertDir, true); if (Directory.Exists(outRoot)) Directory.Delete(outRoot, true); }
+    }
 }

--- a/tests/Mail2Pst.Integration.Tests/Reverse/PstMailReaderTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/Reverse/PstMailReaderTests.cs
@@ -347,4 +347,27 @@ public class PstMailReaderTests
         }
         finally { File.Delete(pst); }
     }
+
+    [Fact]
+    public void EnumerateMessages_OnSkipped_CleanPst_RecordsNoSkips_StreamsAll()
+    {
+        using GeneratedProfile profile = new ThunderbirdProfileBuilder()
+            .WithAccount("alice@example.com", "imap.example.com")
+            .WithFolder("Inbox", messageCount: 2)
+            .Build();
+        var config = new ConversionConfig { Outputs = { new()
+        {
+            Name = "Archive", MaxSizeMB = 50_000, FolderMapping = FolderMappingMode.Mirror, IncludeEmptyFolders = false,
+            Sources = profile.Folders.Select(f => new SourceConfig { Type = "mbox", Path = f.FilePath }).ToList(),
+        }}};
+        var (outputs, dir) = ConvertProfile(config);
+        try
+        {
+            var skips = new List<ExportSkip>();
+            int count = PstMailReader.EnumerateMessages(Assert.Single(outputs), onWarning: null, onSkipped: skips.Add).Count();
+            Assert.Equal(2, count);
+            Assert.Empty(skips);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
 }

--- a/tests/Mail2Pst.Integration.Tests/Reverse/PstMailReaderTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/Reverse/PstMailReaderTests.cs
@@ -232,4 +232,43 @@ public class PstMailReaderTests
         }
         finally { Directory.Delete(dir, true); }
     }
+
+    // AttachmentWriter.Write sets PidTagAttachContentLocation whenever AttachmentSpec.ContentLocation is
+    // non-empty (AttachmentWriter.cs ~55); the reader must recover it so a later plan (MimeReconstructor)
+    // can restore Content-Location on the reassembled MIME part.
+    [Fact]
+    public void Read_MessageWithAttachmentContentLocation_RecoversContentLocation()
+    {
+        var msg = new MailMessage
+        {
+            MessageId = "<contentloc@test>",
+            Subject = "Message with attachment Content-Location",
+            Attachments = new List<MailAttachment>
+            {
+                new()
+                {
+                    FileName = "inline.png", MimeType = "image/png",
+                    Content = AttachmentContent.FromBytes(new byte[] { 1, 2, 3 }),
+                    ContentLocation = "https://example.com/inline.png",
+                },
+            },
+        };
+
+        string dir = Path.Combine(Path.GetTempPath(), "m2p-reverse-contentloc-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var plan = new PstOutputPlan { Name = "ContentLoc", MaxSizeBytes = 100L * 1024 * 1024, IncludeEmptyFolders = false };
+            PlannedMessage[] planned = [ new() { Message = msg, TargetFolderPath = new[] { "Inbox" } } ];
+            var writer = new PstWriter();
+            List<string> outputs = writer.WritePlan(plan, planned, dir, new ConversionReport());
+            string pst = Assert.Single(outputs);
+
+            PstMailItem item = Assert.Single(PstMailReader.EnumerateMessages(pst));
+            PstAttachment att = Assert.Single(item.Message.Attachments);
+
+            Assert.Equal("https://example.com/inline.png", att.ContentLocation);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
 }

--- a/tests/Mail2Pst.Integration.Tests/Reverse/PstMailReaderTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/Reverse/PstMailReaderTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Mail2Pst.Core.Config;
 using Mail2Pst.Core.Mapping;                   // PstOutputPlan (streaming test)
 using Mail2Pst.Core.Models;                    // MailMessage / MailAttachment / AttachmentContent (streaming test)
+using Mail2Pst.Core.OutlookCategories;         // StarCategory (category/flag recovery test)
 using Mail2Pst.Core.Reporting;                 // ConversionReport (streaming test)
 using Mail2Pst.Core.Reverse;
 using Mail2Pst.Core.Writing;                   // PstWriter / PlannedMessage (streaming test)
@@ -159,6 +160,43 @@ public class PstMailReaderTests
 
             Assert.NotNull(recovered);
             Assert.Equal(payload, recovered);   // exact byte-equality across the streamed encode/decode
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    // MailCategoryComposer.Compose appends the synthetic "Star" category (StarCategory.Name) when
+    // IsFlagged is true, alongside any real Thunderbird tags — so a flagged message's recovered
+    // Categories includes "Work" AND "Star". This also covers M2 (In-Reply-To / References recovery).
+    [Fact]
+    public void Read_MessageWithCategoriesFlagAndThreading_RecoversAll()
+    {
+        var msg = new MailMessage
+        {
+            MessageId = "<threaded@test>",
+            Subject = "Threaded, flagged, categorized message",
+            InReplyTo = "<parent@example.com>",
+            References = "<root@example.com> <parent@example.com>",
+            IsFlagged = true,
+            Categories = new List<string> { "Work" },
+        };
+
+        string dir = Path.Combine(Path.GetTempPath(), "m2p-reverse-cat-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var plan = new PstOutputPlan { Name = "Cat", MaxSizeBytes = 100L * 1024 * 1024, IncludeEmptyFolders = false };
+            PlannedMessage[] planned = [ new() { Message = msg, TargetFolderPath = new[] { "Inbox" } } ];
+            var writer = new PstWriter();
+            List<string> outputs = writer.WritePlan(plan, planned, dir, new ConversionReport());
+            string pst = Assert.Single(outputs);
+
+            PstMailItem item = Assert.Single(PstMailReader.EnumerateMessages(pst));
+            PstMailMessage m = item.Message;
+
+            Assert.Equal("<parent@example.com>", m.InReplyTo);
+            Assert.Equal("<root@example.com> <parent@example.com>", m.References);
+            Assert.Contains("Work", m.Categories);
+            Assert.Contains(StarCategory.Name, m.Categories);
         }
         finally { Directory.Delete(dir, true); }
     }

--- a/tests/Mail2Pst.Integration.Tests/Reverse/PstMailReaderTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/Reverse/PstMailReaderTests.cs
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mail2Pst.Core.Config;
+using Mail2Pst.Core.Mapping;                   // PstOutputPlan (streaming test)
+using Mail2Pst.Core.Models;                    // MailMessage / MailAttachment / AttachmentContent (streaming test)
+using Mail2Pst.Core.Reporting;                 // ConversionReport (streaming test)
+using Mail2Pst.Core.Reverse;
+using Mail2Pst.Core.Writing;                   // PstWriter / PlannedMessage (streaming test)
+using Mail2Pst.Integration.Tests;              // RoundTripHarness / RepoPaths live in the parent namespace
+using Mail2Pst.TestSupport;
+using Xunit;
+
+namespace Mail2Pst.Integration.Tests.Reverse;
+
+public class PstMailReaderTests
+{
+    private static (IReadOnlyList<string> outputs, string dir) ConvertProfile(ConversionConfig config)
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "m2p-reverse-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var (outputs, _) = RoundTripHarness.Convert(config, dir);
+        return (outputs, dir);
+    }
+
+    [Fact]
+    public void Read_EngineWrittenPst_RecoversKnownPayload()
+    {
+        using GeneratedProfile profile = new ThunderbirdProfileBuilder()
+            .WithAccount("alice@example.com", "imap.example.com")
+            .WithFolder("Inbox", messageCount: 2)
+            .WithFolder("Sent", messageCount: 1)
+            .Build();
+        var config = new ConversionConfig { Outputs = { new()
+        {
+            Name = "Archive", MaxSizeMB = 50_000, FolderMapping = FolderMappingMode.Mirror, IncludeEmptyFolders = true,
+            Sources = profile.Folders.Select(f => new SourceConfig { Type = "mbox", Path = f.FilePath }).ToList(),
+        }}};
+        var (outputs, dir) = ConvertProfile(config);
+        try
+        {
+            IReadOnlyList<PstMailFolder> folders = PstMailReader.ReadAllForTests(Assert.Single(outputs));
+            Dictionary<string, int> byLeaf = folders.ToDictionary(f => f.Path[^1], f => f.Messages.Count);
+            Assert.Equal(2, byLeaf["Inbox"]);
+            Assert.Equal(1, byLeaf["Sent"]);
+
+            // ThunderbirdProfileBuilder writes: Subject "Generated message N", From sender@example.com,
+            // To alice@example.com, Message-ID <gen-N@example.com>, body "Synthetic body N", a Date header.
+            PstMailMessage m = folders.First(f => f.Path[^1] == "Inbox").Messages[0];
+            Assert.StartsWith("Generated message", m.Subject);
+            Assert.Equal("sender@example.com", m.FromAddress);
+            Assert.Contains(m.Recipients, r => r.Address == "alice@example.com" && r.Kind == PstRecipientKind.To);
+            Assert.NotNull(m.Date);
+            Assert.StartsWith("<gen-", m.MessageId);
+            Assert.Contains("Synthetic body", m.PlainBody);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void Read_PstWithContactFolder_WarnsAndSkips_ButStillReturnsMailFolders()
+    {
+        string mbox = RepoPaths.ResolveAgainstRepoRoot(Path.Combine("fixtures", "sample.mbox"));
+        string abook = RepoPaths.ResolveAgainstRepoRoot(
+            Path.Combine("tests", "Mail2Pst.Core.Tests", "Contacts", "fixtures", "sample-abook.mab"));
+        var config = new ConversionConfig { Outputs = { new()
+        {
+            Name = "Archive", MaxSizeMB = 50_000, FolderMapping = FolderMappingMode.Mirror, IncludeEmptyFolders = false,
+            Sources = { new SourceConfig { Type = "mbox", Path = mbox } },
+            Contacts = { new ContactSourceConfig { Path = abook, Format = "thunderbird-mab" } },
+        }}};
+        var (outputs, dir) = ConvertProfile(config);
+        try
+        {
+            var warnings = new List<string>();
+            IReadOnlyList<PstMailFolder> folders = PstMailReader.ReadAllForTests(Assert.Single(outputs), warnings.Add);
+            Assert.Contains(warnings, w => w.Contains("not a mail folder"));   // contact folder skipped + warned
+            Assert.Contains(folders, f => f.Messages.Count > 0);               // mail folder still returned
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void Read_MboxWithAttachment_RecoversVisibleAttachmentPayload()
+    {
+        string mbox = RepoPaths.ResolveAgainstRepoRoot(Path.Combine("fixtures", "mbox-with-attachments.mbox"));
+        var config = new ConversionConfig { Outputs = { new()
+        {
+            Name = "Archive", MaxSizeMB = 50_000, FolderMapping = FolderMappingMode.Mirror, IncludeEmptyFolders = false,
+            Sources = { new SourceConfig { Type = "mbox", Path = mbox } },
+        }}};
+        var (outputs, dir) = ConvertProfile(config);
+        try
+        {
+            // Read attachment payload DURING enumeration (OpenRead is PST-bound).
+            bool sawVisibleAttachmentWithBytes = false;
+            foreach (PstMailItem item in PstMailReader.EnumerateMessages(Assert.Single(outputs)))
+                foreach (PstAttachment a in item.Message.Attachments)
+                    if (!a.IsInline)
+                    {
+                        using Stream s = a.OpenRead();
+                        Assert.False(string.IsNullOrEmpty(a.FileName));
+                        if (s.ReadByte() != -1) sawVisibleAttachmentWithBytes = true;
+                    }
+            Assert.True(sawVisibleAttachmentWithBytes, "expected at least one visible attachment with non-empty bytes");
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    // OpenRead reads PidTagAttachData via PropertyContext.GetBytesProperty, which dispatches through
+    // GetExternalRecordData -> GetExternalPropertyBytes. The forward AttachmentWriter has TWO write paths
+    // for that property: SetBytesProperty (small, heap-inline) and SetExternalProperty (large, subnode /
+    // XXBlock streaming). The tests above only exercise the small path; this one forces the streaming path
+    // (StreamingThresholdBytes = 1, a >XXBlock-boundary payload) and byte-compares the recovered bytes, so
+    // we prove OpenRead round-trips the streamed encoding too. Mirrors StreamingAttachmentAcceptanceTests.
+    [Fact]
+    public void Read_StreamedAttachment_RecoversPayloadBytes()
+    {
+        // 9 MB > the 8,347,696 B XXBlock boundary — exercises the full XXBlock streaming machinery.
+        const int size = 9_000_000;
+        byte[] payload = new byte[size];
+        for (int i = 0; i < size; i++) payload[i] = (byte)((i * 31 + 7) & 0xFF);
+
+        using AttachmentContent content = AttachmentContent.FromBytes(payload);
+        var msg = new MailMessage
+        {
+            MessageId = "<stream-readback@test>",
+            Subject = "Streaming attachment read-back",
+            Attachments = new List<MailAttachment>
+            {
+                new() { FileName = "large.bin", MimeType = "application/octet-stream", Content = content },
+            },
+        };
+
+        string dir = Path.Combine(Path.GetTempPath(), "m2p-reverse-stream-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var plan = new PstOutputPlan { Name = "Stream", MaxSizeBytes = 100L * 1024 * 1024, IncludeEmptyFolders = false };
+            PlannedMessage[] planned = [ new() { Message = msg, TargetFolderPath = new[] { "Inbox" } } ];
+            var writer = new PstWriter { StreamingThresholdBytes = 1 };   // force the SetExternalProperty path
+            List<string> outputs = writer.WritePlan(plan, planned, dir, new ConversionReport());
+            string pst = Assert.Single(outputs);
+
+            byte[]? recovered = null;
+            foreach (PstMailItem item in PstMailReader.EnumerateMessages(pst))
+                foreach (PstAttachment a in item.Message.Attachments)
+                    if (!a.IsInline)
+                    {
+                        using Stream s = a.OpenRead();
+                        using var ms = new MemoryStream();
+                        s.CopyTo(ms);
+                        recovered = ms.ToArray();
+                    }
+
+            Assert.NotNull(recovered);
+            Assert.Equal(payload, recovered);   // exact byte-equality across the streamed encode/decode
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+}

--- a/tests/Mail2Pst.Integration.Tests/Reverse/PstMailReaderTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/Reverse/PstMailReaderTests.cs
@@ -200,4 +200,36 @@ public class PstMailReaderTests
         }
         finally { Directory.Delete(dir, true); }
     }
+
+    // PstWriter.WriteMessage writes both SenderName/SentRepresentingName from message.From.Name when
+    // present (PstWriter.cs ~722); the reader must recover it via PidTagSentRepresentingName so a later
+    // plan can emit "From: Name <addr>".
+    [Fact]
+    public void Read_MessageWithFromDisplayName_RecoversFromNameAndAddress()
+    {
+        var msg = new MailMessage
+        {
+            MessageId = "<fromname@test>",
+            Subject = "Message with sender display name",
+            From = new Mail2Pst.Core.Models.MailAddress { Name = "John Doe", Email = "john@example.com" },
+        };
+
+        string dir = Path.Combine(Path.GetTempPath(), "m2p-reverse-fromname-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var plan = new PstOutputPlan { Name = "FromName", MaxSizeBytes = 100L * 1024 * 1024, IncludeEmptyFolders = false };
+            PlannedMessage[] planned = [ new() { Message = msg, TargetFolderPath = new[] { "Inbox" } } ];
+            var writer = new PstWriter();
+            List<string> outputs = writer.WritePlan(plan, planned, dir, new ConversionReport());
+            string pst = Assert.Single(outputs);
+
+            PstMailItem item = Assert.Single(PstMailReader.EnumerateMessages(pst));
+            PstMailMessage m = item.Message;
+
+            Assert.Equal("John Doe", m.FromName);
+            Assert.Equal("john@example.com", m.FromAddress);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
 }

--- a/tests/Mail2Pst.Integration.Tests/Reverse/PstMailReaderTests.cs
+++ b/tests/Mail2Pst.Integration.Tests/Reverse/PstMailReaderTests.cs
@@ -14,6 +14,7 @@ using Mail2Pst.Core.Reverse;
 using Mail2Pst.Core.Writing;                   // PstWriter / PlannedMessage (streaming test)
 using Mail2Pst.Integration.Tests;              // RoundTripHarness / RepoPaths live in the parent namespace
 using Mail2Pst.TestSupport;
+using PSTFileFormat;   // synthetic-PST construction for the non-mail-container recursion test
 using Xunit;
 
 namespace Mail2Pst.Integration.Tests.Reverse;
@@ -270,5 +271,80 @@ public class PstMailReaderTests
             Assert.Equal("https://example.com/inline.png", att.ContentLocation);
         }
         finally { Directory.Delete(dir, true); }
+    }
+
+    // EnumerateFolders is the structure authority for the export runner: it must include EMPTY mail
+    // folders (which EnumerateMessages never yields), so MboxTreeWriter can honor --include-empty and
+    // structural parents.
+    [Fact]
+    public void EnumerateFolders_IncludesEmptyFolders_ThatMessageStreamOmits()
+    {
+        using GeneratedProfile profile = new ThunderbirdProfileBuilder()
+            .WithAccount("alice@example.com", "imap.example.com")
+            .WithFolder("Inbox", messageCount: 2)
+            .WithFolder("Archive", messageCount: 0)   // empty leaf
+            .Build();
+        var config = new ConversionConfig { Outputs = { new()
+        {
+            Name = "Archive", MaxSizeMB = 50_000, FolderMapping = FolderMappingMode.Mirror, IncludeEmptyFolders = true,
+            Sources = profile.Folders.Select(f => new SourceConfig { Type = "mbox", Path = f.FilePath }).ToList(),
+        }}};
+        var (outputs, dir) = ConvertProfile(config);
+        try
+        {
+            string pst = Assert.Single(outputs);
+
+            var folderLeaves = PstMailReader.EnumerateFolders(pst).Select(p => p[^1]).ToList();
+            Assert.Contains("Inbox", folderLeaves);
+            Assert.Contains("Archive", folderLeaves);   // EMPTY folder IS present in the structure authority
+
+            var messageBearingLeaves = PstMailReader.EnumerateMessages(pst)
+                .Select(i => i.FolderPath[^1]).Distinct().ToList();
+            Assert.Contains("Inbox", messageBearingLeaves);
+            Assert.DoesNotContain("Archive", messageBearingLeaves);   // empty folder yields no items
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    // LOAD-BEARING for the folder-gap fix: EnumerateFolders must RECURSE THROUGH a non-mail container and
+    // return its mail descendants with their FULL path (and include an empty mail leaf), while NOT returning
+    // the non-mail container itself. The forward writer forces intermediate folders to mail (Note) type, so
+    // this tree is built directly with the vendored API (Begin/EndSavingChanges bracket per AssociatedMessageTests).
+    [Fact]
+    public void EnumerateFolders_RecursesThroughNonMailContainer_ReturnsMailDescendantsWithFullPath()
+    {
+        string pst = Path.Combine(Path.GetTempPath(), "m2p-synth-" + Guid.NewGuid().ToString("N") + ".pst");
+        PSTFile.CreateEmptyStore(pst);
+        var file = new PSTFile(pst, FileAccess.ReadWrite, WriterCompatibilityMode.Outlook2007RTM);
+        try
+        {
+            file.BeginSavingChanges();
+            PSTFolder top = file.TopOfPersonalFolders;
+            PSTFolder container = top.CreateChildFolder("Container", FolderItemTypeName.Contact);  // NON-mail parent
+            PSTFolder mail = container.CreateChildFolder("Mail", FolderItemTypeName.Note);          // mail child
+            Note note = Note.CreateNewNote(file, mail.NodeID);
+            note.Subject = "hello from a nested mail folder";
+            note.SaveChanges();
+            mail.AddMessage(note);
+            mail.SaveChanges();                                                    // flush the contents-table update
+            mail.CreateChildFolder("EmptyChild", FolderItemTypeName.Note);         // empty mail leaf
+            file.EndSavingChanges();
+        }
+        finally { file.CloseFile(); }
+
+        try
+        {
+            List<IReadOnlyList<string>> folders = PstMailReader.EnumerateFolders(pst).ToList();
+            var joined = folders.Select(p => string.Join("/", p)).ToList();
+
+            Assert.Contains("Container/Mail", joined);            // mail descendant, FULL path through the non-mail parent
+            Assert.Contains("Container/Mail/EmptyChild", joined); // empty mail leaf included
+            Assert.DoesNotContain("Container", joined);           // the non-mail container itself is NOT a mail folder
+
+            // The message under the non-mail parent still streams with its full path.
+            PstMailItem item = Assert.Single(PstMailReader.EnumerateMessages(pst));
+            Assert.Equal(new[] { "Container", "Mail" }, item.FolderPath);
+        }
+        finally { File.Delete(pst); }
     }
 }

--- a/vendor/PSTFileFormat/ListsTablesAndProperties/Enums/PropertyID.cs
+++ b/vendor/PSTFileFormat/ListsTablesAndProperties/Enums/PropertyID.cs
@@ -32,6 +32,7 @@ namespace PSTFileFormat
         PidTagSentRepresentingEmailAddress = 0x0065, // String
         PidTagConversationTopic = 0x0070,         // String
         PidTagConversationIndex = 0x0071,         // Binary
+        PidTagTransportMessageHeaders = 0x007D,   // String
         PidTagRecipientType = 0x0C15,             // Int32
         PidTagReplyRequested = 0x0C17,            // Boolean
         PidTagSenderEntryId = 0x0C19,             // Binary

--- a/vendor/PSTFileFormat/ListsTablesAndProperties/Enums/PropertyID.cs
+++ b/vendor/PSTFileFormat/ListsTablesAndProperties/Enums/PropertyID.cs
@@ -69,6 +69,8 @@ namespace PSTFileFormat
         PidTagHtml = 0x1013,                      // Binary
         PidTagNativeBody = 0x1016,                // Int32 (1 = Plain Text, 2 = RTF, 3 = HTML)
         PidTagInternetMessageId = 0x1035,         // String
+        PidTagInternetReferences = 0x1039,        // String
+        PidTagInReplyToId = 0x1042,               // String
         PidTagIconIndex = 0x1080,                 // Int32
         PidTagLastVerbExecuted = 0x1081,          // Int32
         PidTagLastVerbExecutionTime = 0x1082,     // DateTime


### PR DESCRIPTION
## What

Adds a reverse conversion path: turn an Outlook PST into a Thunderbird-importable
mbox folder tree, without Outlook or any Microsoft library. This complements the
existing forward mbox → PST converter, making ContinuMail a two-way bridge for mail.

New CLI subcommand:

    continumail-convert export --input <path.pst> --output <dir> [--include-empty]

It reads the PST, reconstructs each message as MIME, and writes an mbox tree
(`Name.sbd/` nesting mirroring the folder hierarchy) with Thunderbird's
`X-Mozilla-Status` / `-Status2` / `-Keys` headers so Thunderbird regenerates its
own index on import.

## How it works

- **Streaming reader** — walks the PST one message at a time (a large store is never
  fully materialized); recovers subject, sender (name + address), recipients with
  To/Cc/Bcc kind, dates, Message-ID/In-Reply-To/References, plain and HTML bodies
  (with the stored code page), read/replied/forwarded state, categories, and
  attachments (including inline Content-ID and Content-Location).
- **Header mapping** — flags and categories become `X-Mozilla-Status`/`-Status2` bits
  and `X-Mozilla-Keys` tags (the inverse of how the forward parser reads them). The
  "flagged" state maps to the Marked bit.
- **MIME reconstruction** — rebuilds a MimeKit message from the decoded properties,
  regenerating MIME-structural headers from the fresh body/attachment tree; legacy
  code pages decode via the CodePages provider with a UTF-8 fallback.
- **Mbox tree writer** — writes the `.sbd` layout with mboxrd `From ` escaping and the
  raw `X-Mozilla-*` header lines.
- **Export runner** — orchestrates the pipeline, writes into a staging directory and
  publishes on success (an existing non-empty destination is rejected; a failure
  cleans up without leaving a half-written tree), and produces an export report
  (messages exported, folders, structured skips, warnings, output files).
- **CLI events** — streams JSON Lines (`started`/`progress`/`warning`/`skipped`/`done`/
  `error`), each tagged with `command: "export"`; the report is written to sibling
  `<output>.export-report.json` / `.txt` files.

## Vendored code

`vendor/PSTFileFormat` (LGPLv3) gains three additive `PropertyID` enum members
(`PidTagTransportMessageHeaders`, `PidTagInternetReferences`, `PidTagInReplyToId`) —
read-only additions, no behaviour change.

## Testing

Full solution green. Round-trip coverage proves that a forward-written PST exports
back to an mbox tree preserving folder structure, per-folder counts, message bodies,
attachment bytes, and read/starred/tagged state. A manual Thunderbird-import check
remains a release-time validation step.

## Known limitations / follow-ups

- Thunderbird **tag definitions** are not created — tags are written as `X-Mozilla-Keys`
  values, but the visible tag name/colour depends on the importing profile's tag
  configuration, so a tag key may not render as a coloured label in a fresh profile.
- A message that has no Message-ID at all currently gets a non-deterministic generated
  one (only reachable with arbitrary Outlook-authored PSTs).
- Message importance/priority is not yet reconstructed.
