### PR TITLE
fix(desktop): discover and preview Thunderbird folder trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Desktop: selecting a Thunderbird folder export now discovers extensionless mbox files and nested
   `.sbd` folders.** Previously **Select folder** checked only immediate `*.mbox` files, so an
   ImportExportTools NG export could be reported as empty and its subfolder hierarchy was ignored.
-  Folder selection now uses the same content-sniffing discovery pipeline as profile conversion and
+  Folder selection now remains on the `.mbox files` source view, previews the discovered hierarchy
+  before scanning, uses the same content-sniffing discovery pipeline as profile conversion, and
   preserves the discovered tree in the PST.
 - **A corrupt, truncated, or pathologically deep-nested Thunderbird `.mab` (Mork) address book is
   now recorded as a skipped contact instead of aborting the whole conversion.** Previously a Mork

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   replacing them.
 
 ### Fixed
+- **Desktop: selecting a Thunderbird folder export now discovers extensionless mbox files and nested
+  `.sbd` folders.** Previously **Select folder** checked only immediate `*.mbox` files, so an
+  ImportExportTools NG export could be reported as empty and its subfolder hierarchy was ignored.
+  Folder selection now uses the same content-sniffing discovery pipeline as profile conversion and
+  preserves the discovered tree in the PST.
 - **A corrupt, truncated, or pathologically deep-nested Thunderbird `.mab` (Mork) address book is
   now recorded as a skipped contact instead of aborting the whole conversion.** Previously a Mork
   parse failure propagated out of the address-book reader and stopped the run (discarding all other

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -197,26 +197,6 @@ struct FileStat {
 }
 
 #[tauri::command]
-fn list_mbox_in_dir(dir: String) -> Result<Vec<String>, String> {
-    let entries = std::fs::read_dir(&dir).map_err(|e| format!("cannot read folder: {e}"))?;
-    let mut paths: Vec<String> = Vec::new();
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_file()
-            && path
-                .extension()
-                .and_then(|e| e.to_str())
-                .map(|e| e.eq_ignore_ascii_case("mbox"))
-                .unwrap_or(false)
-        {
-            paths.push(path.to_string_lossy().to_string());
-        }
-    }
-    paths.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
-    Ok(paths)
-}
-
-#[tauri::command]
 fn stat_files(paths: Vec<String>) -> Vec<FileStat> {
     paths
         .into_iter()
@@ -677,7 +657,6 @@ pub fn run() {
             check_engine_version,
             scan_sample,
             discover_profile,
-            list_mbox_in_dir,
             stat_files,
             start_convert,
             start_scan,

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -92,6 +92,7 @@ export default function App() {
           onOutputTargetChange={flow.setOutputTarget}
           onInputModeChange={flow.setInputMode}
           onProfileRootChange={flow.setProfileRoot}
+          onAutomaticProfileRootChange={flow.setAutomaticProfileRoot}
           onContinue={flow.continueToScan}
         />
       )}

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -19,6 +19,7 @@ import { CancelledView } from "@/components/views/CancelledView";
 import { useConvert } from "@/lib/useConvert";
 import { useScan } from "@/lib/useScan";
 import { buildSteps, stepIndexForStage, stepIndexForPhase } from "@/lib/steps";
+import { isDiscoveryBackedMode } from "@/lib/inputMode";
 
 export default function App() {
   const { state: conv, start, reset } = useConvert();
@@ -67,7 +68,7 @@ export default function App() {
   // (guarded), step 1 → Accounts (multi) or Review (single), step 2 → Review
   // (multi only). Not offered during scanning/scanError (transient) so the stepper
   // can't bail an in-flight scan.
-  const isMultiAccount = flow.discoveredAccountCount >= 2 && f.inputMode === "profile";
+  const isMultiAccount = flow.discoveredAccountCount >= 2 && isDiscoveryBackedMode(f.inputMode);
   const onStepSelect =
     f.stage === "accounts" || f.stage === "review" || f.stage === "options"
       ? (step: number) => {
@@ -87,17 +88,20 @@ export default function App() {
           outputTarget={f.outputTarget}
           inputMode={f.inputMode}
           profileRoot={f.profileRoot}
+          folderTreeDiscovery={f.folderTreeDiscovery}
+          folderTreeDiscovering={f.folderTreeDiscovering}
           sourceError={f.sourceError}
           onFilesChange={flow.setInputFiles}
           onOutputTargetChange={flow.setOutputTarget}
           onInputModeChange={flow.setInputMode}
           onProfileRootChange={flow.setProfileRoot}
+          onFolderTreeRootChange={flow.setFolderTreeRoot}
           onAutomaticProfileRootChange={flow.setAutomaticProfileRoot}
           onContinue={flow.continueToScan}
         />
       )}
       {f.stage === "scanning" && <ScanningView fileCount={f.scanFileCount} progress={f.scanProgress} />}
-      {f.stage === "accounts" && f.inputMode === "profile" && (
+      {f.stage === "accounts" && isDiscoveryBackedMode(f.inputMode) && (
         <AccountsView
           rows={f.profileRows}
           accounts={f.accounts}
@@ -123,12 +127,12 @@ export default function App() {
           onSkipEmptyChange={flow.setSkipEmpty}
           onContinue={flow.continueToOptions}
           onBack={isMultiAccount ? flow.backToAccounts : requestGoToSource}
-          pairedIds={f.inputMode === "profile" ? flow.pairedIds : undefined}
-          warnings={f.inputMode === "profile" ? f.discoverWarnings : undefined}
+          pairedIds={isDiscoveryBackedMode(f.inputMode) ? flow.pairedIds : undefined}
+          warnings={isDiscoveryBackedMode(f.inputMode) ? f.discoverWarnings : undefined}
         />
       )}
       {f.stage === "options" && (
-        f.inputMode === "profile" && f.profileRoot ? (
+        isDiscoveryBackedMode(f.inputMode) && f.profileRoot ? (
           <ProfileOptionsView
             rows={flow.sortedSources as ProfileSourceRow[]}
             outputTarget={f.outputTarget}

--- a/desktop/src/components/views/ProfileOptionsView.tsx
+++ b/desktop/src/components/views/ProfileOptionsView.tsx
@@ -160,7 +160,7 @@ export function ProfileOptionsView({
             <label className="flex items-center gap-2 text-sm text-foreground">
               <input type="radio" name="mapping" checked={options.folderMapping === "mirror"}
                 onChange={() => onSetOptions({ folderMapping: "mirror" })} />
-              Mirror the Thunderbird tree
+              Mirror the discovered folder tree
             </label>
             <label className="mt-1 flex items-center gap-2 text-sm text-foreground">
               <input type="radio" name="mapping" checked={options.folderMapping === "flatten"}

--- a/desktop/src/components/views/SelectView.tsx
+++ b/desktop/src/components/views/SelectView.tsx
@@ -10,26 +10,31 @@ import { visibleProfiles, hiddenNote, profileAccountLabels, profileSubtext, pick
 import { splitPath } from "@/lib/convert";
 import { formatBytes } from "@/lib/format";
 import { canScan } from "@/lib/outputTarget";
-import type { FileStat, ProfileEntry, OutputTarget } from "@/lib/types";
+import { fileTabClickMode, isFilesTabMode, isProfileTabMode } from "@/lib/inputMode";
+import type { InputMode } from "@/lib/inputMode";
+import type { DiscoverResult, FileStat, ProfileEntry, OutputTarget } from "@/lib/types";
 
 interface SelectViewProps {
   files: FileStat[];
   outputTarget: OutputTarget | null;
-  inputMode: "files" | "profile";
+  inputMode: InputMode;
   profileRoot: string | null;
+  folderTreeDiscovery: DiscoverResult | null;
+  folderTreeDiscovering: boolean;
   sourceError?: string | null;
   onFilesChange: (files: FileStat[]) => void;
   onOutputTargetChange: (target: OutputTarget | null) => void;
-  onInputModeChange: (m: "files" | "profile") => void;
+  onInputModeChange: (m: InputMode) => void;
   onProfileRootChange: (path: string | null) => void;
+  onFolderTreeRootChange: (path: string) => void;
   onAutomaticProfileRootChange: (path: string) => void;
   onContinue: () => void;
 }
 
 export function SelectView({
-  files, outputTarget, inputMode, profileRoot, sourceError,
+  files, outputTarget, inputMode, profileRoot, folderTreeDiscovery, folderTreeDiscovering, sourceError,
   onFilesChange, onOutputTargetChange, onInputModeChange, onProfileRootChange,
-  onAutomaticProfileRootChange, onContinue,
+  onFolderTreeRootChange, onAutomaticProfileRootChange, onContinue,
 }: SelectViewProps) {
   // Picker errors are transient and screen-local. Discovery errors are owned by
   // the parent flow and returned through sourceError.
@@ -72,7 +77,7 @@ export function SelectView({
     const dir = await pickFolder();
     if (!dir) return;
     setPickerError(null);
-    onProfileRootChange(dir);
+    onFolderTreeRootChange(dir);
   }
 
   async function onChooseProfile() {
@@ -97,9 +102,14 @@ export function SelectView({
     onOutputTargetChange(null);
   }
 
+  function onFilesTabClick() {
+    const nextMode = fileTabClickMode(inputMode);
+    if (nextMode !== inputMode) onInputModeChange(nextMode);
+  }
+
   const totalBytes = files.reduce((sum, f) => sum + f.size, 0);
   const outputPath = outputTarget?.kind === "pstFile" ? outputTarget.path : null;
-  const canContinue = canScan(inputMode, files.map((f) => f.path), profileRoot, outputTarget);
+  const canContinue = canScan(inputMode, files.map((f) => f.path), profileRoot, outputTarget, folderTreeDiscovery, folderTreeDiscovering);
 
   // For the "manual path shown when not a scanned profile" check.
   const scannedEntries = scan.k === "done" ? scan.entries : [];
@@ -114,23 +124,23 @@ export function SelectView({
       <div className="mt-4 inline-flex overflow-hidden rounded-md border border-border">
         <button
           type="button"
-          aria-pressed={inputMode === "profile"}
+          aria-pressed={isProfileTabMode(inputMode)}
           onClick={() => onInputModeChange("profile")}
-          className={"px-4 py-1.5 text-sm " + (inputMode === "profile" ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-muted")}
+          className={"px-4 py-1.5 text-sm " + (isProfileTabMode(inputMode) ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-muted")}
         >
           Thunderbird folder / profile
         </button>
         <button
           type="button"
-          aria-pressed={inputMode === "files"}
-          onClick={() => onInputModeChange("files")}
-          className={"px-4 py-1.5 text-sm " + (inputMode === "files" ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-muted")}
+          aria-pressed={isFilesTabMode(inputMode)}
+          onClick={onFilesTabClick}
+          className={"px-4 py-1.5 text-sm " + (isFilesTabMode(inputMode) ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-muted")}
         >
           .mbox files
         </button>
       </div>
 
-      {inputMode === "profile" && (
+      {isProfileTabMode(inputMode) && (
         <div className="mt-4">
           {scan.k === "scanning" && (
             <div className="mb-3 flex items-center gap-2 text-sm text-muted-foreground">
@@ -228,7 +238,7 @@ export function SelectView({
         </div>
       )}
 
-      {inputMode === "files" && (
+      {isFilesTabMode(inputMode) && (
         <>
           <div className="mt-4 flex gap-3">
             <Button onClick={onChooseFiles}>
@@ -239,7 +249,60 @@ export function SelectView({
             </Button>
           </div>
 
-          {files.length > 0 && (
+          {inputMode === "folderTree" && profileRoot && (
+            <div className="mt-4 rounded-lg border border-border bg-card p-3">
+              <div className="text-sm font-medium text-foreground">Selected folder tree</div>
+              <div className="mt-1 break-all text-xs text-light-gray" title={profileRoot}>{profileRoot}</div>
+              <div className="mt-3" role="status" aria-live="polite">
+                {folderTreeDiscovering && (
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <Spinner size="sm" /> Discovering mail folders…
+                  </div>
+                )}
+                {!folderTreeDiscovering && folderTreeDiscovery && folderTreeDiscovery.sources.length > 0 && (
+                  <div className="text-sm font-medium text-foreground">
+                    {folderTreeDiscovery.sources.length} mail folder{folderTreeDiscovery.sources.length === 1 ? "" : "s"} found
+                  </div>
+                )}
+                {sourceError && (
+                  <p className="mt-3 text-sm text-destructive">{sourceError}</p>
+                )}
+              </div>
+              {!folderTreeDiscovering && folderTreeDiscovery && folderTreeDiscovery.sources.length > 0 && (
+                <>
+                  <div className="mt-2 flex max-h-40 flex-col gap-1 overflow-auto">
+                    {folderTreeDiscovery.sources.map((source) => (
+                      <div key={source.path} className="rounded border border-border bg-background px-2 py-1 text-sm text-foreground">
+                        {source.targetFolderPath.join(" / ")}
+                      </div>
+                    ))}
+                  </div>
+                  {(folderTreeDiscovery.warnings.length > 0 || folderTreeDiscovery.skipped.length > 0) && (
+                    <div className="mt-2 text-xs text-light-gray">
+                      {folderTreeDiscovery.warnings.length > 0 && `${folderTreeDiscovery.warnings.length} warning${folderTreeDiscovery.warnings.length === 1 ? "" : "s"}`}
+                      {folderTreeDiscovery.warnings.length > 0 && folderTreeDiscovery.skipped.length > 0 && " · "}
+                      {folderTreeDiscovery.skipped.length > 0 && `${folderTreeDiscovery.skipped.length} item${folderTreeDiscovery.skipped.length === 1 ? "" : "s"} skipped`}
+                    </div>
+                  )}
+                  {folderTreeDiscovery.skipped.length > 0 && (
+                    <details className="mt-2 text-xs text-light-gray">
+                      <summary className="cursor-pointer">Show skipped folder details</summary>
+                      <dl className="mt-1 max-h-28 space-y-1 overflow-auto">
+                        {folderTreeDiscovery.skipped.map((skipped) => (
+                          <div key={`${skipped.path}:${skipped.code}`}>
+                            <dt className="break-all text-foreground">{skipped.path}</dt>
+                            <dd>{skipped.reason}</dd>
+                          </div>
+                        ))}
+                      </dl>
+                    </details>
+                  )}
+                </>
+              )}
+            </div>
+          )}
+
+          {inputMode === "files" && files.length > 0 && (
             <div className="mt-4">
               <div className="text-xs text-light-gray">
                 {files.length} mbox file{files.length === 1 ? "" : "s"} · {formatBytes(totalBytes)}
@@ -269,7 +332,7 @@ export function SelectView({
         </>
       )}
 
-      {inputMode === "files" && (
+      {isFilesTabMode(inputMode) && (
         <div className="mt-5">
           <div className="mb-1 text-sm font-medium text-foreground">Output location and PST name</div>
           <div className="flex items-center gap-2">
@@ -292,7 +355,7 @@ export function SelectView({
         </div>
       )}
 
-      {(pickerError || sourceError) && (
+      {(pickerError || (sourceError && inputMode !== "folderTree")) && (
         <p className="mt-4 text-sm text-destructive">{pickerError ?? sourceError}</p>
       )}
 

--- a/desktop/src/components/views/SelectView.tsx
+++ b/desktop/src/components/views/SelectView.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { FileText, FolderOpen, Save, Search, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
-import { pickMboxFiles, pickFolder, listMboxInDir, statFiles, pickOutputPst, listThunderbirdProfiles } from "@/lib/engine";
+import { pickMboxFiles, pickFolder, statFiles, pickOutputPst, listThunderbirdProfiles } from "@/lib/engine";
 import { visibleProfiles, hiddenNote, profileAccountLabels, profileSubtext, pickDefaultProfile } from "@/lib/profiles";
 import { splitPath } from "@/lib/convert";
 import { formatBytes } from "@/lib/format";
@@ -29,8 +29,8 @@ export function SelectView({
   files, outputTarget, inputMode, profileRoot, sourceError,
   onFilesChange, onOutputTargetChange, onInputModeChange, onProfileRootChange, onContinue,
 }: SelectViewProps) {
-  // Picker errors are transient and screen-local (e.g. "no .mbox in folder").
-  // Parent owns the durable file/output state; this does NOT belong there.
+  // Picker errors are transient and screen-local. Discovery errors are owned by
+  // the parent flow and returned through sourceError.
   const [pickerError, setPickerError] = useState<string | null>(null);
 
   const [scan, setScan] = useState<
@@ -70,12 +70,7 @@ export function SelectView({
     const dir = await pickFolder();
     if (!dir) return;
     setPickerError(null);
-    const found = await listMboxInDir(dir);
-    if (found.length === 0) {
-      setPickerError("No .mbox files found in that folder.");
-      return;
-    }
-    await addFiles(found);
+    onProfileRootChange(dir);
   }
 
   async function onChooseProfile() {
@@ -111,7 +106,7 @@ export function SelectView({
     <div className="flex flex-1 flex-col">
       <h1 className="text-xl font-semibold text-foreground">Choose what to convert</h1>
       <p className="mt-1 text-sm text-muted-foreground">
-        Select a Thunderbird profile or pick individual <code>.mbox</code> files.
+        Select a Thunderbird folder/profile or pick individual <code>.mbox</code> files.
       </p>
 
       <div className="mt-4 inline-flex overflow-hidden rounded-md border border-border">
@@ -121,7 +116,7 @@ export function SelectView({
           onClick={() => onInputModeChange("profile")}
           className={"px-4 py-1.5 text-sm " + (inputMode === "profile" ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-muted")}
         >
-          Thunderbird profile
+          Thunderbird folder / profile
         </button>
         <button
           type="button"
@@ -226,7 +221,7 @@ export function SelectView({
             <div className="mt-1 text-xs text-light-gray">{profileRoot}</div>
           )}
           <p className="mt-2 text-xs text-light-gray">
-            Point at a Thunderbird profile, a Mail/ImapMail store, or a single account folder. Nested folders and tags/flags are detected automatically.
+            Point at a Thunderbird profile, Mail/ImapMail store, account folder, or an ImportExportTools NG folder export. Extensionless mbox files, nested .sbd folders, and available tags/flags are detected automatically.
           </p>
         </div>
       )}
@@ -238,7 +233,7 @@ export function SelectView({
               <FileText /> Choose .mbox files…
             </Button>
             <Button variant="outline" onClick={onChooseFolder}>
-              <FolderOpen /> Select folder…
+              <FolderOpen /> Select folder tree…
             </Button>
           </div>
 

--- a/desktop/src/components/views/SelectView.tsx
+++ b/desktop/src/components/views/SelectView.tsx
@@ -22,12 +22,14 @@ interface SelectViewProps {
   onOutputTargetChange: (target: OutputTarget | null) => void;
   onInputModeChange: (m: "files" | "profile") => void;
   onProfileRootChange: (path: string | null) => void;
+  onAutomaticProfileRootChange: (path: string) => void;
   onContinue: () => void;
 }
 
 export function SelectView({
   files, outputTarget, inputMode, profileRoot, sourceError,
-  onFilesChange, onOutputTargetChange, onInputModeChange, onProfileRootChange, onContinue,
+  onFilesChange, onOutputTargetChange, onInputModeChange, onProfileRootChange,
+  onAutomaticProfileRootChange, onContinue,
 }: SelectViewProps) {
   // Picker errors are transient and screen-local. Discovery errors are owned by
   // the parent flow and returned through sourceError.
@@ -46,7 +48,7 @@ export function SelectView({
       const entries = await listThunderbirdProfiles();
       setScan({ k: "done", entries });
       const pick = pickDefaultProfile(entries, profileRoot);
-      if (pick) onProfileRootChange(pick);
+      if (pick) onAutomaticProfileRootChange(pick);
     } catch {
       setScan({ k: "error" });
     }

--- a/desktop/src/lib/engine.test.ts
+++ b/desktop/src/lib/engine.test.ts
@@ -10,7 +10,7 @@ vi.mock("@tauri-apps/api/event", () => ({ listen: vi.fn() }));
 vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn(), save: vi.fn() }));
 
 import { invoke } from "@tauri-apps/api/core";
-import { buildStartConvertPayload, startConvert } from "./engine";
+import { buildStartConvertPayload, discoverProfile, startConvert } from "./engine";
 import type { ConversionConfig } from "./types";
 
 const config = { outputs: [] } as unknown as ConversionConfig;
@@ -43,5 +43,56 @@ describe("startConvert", () => {
     invokeMock.mockResolvedValueOnce(undefined);
     await startConvert(config, "C:/out");
     expect(invokeMock).toHaveBeenCalledWith("start_convert", { config, outputDir: "C:/out" });
+  });
+});
+
+describe("discoverProfile", () => {
+  beforeEach(() => invokeMock.mockReset());
+
+  it("invokes Core discovery and returns nested extensionless mbox paths", async () => {
+    invokeMock.mockResolvedValueOnce(JSON.stringify({
+      type: "discovery",
+      schemaVersion: 1,
+      root: "C:/fixtures/tb-export",
+      layout: "thunderbird",
+      sources: [
+        {
+          path: "C:/fixtures/tb-export/Inbox",
+          type: "mbox",
+          targetFolderPath: ["Inbox"],
+          displayName: "Inbox",
+          sourceBytes: 100,
+          msfPath: null,
+          accountId: null,
+        },
+        {
+          path: "C:/fixtures/tb-export/Inbox.sbd/Archive.sbd/2022",
+          type: "mbox",
+          targetFolderPath: ["Inbox", "Archive", "2022"],
+          displayName: "2022",
+          sourceBytes: 50,
+          msfPath: null,
+          accountId: null,
+        },
+      ],
+      accounts: [],
+      warnings: [],
+      skipped: [],
+      pairing: { pairedMsfCount: 0, unpairedMboxCount: 2, orphanMsfCount: 0 },
+      calendars: [],
+      addressBooks: [],
+    }));
+
+    const result = await discoverProfile("C:/fixtures/tb-export");
+
+    expect(invokeMock).toHaveBeenCalledWith("discover_profile", { dir: "C:/fixtures/tb-export" });
+    expect(result.sources.map((source) => source.path)).toEqual([
+      "C:/fixtures/tb-export/Inbox",
+      "C:/fixtures/tb-export/Inbox.sbd/Archive.sbd/2022",
+    ]);
+    expect(result.sources.map((source) => source.targetFolderPath)).toEqual([
+      ["Inbox"],
+      ["Inbox", "Archive", "2022"],
+    ]);
   });
 });

--- a/desktop/src/lib/engine.ts
+++ b/desktop/src/lib/engine.ts
@@ -126,10 +126,6 @@ export async function pickFolder(): Promise<string | null> {
   return typeof result === "string" ? result : null;
 }
 
-export function listMboxInDir(dir: string): Promise<string[]> {
-  return invoke<string[]>("list_mbox_in_dir", { dir });
-}
-
 export function statFiles(paths: string[]): Promise<FileStat[]> {
   return invoke<FileStat[]>("stat_files", { paths });
 }

--- a/desktop/src/lib/inputMode.test.ts
+++ b/desktop/src/lib/inputMode.test.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { fileTabClickMode, isDiscoveryBackedMode, isFilesTabMode, isProfileTabMode } from "./inputMode";
+
+describe("input-mode predicates", () => {
+  it("keeps folder trees on the files tab while treating them as discovery-backed", () => {
+    expect(isFilesTabMode("folderTree")).toBe(true);
+    expect(isProfileTabMode("folderTree")).toBe(false);
+    expect(isDiscoveryBackedMode("folderTree")).toBe(true);
+  });
+
+  it("keeps installed profiles as the only profile-tab mode", () => {
+    expect(isProfileTabMode("profile")).toBe(true);
+    expect(isFilesTabMode("profile")).toBe(false);
+    expect(isDiscoveryBackedMode("profile")).toBe(true);
+    expect(isDiscoveryBackedMode("files")).toBe(false);
+  });
+
+  it("does not silently leave folder-tree mode when the highlighted files tab is clicked", () => {
+    expect(fileTabClickMode("profile")).toBe("files");
+    expect(fileTabClickMode("files")).toBe("files");
+    expect(fileTabClickMode("folderTree")).toBe("folderTree");
+  });
+});

--- a/desktop/src/lib/inputMode.ts
+++ b/desktop/src/lib/inputMode.ts
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/** The source selection paths supported by the desktop flow. */
+export type InputMode = "files" | "profile" | "folderTree";
+
+export function isDiscoveryBackedMode(mode: InputMode): boolean {
+  return mode === "profile" || mode === "folderTree";
+}
+
+export function isProfileTabMode(mode: InputMode): boolean {
+  return mode === "profile";
+}
+
+export function isFilesTabMode(mode: InputMode): boolean {
+  return mode === "files" || mode === "folderTree";
+}
+
+/** The highlighted file tab represents both ordinary files and a folder tree. */
+export function fileTabClickMode(mode: InputMode): InputMode {
+  return mode === "profile" ? "files" : mode;
+}

--- a/desktop/src/lib/outputTarget.test.ts
+++ b/desktop/src/lib/outputTarget.test.ts
@@ -14,4 +14,11 @@ describe("canScan", () => {
     expect(canScan("profile", [], "/p", null)).toBe(true);
     expect(canScan("profile", [], null, null)).toBe(false);
   });
+  it("folder-tree mode requires a completed nonempty discovery and a pstFile target", () => {
+    const discovered = { sources: [{ path: "C:/export/Inbox", targetFolderPath: ["Inbox"] }] };
+    expect(canScan("folderTree", [], "C:/export", { kind: "pstFile", path: "C:/out/Mail.pst" }, discovered, false)).toBe(true);
+    expect(canScan("folderTree", [], "C:/export", { kind: "pstFile", path: "C:/out/Mail.pst" }, discovered, true)).toBe(false);
+    expect(canScan("folderTree", [], "C:/export", { kind: "pstFile", path: "C:/out/Mail.pst" }, { sources: [] }, false)).toBe(false);
+    expect(canScan("folderTree", [], "C:/export", null, discovered, false)).toBe(false);
+  });
 });

--- a/desktop/src/lib/outputTarget.ts
+++ b/desktop/src/lib/outputTarget.ts
@@ -2,13 +2,19 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import type { OutputTarget } from "./types";
+import type { InputMode } from "./inputMode";
 
 export function canScan(
-  inputMode: "files" | "profile",
+  inputMode: InputMode,
   files: string[],
   profileRoot: string | null,
   outputTarget: OutputTarget | null,
+  folderTreeDiscovery: { sources: unknown[] } | null = null,
+  folderTreeDiscovering = false,
 ): boolean {
   if (inputMode === "profile") return profileRoot !== null; // output chosen after discovery
+  if (inputMode === "folderTree") {
+    return profileRoot !== null && !folderTreeDiscovering && (folderTreeDiscovery?.sources.length ?? 0) > 0 && outputTarget?.kind === "pstFile";
+  }
   return files.length > 0 && outputTarget?.kind === "pstFile";
 }

--- a/desktop/src/lib/profileConfig.test.ts
+++ b/desktop/src/lib/profileConfig.test.ts
@@ -129,6 +129,44 @@ describe("buildProfileConfig", () => {
       expect(config.dropExpunged).toBe(true);
     }
   });
+
+  it("mirror: preserves an accountless exported Thunderbird folder tree", () => {
+    const exportedRows: ProfileSourceRow[] = [
+      {
+        ...rows[0],
+        id: "C:/fixtures/tb-export/Inbox",
+        path: "C:/fixtures/tb-export/Inbox",
+        displayName: "Inbox",
+        targetFolderPath: ["Inbox"],
+        msfPath: null,
+        accountId: null,
+      },
+      {
+        ...rows[1],
+        id: "C:/fixtures/tb-export/Inbox.sbd/Archive.sbd/2022",
+        path: "C:/fixtures/tb-export/Inbox.sbd/Archive.sbd/2022",
+        displayName: "Inbox / Archive / 2022",
+        targetFolderPath: ["Inbox", "Archive", "2022"],
+        msfPath: null,
+        accountId: null,
+      },
+    ];
+    const selected = new Set(exportedRows.map((row) => row.id));
+
+    const { config } = buildProfileConfig(
+      exportedRows,
+      selected,
+      false,
+      opts({ folderMapping: "mirror" }),
+      "C:/out/Export.pst",
+      "C:/fixtures/tb-export",
+    );
+
+    expect(config.outputs[0].sources.map((source) => source.targetFolderPath)).toEqual([
+      ["Inbox"],
+      ["Inbox", "Archive", "2022"],
+    ]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/desktop/src/lib/steps.test.ts
+++ b/desktop/src/lib/steps.test.ts
@@ -14,6 +14,9 @@ describe("buildSteps", () => {
   it("profile multi-account inserts Accounts after Source", () => {
     expect(buildSteps("profile", 3)).toEqual(["Source", "Accounts", "Review", "Options", "Convert", "Done"]);
   });
+  it("folder-tree mode is discovery-backed for account routing", () => {
+    expect(buildSteps("folderTree", 3)).toEqual(["Source", "Accounts", "Review", "Options", "Convert", "Done"]);
+  });
 });
 
 describe("stepIndexForStage", () => {

--- a/desktop/src/lib/steps.ts
+++ b/desktop/src/lib/steps.ts
@@ -1,10 +1,13 @@
 // SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+import { isDiscoveryBackedMode } from "./inputMode";
+import type { InputMode } from "./inputMode";
+
 export type StepList = string[];
 
-export function buildSteps(inputMode: "files" | "profile", accountCount: number): StepList {
-  const multi = inputMode === "profile" && accountCount >= 2;
+export function buildSteps(inputMode: InputMode, accountCount: number): StepList {
+  const multi = isDiscoveryBackedMode(inputMode) && accountCount >= 2;
   return multi
     ? ["Source", "Accounts", "Review", "Options", "Convert", "Done"]
     : ["Source", "Review", "Options", "Convert", "Done"];

--- a/desktop/src/lib/useScan.test.ts
+++ b/desktop/src/lib/useScan.test.ts
@@ -6,6 +6,7 @@
  *   - computeAccountRouting  (stage + seed selection/pstNames)
  *   - filterSourcesBySelection (sortedSources filtering)
  *   - selectDiscoveryRootState (folder selection transition)
+ *   - selectAutomaticDiscoveryRootState (late automatic default guard)
  *
  * useScan itself has no exported reducer — these helpers are the test seam.
  */
@@ -15,6 +16,7 @@ import {
   computeAccountRouting,
   filterSourcesBySelection,
   initialState,
+  selectAutomaticDiscoveryRootState,
   selectDiscoveryRootState,
 } from "./useScan";
 import type { PreConvertState } from "./useScan";
@@ -208,5 +210,47 @@ describe("selectDiscoveryRootState", () => {
     expect(next.addressBooks).toEqual([]);
     expect(next.inputFiles).toBe(inputFiles);
     expect(next.outputTarget).toBe(outputTarget);
+  });
+});
+
+describe("selectAutomaticDiscoveryRootState", () => {
+  it("ignores a late automatic default after the user switches from profile mode to files", () => {
+    const pendingScanState: PreConvertState = {
+      ...initialState(),
+      inputMode: "profile",
+    };
+    const latestState: PreConvertState = {
+      ...pendingScanState,
+      inputMode: "files",
+    };
+
+    const next = selectAutomaticDiscoveryRootState(latestState, "C:/profiles/default");
+
+    expect(next).toBe(latestState);
+  });
+
+  it("accepts an automatic default while still in profile mode with no root", () => {
+    const state: PreConvertState = {
+      ...initialState(),
+      inputMode: "profile",
+    };
+
+    const next = selectAutomaticDiscoveryRootState(state, "C:/profiles/default");
+
+    expect(next).not.toBe(state);
+    expect(next.inputMode).toBe("profile");
+    expect(next.profileRoot).toBe("C:/profiles/default");
+  });
+
+  it("ignores an automatic default when the user already selected an explicit root", () => {
+    const state: PreConvertState = {
+      ...initialState(),
+      inputMode: "profile",
+      profileRoot: "C:/profiles/explicit",
+    };
+
+    const next = selectAutomaticDiscoveryRootState(state, "C:/profiles/default");
+
+    expect(next).toBe(state);
   });
 });

--- a/desktop/src/lib/useScan.test.ts
+++ b/desktop/src/lib/useScan.test.ts
@@ -18,9 +18,12 @@ import {
   initialState,
   selectAutomaticDiscoveryRootState,
   selectDiscoveryRootState,
+  selectFolderTreeRootState,
+  applyFolderTreeDiscovery,
+  applyFolderTreeDiscoveryError,
 } from "./useScan";
 import type { PreConvertState } from "./useScan";
-import type { Account, OutputTarget, ProfileSourceRow } from "./types";
+import type { Account, DiscoverResult, OutputTarget, ProfileSourceRow } from "./types";
 
 const acct = (id: string, email: string | null, seg: string): Account => ({
   id,
@@ -62,6 +65,14 @@ const rows2 = [
   row("a2", "A", ["imap.example.com", "Sent"]),
   row("b1", "B", ["imap2.example.com", "Inbox"]),
 ];
+
+const discovery = (root: string): DiscoverResult => ({
+  root,
+  layout: "folder-export",
+  sources: [{ path: `${root}/Inbox`, type: "mbox", targetFolderPath: ["Inbox"], displayName: "Inbox", sourceBytes: 1, msfPath: null, accountId: null }],
+  warnings: [], skipped: [], pairing: { pairedMsfCount: 0, unpairedMboxCount: 1, orphanMsfCount: 0 },
+  accounts: [], calendars: [], addressBooks: [],
+});
 
 // ── computeAccountRouting ─────────────────────────────────────────────────────
 
@@ -138,6 +149,13 @@ describe("filterSourcesBySelection", () => {
     const selected = new Set(["A"]);
     const filtered = filterSourcesBySelection(rows1, selected, "profile", accounts1);
     expect(filtered).toHaveLength(1);
+  });
+
+  it("filters folder-tree profile rows and keeps their nested review identities", () => {
+    const filtered = filterSourcesBySelection(rows2, new Set(["A"]), "folderTree", accounts2);
+    expect(filtered.map((r) => r.targetFolderPath)).toEqual([
+      ["imap.example.com", "Inbox"], ["imap.example.com", "Sent"],
+    ]);
   });
 });
 
@@ -252,5 +270,78 @@ describe("selectAutomaticDiscoveryRootState", () => {
     const next = selectAutomaticDiscoveryRootState(state, "C:/profiles/default");
 
     expect(next).toBe(state);
+  });
+
+  it("keeps automatic profile defaults profile-only after an explicit folder-tree choice", () => {
+    const state = selectFolderTreeRootState(initialState(), "C:/export");
+
+    expect(selectAutomaticDiscoveryRootState(state, "C:/profiles/default")).toBe(state);
+  });
+});
+
+describe("folder-tree discovery state", () => {
+  it("starts explicit folder-tree selection with a clean pending discovery while retaining file/output choices", () => {
+    const inputFiles = [{ path: "C:/mail/old.mbox", size: 1 }];
+    const outputTarget: OutputTarget = { kind: "pstFile", path: "C:/out/Mail.pst" };
+    const state: PreConvertState = {
+      ...initialState(), inputFiles, outputTarget, inputMode: "profile", profileRoot: "C:/old",
+      profileRows: [row("old", null, ["Old"])], sourceError: "old error", accounts: accounts2,
+      folderTreeDiscovery: discovery("C:/stale"),
+    };
+
+    const next = selectFolderTreeRootState(state, "C:/export");
+
+    expect(next.inputMode).toBe("folderTree");
+    expect(next.profileRoot).toBe("C:/export");
+    expect(next.folderTreeDiscovering).toBe(true);
+    expect(next.folderTreeDiscovery).toBeNull();
+    expect(next.profileRows).toEqual([]);
+    expect(next.accounts).toEqual([]);
+    expect(next.sourceError).toBeNull();
+    expect(next.inputFiles).toBe(inputFiles);
+    expect(next.outputTarget).toBe(outputTarget);
+  });
+
+  it("accepts only a completion for the currently selected folder tree", () => {
+    const pending = selectFolderTreeRootState(initialState(), "C:/export/a");
+    const accepted = applyFolderTreeDiscovery(pending, "C:/export/a", pending.folderTreeRequestId, discovery("C:/export/a"));
+    expect(accepted.folderTreeDiscovering).toBe(false);
+    expect(accepted.folderTreeDiscovery?.root).toBe("C:/export/a");
+
+    const changedMode = { ...pending, inputMode: "files" as const };
+    expect(applyFolderTreeDiscovery(changedMode, "C:/export/a", pending.folderTreeRequestId, discovery("C:/export/a"))).toBe(changedMode);
+
+    const newerRoot = selectFolderTreeRootState(pending, "C:/export/b");
+    expect(applyFolderTreeDiscovery(newerRoot, "C:/export/a", pending.folderTreeRequestId, discovery("C:/export/a"))).toBe(newerRoot);
+  });
+
+  it("rejects a superseded completion when the same root is selected twice", () => {
+    const first = selectFolderTreeRootState(initialState(), "C:/export/a", 10);
+    const newest = selectFolderTreeRootState(first, "C:/export/a", 11);
+
+    expect(newest.folderTreeRequestId).toBe(11);
+    expect(applyFolderTreeDiscovery(newest, "C:/export/a", 10, discovery("C:/export/a"))).toBe(newest);
+
+    const accepted = applyFolderTreeDiscovery(newest, "C:/export/a", 11, discovery("C:/export/a"));
+    expect(accepted.folderTreeDiscovery?.root).toBe("C:/export/a");
+  });
+
+  it("rejects an older A completion after A-to-B-to-A selection", () => {
+    const firstA = selectFolderTreeRootState(initialState(), "C:/export/a", 1);
+    const b = selectFolderTreeRootState(firstA, "C:/export/b", 2);
+    const newestA = selectFolderTreeRootState(b, "C:/export/a", 3);
+
+    expect(applyFolderTreeDiscovery(newestA, "C:/export/a", 1, discovery("C:/export/a"))).toBe(newestA);
+    expect(applyFolderTreeDiscovery(newestA, "C:/export/a", 3, discovery("C:/export/a")).folderTreeDiscovery?.root).toBe("C:/export/a");
+  });
+
+  it("rejects a stale same-root error while accepting the newest error", () => {
+    const first = selectFolderTreeRootState(initialState(), "C:/export/a", 20);
+    const newest = selectFolderTreeRootState(first, "C:/export/a", 21);
+
+    expect(applyFolderTreeDiscoveryError(newest, "C:/export/a", 20, "old error")).toBe(newest);
+    const accepted = applyFolderTreeDiscoveryError(newest, "C:/export/a", 21, "new error");
+    expect(accepted.sourceError).toBe("new error");
+    expect(accepted.folderTreeDiscovering).toBe(false);
   });
 });

--- a/desktop/src/lib/useScan.test.ts
+++ b/desktop/src/lib/useScan.test.ts
@@ -5,13 +5,20 @@
  * Tests for the pure helpers extracted from useScan:
  *   - computeAccountRouting  (stage + seed selection/pstNames)
  *   - filterSourcesBySelection (sortedSources filtering)
+ *   - selectDiscoveryRootState (folder selection transition)
  *
  * useScan itself has no exported reducer — these helpers are the test seam.
  */
 
 import { describe, it, expect } from "vitest";
-import { computeAccountRouting, filterSourcesBySelection } from "./useScan";
-import type { Account, ProfileSourceRow } from "./types";
+import {
+  computeAccountRouting,
+  filterSourcesBySelection,
+  initialState,
+  selectDiscoveryRootState,
+} from "./useScan";
+import type { PreConvertState } from "./useScan";
+import type { Account, OutputTarget, ProfileSourceRow } from "./types";
 
 const acct = (id: string, email: string | null, seg: string): Account => ({
   id,
@@ -129,5 +136,77 @@ describe("filterSourcesBySelection", () => {
     const selected = new Set(["A"]);
     const filtered = filterSourcesBySelection(rows1, selected, "profile", accounts1);
     expect(filtered).toHaveLength(1);
+  });
+});
+
+describe("selectDiscoveryRootState", () => {
+  it("promotes a selected folder to discovery mode, clears stale discovery state, and preserves file/output choices", () => {
+    const inputFiles = [{ path: "C:/mail/Inbox.mbox", size: 10 }];
+    const outputTarget: OutputTarget = { kind: "pstFile", path: "C:/out/Mail.pst" };
+    const stale: PreConvertState = {
+      ...initialState(),
+      inputFiles,
+      outputTarget,
+      scan: { kind: "scan", totals: { messages: 1, bytes: 1, sourceBytes: 1, sources: 1 }, sources: [] },
+      errorMessage: "old scan error",
+      checkedIds: new Set(["old"]),
+      scanProgress: { bytes: 1, totalBytes: 2 },
+      scanFileCount: 1,
+      sourceError: "old source error",
+      profileRows: [row("old", "A", ["Old"])],
+      discoverWarnings: [{
+        code: "old",
+        path: "C:/old",
+        targetFolderPath: null,
+        segment: null,
+        segmentIndex: null,
+        relatedPaths: null,
+        message: "old",
+      }],
+      accounts: accounts2,
+      selectedAccountKeys: new Set(["A"]),
+      pstNames: { A: "Old" },
+      calendars: [{
+        calId: "old",
+        displayName: "Old",
+        storeKind: "local",
+        storePath: "C:/old.sqlite",
+        calendarType: "calendar",
+        isVisibleInThunderbird: true,
+        eventCount: 1,
+        taskCount: 0,
+        defaultCalendarFolderPath: ["Calendar"],
+        defaultTaskFolderPath: ["Tasks"],
+        accountId: "A",
+      }],
+      addressBooks: [{
+        displayName: "Old",
+        path: "C:/old.sqlite",
+        format: "thunderbird-sqlite",
+        contactCount: 1,
+        accountId: "A",
+      }],
+    };
+
+    const next = selectDiscoveryRootState(stale, "C:/fixtures/tb-export");
+
+    expect(next.inputMode).toBe("profile");
+    expect(next.profileRoot).toBe("C:/fixtures/tb-export");
+    expect(next.stage).toBe("select");
+    expect(next.scan).toBeNull();
+    expect(next.errorMessage).toBeNull();
+    expect(next.sourceError).toBeNull();
+    expect(next.checkedIds.size).toBe(0);
+    expect(next.scanProgress).toBeNull();
+    expect(next.scanFileCount).toBe(0);
+    expect(next.profileRows).toEqual([]);
+    expect(next.discoverWarnings).toEqual([]);
+    expect(next.accounts).toEqual([]);
+    expect(next.selectedAccountKeys.size).toBe(0);
+    expect(next.pstNames).toEqual({});
+    expect(next.calendars).toEqual([]);
+    expect(next.addressBooks).toEqual([]);
+    expect(next.inputFiles).toBe(inputFiles);
+    expect(next.outputTarget).toBe(outputTarget);
   });
 });

--- a/desktop/src/lib/useScan.ts
+++ b/desktop/src/lib/useScan.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Aksel Visby (ContinuMail)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { scan as runScan, discoverProfile } from "./engine";
 import { mergeProfileSources } from "./profileConfig";
 import { checkSchemaVersion } from "./schema";
@@ -10,6 +10,8 @@ import { sortSources, type SortField, type SortDir } from "./review";
 import { groupByAccount, accountKeyForRow } from "./accounts";
 import type { FileStat, SourceRow, ProfileSourceRow, DiscoverWarning, DiscoverResult, OutputTarget, Account, DiscoveredCalendar, DiscoveredAddressBook } from "./types";
 import type { ScanResult } from "./parse";
+import { isDiscoveryBackedMode } from "./inputMode";
+import type { InputMode } from "./inputMode";
 
 export type FlowStage = "select" | "scanning" | "review" | "options" | "scanError" | "accounts";
 
@@ -43,10 +45,10 @@ export function computeAccountRouting(
 export function filterSourcesBySelection(
   rows: ProfileSourceRow[],
   selectedAccountKeys: Set<string>,
-  inputMode: "files" | "profile",
+  inputMode: InputMode,
   accounts: Account[],
 ): ProfileSourceRow[] {
-  if (inputMode !== "profile" || accounts.length < 2) return rows;
+  if (!isDiscoveryBackedMode(inputMode) || accounts.length < 2) return rows;
   return rows.filter((r) => selectedAccountKeys.has(accountKeyForRow(r)));
 }
 
@@ -65,8 +67,11 @@ export interface PreConvertState {
   scanFileCount: number; // sources being scanned: files (.mbox mode) or discovered folders (profile mode); 0 until known
   sortBy: SortField;
   sortDir: SortDir;
-  inputMode: "files" | "profile";
+  inputMode: InputMode;
   profileRoot: string | null;
+  folderTreeDiscovery: DiscoverResult | null;
+  folderTreeDiscovering: boolean;
+  folderTreeRequestId: number;
   profileRows: ProfileSourceRow[];
   discoverWarnings: DiscoverWarning[];
   sourceError: string | null; // parent-owned discover-time error, shown on the Source screen
@@ -94,6 +99,9 @@ export function initialState(): PreConvertState {
     sortDir: "desc",
     inputMode: "files",
     profileRoot: null,
+    folderTreeDiscovery: null,
+    folderTreeDiscovering: false,
+    folderTreeRequestId: 0,
     profileRows: [],
     discoverWarnings: [],
     sourceError: null,
@@ -119,6 +127,8 @@ export function selectDiscoveryRootState(
     scanFileCount: 0,
     inputMode: "profile",
     profileRoot,
+    folderTreeDiscovery: null,
+    folderTreeDiscovering: false,
     profileRows: [],
     discoverWarnings: [],
     sourceError: null,
@@ -128,6 +138,47 @@ export function selectDiscoveryRootState(
     calendars: [],
     addressBooks: [],
   };
+}
+
+/** Begin an explicit export-folder discovery without changing the visible files tab. */
+export function selectFolderTreeRootState(
+  state: PreConvertState,
+  profileRoot: string,
+  requestId = state.folderTreeRequestId + 1,
+): PreConvertState {
+  return {
+    ...selectDiscoveryRootState(state, profileRoot),
+    inputMode: "folderTree",
+    folderTreeDiscovery: null,
+    folderTreeDiscovering: true,
+    folderTreeRequestId: requestId,
+  };
+}
+
+/** Apply an async folder-tree result only when it still belongs to the active root. */
+export function applyFolderTreeDiscovery(
+  state: PreConvertState,
+  profileRoot: string,
+  requestId: number,
+  discovery: DiscoverResult,
+): PreConvertState {
+  if (state.inputMode !== "folderTree" || state.profileRoot !== profileRoot || state.folderTreeRequestId !== requestId) return state;
+  return {
+    ...state,
+    folderTreeDiscovery: discovery,
+    folderTreeDiscovering: false,
+    sourceError: discovery.sources.length === 0 ? "No mail folders found in that location." : null,
+  };
+}
+
+export function applyFolderTreeDiscoveryError(
+  state: PreConvertState,
+  profileRoot: string,
+  requestId: number,
+  sourceError: string,
+): PreConvertState {
+  if (state.inputMode !== "folderTree" || state.profileRoot !== profileRoot || state.folderTreeRequestId !== requestId) return state;
+  return { ...state, folderTreeDiscovery: null, folderTreeDiscovering: false, sourceError };
 }
 
 export function selectAutomaticDiscoveryRootState(
@@ -140,9 +191,14 @@ export function selectAutomaticDiscoveryRootState(
 
 export function useScan() {
   const [state, setState] = useState<PreConvertState>(() => initialState());
+  const folderTreeRequestId = useRef(0);
 
   const setInputFiles = useCallback(
-    (inputFiles: FileStat[]) => setState((s) => ({ ...s, inputFiles })),
+    (inputFiles: FileStat[]) => setState((s) => (
+      s.inputMode === "folderTree"
+        ? { ...s, inputFiles, inputMode: "files", profileRoot: null, folderTreeDiscovery: null, folderTreeDiscovering: false, sourceError: null }
+        : { ...s, inputFiles }
+    )),
     [],
   );
   const setOutputTarget = useCallback(
@@ -151,7 +207,7 @@ export function useScan() {
   );
 
   const setInputMode = useCallback(
-    (inputMode: "files" | "profile") => setState((s) => ({ ...s, inputMode, sourceError: null })),
+    (inputMode: InputMode) => setState((s) => ({ ...s, inputMode, sourceError: null })),
     [],
   );
   const setProfileRoot = useCallback(
@@ -166,9 +222,22 @@ export function useScan() {
     (profileRoot: string) => setState((s) => selectAutomaticDiscoveryRootState(s, profileRoot)),
     [],
   );
+  const setFolderTreeRoot = useCallback((profileRoot: string) => {
+    const requestId = ++folderTreeRequestId.current;
+    setState((s) => selectFolderTreeRootState(s, profileRoot, requestId));
+    void discoverProfile(profileRoot).then(
+      (discovery) => setState((s) => applyFolderTreeDiscovery(s, profileRoot, requestId, discovery)),
+      (e: unknown) => setState((s) => applyFolderTreeDiscoveryError(
+        s,
+        profileRoot,
+        requestId,
+        e instanceof Error ? e.message : String(e),
+      )),
+    );
+  }, []);
 
   const continueToScan = useCallback(async () => {
-    if (state.inputMode === "profile") {
+    if (isDiscoveryBackedMode(state.inputMode)) {
       if (!state.profileRoot) {
         setState((s) => ({ ...s, sourceError: "Choose a Thunderbird profile or mail folder." }));
         return;
@@ -178,12 +247,20 @@ export function useScan() {
       // Discovery failure / empty discovery is a SOURCE-selection problem → return to Source with
       // sourceError. Only a scan failure AFTER successful discovery goes to the ScanError view.
       let disc: DiscoverResult;
-      try {
-        disc = await discoverProfile(state.profileRoot);
-      } catch (e) {
-        const sourceError = e instanceof Error ? e.message : String(e);
-        setState((s) => ({ ...s, stage: "select", sourceError, scanProgress: null }));
-        return;
+      if (state.inputMode === "folderTree") {
+        if (state.folderTreeDiscovering || !state.folderTreeDiscovery) {
+          setState((s) => ({ ...s, stage: "select", sourceError: "Choose a folder tree with mail folders first.", scanProgress: null }));
+          return;
+        }
+        disc = state.folderTreeDiscovery;
+      } else {
+        try {
+          disc = await discoverProfile(state.profileRoot);
+        } catch (e) {
+          const sourceError = e instanceof Error ? e.message : String(e);
+          setState((s) => ({ ...s, stage: "select", sourceError, scanProgress: null }));
+          return;
+        }
       }
       if (disc.sources.length === 0) {
         setState((s) => ({ ...s, stage: "select", sourceError: "No mail folders found in that location.", scanProgress: null }));
@@ -262,7 +339,7 @@ export function useScan() {
       const errorMessage = e instanceof Error ? e.message : String(e);
       setState((s) => ({ ...s, stage: "scanError", errorMessage, scanProgress: null }));
     }
-  }, [state.inputMode, state.profileRoot, state.inputFiles]);
+  }, [state.inputMode, state.profileRoot, state.folderTreeDiscovering, state.folderTreeDiscovery, state.inputFiles]);
 
   const toggleChecked = useCallback((id: string) => {
     setState((s) => {
@@ -324,7 +401,7 @@ export function useScan() {
   const resetFlow = useCallback(() => setState(initialState()), []);
 
   const sortedSources: SourceRow[] = useMemo(() => {
-    if (state.inputMode === "profile") {
+    if (isDiscoveryBackedMode(state.inputMode)) {
       const filtered = filterSourcesBySelection(state.profileRows, state.selectedAccountKeys, state.inputMode, state.accounts);
       return sortSources(filtered, state.sortBy, state.sortDir);
     }
@@ -345,6 +422,7 @@ export function useScan() {
     setInputMode,
     setProfileRoot,
     setAutomaticProfileRoot,
+    setFolderTreeRoot,
     continueToScan,
     toggleChecked,
     setSkipEmpty,

--- a/desktop/src/lib/useScan.ts
+++ b/desktop/src/lib/useScan.ts
@@ -78,7 +78,7 @@ export interface PreConvertState {
   addressBooks: DiscoveredAddressBook[];
 }
 
-function initialState(): PreConvertState {
+export function initialState(): PreConvertState {
   return {
     inputFiles: [],
     outputTarget: null,
@@ -94,6 +94,31 @@ function initialState(): PreConvertState {
     sortDir: "desc",
     inputMode: "files",
     profileRoot: null,
+    profileRows: [],
+    discoverWarnings: [],
+    sourceError: null,
+    accounts: [],
+    selectedAccountKeys: new Set(),
+    pstNames: {},
+    calendars: [],
+    addressBooks: [],
+  };
+}
+
+export function selectDiscoveryRootState(
+  state: PreConvertState,
+  profileRoot: string,
+): PreConvertState {
+  return {
+    ...state,
+    stage: "select",
+    scan: null,
+    errorMessage: null,
+    checkedIds: new Set(),
+    scanProgress: null,
+    scanFileCount: 0,
+    inputMode: "profile",
+    profileRoot,
     profileRows: [],
     discoverWarnings: [],
     sourceError: null,
@@ -122,7 +147,11 @@ export function useScan() {
     [],
   );
   const setProfileRoot = useCallback(
-    (profileRoot: string | null) => setState((s) => ({ ...s, profileRoot, sourceError: null })),
+    (profileRoot: string | null) => setState((s) => (
+      profileRoot === null
+        ? { ...s, profileRoot: null, sourceError: null }
+        : selectDiscoveryRootState(s, profileRoot)
+    )),
     [],
   );
 

--- a/desktop/src/lib/useScan.ts
+++ b/desktop/src/lib/useScan.ts
@@ -130,6 +130,14 @@ export function selectDiscoveryRootState(
   };
 }
 
+export function selectAutomaticDiscoveryRootState(
+  state: PreConvertState,
+  profileRoot: string,
+): PreConvertState {
+  if (state.inputMode !== "profile" || state.profileRoot !== null) return state;
+  return selectDiscoveryRootState(state, profileRoot);
+}
+
 export function useScan() {
   const [state, setState] = useState<PreConvertState>(() => initialState());
 
@@ -152,6 +160,10 @@ export function useScan() {
         ? { ...s, profileRoot: null, sourceError: null }
         : selectDiscoveryRootState(s, profileRoot)
     )),
+    [],
+  );
+  const setAutomaticProfileRoot = useCallback(
+    (profileRoot: string) => setState((s) => selectAutomaticDiscoveryRootState(s, profileRoot)),
     [],
   );
 
@@ -332,6 +344,7 @@ export function useScan() {
     setOutputTarget,
     setInputMode,
     setProfileRoot,
+    setAutomaticProfileRoot,
     continueToScan,
     toggleChecked,
     setSkipEmpty,


### PR DESCRIPTION
## Summary

- Route selected folder trees through the existing content-sniffing discovery pipeline.
- Preview extensionless mbox files and nested `.sbd` hierarchy on the `.mbox files` source view before scanning.
- Preserve discovered folder paths through Review and mirror conversion, remove the obsolete flat enumerator, and guard asynchronous source-selection races.

## Root cause

The desktop folder picker used a separate non-recursive Tauri command that accepted only files with a `.mbox` extension. Thunderbird exports commonly store mail in extensionless files and represent subfolders with nested `.sbd` directories, so valid exports could appear empty or lose their hierarchy.

## User impact

Selecting a Thunderbird folder export now stays on the `.mbox files` view, immediately previews the reconstructed folder tree, and converts the same hierarchy into the PST. Individual `.mbox` file selection and installed-profile discovery remain separate workflows.

## Validation

- `dotnet test Mail2Pst.sln` — 1,407 passed; 15 expected opt-in skips
- `npm test` — 274 passed
- `npm run build`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml` — 17 passed
- Nested Thunderbird export smoke conversion and independent PST hierarchy validation
