### PR TITLE
chore(release): prepare v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3] — 2026-07-23
+
+### Security
+- Updated the bundled SQLite library to a non-vulnerable release and synchronized the third-party
+  attribution ledger with the shipped dependency versions.
+
 ### Changed
 - **A Thunderbird-starred (Marked) message now converts to a yellow "Star" category instead of an
   Outlook follow-up flag.** Previously every starred message was written with a follow-up flag,

--- a/NOTICE
+++ b/NOTICE
@@ -58,7 +58,7 @@ Microsoft .NET runtime & libraries (bundled in the self-contained CLI binaries)
   System.Text.Encoding.CodePages), licensed under the MIT License.
   License text: https://github.com/dotnet/runtime/blob/main/LICENSE.TXT
 -------------------------------------------------------------------------------
-Microsoft.Data.Sqlite / Microsoft.Data.Sqlite.Core (10.0.9)
+Microsoft.Data.Sqlite / Microsoft.Data.Sqlite.Core (10.0.10)
   Copyright (c) .NET Foundation and Contributors
   Licensed under the MIT License.
   License text: https://github.com/dotnet/efcore/blob/main/LICENSE.txt
@@ -72,7 +72,7 @@ Microsoft.Win32.Registry (5.0.0)
   Windows time-zone rules; registry calls are Windows-only at runtime.
 -------------------------------------------------------------------------------
 SQLitePCLRaw.core / SQLitePCLRaw.bundle_e_sqlite3 /
-SQLitePCLRaw.lib.e_sqlite3 / SQLitePCLRaw.provider.e_sqlite3 (2.1.11)
+SQLitePCLRaw.lib.e_sqlite3 / SQLitePCLRaw.provider.e_sqlite3 (2.1.12)
   Copyright (c) Zumero Systems LLC (Eric Sink)
   Licensed under the Apache License, Version 2.0.
   License text: https://www.apache.org/licenses/LICENSE-2.0
@@ -83,7 +83,7 @@ SQLitePCLRaw.lib.e_sqlite3 / SQLitePCLRaw.provider.e_sqlite3 (2.1.11)
   by its authors and contributors. The SQLitePCLRaw packaging itself
   is licensed Apache-2.0 as above.
 -------------------------------------------------------------------------------
-Ical.Net (5.2.2)
+Ical.Net (5.2.3)
   Copyright (c) Rian Stockbower and contributors
   Licensed under the MIT License.
   License text: https://github.com/ical-org/ical.net/blob/main/license.md
@@ -93,9 +93,9 @@ Ical.Net (5.2.2)
   NodaTime (3.2.2) — Copyright (c) The Noda Time Authors — Apache License 2.0
   License text: https://www.apache.org/licenses/LICENSE-2.0
 -------------------------------------------------------------------------------
-FolkerKinzel.VCards (8.1.3) and its transitive dependencies:
-  FolkerKinzel.DataUrls (2.0.6), FolkerKinzel.Helpers (1.1.1),
-  FolkerKinzel.MimeTypes (5.5.2), FolkerKinzel.Strings (9.4.3)
+FolkerKinzel.VCards (8.2.0) and its transitive dependencies:
+  FolkerKinzel.DataUrls (2.0.7), FolkerKinzel.Helpers (1.1.2),
+  FolkerKinzel.MimeTypes (5.6.0), FolkerKinzel.Strings (9.5.0)
   Copyright (c) Frank Puck (FolkerKinzel)
   Licensed under the MIT License.
   License text: https://github.com/FolkerKinzel/VCards/blob/master/LICENSE

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@radix-ui/react-slot": "^1.3.0",
         "@tauri-apps/api": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.3.2"
+version = "0.3.3"
 description = "ContinuMail Converter — convert mbox mail archives to Outlook PST"
 authors = ["Aksel Visby <aksel@visby.it>"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ContinuMail Converter",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "identifier": "com.continumail.converter",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/Mail2Pst.Cli/Mail2Pst.Cli.csproj
+++ b/src/Mail2Pst.Cli/Mail2Pst.Cli.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Mail2Pst.Cli</RootNamespace>
-    <Version>0.3.2</Version>
+    <Version>0.3.3</Version>
     <!-- Server GC: measured win on the parallel byte-range scan (4.5 GB gmail corpus:
          ~19s -> ~13.5s wall-clock, ~30% faster). Peak working set rises 163 -> 314 MB,
          still size-independent and modest. See docs/pst-engine-benchmarks.md. -->

--- a/src/Mail2Pst.Core/Mail2Pst.Core.csproj
+++ b/src/Mail2Pst.Core/Mail2Pst.Core.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="FolkerKinzel.VCards" Version="8.2.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="10.0.10" />
     <PackageReference Include="Ical.Net" Version="5.2.3" />
     <PackageReference Include="MimeKit" Version="4.17.0" />


### PR DESCRIPTION
## Summary

- update the bundled SQLite library to 2.1.12 and synchronize third-party attribution versions
- bump the desktop, Tauri, Rust crate, and CLI versions to 0.3.3
- roll the accumulated Thunderbird export and conversion-hardening changes into the 0.3.3 changelog

## Validation

- `dotnet test Mail2Pst.sln -c Release --no-restore` — 1,417 passed, 21 expected skips
- `npm test` — 274 passed
- `npm run build`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml` — 17 passed
- `npm audit --audit-level=moderate` — no vulnerabilities
- `dotnet list Mail2Pst.sln package --vulnerable --include-transitive` — no vulnerable packages
- full-history secret scan — no leaks